### PR TITLE
fix(imports): remove resolve.root config in webpack

### DIFF
--- a/karma.conf.babel.js
+++ b/karma.conf.babel.js
@@ -54,10 +54,8 @@ export default (config) => {
         ]
       },
       resolve: {
-        root: paths.root,
         modulesDirectories: [
           'node_modules',
-          '.',
         ],
         alias: {
           // When these key names are require()'d, the value will be supplied instead

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -2,11 +2,11 @@ import React, {Component, PropTypes} from 'react';
 import Promise from 'bluebird';
 import classNames from 'classnames';
 
-import META from 'src/utils/Meta.js';
-import Modal from 'src/modules/Modal/Modal';
-import ModalContent from 'src/modules/Modal/ModalContent';
-import ModalFooter from 'src/modules/Modal/ModalFooter';
-import ModalHeader from 'src/modules/Modal/ModalHeader';
+import META from '../../utils/Meta.js';
+import Modal from '../../modules/Modal/Modal';
+import ModalContent from '../../modules/Modal/ModalContent';
+import ModalFooter from '../../modules/Modal/ModalFooter';
+import ModalHeader from '../../modules/Modal/ModalHeader';
 
 export default class Confirm extends Component {
   static propTypes = {

--- a/src/addons/Textarea/Textarea.js
+++ b/src/addons/Textarea/Textarea.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Textarea extends Component {
   static propTypes = {

--- a/src/collections/Form/Field.js
+++ b/src/collections/Form/Field.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import numberToWord from 'src/utils/numberToWord';
-import META from 'src/utils/Meta.js';
+import numberToWord from '../../utils/numberToWord';
+import META from '../../utils/Meta.js';
 
 export default class Field extends Component {
   static propTypes = {

--- a/src/collections/Form/Fields.js
+++ b/src/collections/Form/Fields.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import React, {Children, Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import getUnhandledProps from 'src/utils/getUnhandledProps';
-import numberToWord from 'src/utils/numberToWord';
-import META from 'src/utils/Meta.js';
+import getUnhandledProps from '../../utils/getUnhandledProps';
+import numberToWord from '../../utils/numberToWord';
+import META from '../../utils/Meta.js';
 
 export default class Fields extends Component {
   static propTypes = {

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import $ from 'jquery';
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Form extends Component {
   static propTypes = {

--- a/src/collections/Grid/Column.js
+++ b/src/collections/Grid/Column.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import classNames from 'classnames';
 import React, {Component, PropTypes} from 'react';
-import numberToWord from 'src/utils/numberToWord';
-import META from 'src/utils/Meta.js';
+import numberToWord from '../../utils/numberToWord';
+import META from '../../utils/Meta.js';
 
 export default class Column extends Component {
   static propTypes = {

--- a/src/collections/Grid/Grid.js
+++ b/src/collections/Grid/Grid.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React, {Component, PropTypes} from 'react';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Grid extends Component {
   static propTypes = {

--- a/src/collections/Grid/Row.js
+++ b/src/collections/Grid/Row.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React, {Component, PropTypes} from 'react';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Row extends Component {
   static propTypes = {

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
-import getUnhandledProps from 'src/utils/getUnhandledProps';
+import META from '../../utils/Meta';
+import getUnhandledProps from '../../utils/getUnhandledProps';
 
 export default class Menu extends Component {
   static propTypes = {

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class MenuItem extends Component {
   static propTypes = {

--- a/src/collections/Message/Message.js
+++ b/src/collections/Message/Message.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
 import $ from 'jquery';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Message extends Component {
   static propTypes = {

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import React, {Children, Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import {ofComponentTypes} from 'src/utils/customPropTypes';
-import META from 'src/utils/Meta';
+import {ofComponentTypes} from '../../utils/customPropTypes';
+import META from '../../utils/Meta';
 
 export default class Table extends Component {
   static propTypes = {

--- a/src/collections/Table/TableColumn.js
+++ b/src/collections/Table/TableColumn.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class TableColumn extends Component {
   static propTypes = {

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Button extends Component {
   static propTypes = {

--- a/src/elements/Button/Buttons.js
+++ b/src/elements/Button/Buttons.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Buttons extends Component {
   static propTypes = {

--- a/src/elements/Container/Container.js
+++ b/src/elements/Container/Container.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 /**
  * A container that gives your content some side padding.

--- a/src/elements/Divider/Divider.js
+++ b/src/elements/Divider/Divider.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Divider extends Component {
   static propTypes = {

--- a/src/elements/Header/H1.js
+++ b/src/elements/Header/H1.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 import _Header from './_Header';
 
 export default class H1 extends Component {

--- a/src/elements/Header/H2.js
+++ b/src/elements/Header/H2.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 import _Header from './_Header';
 
 export default class H2 extends Component {

--- a/src/elements/Header/H3.js
+++ b/src/elements/Header/H3.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 import _Header from './_Header';
 
 export default class H3 extends Component {

--- a/src/elements/Header/H4.js
+++ b/src/elements/Header/H4.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 import _Header from './_Header';
 
 export default class H4 extends Component {

--- a/src/elements/Header/H5.js
+++ b/src/elements/Header/H5.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 import _Header from './_Header';
 
 export default class H5 extends Component {

--- a/src/elements/Header/H6.js
+++ b/src/elements/Header/H6.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 import _Header from './_Header';
 
 export default class H6 extends Component {

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 import _Header from './_Header';
 import H1 from './H1';
 import H2 from './H2';

--- a/src/elements/Header/Subheader.js
+++ b/src/elements/Header/Subheader.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
-import getUnhandledProps from 'src/utils/getUnhandledProps';
+import META from '../../utils/Meta';
+import getUnhandledProps from '../../utils/getUnhandledProps';
 
 export default class Subheader extends Component {
   static propTypes = {

--- a/src/elements/Header/_Header.js
+++ b/src/elements/Header/_Header.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
-import getUnhandledProps from 'src/utils/getUnhandledProps';
+import META from '../../utils/Meta';
+import getUnhandledProps from '../../utils/getUnhandledProps';
 
 export default class _Header extends Component {
   static propTypes = {

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Image extends Component {
   static propTypes = {

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import classNames from 'classnames';
 import React, {Component, PropTypes, Children} from 'react';
-import META from 'src/utils/Meta';
-import getUnhandledProps from 'src/utils/getUnhandledProps';
+import META from '../../utils/Meta';
+import getUnhandledProps from '../../utils/getUnhandledProps';
 
 export default class Input extends Component {
   static propTypes = {

--- a/src/elements/List/List.js
+++ b/src/elements/List/List.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class List extends Component {
   static propTypes = {

--- a/src/elements/List/ListItem.js
+++ b/src/elements/List/ListItem.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class ListItem extends Component {
   static propTypes = {

--- a/src/elements/Segment/Segment.js
+++ b/src/elements/Segment/Segment.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 import Segments from './Segments';
 
 /**

--- a/src/elements/Segment/Segments.js
+++ b/src/elements/Segment/Segments.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
-import {ofComponentTypes} from 'src/utils/customPropTypes';
+import META from '../../utils/Meta';
+import {ofComponentTypes} from '../../utils/customPropTypes';
 
 /**
  * A group of segments can be formatted to appear together.

--- a/src/index.js
+++ b/src/index.js
@@ -1,46 +1,46 @@
 // Addons
-import Confirm from 'src/addons/Confirm/Confirm';
-import Textarea from 'src/addons/Textarea/Textarea';
+import Confirm from './addons/Confirm/Confirm';
+import Textarea from './addons/Textarea/Textarea';
 
 // Collections
-import Column from 'src/collections/Grid/Column';
-import Field from 'src/collections/Form/Field';
-import Fields from 'src/collections/Form/Fields';
-import Form from 'src/collections/Form/Form';
-import Grid from 'src/collections/Grid/Grid';
-import Row from 'src/collections/Grid/Row';
-import Menu from 'src/collections/Menu/Menu';
-import MenuItem from 'src/collections/Menu/MenuItem';
-import Message from 'src/collections/Message/Message';
-import Table from 'src/collections/Table/Table';
-import TableColumn from 'src/collections/Table/TableColumn';
+import Column from './collections/Grid/Column';
+import Field from './collections/Form/Field';
+import Fields from './collections/Form/Fields';
+import Form from './collections/Form/Form';
+import Grid from './collections/Grid/Grid';
+import Row from './collections/Grid/Row';
+import Menu from './collections/Menu/Menu';
+import MenuItem from './collections/Menu/MenuItem';
+import Message from './collections/Message/Message';
+import Table from './collections/Table/Table';
+import TableColumn from './collections/Table/TableColumn';
 
 // Elements
-import Button from 'src/elements/Button/Button';
-import Buttons from 'src/elements/Button/Buttons';
-import Container from 'src/elements/Container/Container';
-import Divider from 'src/elements/Divider/Divider';
-import Header from 'src/elements/Header/Header';
-import Image from 'src/elements/Image/Image';
-import Input from 'src/elements/Input/Input';
-import List from 'src/elements/List/List';
-import ListItem from 'src/elements/List/ListItem';
-import Segment from 'src/elements/Segment/Segment';
-import Segments from 'src/elements/Segment/Segments';
+import Button from './elements/Button/Button';
+import Buttons from './elements/Button/Buttons';
+import Container from './elements/Container/Container';
+import Divider from './elements/Divider/Divider';
+import Header from './elements/Header/Header';
+import Image from './elements/Image/Image';
+import Input from './elements/Input/Input';
+import List from './elements/List/List';
+import ListItem from './elements/List/ListItem';
+import Segment from './elements/Segment/Segment';
+import Segments from './elements/Segment/Segments';
 
 // Modules
-import Checkbox from 'src/modules/Checkbox/Checkbox';
-import Progress from 'src/modules/Progress/Progress';
-import Modal from 'src/modules/Modal/Modal';
-import ModalContent from 'src/modules/Modal/ModalContent';
-import ModalFooter from 'src/modules/Modal/ModalFooter';
-import ModalHeader from 'src/modules/Modal/ModalHeader';
-import Dropdown from 'src/modules/Dropdown/Dropdown';
+import Checkbox from './modules/Checkbox/Checkbox';
+import Progress from './modules/Progress/Progress';
+import Modal from './modules/Modal/Modal';
+import ModalContent from './modules/Modal/ModalContent';
+import ModalFooter from './modules/Modal/ModalFooter';
+import ModalHeader from './modules/Modal/ModalHeader';
+import Dropdown from './modules/Dropdown/Dropdown';
 
 // Views
-import Item from 'src/views/Items/Item';
-import Items from 'src/views/Items/Items';
-import Statistic from 'src/views/Statistic/Statistic';
+import Item from './views/Items/Item';
+import Items from './views/Items/Items';
+import Statistic from './views/Statistic/Statistic';
 
 const stardust = {
   // Addons

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import META from 'src/utils/Meta';
-import getUnhandledProps from 'src/utils/getUnhandledProps';
+import META from '../../utils/Meta';
+import getUnhandledProps from '../../utils/getUnhandledProps';
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
 import $ from 'jquery';

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -2,8 +2,8 @@ import _ from 'lodash';
 import $ from 'jquery';
 import classNames from 'classnames';
 import React, {Component, PropTypes} from 'react';
-import META from 'src/utils/Meta';
-import getUnhandledProps from 'src/utils/getUnhandledProps';
+import META from '../../utils/Meta';
+import getUnhandledProps from '../../utils/getUnhandledProps';
 
 export default class Dropdown extends Component {
   static propTypes = {

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Modal extends Component {
   static propTypes = {

--- a/src/modules/Modal/ModalContent.js
+++ b/src/modules/Modal/ModalContent.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class ModalContent extends Component {
   static propTypes = {

--- a/src/modules/Modal/ModalFooter.js
+++ b/src/modules/Modal/ModalFooter.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class ModalFooter extends Component {
   static propTypes = {

--- a/src/modules/Modal/ModalHeader.js
+++ b/src/modules/Modal/ModalHeader.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class ModalHeader extends Component {
   static propTypes = {

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
 import $ from 'jquery';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 import _ from 'lodash';
 
 export default class Progress extends Component {

--- a/src/views/Items/Item.js
+++ b/src/views/Items/Item.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import {mutuallyExclusive} from 'src/utils/customPropTypes';
-import META from 'src/utils/Meta';
+import {mutuallyExclusive} from '../../utils/customPropTypes';
+import META from '../../utils/Meta';
 
 export default class Item extends Component {
   static propTypes = {

--- a/src/views/Items/Items.js
+++ b/src/views/Items/Items.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Items extends Component {
   static propTypes = {

--- a/src/views/Statistic/Label.js
+++ b/src/views/Statistic/Label.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import getUnhandledProps from 'src/utils/getUnhandledProps';
-import META from 'src/utils/Meta';
+import getUnhandledProps from '../../utils/getUnhandledProps';
+import META from '../../utils/Meta';
 
 export default class Label extends Component {
   static propTypes = {

--- a/src/views/Statistic/Statistic.js
+++ b/src/views/Statistic/Statistic.js
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import React, {Component, PropTypes} from 'react';
 
-import getUnhandledProps from 'src/utils/getUnhandledProps';
-import {ofComponentTypes} from 'src/utils/customPropTypes';
-import META from 'src/utils/Meta';
+import getUnhandledProps from '../../utils/getUnhandledProps';
+import {ofComponentTypes} from '../../utils/customPropTypes';
+import META from '../../utils/Meta';
 
 import Statistics from './Statistics';
 import Label from './Label';

--- a/src/views/Statistic/Statistics.js
+++ b/src/views/Statistic/Statistics.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import META from 'src/utils/Meta';
+import META from '../../utils/Meta';
 
 export default class Statistics extends Component {
   static propTypes = {

--- a/src/views/Statistic/Value.js
+++ b/src/views/Statistic/Value.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import getUnhandledProps from 'src/utils/getUnhandledProps';
-import META from 'src/utils/Meta';
+import getUnhandledProps from '../../utils/getUnhandledProps';
+import META from '../../utils/Meta';
 
 export default class Value extends Component {
   static propTypes = {

--- a/test/mocks/SemanticjQuery-mock.js
+++ b/test/mocks/SemanticjQuery-mock.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import sandbox from 'test/utils/Sandbox-util';
+import sandbox from '../utils/Sandbox-util';
 
 //
 // jQuery Mock

--- a/test/specs/Conformance-test.js
+++ b/test/specs/Conformance-test.js
@@ -3,7 +3,7 @@ import faker from 'faker';
 import React, {Component} from 'react';
 import {isDOMComponent} from 'react-addons-test-utils';
 import stardust from 'stardust';
-import META from 'src/utils/Meta';
+import META from '../../src/utils/Meta';
 
 const getSDClassName = componentName => `sd-${_.kebabCase(componentName)}`;
 

--- a/test/specs/collections/Form/Field-test.js
+++ b/test/specs/collections/Form/Field-test.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import {Field} from 'stardust';
-import numberToWord from 'src/utils/numberToWord';
+import numberToWord from '../../../../src/utils/numberToWord';
 
 describe('Field', () => {
   it('has a label', () => {

--- a/test/specs/elements/Button/Button-test.js
+++ b/test/specs/elements/Button/Button-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Simulate} from 'react-addons-test-utils';
-import sandbox from 'test/utils/Sandbox-util';
+import sandbox from '../../../utils/Sandbox-util';
 import {Button} from 'stardust';
 
 describe('Button', () => {

--- a/test/specs/index-test.js
+++ b/test/specs/index-test.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 import path from 'path';
 import stardust from 'stardust';
-import META from 'src/utils/Meta';
+import META from '../../src/utils/Meta';
 
 const componentCtx = require.context(
-  'src/',
+  '../../src/',
   true,
   /(addons|collections|elements|modules|views).*\.js$/
 );

--- a/test/specs/utils/numberToWord-test.js
+++ b/test/specs/utils/numberToWord-test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import numberToWord from 'src/utils/numberToWord';
+import numberToWord from '../../../src/utils/numberToWord';
 
 const words = [
   'one',

--- a/test/utils/getUnhandledPops-test.js
+++ b/test/utils/getUnhandledPops-test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import getUnhandledProps from 'src/utils/getUnhandledProps';
+import getUnhandledProps from '../../src/utils/getUnhandledProps';
 
 // Helper class that takes in props and merges defaultProps
 class TestClass {

--- a/webpack.dev.babel.js
+++ b/webpack.dev.babel.js
@@ -52,10 +52,8 @@ export default {
   },
   devtool: 'source-map',
   resolve: {
-    root: paths.root,
     modulesDirectories: [
       'node_modules',
-      '.',
     ],
     alias: {
       stardust: `${paths.src}/index.js`,

--- a/webpack.tests.babel.js
+++ b/webpack.tests.babel.js
@@ -50,10 +50,8 @@ module.exports = {
     ],
   },
   resolve: {
-    root: paths.root,
     modulesDirectories: [
       'node_modules',
-      '.',
     ],
     alias: {
       // When these key names are require()'d, the value will be supplied instead


### PR DESCRIPTION
…bution issues

By using `resolve.root` and `modulesDirectories` overrides with webpack, consuming packages _must_ use webpack and _must_ have a very specific setup in order for Stardust's imports to work correctly. By using all relative paths, Stardust is able to be consumed by any bundler/environment.
