### PR TITLE
Fix test warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 _builds/
 _projects/
 _steps/
-npm-debug.log
+npm-debug.log*
 node_modules/
 bower_components/
 testBundle.js

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -1,6 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
 import META from 'src/utils/Meta';
+import getUnhandledProps from 'src/utils/getUnhandledProps';
 
 export default class Menu extends Component {
   static propTypes = {
@@ -38,8 +39,9 @@ export default class Menu extends Component {
         callbackParent: this.handleClickItem,
       });
     });
+    const props = getUnhandledProps(this);
     return (
-      <div {...this.props} className={classes}>
+      <div {...props} className={classes}>
         {children}
       </div>
     );

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -19,7 +19,7 @@ export default class Table extends Component {
       }
     },
     className: PropTypes.string,
-    data: PropTypes.array.isRequired,
+    data: PropTypes.array,
   };
 
   static getSafeCellContents(content) {

--- a/test/specs/Conformance-test.js
+++ b/test/specs/Conformance-test.js
@@ -12,7 +12,7 @@ const getSDClassName = componentName => `sd-${_.kebabCase(componentName)}`;
  */
 describe('Conformance', () => {
   /* eslint-disable no-console */
-  console.info('Conformance-test renders all components with no props, warnings may occur.');
+  console.info('Conformance-test renders each component with no props, required prop warnings may occur.');
   /* eslint-enable no-console */
   _.each(stardust, (SDComponent, name) => {
     const classes = faker.fake('{{hacker.noun}} {{hacker.noun}} {{hacker.noun}}');

--- a/test/specs/addons/Textarea-test.js
+++ b/test/specs/addons/Textarea-test.js
@@ -5,15 +5,17 @@ describe('Textarea', () => {
   it('has a default value', () => {
     render(<Textarea defaultValue='Hello World' />)
       .findTag('textarea')
-      .getDOMNode()
       .value.should.equal('Hello World');
   });
   it('has a name assigned', () => {
-    const renderedTextarea = render(<Textarea name='sample-post' />);
-    expect(renderedTextarea.first().props.name).to.equal('sample-post');
+    render(<Textarea name='sample-post' />)
+      .first()
+      .props.name.should.equal('sample-post');
   });
   it('has assigned amount of rows', () => {
-    const renderedTextarea = render(<Textarea rows='6' />);
-    expect(renderedTextarea.findTag('textarea').props.rows).to.equal('6');
+    render(<Textarea rows='6' />)
+      .findTag('textarea')
+      .getAttribute('rows')
+      .should.equal('6');
   });
 });

--- a/test/specs/collections/Form/Field-test.js
+++ b/test/specs/collections/Form/Field-test.js
@@ -12,7 +12,7 @@ describe('Field', () => {
 
   it('renders children', () => {
     render(<Field label='First Name'>yo child</Field>)
-      .findText('yo child');
+      .assertText('yo child');
   });
 
   it('can specify a width', () => {

--- a/test/specs/collections/Form/Field-test.js
+++ b/test/specs/collections/Form/Field-test.js
@@ -7,18 +7,16 @@ describe('Field', () => {
   it('has a label', () => {
     render(<Field label='First Name' />)
       .findTag('label')
-      .props.children.should.equal('First Name');
+      .textContent.should.equal('First Name');
   });
 
   it('renders children', () => {
-    render(<Field label='First Name'>yo child</Field>)
-      .assertText('yo child');
+    render(<Field>yo child</Field>).assertText('yo child');
   });
 
   it('can specify a width', () => {
     _.each(_.range(1, 17), n => {
-      const classes = numberToWord(n) + ' wide';
-      render(<Field width={n} />).findClass(classes);
+      render(<Field width={n} />).findClass(`${numberToWord(n)} wide`);
     });
   });
 });

--- a/test/specs/collections/Form/Fields-test.js
+++ b/test/specs/collections/Form/Fields-test.js
@@ -16,6 +16,6 @@ describe('Fields', () => {
   it('renders children', () => {
     const child = faker.hacker.phrase();
     render(<Fields>{child}</Fields>)
-      .findText(child);
+      .assertText(child);
   });
 });

--- a/test/specs/collections/Grid/Grid-test.js
+++ b/test/specs/collections/Grid/Grid-test.js
@@ -1,49 +1,8 @@
-import _ from 'lodash';
 import React from 'react';
-import faker from 'faker';
 import {Grid} from 'stardust';
 
 describe('Grid', () => {
-  it('is an sd-grid', () => {
-    const gridClassName = render(<Grid />).findClass('sd-grid').props.className;
-    gridClassName.should.contain('sd-grid');
-    const nodeClass = render(<Grid />).findClass('sd-grid').getDOMNode().getAttribute('class');
-    nodeClass.should.contain('sd-grid');
-  });
-
-  it('inherits classes', () => {
-    // generate crap classes like "system firewall protocol"
-    const classes = _.times(_.random(3), faker.hacker.noun).join(' ');
-
-    const renderedGridClasses = render(<Grid className={classes} />)
-      .findClass('sd-grid')
-      .getDOMNode()
-      .getAttribute('class');
-    renderedGridClasses.should.contain(classes);
-  });
-
-  it('inherits style', () => {
-    const style = {display: 'block'};
-    render(<Grid style={style} />).findClass('sd-grid').props.style.should.deep.equal(style);
-  });
-
   it('renders its children', () => {
     render(<Grid><br /></Grid>).findClass('sd-grid').props.children.type.should.equal('br');
-  });
-
-  it('text example', () => {
-    render(
-      <Grid>
-        root
-        <div>div1</div>
-        <div>div2</div>
-        after
-        <div className='nested'>
-          child div
-          <div>nested child div</div>
-        </div>
-      </Grid>
-    )
-      .findText('root');
   });
 });

--- a/test/specs/collections/Grid/Grid-test.js
+++ b/test/specs/collections/Grid/Grid-test.js
@@ -3,6 +3,7 @@ import {Grid} from 'stardust';
 
 describe('Grid', () => {
   it('renders its children', () => {
-    render(<Grid><br /></Grid>).findClass('sd-grid').props.children.type.should.equal('br');
+    render(<Grid>check it out</Grid>)
+      .assertText('check it out');
   });
 });

--- a/test/specs/collections/Menu/Menu-test.js
+++ b/test/specs/collections/Menu/Menu-test.js
@@ -53,12 +53,12 @@ describe('MenuItem', () => {
   it('should have active class after click', () => {
     const renderedMenuItems = render(
       <Menu>
-        <MenuItem name='item1' />
-        <MenuItem name='item2' />
+        <MenuItem name='item1' className='firstItem' />
+        <MenuItem name='item2' className='secondItem'/>
       </Menu>
     );
-    const firstItem = renderedMenuItems.findText('item1');
-    const secondItem = renderedMenuItems.findText('item2');
+    const firstItem = renderedMenuItems.findClass('firstItem');
+    const secondItem = renderedMenuItems.findClass('secondItem');
     const secondNode = secondItem.getDOMNode();
     Simulate.click(secondNode);
     firstItem.props.className.should.not.contain('active');

--- a/test/specs/collections/Menu/Menu-test.js
+++ b/test/specs/collections/Menu/Menu-test.js
@@ -1,67 +1,73 @@
-import _ from 'lodash';
+import faker from 'faker';
 import React from 'react';
 import {Simulate} from 'react-addons-test-utils';
 import {Menu, MenuItem} from 'stardust';
 
+let string;
 describe('Menu', () => {
+  beforeEach(() => {
+    string = faker.hacker.phrase();
+  });
+
   it('should render children', () => {
-    const renderedMenu = render(
-      <Menu>
-        <span className='sd-test-span'>Hello</span>
-      </Menu>
-    ).findClass('sd-menu');
-    renderedMenu.props.children.should.be.ok;
-    let childComponentClass;
-    React.Children.forEach(renderedMenu.props.children, (child, i) => {
-      if (i === 0) {
-        childComponentClass = child.props.className;
-      }
+    // TODO: Menu does not render child text without a containing element
+    render(<Menu><i>{string}</i></Menu>)
+      .assertText(string);
+  });
+
+  describe('MenuItem', () => {
+    it('uses the name prop as text', () => {
+      render(<MenuItem name='This is an item' />)
+        .assertText('This is an item');
     });
-    childComponentClass.should.equal('sd-test-span');
-  });
-});
+    it('should not have a label by default', () => {
+      render(<MenuItem name='item' />)
+        .scryClass('sd-menu-label')
+        .should.have.length(0);
+    });
+    it('should not have active class by default', () => {
+      render(<MenuItem name='item' />)
+        .scryClass('active')
+        .should.have.length(0);
+    });
+    it('should render a label if prop given', () => {
+      render(<MenuItem name='item' label='37' />)
+        .findClass('sd-menu-label')
+        .textContent
+        .should.equal('37');
+    });
+    it('should have active class if first child', () => {
+      const [firstItem, secondItem] = render(
+        <Menu>
+          <MenuItem name='item1' />
+          <MenuItem name='item2' />
+        </Menu>
+      ).scryClass('sd-menu-item');
 
-describe('MenuItem', () => {
-  it('should have name property', () => {
-    const renderedMenuItem = render(<MenuItem name='This is an item' />).findClass('sd-menu-item');
-    _.includes(renderedMenuItem.props.children, 'This is an item').should.be.true;
-  });
-  it('should not have a label by default', () => {
-    const renderedMenuLabel = render(<MenuItem name='item' />).scryClass('sd-menu-label');
-    _.isEmpty(renderedMenuLabel).should.be.true;
-  });
-  it('should not have active class by default', () => {
-    const renderedMenuItem = render(<MenuItem name='item' />).scryClass('active');
-    _.isEmpty(renderedMenuItem).should.be.true;
-  });
-  it('should render a label if prop given', () => {
-    const renderedMenuLabel = render(<MenuItem name='item' label='37' />).findClass('sd-menu-label');
-    renderedMenuLabel.should.be.ok;
-    renderedMenuLabel.props.children.should.equal('37');
-  });
-  it('should have active class if first child', () => {
-    const renderedMenuItems = render(
-      <Menu>
-        <MenuItem name='item1' />
-        <MenuItem name='item2' />
-      </Menu>
-    ).scryClass('sd-menu-item');
-    _.first(renderedMenuItems).props.className.should.contain('active');
-    _.last(renderedMenuItems).props.className.should.not.contain('active');
-  });
+      firstItem
+        .getAttribute('class')
+        .should.contain('active');
+      secondItem
+        .getAttribute('class')
+        .should.not.contain('active');
+    });
 
-  it('should have active class after click', () => {
-    const renderedMenuItems = render(
-      <Menu>
-        <MenuItem name='item1' className='firstItem' />
-        <MenuItem name='item2' className='secondItem'/>
-      </Menu>
-    );
-    const firstItem = renderedMenuItems.findClass('firstItem');
-    const secondItem = renderedMenuItems.findClass('secondItem');
-    const secondNode = secondItem.getDOMNode();
-    Simulate.click(secondNode);
-    firstItem.props.className.should.not.contain('active');
-    secondItem.props.className.should.contain('active');
+    it('should have active class after click', () => {
+      const [firstItem, secondItem] = render(
+        <Menu>
+          <MenuItem name='item1' />
+          <MenuItem name='item2' />
+        </Menu>
+      ).scryClass('sd-menu-item');
+
+      Simulate.click(secondItem);
+
+      firstItem
+        .getAttribute('class')
+        .should.not.contain('active');
+      secondItem
+        .getAttribute('class')
+        .should.contain('active');
+    });
   });
 });

--- a/test/specs/collections/Message/Message-test.js
+++ b/test/specs/collections/Message/Message-test.js
@@ -15,7 +15,8 @@ describe('Message', () => {
   });
   describe('without header', () => {
     it('has no header', () => {
-      render(<Message />).scryClass('sd-message-header')
+      render(<Message />)
+        .scryClass('sd-message-header')
         .should.have.a.lengthOf(0);
     });
   });
@@ -29,11 +30,13 @@ describe('Message', () => {
   });
   describe('without icon', () => {
     it('has no icon', () => {
-      render(<Message />).scryClass('sd-message-icon')
+      render(<Message />)
+        .scryClass('sd-message-icon')
         .should.have.a.lengthOf(0);
     });
     it('has no "content" wrapper', () => {
-      render(<Message />).scryClass('sd-message-content')
+      render(<Message />)
+        .scryClass('sd-message-content')
         .should.have.a.lengthOf(0);
     });
   });
@@ -54,7 +57,8 @@ describe('Message', () => {
   });
   describe('not dismissable', () => {
     it('has no close icon', () => {
-      render(<Message />).scryClass('sd-message-close-icon')
+      render(<Message />)
+        .scryClass('sd-message-close-icon')
         .should.have.a.lengthOf(0);
     });
   });

--- a/test/specs/collections/Message/Message-test.js
+++ b/test/specs/collections/Message/Message-test.js
@@ -10,7 +10,7 @@ describe('Message', () => {
       const message = render(<Message header={header} />);
 
       message.findClass('sd-message-header');
-      message.findText(header);
+      message.assertText(header);
     });
   });
   describe('without header', () => {

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -11,9 +11,6 @@ describe('Table', () => {
       firstName: faker.name.firstName(),
       lastName: faker.name.lastName(),
       email: faker.internet.email(),
-      posts: _.random(100),
-      status: faker.hacker.verb(),
-      role: faker.hacker.noun(),
       permissions: {
         read: !!_.random(),
         write: !!_.random(),
@@ -34,7 +31,7 @@ describe('Table', () => {
         </Table>
       )
         .findClass('sd-table-header')
-        .props.children.should.equal('First Name');
+        .textContent.should.equal('First Name');
     });
 
     it('renders contents with headerRenderer', () => {
@@ -44,7 +41,7 @@ describe('Table', () => {
         </Table>
       )
         .findClass('sd-table-header')
-        .props.children.should.equal('YO!');
+        .textContent.should.equal('YO!');
     });
   });
 
@@ -59,7 +56,7 @@ describe('Table', () => {
         .forEach((tableCell, i) => {
           const originalItem = tableData[i][randomDataKey];
           const originalValue = Table.getSafeCellContents(originalItem);
-          tableCell.props.children.should.equal(originalValue);
+          tableCell.textContent.should.equal(originalValue);
         });
     });
 
@@ -71,7 +68,7 @@ describe('Table', () => {
       )
         .scryClass('sd-table-cell')
         .forEach((tableCell) => {
-          tableCell.props.children.should.equal('REDACTED');
+          tableCell.textContent.should.equal('REDACTED');
         });
     });
 
@@ -84,7 +81,7 @@ describe('Table', () => {
       )
         .scryClass('sd-table-cell')
         .forEach((tableCell) => {
-          tableCell.props.children.should.be.a('string');
+          tableCell.textContent.should.be.a('string');
         });
     });
   });
@@ -101,9 +98,9 @@ describe('Table', () => {
           // remove this table's column from the current data object
           // then expect this cell's value to not be found in the object
           const itemWithoutRandomKey = _.omit(tableData[i], randomDataKey);
-          const cellText = tableCell.props.children;
+          const cellText = tableCell.textContent;
 
-          _.each(itemWithoutRandomKey, (val, key) => {
+          _.each(itemWithoutRandomKey, val => {
             Table.getSafeCellContents(val).should.not.equal(cellText);
           });
         });

--- a/test/specs/elements/Button/Button-test.js
+++ b/test/specs/elements/Button/Button-test.js
@@ -13,7 +13,7 @@ describe('Button', () => {
   it('renders "Click Here" by default', () => {
     render(<Button />).assertText('Click Here');
   });
-  it('has type of submit', () => {
+  it('inherits type', () => {
     render(<Button type='submit' />)
       .findTag('button')
       .getAttribute('type')
@@ -22,7 +22,7 @@ describe('Button', () => {
   it('renders its children', () => {
     render(<Button>Save Now</Button>).assertText('Save Now');
   });
-  it('should run passed in handleClick function', () => {
+  it('spreads callbacks on the button element', () => {
     const handleClick = sandbox.spy();
     const button = render(<Button type='submit' onClick={handleClick} />).findTag('button');
     Simulate.click(button);

--- a/test/specs/elements/Button/Button-test.js
+++ b/test/specs/elements/Button/Button-test.js
@@ -11,7 +11,7 @@ describe('Button', () => {
       .should.equal('button');
   });
   it('renders "Click Here" by default', () => {
-    render(<Button />).findText('Click Here');
+    render(<Button />).assertText('Click Here');
   });
   it('has type of submit', () => {
     render(<Button type='submit' />)
@@ -20,7 +20,7 @@ describe('Button', () => {
       .should.equal('submit');
   });
   it('renders its children', () => {
-    render(<Button>Save Now</Button>).findText('Save Now');
+    render(<Button>Save Now</Button>).assertText('Save Now');
   });
   it('should run passed in handleClick function', () => {
     const handleClick = sandbox.spy();

--- a/test/specs/elements/Input/Input-test.js
+++ b/test/specs/elements/Input/Input-test.js
@@ -5,34 +5,32 @@ describe('Input', () => {
   it('has the input type of text by default', () => {
     render(<Input />)
       .findTag('input')
-      .props.type.should.equal('text');
+      .getAttribute('type')
+      .should.equal('text');
   });
 
-  it('has a default value', () => {
+  it('allows a defaultValue', () => {
     render(<Input defaultValue='John' />)
       .findTag('input')
       .value.should.equal('John');
   });
 
-  it('has a type of phone', () => {
+  it('spreads type on the input element', () => {
     render(<Input type='phone' />)
       .findTag('input')
-      .props.type.should.equal('phone');
+      .getAttribute('type')
+      .should.equal('phone');
   });
 
-  it('has a name of emailAddress', () => {
+  it('spreads name on the input element', () => {
     render(<Input name='emailAddress' />)
       .findTag('input')
-      .props.name.should.equal('emailAddress');
+      .getAttribute('name')
+      .should.equal('emailAddress');
   });
 
-  it('is an icon input if icon given', () => {
+  it('adds an icon element given an icon class and prop', () => {
     render(<Input className='icon' icon='linkedin' />)
       .findTag('i');
-  });
-
-  it('has an icon class if icon given', () => {
-    render(<Input className='icon' icon='foo' />)
-      .findClass('ui icon input');
   });
 });

--- a/test/specs/elements/Segment/Segment-test.js
+++ b/test/specs/elements/Segment/Segment-test.js
@@ -2,22 +2,16 @@ import React from 'react';
 import {Segment} from 'stardust';
 
 describe('Segment', () => {
-  it('is an sd-segment', () => {
-    const segmentElement = <Segment heading='This is a segment' />;
-    const renderedSegmentClasses = render(segmentElement).findClass('sd-segment').props.className;
-    renderedSegmentClasses.should.contain('sd-segment');
-    const nodeClass = render(segmentElement).findClass('sd-segment').getDOMNode().getAttribute('class');
-    nodeClass.should.contain('sd-segment');
-  });
   it('does not have a heading', () => {
-    const renderedSegment = render(<Segment />);
-    expect(renderedSegment.first().props.heading).to.not.exist;
-    renderedSegment.scryClass('sd-segment-heading').should.be.empty;
+    render(<Segment />)
+      .scryClass('sd-segment-heading')
+      .should.have.length(0);
   });
   it('has a heading', () => {
-    const segment = render(<Segment heading='This is a segment' />);
-    segment.findClass('sd-segment-heading');
-    segment.assertText('This is a segment');
+    render(<Segment heading='This is a segment' />)
+      .findClass('sd-segment-heading')
+      .textContent
+      .should.equal('This is a segment');
   });
   it('renders its children', () => {
     render(<Segment>Some text</Segment>)

--- a/test/specs/elements/Segment/Segment-test.js
+++ b/test/specs/elements/Segment/Segment-test.js
@@ -17,10 +17,10 @@ describe('Segment', () => {
   it('has a heading', () => {
     const segment = render(<Segment heading='This is a segment' />);
     segment.findClass('sd-segment-heading');
-    segment.findText('This is a segment');
+    segment.assertText('This is a segment');
   });
   it('renders its children', () => {
     render(<Segment>Some text</Segment>)
-      .findText('Some text');
+      .assertText('Some text');
   });
 });

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -1,63 +1,39 @@
-import _ from 'lodash';
 import React from 'react';
-import faker from 'faker';
 import {Modal, ModalHeader, ModalContent, ModalFooter} from 'stardust';
 
 describe('Modal', () => {
   it('should default ref to be "modal"', () => {
-    const modal = render(<Modal />).first();
-    modal.props.ref.should.equal('modal');
+    Modal.defaultProps.ref.should.equal('modal');
   });
   it('should initially have a state where `isShown` is false', () => {
     render(<Modal />).first().state.isShown.should.equal(false);
   });
   it('should render children', () => {
-    render(<Modal>Hello</Modal>).findText('Hello');
-  });
-  it('inherits classes', () => {
-    // generate crap classes like "system firewall protocol"
-    const classes = _.times(_.random(3), faker.hacker.noun).join(' ');
-    const renderedGridClasses = render(<Modal className={classes} />).findClass('sd-modal');
-    renderedGridClasses.props.className.should.contain(classes);
+    render(<Modal>Hello</Modal>).assertText('Hello');
   });
   it('sets isShown true', () => {
-    const renderedModal = render(<Modal />).first();
-    renderedModal.showModal();
-    renderedModal.state.isShown.should.equal(true);
+    const modal = render(<Modal />).first();
+    modal.showModal();
+    modal.state.isShown.should.equal(true);
   });
   it('sets isShown false', () => {
-    const renderedModal = render(<Modal />).first();
-    renderedModal.hideModal();
-    renderedModal.state.isShown.should.equal(false);
+    const modal = render(<Modal />).first();
+    modal.hideModal();
+    modal.state.isShown.should.equal(false);
   });
   describe('ModalHeader', () => {
     it('should render children', () => {
-      render(<Modal><ModalHeader>Hello</ModalHeader></Modal>).findText('Hello');
-    });
-    it('inherits classes', () => {
-      const classes = _.times(_.random(3), faker.hacker.noun).join(' ');
-      const renderedGridClasses = render(<ModalHeader className={classes} />).findClass('sd-modal-header');
-      renderedGridClasses.props.className.should.contain(classes);
+      render(<ModalHeader>Hello</ModalHeader>).assertText('Hello');
     });
   });
   describe('ModalContent', () => {
     it('should render children', () => {
-      render(<Modal><ModalContent>Hello</ModalContent></Modal>).findText('Hello');
-    });
-    it('inherits classes', () => {
-      const classes = _.times(_.random(3), faker.hacker.noun).join(' ');
-      const renderedGridClasses = render(<ModalContent className={classes} />).findClass('sd-modal-content');
-      renderedGridClasses.props.className.should.contain(classes);
+      render(<ModalContent>Hello</ModalContent>).assertText('Hello');
     });
   });
   describe('ModalFooter', () => {
     it('should render children', () => {
-      render(<Modal><ModalFooter>Hey You</ModalFooter></Modal>).findText('Hey You');
-    });
-    it('inherits classes', () => {
-      const classes = _.times(_.random(3), faker.hacker.noun).join(' ');
-      const renderedGridClasses = render(<ModalFooter className={classes} />).findClass('sd-modal-footer');
-      renderedGridClasses.props.className.should.contain(classes);
+      render(<ModalFooter>Hey You</ModalFooter>).assertText('Hey You');
     });
   });
 });

--- a/test/specs/views/Items/Item-test.js
+++ b/test/specs/views/Items/Item-test.js
@@ -5,6 +5,6 @@ import faker from 'faker';
 describe('Item', () => {
   it('renders children', () => {
     const child = faker.hacker.phrase();
-    render(<Item>{child}</Item>).findText(child);
+    render(<Item>{child}</Item>).assertText(child);
   });
 });


### PR DESCRIPTION
Fixes #60 #95 
- Make tests pass without warnings (React 0.14 compliant)
- Simplify and cleanup test code
- Remove component tests for which there is a conformance test
  
  > inheriting classes, spreading props, etc
