### PR TITLE
Add form validate prop types

### DIFF
--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -9,6 +9,8 @@ export default class Form extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     settings: PropTypes.object,
+    validate: PropTypes.bool,
+    validateInline: PropTypes.bool,
   };
 
   componentDidMount() {


### PR DESCRIPTION
# Not Ready

Extend the `<Form />` component to generate Semantic UI form validation [settings](http://semantic-ui.com/behaviors/form.html) by scanning the props of its inputs.  The extended format should be used to support multiple rules per control and allowing simultaneous inline/blur/etc options.

The default form behavior will be no validation.
The following bool props will be available on the form to enable validation:
- [ ] `validate` enable validation on submit
- [ ] `validateInline` adds error messages inline with fields
- [ ] `validateOnBlur` validate on input blur instead of submit

The following input attributes will generate validation rules automatically where:
**`<attr>`**
- [ ] `<Semantic UI rule>`

---

**required**
- [ ] empty
- [ ] checked

**type**
- [ ] email
- [ ] url
- [ ] decimal
- [ ] number
- [ ] creditCard
- [ ] tel => regEx html5pattern phone
- [ ] password => regEx html5pattern password
  >default password upper lower number special 6 char

**pattern**
- [ ] regEx

**minLength/maxLength**
- [ ] minLength
- [ ] maxLength
