### PR TITLE
add getUnhandledProps util

### DIFF
--- a/src/utils/getUnhandledProps.js
+++ b/src/utils/getUnhandledProps.js
@@ -1,0 +1,16 @@
+import _ from 'lodash';
+
+/**
+ * Returns an object consisting of props not defined in propTypes nor defaultProps.
+ * @param {*} instance The `this` keyword in a React Component class.
+ * @returns {{}} A shallow copy of the prop object
+ */
+const getUnhandledProps = instance => {
+  return _.omit(instance.props, (val, key) => {
+    const inPropTypes = _.has(instance.constructor.propTypes, key);
+    const inDefaultProps = _.has(instance.constructor.defaultProps, key);
+    return inPropTypes || inDefaultProps;
+  });
+};
+
+export default getUnhandledProps;

--- a/test/utils/getUnhandledPops-test.js
+++ b/test/utils/getUnhandledPops-test.js
@@ -1,0 +1,33 @@
+import _ from 'lodash';
+import getUnhandledProps from 'src/utils/getUnhandledProps';
+
+// Helper class that takes in props and merges defaultProps
+class TestClass {
+  constructor(props) {
+    this.props = _.assign({}, this.constructor.defaultProps, props);
+    this.unhandledProps = getUnhandledProps(this);
+  }
+}
+
+describe.only('getUnhandledProps', () => {
+  it('removes props defined in defaultProps', () => {
+    TestClass.defaultProps = {imHandled: 'thanks'};
+    new TestClass()
+      .unhandledProps
+      .should.not.have.any.keys(_.keys(TestClass.defaultProps));
+  });
+  it('removes props defined in propTypes', () => {
+    TestClass.propTypes = {imHandled: 'thanks'};
+    new TestClass()
+      .unhandledProps
+      .should.not.have.any.keys(_.keys(TestClass.defaultProps));
+  });
+  it('leave props not in defaultProps || propTypes in tact', () => {
+    TestClass.defaultProps = {imHandled: 'thanks'};
+    TestClass.propTypes = {alsoHandled: 'got it'};
+    const props = {thisShould: 'still be here'};
+    new TestClass(props)
+      .unhandledProps
+      .should.eql(props);
+  });
+});


### PR DESCRIPTION
Fixes #69 

This util gets all props for a component that are not defined in `propTypes` nor in `defaultProps`.  These extra props are considered 'unhandled` by the component at hand.

The immediate usage of this util will be for spreading props the user passed in that we aren't already explicitly handling.
