### PR TITLE
Docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 npm i stardust -S
 ```
 
+## Learn
+Checkout the **[Docs](https://technologyadvice.github.io/stardust/)**.
+
 ## Develop
 
 ### Commands

--- a/wercker.yml
+++ b/wercker.yml
@@ -59,3 +59,7 @@ deploy:
           git add --force docs/build
           git commit -m "deploy commit from $WERCKER_STARTED_BY"
           git push -f $GIT_REMOTE master:gh-pages
+
+  after-steps:
+    - slack-notifier:
+        url: https://hooks.slack.com/services/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


### PR DESCRIPTION
Doc site should auto generate and publish to `gh-pages` as part of the wercker deploy step.  We'll need to merge a PR before that happens.  This PR just adds the link, but the docs won't actually be there, yet.
