### PR TITLE
Add form plugin

### DIFF
--- a/docs/app/Examples/collections/Form/FormExamples.js
+++ b/docs/app/Examples/collections/Form/FormExamples.js
@@ -5,6 +5,7 @@ import FormFieldVariationsExamples from './FieldVariations/FormFieldVariationsEx
 import FormGroupVariationsExamples from './GroupVariations/FormGroupVariationsExamples';
 import FormFormVariationsExamples from './FormVariations/FormFormVariationsExamples';
 import FormStatesExamples from './States/FormStatesExamples';
+import FormValidationExamples from './Validation/FormValidationExamples';
 
 export default class FormExamples extends Component {
   render() {
@@ -16,6 +17,7 @@ export default class FormExamples extends Component {
         <FormFormVariationsExamples />
         <FormFieldVariationsExamples />
         <FormGroupVariationsExamples />
+        <FormValidationExamples />
       </div>
     );
   }

--- a/docs/app/Examples/collections/Form/Types/FormFormExample.js
+++ b/docs/app/Examples/collections/Form/Types/FormFormExample.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import {Button, Checkbox, Field, Form, Input} from 'stardust';
 
-export default class FormFieldExample extends Component {
+export default class FormFormExample extends Component {
   render() {
     return (
       <Form>

--- a/docs/app/Examples/collections/Form/Validation/FormSpecifyingValidationRulesExample.js
+++ b/docs/app/Examples/collections/Form/Validation/FormSpecifyingValidationRulesExample.js
@@ -32,7 +32,7 @@ export default class FormSpecifyingValidationRulesExample extends Component {
 
   render() {
     return (
-      <Form settings={this.formSettings}>
+      <Form settings={this.formSettings} className='segment'>
         <p>Tell Us About Yourself</p>
         <Fields evenlyDivided>
           <Field>
@@ -52,10 +52,10 @@ export default class FormSpecifyingValidationRulesExample extends Component {
           </Field>
         </Fields>
         <Field label='Skills'>
-          <Dropdown className='selection multiple' options={this.skillsOptions} multiple='' />
+          <Dropdown className='selection multiple' options={this.skillsOptions} />
         </Field>
         <Field className='inline'>
-          <Checkbox name='terms' tabIndex='0' className='hidden' label='I agree to the terms and conditions' />
+          <Checkbox name='terms' className='hidden' label='I agree to the terms and conditions' />
         </Field>
         <Button className='blue submit'>Submit</Button>
         <Message className='error' />

--- a/docs/app/Examples/collections/Form/Validation/FormSpecifyingValidationRulesExample.js
+++ b/docs/app/Examples/collections/Form/Validation/FormSpecifyingValidationRulesExample.js
@@ -40,7 +40,7 @@ export default class FormSpecifyingValidationRulesExample extends Component {
             <Input placeholder='First Name' name='name' type='text' />
           </Field>
           <Field label='Gender'>
-            <Dropdown className='selection' options={this.genderOptions} />
+            <Dropdown className='selection' name='gender' options={this.genderOptions} />
           </Field>
         </Fields>
         <Fields evenlyDivided>
@@ -52,7 +52,7 @@ export default class FormSpecifyingValidationRulesExample extends Component {
           </Field>
         </Fields>
         <Field label='Skills'>
-          <Dropdown className='selection multiple' options={this.skillsOptions} />
+          <Dropdown className='selection multiple' name='skills' options={this.skillsOptions} />
         </Field>
         <Field className='inline'>
           <Checkbox name='terms' className='hidden' label='I agree to the terms and conditions' />

--- a/docs/app/Examples/collections/Form/Validation/FormSpecifyingValidationRulesExample.js
+++ b/docs/app/Examples/collections/Form/Validation/FormSpecifyingValidationRulesExample.js
@@ -1,0 +1,65 @@
+import React, {Component} from 'react';
+import {Button, Checkbox, Dropdown, Field, Fields, Form, Input, Message} from 'stardust';
+
+export default class FormSpecifyingValidationRulesExample extends Component {
+  formSettings = {
+    fields: {
+      name: 'empty',
+      gender: 'empty',
+      username: 'empty',
+      password: ['minLength[6]', 'empty'],
+      skills: ['minCount[2]', 'empty'],
+      terms: 'checked'
+    }
+  }
+
+  genderOptions = [
+    {value: '', text: 'Gender'},
+    {value: 'male', text: 'Male'},
+    {value: 'female', text: 'Female'},
+  ];
+
+  skillsOptions = [
+    {value: '', text: 'Select Skills'},
+    {value: 'css', text: 'CSS'},
+    {value: 'html', text: 'HTML'},
+    {value: 'javascript', text: 'Javascript'},
+    {value: 'design', text: 'Graphic Design'},
+    {value: 'plumbing', text: 'Plumbing'},
+    {value: 'mech', text: 'Mechanical Engineering'},
+    {value: 'repair', text: 'Kitchen Repair'},
+  ];
+
+  render() {
+    return (
+      <Form settings={this.formSettings}>
+        <p>Tell Us About Yourself</p>
+        <Fields evenlyDivided>
+          <Field>
+            <label>Name</label>
+            <Input placeholder='First Name' name='name' type='text' />
+          </Field>
+          <Field label='Gender'>
+            <Dropdown className='selection' options={this.genderOptions} />
+          </Field>
+        </Fields>
+        <Fields evenlyDivided>
+          <Field label='Username'>
+            <Input placeholder='Username' name='username' type='text' />
+          </Field>
+          <Field label='Password'>
+            <Input type='password' name='password' />
+          </Field>
+        </Fields>
+        <Field label='Skills'>
+          <Dropdown className='selection multiple' options={this.skillsOptions} multiple='' />
+        </Field>
+        <Field className='inline'>
+          <Checkbox name='terms' tabIndex='0' className='hidden' label='I agree to the terms and conditions' />
+        </Field>
+        <Button className='blue submit'>Submit</Button>
+        <Message className='error' />
+      </Form>
+    );
+  }
+}

--- a/docs/app/Examples/collections/Form/Validation/FormValidatingOnBlurAndOtherEventsExample.js
+++ b/docs/app/Examples/collections/Form/Validation/FormValidatingOnBlurAndOtherEventsExample.js
@@ -43,7 +43,7 @@ export default class FormValidatingOnBlurAndOtherEventsExample extends Component
   render() {
     return (
       <Form settings={this.formSettings} className='segment'>
-        <p>Tell Us About Yourself</p>
+        <p>Let's go ahead and get you signed up.</p>
         <Fields evenlyDivided>
           <Field>
             <label>Name</label>
@@ -62,7 +62,7 @@ export default class FormValidatingOnBlurAndOtherEventsExample extends Component
             <Input type='password' name='password' />
           </Field>
         </Fields>
-        <Field>
+        <Field className='inline'>
           <Checkbox name='terms' className='hidden' label='I agree to the terms and conditions' />
         </Field>
         <Button className='blue submit'>Submit</Button>

--- a/docs/app/Examples/collections/Form/Validation/FormValidatingOnBlurAndOtherEventsExample.js
+++ b/docs/app/Examples/collections/Form/Validation/FormValidatingOnBlurAndOtherEventsExample.js
@@ -1,0 +1,73 @@
+import React, {Component} from 'react';
+import {Button, Checkbox, Field, Fields, Form, Input, Message} from 'stardust';
+
+export default class FormValidatingOnBlurAndOtherEventsExample extends Component {
+  formSettings = {
+    inline: true,
+    on: 'blur',
+    fields: {
+      'first-name': {
+        identifier: 'first-name',
+        rules: [
+          {type: 'empty'}
+        ],
+      },
+      'last-name': {
+        identifier: 'last-name',
+        rules: [
+          {type: 'empty'}
+        ],
+      },
+      'username': {
+        identifier: 'username',
+        rules: [
+          {type: 'empty'}
+        ],
+      },
+      'password': {
+        identifier: 'password',
+        rules: [
+          {type: 'empty'},
+          {type: 'minLength[6]'},
+        ],
+      },
+      'terms': {
+        identifier: 'terms',
+        rules: [
+          {type: 'checked'}
+        ],
+      },
+    }
+  }
+
+  render() {
+    return (
+      <Form settings={this.formSettings} className='segment'>
+        <p>Tell Us About Yourself</p>
+        <Fields evenlyDivided>
+          <Field>
+            <label>Name</label>
+            <Input placeholder='First Name' name='first-name' type='text' />
+          </Field>
+          <Field>
+            <label>Name</label>
+            <Input placeholder='First Name' name='last-name' type='text' />
+          </Field>
+        </Fields>
+        <Fields evenlyDivided>
+          <Field label='Username'>
+            <Input placeholder='Username' name='username' type='text' />
+          </Field>
+          <Field label='Password'>
+            <Input type='password' name='password' />
+          </Field>
+        </Fields>
+        <Field>
+          <Checkbox name='terms' className='hidden' label='I agree to the terms and conditions' />
+        </Field>
+        <Button className='blue submit'>Submit</Button>
+        <Message className='error' />
+      </Form>
+    );
+  }
+}

--- a/docs/app/Examples/collections/Form/Validation/FormValidationExamples.js
+++ b/docs/app/Examples/collections/Form/Validation/FormValidationExamples.js
@@ -1,0 +1,17 @@
+import React, {Component} from 'react';
+import ExampleSection from '../../../../Components/ComponentDoc/ExampleSection';
+import ComponentExample from '../../../../Components/ComponentDoc/ComponentExample';
+
+export default class FormUsageExamples extends Component {
+  render() {
+    return (
+      <ExampleSection title='Usage'>
+        <ComponentExample
+          title='Specifying Validation Rules'
+          description='Form validation requires passing in a validation object with the rules required to validate your form.'
+          examplePath='behaviors/Form Validation/Usage/FormSpecifyingValidationRulesExample'
+        />
+      </ExampleSection>
+    );
+  }
+}

--- a/docs/app/Examples/collections/Form/Validation/FormValidationExamples.js
+++ b/docs/app/Examples/collections/Form/Validation/FormValidationExamples.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection';
 import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample';
+import {Message} from 'stardust';
 
 export default class FormValidationExamples extends Component {
   render() {
@@ -11,6 +12,20 @@ export default class FormValidationExamples extends Component {
           description='Pass in a validation object with the rules required to validate your form.'
           examplePath='collections/Form/Validation/FormSpecifyingValidationRulesExample'
         />
+        <ComponentExample
+          title='Validating on Blur and other Events'
+          description={`
+            Validation messages can also appear inline.
+            UI Forms automatically format labels with the class name <code>prompt</code>.
+            These validation prompts are also set to appear on input change instead of form submission.
+          `}
+          examplePath='collections/Form/Validation/FormValidatingOnBlurAndOtherEventsExample'
+        >
+          <Message className='warning'>
+            This example also uses a different validation event.
+            Each element will be validated on input blur instead of the default form submit.
+          </Message>
+        </ComponentExample>
       </ExampleSection>
     );
   }

--- a/docs/app/Examples/collections/Form/Validation/FormValidationExamples.js
+++ b/docs/app/Examples/collections/Form/Validation/FormValidationExamples.js
@@ -1,15 +1,15 @@
 import React, {Component} from 'react';
-import ExampleSection from '../../../../Components/ComponentDoc/ExampleSection';
-import ComponentExample from '../../../../Components/ComponentDoc/ComponentExample';
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection';
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample';
 
-export default class FormUsageExamples extends Component {
+export default class FormValidationExamples extends Component {
   render() {
     return (
       <ExampleSection title='Usage'>
         <ComponentExample
           title='Specifying Validation Rules'
-          description='Form validation requires passing in a validation object with the rules required to validate your form.'
-          examplePath='behaviors/Form Validation/Usage/FormSpecifyingValidationRulesExample'
+          description='Pass in a validation object with the rules required to validate your form.'
+          examplePath='collections/Form/Validation/FormSpecifyingValidationRulesExample'
         />
       </ExampleSection>
     );

--- a/docs/app/Examples/collections/Form/Validation/FormValidationExamples.js
+++ b/docs/app/Examples/collections/Form/Validation/FormValidationExamples.js
@@ -6,7 +6,7 @@ import {Message} from 'stardust';
 export default class FormValidationExamples extends Component {
   render() {
     return (
-      <ExampleSection title='Usage'>
+      <ExampleSection title='Validation'>
         <ComponentExample
           title='Specifying Validation Rules'
           description='Pass in a validation object with the rules required to validate your form.'

--- a/docs/app/index.html
+++ b/docs/app/index.html
@@ -3,14 +3,14 @@
 <head>
   <title>Stardust Docs</title>
 
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.4/semantic.min.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.6/semantic.css" />
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.8.0/styles/github.min.css">
 
   <script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.0/lodash.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/Faker/3.0.1/faker.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.0.0/semantic.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.6/semantic.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/bluebird/2.9.33/bluebird.min.js"></script>
 
   <!-- build:development-->

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import $ from 'jquery';
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
 import META from 'src/utils/Meta';
@@ -7,7 +8,21 @@ export default class Form extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
+    settings: PropTypes.object,
   };
+
+  componentDidMount() {
+    this.element = $(this.refs.element);
+    this.element.form(this.props.settings);
+  }
+
+  componentWillUnmount() {
+    this.element.off();
+  }
+
+  plugin() {
+    return this.element.form(...arguments);
+  }
 
   serializeJson = () => {
     const form = this.refs.form;
@@ -52,7 +67,7 @@ export default class Form extends Component {
       'form'
     );
     return (
-      <form {...this.props} className={classes} ref='form'>
+      <form {...this.props} className={classes} ref='element'>
         {this.props.children}
       </form>
     );

--- a/test/mocks/SemanticjQuery-mock.js
+++ b/test/mocks/SemanticjQuery-mock.js
@@ -20,6 +20,7 @@ jQuery.ajax = sandbox.stub().returnsThis();
 const jQueryPlugins = {
   checkbox: sandbox.stub().returnsThis(),
   dropdown: sandbox.stub().returnsThis(),
+  form: sandbox.stub().returnsThis(),
   modal: sandbox.stub().returnsThis(),
   popup: sandbox.stub().returnsThis(),
   progress: sandbox.stub().returnsThis(),


### PR DESCRIPTION
This PR adds the form plugin and a single validation example.  This will allow us to do form field validation in a consistent way.

**Message validation on submit**
Filling in the form and hitting submit does validation.  Fixes made are updated on blur for a good UX.
![image](https://cloud.githubusercontent.com/assets/5067638/11828414/6719836e-a349-11e5-9ebb-b7e6d1cd473f.png)

**Inline validation on blur**
Validation can be done on blur.  Errors can also be shown inline with animations consistent with the framework.
![image](https://cloud.githubusercontent.com/assets/5067638/11828397/4b6b049e-a349-11e5-82f0-0e670d440311.png)

**Future Iterations**

Future PRs will add more support, such as:
- [ ] custom prop type validation for the form settings (customPropTypes.optionalShape({...})
  >Validates settings against valid Semantic UI `form()` settings
- [ ] Generating validation rules from html attributes: `minlength='2' => rules: [{type: 'minLength[2]}]`
- [ ] META extension to include Semantic UI transition types (for use in custom prop validation)
- [ ] META extension to include `behaviors` section
- [ ] full set of form validation examples in the designated Behaviors section

_Note:_
This PR uncovered an error with the Dropdown component.  It is not correctly handling the `multiple` attribute which also prevents it from being validated.  The Dropdown has been scheduled for reworking for a while, time we get to that I suppose.
