### PR TITLE
Eslint Ignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,7 @@
+_builds/*
+_projects/*
+_steps/*
+bower_components/*
 node_modules/*
 docs/build/*
+testBundle.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/*
+docs/build/*

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "test": "karma start karma.conf.js",
-    "lint": "eslint src gulp test ./*.js",
+    "lint": "eslint .",
     "test-watch": "webpack-dev-server --config webpack.tests.js",
     "deploy": "git push && git push --tags && npm publish",
     "start": "gulp"


### PR DESCRIPTION
`/docs/app` was excluded from linting on precommit.   This PR lints the entire code base on `npm run lint` which is also run on the precommit hook.  I've also added an `.eslintignore` to exclude vendors, build artifacts, and test artifacts.
