### PR TITLE
Watch

### DIFF
--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -6,6 +6,7 @@ gulp.task('default', function(cb) {
   runSequence(
     'build',
     'serve',
+    'watch',
     cb
   );
 });

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -1,0 +1,10 @@
+var g = require('gulp-load-plugins')();
+var gulp = g.help(require('gulp'), require('../gulphelp'));
+
+var paths = require('../../paths');
+
+gulp.task('watch', 'watch and build docs', function(cb) {
+  gulp.watch([paths.src + '/**/*.js'], ['generate-doc-json']);
+  gulp.watch([paths.docsRoot + '/**/*.html'], ['build-doc-html']);
+  cb();
+});


### PR DESCRIPTION
Makes it so that components are rescanned and doc info is created on change.  Also, reloads when html changes.

Webpack still handles reloading when JS changes.  This just makes docgen regenerate doc info when component syntax changes.
