### PR TITLE
Conformance Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ npm i stardust -S
 ```
 
 ## Learn
-Checkout the **[Docs](https://technologyadvice.github.io/stardust/)**.
+Checkout the [Documentation](https://technologyadvice.github.io/stardust/).
+
+Review our [Component Guidelines]
+(https://github.com/TechnologyAdvice/stardust/blob/master/docs/app/Component Guidelines.md).
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ gulp help                 # list gulp commands
 ### Deploying
 
 ```
-npm version <version>
-npm run deploy
+npm version <version>     # bump the new version
+npm run deploy            # pushes tags and publishes package
 ```

--- a/docs/app/Component Guidelines.md
+++ b/docs/app/Component Guidelines.md
@@ -1,0 +1,199 @@
+# Stardust Component Guidelines
+
+Every component in Stardust must conform to these guidelines.  They ensure consistency and optimal development experience for Stardust users.
+
+This document will be minimally maintained.  See [`\test`](https://github.com/TechnologyAdvice/stardust/tree/master/test) for the current conformance tests.
+
+## Extends React.Component
+
+**Valid**
+
+```jsx
+import React, {Component} from 'react';
+
+export default class MyComponent extends Component {...}
+```
+
+**Invalid**
+
+```jsx
+import React, {Component} from 'react';
+
+export default class MyComponent {...}
+```
+>This is a new class, does not extend React.Component.
+
+## Constructor name matches component name
+
+Give `MyComponent.js` is a component attached to `stardust.MyComponent`:
+
+**Valid**
+
+```jsx
+export default class MyComponent extends Component {...}
+```
+
+**Invalid**
+
+```jsx
+export default class extends Component {...}
+```
+>This is an anonymous class, actually named `_deafult`.
+
+```jsx
+export default class YourComponent extends Component {...}
+```
+>This class has the wrong name, it should be .
+
+## Has the `sd-<component>` element as its first child (no wrapper elements)
+
+**Valid**
+
+```jsx
+export default class Input extends Component {
+  render() {
+    return (
+      <Input />
+    );
+  }
+}
+```
+
+**Invalid**
+
+```jsx
+export default class Input extends Component {
+  render() {
+    return (
+      <Field
+        <Input />
+      </Field>
+    );
+  }
+}
+```
+>Never wrap the component with other components, whether DOM or Composite.
+
+## Has props.className after `sd-<component>`
+
+**Valid**
+
+```jsx
+<Field className='inherit-this' />
+// => <div className='sd-field inherit-this field>...
+```
+
+**Invalid**
+
+```jsx
+<Field className='inherit-this' />
+// => <div className='sd-field field>...
+```
+>className was not inherited
+
+```jsx
+<Field className='inherit-this' />
+// => <div className='inherit-this sd-field field>...
+```
+>className was inherited before sd-field
+
+```jsx
+<Field className='inherit-this' />
+// => <div className='inherit-this sd-field field>...
+```
+>className was not inherited before sd-field
+
+## Has `sd-<component>` as the first class
+
+**Valid**
+
+```jsx
+<Divider />
+// => <div className='sd-divider ui divider' /> 
+```
+
+**Invalid**
+
+```jsx
+<Divider />
+// => <div className='ui divider' /> 
+```
+>Missing `sd-divider` className.
+
+```jsx
+<Divider />
+// => <div className='ui sd-divider divider' /> 
+```
+>`sd-divider` className does not come first.
+
+## Has `ui` class immediately after `sd-<component>`
+Only for components that utilize the `ui` class (i.e `ui grid` but not `column`).
+
+**Valid**
+
+```jsx
+<Grid />
+// => <div className='sd-grid ui grid' /> 
+```
+
+**Invalid**
+
+```jsx
+<Grid />
+// => <div className='sd-grid grid ui' /> 
+```
+>`grid` is immediately after `sd-grid`.
+
+## Has props.className immediately after `ui`
+
+Only for components that utilize the `ui` class (i.e `ui form` but not `field`).
+
+**Valid**
+
+```jsx
+<Form />
+// => <div className='sd-form ui form' /> 
+```
+
+**Invalid**
+
+```jsx
+<Form className='loading' />
+// => <div className='sd-form loading ui form' /> 
+```
+>Inherited `loading` className comes before `ui`.
+
+```jsx
+<Form className='loading' />
+// => <div className='sd-form ui form loading' /> 
+```
+>Inherited `loading` className comes after `form`.
+
+## Spreads props
+Allows access to the underlying element of concern.
+
+**Valid**
+
+```jsx
+<Input onFocus={this.handleFocus} />
+// => <input type='text' className='sd-input ui input' onFocus={this.handleFocus} /> 
+```
+
+```jsx
+<Input data-my-plugin='do-magic' />
+// => <input type='text' className='sd-input ui input' data-my-plugin='do-magic' /> 
+```
+
+**Invalid**
+
+```jsx
+<Input onFocus={this.handleFocus} />
+// => <input type='text' className='sd-input ui input' /> 
+```
+>`onFocus` prop was lost.
+
+```jsx
+<Input data-my-plugin='do-magic' />
+// => <input type='text' className='sd-input ui input' /> 
+```
+>`data-my-plugin` prop was lost.

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -6,7 +6,7 @@ import ModalContent from 'src/modules/Modal/ModalContent';
 import ModalFooter from 'src/modules/Modal/ModalFooter';
 import ModalHeader from 'src/modules/Modal/ModalHeader';
 
-class Confirm extends Component {
+export default class Confirm extends Component {
   static propTypes = {
     abortLabel: PropTypes.string,
     confirmLabel: PropTypes.string,
@@ -53,7 +53,7 @@ class Confirm extends Component {
 
   render() {
     return (
-      <Modal ref='modal' className='small'>
+      <Modal {...this.props} className='small' ref='modal'>
         <ModalHeader>
           {this.props.header}
         </ModalHeader>
@@ -68,5 +68,3 @@ class Confirm extends Component {
     );
   }
 }
-
-export default Confirm;

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -1,5 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import Promise from 'bluebird';
+import classNames from 'classnames';
 
 import Modal from 'src/modules/Modal/Modal';
 import ModalContent from 'src/modules/Modal/ModalContent';
@@ -9,6 +10,7 @@ import ModalHeader from 'src/modules/Modal/ModalHeader';
 export default class Confirm extends Component {
   static propTypes = {
     abortLabel: PropTypes.string,
+    className: PropTypes.string,
     confirmLabel: PropTypes.string,
     header: PropTypes.string,
     ref: PropTypes.string,
@@ -52,8 +54,12 @@ export default class Confirm extends Component {
   };
 
   render() {
+    let classes = classNames(
+      'sd-confirm',
+      this.props.className,
+    );
     return (
-      <Modal {...this.props} className='small' ref='modal'>
+      <Modal {...this.props} className={classes} ref='modal'>
         <ModalHeader>
           {this.props.header}
         </ModalHeader>

--- a/src/addons/Textarea/Textarea.js
+++ b/src/addons/Textarea/Textarea.js
@@ -1,40 +1,22 @@
 import React, {Component, PropTypes} from 'react';
 import Field from 'src/collections/Form/Field';
+import classNames from 'classnames';
 
-class Textarea extends Component {
+export default class Textarea extends Component {
   static propTypes = {
-    dataContent: PropTypes.string,
+    className: PropTypes.string,
     label: PropTypes.string,
-    name: PropTypes.string,
-    onChange: PropTypes.func,
-    ref: PropTypes.string,
-    rows: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
-    value: PropTypes.string,
-  };
-
-  static defaultProps = {
-    rows: '3',
-    ref: 'textarea',
-  };
-
-  handleChange = (e) => {
-    this.props.onChange(e);
   };
 
   render() {
+    let classes = classNames(
+      'sd-textarea',
+      this.props.className
+    );
     return (
       <Field label={this.props.label}>
-        <textarea
-          {...this.props}
-          onChange={this.handleChange}
-          data-content={this.props.dataContent}
-        />
+        <textarea {...this.props} className={classes}/>
       </Field>
     );
   }
 }
-
-export default Textarea;

--- a/src/addons/Textarea/Textarea.js
+++ b/src/addons/Textarea/Textarea.js
@@ -1,5 +1,4 @@
 import React, {Component, PropTypes} from 'react';
-import Field from 'src/collections/Form/Field';
 import classNames from 'classnames';
 
 export default class Textarea extends Component {
@@ -14,9 +13,7 @@ export default class Textarea extends Component {
       this.props.className
     );
     return (
-      <Field label={this.props.label}>
-        <textarea {...this.props} className={classes}/>
-      </Field>
+      <textarea {...this.props} className={classes} />
     );
   }
 }

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import React, {Children, Component, PropTypes} from 'react';
 import Button from 'src/elements/Button/Button';
+import classNames from 'classnames';
 
 class Form extends Component {
   static propTypes = {
@@ -21,13 +22,14 @@ class Form extends Component {
           }
         });
       }
+
       loopThruChildren(props.children);
 
       if (formButtons.length === 0 || !_.include(formButtons, 'submit')) {
         return new Error('`Form` must have `Button` child with type of "submit".');
       }
     },
-    onSubmit: PropTypes.func,
+    className: PropTypes.string,
   };
 
   serializeJson = () => {
@@ -60,8 +62,14 @@ class Form extends Component {
   };
 
   render() {
+    let classes = classNames(
+      'sd-form',
+      'form',
+      'ui',
+      this.props.className,
+    );
     return (
-      <form className='sd-form ui form' onSubmit={this.props.onSubmit} ref='form'>
+      <form {...this.props} className={classes} ref='form'>
         {this.props.children}
       </form>
     );

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -3,7 +3,7 @@ import React, {Children, Component, PropTypes} from 'react';
 import Button from 'src/elements/Button/Button';
 import classNames from 'classnames';
 
-class Form extends Component {
+export default class Form extends Component {
   static propTypes = {
     children: function(props, propName, componentName) {
       let formButtons = [];
@@ -75,5 +75,3 @@ class Form extends Component {
     );
   }
 }
-
-export default Form;

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -64,9 +64,9 @@ class Form extends Component {
   render() {
     let classes = classNames(
       'sd-form',
-      'form',
       'ui',
       this.props.className,
+      'form',
     );
     return (
       <form {...this.props} className={classes} ref='form'>

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
 
-class Menu extends Component {
+export default class Menu extends Component {
   static propTypes = {
     activeItem: PropTypes.string,
     children: PropTypes.node,
@@ -24,15 +24,8 @@ class Menu extends Component {
   render() {
     let classes = classNames(
       'sd-menu',
-      this.props.className,
       'ui',
-      {inverted: this.props.inverted},
-      {secondary: this.props.secondary},
-      {small: this.props.small},
-      {pointing: this.props.pointing},
-      {fluid: this.props.fluid},
-      {text: this.props.text},
-      {vertical: this.props.vertical},
+      this.props.className,
       'menu'
     );
     let hasActiveItem = !!this.state.activeItem || !!this.props.activeItem;
@@ -46,11 +39,9 @@ class Menu extends Component {
       });
     });
     return (
-      <div className={classes}>
+      <div {...this.props} className={classes}>
         {children}
       </div>
     );
   }
 }
-
-export default Menu;

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -6,13 +6,6 @@ export default class Menu extends Component {
     activeItem: PropTypes.string,
     children: PropTypes.node,
     className: PropTypes.string,
-    fluid: PropTypes.bool,
-    inverted: PropTypes.bool,
-    pointing: PropTypes.bool,
-    secondary: PropTypes.bool,
-    small: PropTypes.bool,
-    text: PropTypes.bool,
-    vertical: PropTypes.bool,
   };
 
   state = {activeItem: this.props.activeItem};

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -5,23 +5,23 @@ import classNames from 'classnames';
  * @example
  * <MenuItem label='Home Page' name='home' />
  */
-class MenuItem extends Component {
+export default class MenuItem extends Component {
   static propTypes = {
     activeItem: PropTypes.string,
     callbackParent: PropTypes.func,
     children: PropTypes.node,
-    href: PropTypes.string,
+    className: PropTypes.string,
     label: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string,
     ]),
     name: PropTypes.string.isRequired,
-    onClickMenuItem: PropTypes.func,
+    onClick: PropTypes.func,
   };
 
   handleClick = (e) => {
-    if (this.props.onClickMenuItem) {
-      this.props.onClickMenuItem(this.props.name);
+    if (this.props.onClick) {
+      this.props.onClick(this.props.name);
     }
     this.props.callbackParent(this.props.name);
   };
@@ -29,9 +29,15 @@ class MenuItem extends Component {
   render() {
     let menuLabel = <div className='sd-menu-label ui blue label'>{this.props.label}</div>;
     let isActive = this.props.activeItem === this.props.name;
-    let classes = classNames('sd-menu-item', 'blue', 'item', {active: isActive});
+    let classes = classNames(
+      'sd-menu-item',
+      this.props.className,
+      'blue',
+      'item',
+      {active: isActive}
+    );
     return (
-      <a className={classes} onClick={this.handleClick} href={this.props.href}>
+      <a {...this.props} className={classes} onClick={this.handleClick}>
         {this.props.name}
         {this.props.label && menuLabel}
         {this.props.children}
@@ -39,5 +45,3 @@ class MenuItem extends Component {
     );
   }
 }
-
-export default MenuItem;

--- a/src/collections/Table/TableCell.js
+++ b/src/collections/Table/TableCell.js
@@ -1,17 +1,21 @@
 import React, {Component, PropTypes} from 'react';
+import classNames from 'classnames';
 
-class TableCell extends Component {
+export default class TableCell extends Component {
   static propTypes = {
-    children: PropTypes.node
+    children: PropTypes.node,
+    className: PropTypes.string,
   };
 
   render() {
+    let classes = classNames(
+      'sd-table-cell',
+      this.props.className,
+    );
     return (
-      <td className='sd-table-cell'>
+      <td {...this.props} className={classes}>
         {this.props.children}
       </td>
     );
   }
 }
-
-export default TableCell;

--- a/src/collections/Table/TableColumn.js
+++ b/src/collections/Table/TableColumn.js
@@ -1,15 +1,19 @@
 import React, {Component, PropTypes} from 'react';
+import classNames from 'classnames';
 
-class TableColumn extends Component {
+export default class TableColumn extends Component {
   static propTypes = {
     cellRenderer: PropTypes.func,
+    className: PropTypes.string,
     dataKey: PropTypes.string,
     headerRenderer: PropTypes.func,
   };
 
   render() {
-    return <div className='sd-table-column'></div>;
+    let classes = classNames(
+      'sd-table-column',
+      this.props.className
+    );
+    return <div {...this.props} className={classes}></div>;
   }
 }
-
-export default TableColumn;

--- a/src/collections/Table/TableHeader.js
+++ b/src/collections/Table/TableHeader.js
@@ -1,17 +1,21 @@
 import React, {Component, PropTypes} from 'react';
+import classNames from 'classnames';
 
-class TableHeader extends Component {
+export default class TableHeader extends Component {
   static propTypes = {
-    children: PropTypes.node
+    children: PropTypes.node,
+    className: PropTypes.string,
   };
 
   render() {
+    let classes = classNames(
+      'sd-table-header',
+      this.props.className
+    );
     return (
-      <th className='sd-table-header'>
+      <th {...this.props} className={classes}>
         {this.props.children}
       </th>
     );
   }
 }
-
-export default TableHeader;

--- a/src/collections/Table/TableRow.js
+++ b/src/collections/Table/TableRow.js
@@ -1,13 +1,21 @@
 import React, {Component, PropTypes} from 'react';
+import classNames from 'classnames';
 
-class TableRow extends Component {
+export default class TableRow extends Component {
   static propTypes = {
     children: PropTypes.node,
+    className: PropTypes.string,
   };
 
   render() {
-    return <tr className='sd-table-row'>{this.props.children}</tr>;
+    let classes = classNames(
+      'sd-table-row',
+      this.props.className
+    );
+    return (
+      <tr {...this.props} className={classes}>
+        {this.props.children}
+      </tr>
+    );
   }
 }
-
-export default TableRow;

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1,8 +1,9 @@
 import React, {Component, PropTypes} from 'react';
-import Field from 'src/collections/Form/Field';
+import classNames from 'classnames';
 
-class Select extends Component {
+export default class Dropdown extends Component {
   static propTypes = {
+    className: PropTypes.string,
     label: PropTypes.string,
     options: PropTypes.array,
     value: PropTypes.string,
@@ -17,14 +18,16 @@ class Select extends Component {
       return <option key={i} value={opt.value}>{opt.text}</option>;
     });
     let value = _.isEmpty(this.props.value) ? '' : this.props.value;
+    let classes = classNames(
+      'sd-dropdown',
+      'ui',
+      this.props.className,
+      'dropdown'
+    );
     return (
-      <Field label={this.props.label}>
-        <select className='sd-select ui fluid dropdown' value={value}>
-          {options}
-        </select>
-      </Field>
+      <select {...this.props} className={classes} value={value}>
+        {options}
+      </select>
     );
   }
 }
-
-export default Select;

--- a/src/modules/Modal/ModalContent.js
+++ b/src/modules/Modal/ModalContent.js
@@ -1,20 +1,22 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
 
-class ModalContent extends Component {
+export default class ModalContent extends Component {
   static propTypes = {
     children: PropTypes.any,
     className: PropTypes.string,
   };
 
   render() {
-    let classes = classNames('sd-modal-content', this.props.className, 'content');
+    let classes = classNames(
+      'sd-modal-content',
+      this.props.className,
+      'content'
+    );
     return (
-      <div className={classes}>
+      <div {...this.props} className={classes}>
         {this.props.children}
       </div>
     );
   }
 }
-
-export default ModalContent;

--- a/src/modules/Modal/ModalFooter.js
+++ b/src/modules/Modal/ModalFooter.js
@@ -1,20 +1,22 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
 
-class ModalFooter extends Component {
+export default class ModalFooter extends Component {
   static propTypes = {
     children: PropTypes.any,
     className: PropTypes.string,
   };
 
   render() {
-    let classes = classNames('sd-modal-footer', this.props.className, 'actions');
+    let classes = classNames(
+      'sd-modal-footer',
+      this.props.className,
+      'actions'
+    );
     return (
-      <div className={classes}>
+      <div {...this.props} className={classes}>
         {this.props.children}
       </div>
     );
   }
 }
-
-export default ModalFooter;

--- a/src/modules/Modal/ModalHeader.js
+++ b/src/modules/Modal/ModalHeader.js
@@ -1,20 +1,22 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
 
-class ModalHeader extends Component {
+export default class ModalHeader extends Component {
   static propTypes = {
     children: PropTypes.any,
     className: PropTypes.string,
   };
 
   render() {
-    let classes = classNames('sd-modal-header', this.props.className, 'header');
+    let classes = classNames(
+      'sd-modal-header',
+      this.props.className,
+      'header'
+    );
     return (
-      <div className={classes}>
+      <div {...this.props} className={classes}>
         {this.props.children}
       </div>
     );
   }
 }
-
-export default ModalHeader;

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "ta-webapp/lib/tests"
+  "extends": "ta-webapp/lib/tests",
+  "rules": {
+    "max-nested-callbacks": [2, 6]
+  }
 }

--- a/test/specs/Conformance-test.js
+++ b/test/specs/Conformance-test.js
@@ -12,11 +12,13 @@ describe('Conformance', () => {
     let sdClass = `sd-${_.kebabCase(name)}`;
 
     describe(name, () => {
-      describe('elements', () => {
-        it(`its first child is the "${sdClass}" element (no parent elements)`, () => {
-          let firstChild = _.first(render(<SDComponent />).children());
-          expect(firstChild.props.className).to.contain(sdClass);
-        });
+      it('extends React.Component', () => {
+        expect(new SDComponent()).to.be.an.instanceOf(React.Component);
+      });
+
+      it(`has the "${sdClass}" element as its first child`, () => {
+        let firstChild = _.first(render(<SDComponent />).children());
+        expect(firstChild.props.className).to.contain(sdClass);
       });
 
       describe('classes', () => {

--- a/test/specs/Conformance-test.js
+++ b/test/specs/Conformance-test.js
@@ -16,7 +16,7 @@ describe('Conformance', () => {
         expect(SDComponent.prototype).to.eql(React.Component.prototype);
       });
 
-      it('has identical constructor (class) and component names', () => {
+      it(`constructor name is "${name}" (matches component name)`, () => {
         SDComponent.prototype.constructor.name.should.equal(name);
       });
 

--- a/test/specs/Conformance-test.js
+++ b/test/specs/Conformance-test.js
@@ -77,9 +77,15 @@ describe('Conformance', () => {
 
       describe('props', () => {
         it('spreads props', () => {
-          // create random props object
           let props = {};
-          _.times(5, () => props[faker.hacker.noun()] = faker.hacker.noun());
+          _.times(2, () => {
+            // single word props
+            props[faker.hacker.noun()] = faker.hacker.noun();
+            // camelCased props
+            props[_.camelCase(faker.hacker.phrase())] = faker.hacker.phrase();
+            // kebab-cased props
+            props[_.kebabCase(faker.hacker.phrase())] = faker.hacker.phrase();
+          });
 
           // create element with random props
           let componentWithProps = <SDComponent {...props} />;

--- a/test/specs/Conformance-test.js
+++ b/test/specs/Conformance-test.js
@@ -13,7 +13,7 @@ describe('Conformance', () => {
 
     describe(name, () => {
       it('extends React.Component', () => {
-        expect(new SDComponent()).to.be.an.instanceOf(React.Component);
+        expect(SDComponent.prototype).to.eql(React.Component.prototype);
       });
 
       it(`has the "${sdClass}" element as its first child`, () => {

--- a/test/specs/Conformance-test.js
+++ b/test/specs/Conformance-test.js
@@ -16,6 +16,10 @@ describe('Conformance', () => {
         expect(SDComponent.prototype).to.eql(React.Component.prototype);
       });
 
+      it('has identical constructor (class) and component names', () => {
+        SDComponent.prototype.constructor.name.should.equal(name);
+      });
+
       it(`has the "${sdClass}" element as its first child`, () => {
         let firstChild = _.first(render(<SDComponent />).children());
         expect(firstChild.props.className).to.contain(sdClass);

--- a/test/specs/Conformance-test.js
+++ b/test/specs/Conformance-test.js
@@ -1,0 +1,71 @@
+import _ from 'lodash';
+import React from 'react';
+import stardust from 'stardust';
+import faker from 'faker';
+
+/**
+ * This test ensures all Stardust components conform to our guidelines.
+ */
+describe('Conformance', () => {
+  _.each(stardust, (SDComponent, name) => {
+    let classes = faker.hacker.noun();
+    let sdClass = `sd-${_.kebabCase(name)}`;
+
+    describe(name, () => {
+      describe('elements', () => {
+        it(`its first child is the "${sdClass}" element (no parent elements)`, () => {
+          let firstChild = _.first(render(<SDComponent />).children());
+          expect(firstChild.props.className).to.contain(sdClass);
+        });
+      });
+
+      describe('classes', () => {
+        it(`has "${sdClass}" as the first class`, () => {
+          render(<SDComponent />)
+            .findClass(sdClass)
+            .props.className.indexOf(sdClass).should.equal(0);
+        });
+
+        it(`has props.className after "${sdClass}"`, () => {
+          let renderedClasses = render(<SDComponent className={classes} />)
+            .findClass(sdClass)
+            .props.className;
+
+          expect(renderedClasses).to.include(classes);
+          let sdClassIndex = renderedClasses.indexOf(sdClass);
+          let classesIndex = renderedClasses.indexOf(classes);
+          expect(sdClassIndex).to.be.below(classesIndex);
+        });
+
+        // test ui class guidelines, if present
+        let uiComponent = render(<SDComponent className={classes} />);
+        let hasUIClass = uiComponent.scryClass('ui').length;
+        if (hasUIClass) {
+          it(`has "ui" class immediately after "${sdClass}"`, () => {
+            uiComponent.findClass(`${sdClass} ui`);
+          });
+          it('has props.className immediately after "ui" ', () => {
+            uiComponent.findClass(`ui ${classes}`);
+          });
+        }
+      });
+
+      describe('props', () => {
+        it('spreads props', () => {
+          // create random props object
+          let props = {};
+          _.times(5, () => props[faker.hacker.noun()] = faker.hacker.noun());
+
+          // create element with random props
+          let componentWithProps = <SDComponent {...props} />;
+
+          let hasSpreadProps = render(componentWithProps)
+            .children()
+            .some(element => _.every([element.props], props));
+
+          hasSpreadProps.should.equal(true);
+        });
+      });
+    });
+  });
+});

--- a/test/specs/Conformance-test.js
+++ b/test/specs/Conformance-test.js
@@ -8,7 +8,7 @@ import faker from 'faker';
  */
 describe('Conformance', () => {
   _.each(stardust, (SDComponent, name) => {
-    let classes = faker.hacker.noun();
+    let classes = faker.hacker.phrase();
     let sdClass = `sd-${_.kebabCase(name)}`;
 
     describe(name, () => {
@@ -20,7 +20,7 @@ describe('Conformance', () => {
         SDComponent.prototype.constructor.name.should.equal(name);
       });
 
-      it(`has the "${sdClass}" element as its first child`, () => {
+      it(`has the "${sdClass}" element as its first child (no wrapper elements)`, () => {
         let firstChild = _.first(render(<SDComponent />).children());
         expect(firstChild.props.className).to.contain(sdClass);
       });

--- a/test/specs/addons/Textarea-test.js
+++ b/test/specs/addons/Textarea-test.js
@@ -10,10 +10,6 @@ describe('Textarea', () => {
     var renderedTextarea = render(<Textarea name='sample-post' />);
     expect(renderedTextarea.first().props.name).to.equal('sample-post');
   });
-  it('has 3 rows by default', () => {
-    var renderedTextarea = render(<Textarea name='sample' />);
-    expect(renderedTextarea.findTag('textarea').props.rows).to.equal('3');
-  });
   it('has assigned amount of rows', () => {
     var renderedTextarea = render(<Textarea rows='6' />);
     expect(renderedTextarea.findTag('textarea').props.rows).to.equal('6');


### PR DESCRIPTION
The below document is linked in the README.md.  I included it here for ease of access.

---
# Stardust Component Guidelines

Every component in Stardust must conform to these guidelines.  They ensure consistency and optimal development experience for Stardust users.

This document will be minimally maintained.  See [`\test`](https://github.com/TechnologyAdvice/stardust/tree/master/test) for the current conformance tests.
## Extends React.Component

**Valid**

``` jsx
import React, {Component} from 'react';

export default class MyComponent extends Component {...}
```

**Invalid**

``` jsx
import React, {Component} from 'react';

export default class MyComponent {...}
```

> This is a new class, does not extend React.Component.
## Constructor name matches component name

Give `MyComponent.js` is a component attached to `stardust.MyComponent`:

**Valid**

``` jsx
export default class MyComponent extends Component {...}
```

**Invalid**

``` jsx
export default class extends Component {...}
```

> This is an anonymous class, actually named `_deafult`.

``` jsx
export default class YourComponent extends Component {...}
```

> This class has the wrong name, it should be .
## Has the `sd-<component>` element as its first child (no wrapper elements)

**Valid**

``` jsx
export default class Input extends Component {
  render() {
    return (
      <Input />
    );
  }
}
```

**Invalid**

``` jsx
export default class Input extends Component {
  render() {
    return (
      <Field
        <Input />
      </Field>
    );
  }
}
```

> Never wrap the component with other components, whether DOM or Composite.
## Has props.className after `sd-<component>`

**Valid**

``` jsx
<Field className='inherit-this' />
// => <div className='sd-field inherit-this field>...
```

**Invalid**

``` jsx
<Field className='inherit-this' />
// => <div className='sd-field field>...
```

> className was not inherited

``` jsx
<Field className='inherit-this' />
// => <div className='inherit-this sd-field field>...
```

> className was inherited before sd-field

``` jsx
<Field className='inherit-this' />
// => <div className='inherit-this sd-field field>...
```

> className was not inherited before sd-field
## Has `sd-<component>` as the first class

**Valid**

``` jsx
<Divider />
// => <div className='sd-divider ui divider' /> 
```

**Invalid**

``` jsx
<Divider />
// => <div className='ui divider' /> 
```

> Missing `sd-divider` className.

``` jsx
<Divider />
// => <div className='ui sd-divider divider' /> 
```

> `sd-divider` className does not come first.
## Has `ui` class immediately after `sd-<component>`

Only for components that utilize the `ui` class (i.e `ui grid` but not `column`).

**Valid**

``` jsx
<Grid />
// => <div className='sd-grid ui grid' /> 
```

**Invalid**

``` jsx
<Grid />
// => <div className='sd-grid grid ui' /> 
```

> `grid` is immediately after `sd-grid`.
## Has props.className immediately after `ui`

Only for components that utilize the `ui` class (i.e `ui form` but not `field`).

**Valid**

``` jsx
<Form />
// => <div className='sd-form ui form' /> 
```

**Invalid**

``` jsx
<Form className='loading' />
// => <div className='sd-form loading ui form' /> 
```

> Inherited `loading` className comes before `ui`.

``` jsx
<Form className='loading' />
// => <div className='sd-form ui form loading' /> 
```

> Inherited `loading` className comes after `form`.
## Spreads props

Allows access to the underlying element of concern.

**Valid**

``` jsx
<Input onFocus={this.handleFocus} />
// => <input type='text' className='sd-input ui input' onFocus={this.handleFocus} /> 
```

``` jsx
<Input data-my-plugin='do-magic' />
// => <input type='text' className='sd-input ui input' data-my-plugin='do-magic' /> 
```

**Invalid**

``` jsx
<Input onFocus={this.handleFocus} />
// => <input type='text' className='sd-input ui input' /> 
```

> `onFocus` prop was lost.

``` jsx
<Input data-my-plugin='do-magic' />
// => <input type='text' className='sd-input ui input' /> 
```

> `data-my-plugin` prop was lost.

---

![image](https://cloud.githubusercontent.com/assets/5067638/10499306/5186e96a-7284-11e5-98e4-9fdab0454837.png)
