### PR TITLE
Selectable table rows

### DIFF
--- a/karma.conf.babel.js
+++ b/karma.conf.babel.js
@@ -55,10 +55,6 @@ export default (config) => {
       },
       resolve: {
         root: paths.root,
-        modulesDirectories: [
-          'node_modules',
-          '.'
-        ],
         alias: {
           // When these key names are require()'d, the value will be supplied instead
           jquery: paths.testMocks + '/SemanticjQuery-mock.js',

--- a/karma.conf.babel.js
+++ b/karma.conf.babel.js
@@ -54,8 +54,10 @@ export default (config) => {
         ]
       },
       resolve: {
+        root: paths.root,
         modulesDirectories: [
           'node_modules',
+          '.'
         ],
         alias: {
           // When these key names are require()'d, the value will be supplied instead

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-preset-stage-1": "^6.1.18",
     "chai": "^3.3.0",
     "del": "^2.0.2",
+    "dirty-chai": "^1.2.2",
     "doctrine": "^0.7.0",
     "eslint": "^1.5.1",
     "eslint-config-ta-webapp": "^2.1.0",

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -40,8 +40,7 @@ export default class Table extends Component {
   }
 
   _isSelectable = () => {
-    const {className, onSelectRow} = this.props;
-    return _.includes(className, 'selectable') && !!onSelectRow;
+    return _.includes(this.props.className, 'selectable');
   };
 
   _deselectRow(index) {

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -6,7 +6,6 @@ import META from '../../utils/Meta';
 
 export default class Table extends Component {
   static propTypes = {
-    basic: PropTypes.bool,
     children: ofComponentTypes(['TableColumn']),
     className: PropTypes.string,
     data: PropTypes.array,
@@ -20,7 +19,6 @@ export default class Table extends Component {
   };
 
   static defaultProps = {
-    selectedRows: [],
     sort: {
       key: null,
       direction: 'descending',
@@ -30,7 +28,7 @@ export default class Table extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
-      selectedRows: this.props.selectedRows,
+      selectedRows: this.props.selectedRows || [],
     };
   }
 

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -121,16 +121,9 @@ export default class Table extends Component {
       const classes = classNames('sd-table-row', {
         active: this._isRowSelected(rowIndex),
       });
+      const onClick = () => this._handleSelectRow(dataItem, rowIndex);
 
-      return (
-        <tr
-          className={classes}
-          key={rowIndex}
-          onClick={this._handleSelectRow.bind(this, dataItem, rowIndex)}
-        >
-          {cells}
-        </tr>
-      );
+      return <tr className={classes} key={rowIndex} onClick={onClick}>{cells}</tr>;
     });
   }
 

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -12,11 +12,23 @@ export default class Table extends Component {
     data: PropTypes.array,
     onSelectRow: PropTypes.func,
     onSortChange: PropTypes.func,
+    selectedRows: PropTypes.arrayOf(PropTypes.number),
     sort: PropTypes.shape({
       key: PropTypes.string,
       direction: PropTypes.string, // descending|ascending, defaults to descending
     }),
   };
+
+  static defaultProps = {
+    selectedRows: []
+  }
+
+  constructor(props, context) {
+    super(props, context);
+    this.state = {
+      selectedRows: this.props.selectedRows,
+    };
+  }
 
   static getSafeCellContents(content) {
     // React cannot render objects, stringify them instead

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -43,7 +43,7 @@ export default class Table extends Component {
     return _.includes(this.props.className, 'selectable');
   };
 
-  _deselectRow(index) {
+  _unselectRow(index) {
     if (!this._isSelectable()) return;
     this.setState({
       selectedRows: _.without(this.state.selectedRows, index)
@@ -55,9 +55,13 @@ export default class Table extends Component {
     this.setState({selectedRows: [index]});
   }
 
+  _unselectAllRows() {
+    this.setState({selectedRows: []});
+  }
+
   _toggleSelectRow(index) {
     if (this._isRowSelected(index)) {
-      this._deselectRow(index);
+      this._unselectRow(index);
     } else {
       this._selectRow(index);
     }
@@ -71,6 +75,7 @@ export default class Table extends Component {
   _handleSortHeaderChange(key, direction) {
     const {onSortChange} = this.props;
     if (onSortChange) {
+      this._unselectAllRows();
       onSortChange(key, direction);
     }
   }

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -10,6 +10,7 @@ export default class Table extends Component {
     children: ofComponentTypes(['TableColumn']),
     className: PropTypes.string,
     data: PropTypes.array,
+    onSelectRow: PropTypes.func,
     onSortChange: PropTypes.func,
     sort: PropTypes.shape({
       key: PropTypes.string,
@@ -65,10 +66,11 @@ export default class Table extends Component {
   }
 
   _getRows() {
-    return _.map(this.props.data, (dataItem, rowIndex) => {
+    const {data, onSelectRow} = this.props;
+    return _.map(data, (dataItem, rowIndex) => {
       const cells = this._getCells(dataItem, rowIndex);
 
-      return <tr className='sd-table-row' key={rowIndex}>{cells}</tr>;
+      return <tr className='sd-table-row' key={rowIndex} onSelectRow={onSelectRow}>{cells}</tr>;
     });
   }
 

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -76,11 +76,17 @@ export default class Table extends Component {
   }
 
   _getRows() {
-    const {data, onSelectRow} = this.props;
-    return _.map(data, (dataItem, rowIndex) => {
+    return _.map(this.props.data, (dataItem, rowIndex) => {
       const cells = this._getCells(dataItem, rowIndex);
-
-      return <tr className='sd-table-row' key={rowIndex} onSelectRow={onSelectRow}>{cells}</tr>;
+      return (
+        <tr
+          className='sd-table-row'
+          key={rowIndex}
+          onClick={this._handleSelectRow.bind(this, dataItem, rowIndex)}
+        >
+          {cells}
+        </tr>
+      );
     });
   }
 

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -60,6 +60,7 @@ export default class Table extends Component {
   }
 
   _unselectAllRows() {
+    if (!this._isSelectable()) return;
     this.setState({selectedRows: []});
   }
 
@@ -137,11 +138,12 @@ export default class Table extends Component {
   };
 
   render() {
+    const {onSelectRow, onSortChange, selectedRows} = this.props;
     const classes = classNames(
       'sd-table',
       'ui',
-      {selectable: !!this.props.onSelectRow},
-      {sortable: !!this.props.onSortChange},
+      {selectable: !!onSelectRow || !!selectedRows},
+      {sortable: !!onSortChange},
       this.props.className,
       'table'
     );

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -23,6 +23,11 @@ export default class Table extends Component {
     return _.isObject(content) ? JSON.stringify(content) : content;
   }
 
+  _isSelectable = () => {
+    const {className, onSelectRow} = this.props;
+    return _.includes(className, 'selectable') && !!onSelectRow;
+  };
+
   _handleSortHeaderChange(key, direction) {
     const {onSortChange} = this.props;
     if (onSortChange) {

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -137,6 +137,7 @@ export default class Table extends Component {
     const classes = classNames(
       'sd-table',
       'ui',
+      {selectable: !!this.props.onSelectRow},
       {sortable: !!this.props.onSortChange},
       this.props.className,
       'table'

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -28,6 +28,11 @@ export default class Table extends Component {
     return _.includes(className, 'selectable') && !!onSelectRow;
   };
 
+  _handleSelectRow(rowItem, rowIndex) {
+    if (!this._isSelectable()) return;
+    this.props.onSelectRow(rowItem, rowIndex);
+  }
+
   _handleSortHeaderChange(key, direction) {
     const {onSortChange} = this.props;
     if (onSortChange) {

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -15,12 +15,16 @@ export default class Table extends Component {
     selectedRows: PropTypes.arrayOf(PropTypes.number),
     sort: PropTypes.shape({
       key: PropTypes.string,
-      direction: PropTypes.string, // descending|ascending, defaults to descending
+      direction: PropTypes.oneOf(['descending', 'ascending']),
     }),
   };
 
   static defaultProps = {
-    selectedRows: []
+    selectedRows: [],
+    sort: {
+      key: null,
+      direction: 'descending',
+    },
   }
 
   constructor(props, context) {
@@ -81,23 +85,22 @@ export default class Table extends Component {
   }
 
   _getHeaders() {
-    return Children.map(this.props.children, (column) => {
-      const key = column.props.dataKey;
-      const content = column.props.headerRenderer
-        ? column.props.headerRenderer(this.props.data[0])
-        : _.startCase(column.props.dataKey);
-      const sorted = _.get(this, 'props.sort.key') === key;
-      const direction = _.get(this, 'props.sort.direction', 'descending');
+    const {children, data, sort} = this.props;
+
+    return Children.map(children, (column) => {
+      const {dataKey, headerRenderer} = column.props;
+      const content = headerRenderer ? headerRenderer(data[0]) : _.startCase(dataKey);
+      const isSorted = sort.key === dataKey;
       const onClick = () => this._handleSortHeaderChange(
-        key, direction === 'ascending' ? 'descending' : 'ascending'
+        dataKey, sort.direction === 'ascending' ? 'descending' : 'ascending'
       );
       const classes = classNames('sd-table-header', {
-        sorted,
-        ascending: sorted && direction === 'ascending',
-        descending: sorted && direction === 'descending',
+        sorted: isSorted,
+        ascending: isSorted && sort.direction === 'ascending',
+        descending: isSorted && sort.direction === 'descending',
       });
 
-      return <th className={classes} key={key} onClick={onClick}>{content}</th>;
+      return <th className={classes} key={dataKey} onClick={onClick}>{content}</th>;
     });
   }
 

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -35,14 +35,38 @@ export default class Table extends Component {
     return _.isObject(content) ? JSON.stringify(content) : content;
   }
 
+  _isRowSelected(index) {
+    return _.includes(this.state.selectedRows, index);
+  }
+
   _isSelectable = () => {
     const {className, onSelectRow} = this.props;
     return _.includes(className, 'selectable') && !!onSelectRow;
   };
 
-  _handleSelectRow(rowItem, rowIndex) {
+  _deselectRow(index) {
     if (!this._isSelectable()) return;
-    this.props.onSelectRow(rowItem, rowIndex);
+    this.setState({
+      selectedRows: _.without(this.state.selectedRows, index)
+    });
+  }
+
+  _selectRow(index) {
+    if (!this._isSelectable()) return;
+    this.setState({selectedRows: [index]});
+  }
+
+  _toggleSelectRow(index) {
+    if (this._isRowSelected(index)) {
+      this._deselectRow(index);
+    } else {
+      this._selectRow(index);
+    }
+  }
+
+  _handleSelectRow(rowItem, rowIndex) {
+    this._toggleSelectRow(rowIndex);
+    if (this.props.onSelectRow) this.props.onSelectRow(rowItem, rowIndex);
   }
 
   _handleSortHeaderChange(key, direction) {
@@ -90,9 +114,13 @@ export default class Table extends Component {
   _getRows() {
     return _.map(this.props.data, (dataItem, rowIndex) => {
       const cells = this._getCells(dataItem, rowIndex);
+      const classes = classNames('sd-table-row', {
+        active: this._isRowSelected(rowIndex),
+      });
+
       return (
         <tr
-          className='sd-table-row'
+          className={classes}
           key={rowIndex}
           onClick={this._handleSelectRow.bind(this, dataItem, rowIndex)}
         >

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,6 +4,7 @@
  */
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
+import dirtyChai from 'dirty-chai';
 
 //
 // Mocha
@@ -18,3 +19,4 @@ mocha.setup({
 global.expect = chai.expect;
 chai.should();
 chai.use(sinonChai);
+chai.use(dirtyChai);

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import faker from 'faker';
 import React from 'react';
+import {Simulate} from 'react-addons-test-utils';
 import {Table, TableColumn} from 'stardust';
 import sandbox from 'test/utils/Sandbox-util';
 
@@ -152,6 +153,23 @@ describe('Table', () => {
       spy.called.should.equal(false);
       table._handleSelectRow();
       spy.called.should.equal(false);
+    });
+  });
+
+  describe('select row', () => {
+    it('is called with the rowItem and index onClick', () => {
+      const spy = sandbox.spy();
+      const rowItem = {name: 'bob'};
+      const row = render(
+        <Table className='selectable' onSelectRow={spy} data={[rowItem]}>
+          <TableColumn dataKey='name' />
+        </Table>
+      )
+        .scryClass('sd-table-row')[0];
+
+      spy.called.should.equal(false);
+      Simulate.click(row);
+      spy.calledWith(rowItem, 0).should.equal(true);
     });
   });
 

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import faker from 'faker';
 import React from 'react';
 import {Table, TableColumn} from 'stardust';
+import sandbox from 'test/utils/Sandbox-util';
 
 describe('Table', () => {
   let randomDataKey;
@@ -127,6 +128,30 @@ describe('Table', () => {
         .first()
         ._isSelectable()
         .should.equal(false);
+    });
+  });
+
+  describe('_handleSelectRow', () => {
+    let table;
+    let spy;
+
+    beforeEach(() => {
+      spy = sandbox.spy();
+      table = render(<Table className='selectable' onSelectRow={spy} data={tableData} />).first();
+    });
+
+    it('calls onSelectRow prop if _isSelectable', () => {
+      table._isSelectable = () => true;
+      spy.called.should.equal(false);
+      table._handleSelectRow();
+      spy.called.should.equal(true);
+    });
+
+    it('does not call onSelectRow prop if !_isSelectable', () => {
+      table._isSelectable = () => false;
+      spy.called.should.equal(false);
+      table._handleSelectRow();
+      spy.called.should.equal(false);
     });
   });
 

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -153,22 +153,6 @@ describe('Table', () => {
     });
   });
 
-  describe('_isSelectable', () => {
-    it('returns true when "selectable" class is present', () => {
-      render(<Table className='selectable' />)
-        .first()
-        ._isSelectable()
-        .should.equal(true);
-    });
-
-    it('returns false when "selectable" class is not present', () => {
-      render(<Table />)
-        .first()
-        ._isSelectable()
-        .should.equal(false);
-    });
-  });
-
   describe('row select', () => {
     let rows;
 

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -207,4 +207,20 @@ describe('Table', () => {
       });
     });
   });
+
+  describe('"selectable" class', () => {
+    it('is auto applied when "onSelectRow" prop is present', () => {
+      render(<Table onSelectRow={_.noop} />)
+        .findClass('selectable');
+    });
+
+    it('is not auto applied when "onSelectRow" prop is not present', () => {
+      it('does not have class "selectable"', () => {
+        render(<Table />)
+          .findClass('sd-table')
+          .props.className
+          .should.not.include('selectable');
+      });
+    });
+  });
 });

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -176,27 +176,40 @@ describe('Table', () => {
     });
   });
 
-  describe('_handleSelectRow', () => {
-    let table;
-    let spy;
+  describe('row select', () => {
+    let rows;
 
     beforeEach(() => {
-      spy = sandbox.spy();
-      table = render(<Table className='selectable' onSelectRow={spy} />).first();
+      rows = render(
+        <Table className='selectable' data={[{row: 1}, {row: 2}]}>
+          <TableColumn dataKey='row' />
+        </Table>
+      )
+        .scryClass('sd-table-row');
     });
 
-    it('calls onSelectRow prop if _isSelectable', () => {
-      table._isSelectable = () => true;
-      spy.called.should.equal(false);
-      table._handleSelectRow();
-      spy.called.should.equal(true);
+    it('applies class "active" only to the clicked row', () => {
+      rows[0].getAttribute('class').should.not.include('active');
+      rows[1].getAttribute('class').should.not.include('active');
+
+      Simulate.click(rows[0]);
+
+      rows[0].getAttribute('class').should.include('active');
+      rows[1].getAttribute('class').should.not.include('active');
     });
 
-    it('does not call onSelectRow prop if !_isSelectable', () => {
-      table._isSelectable = () => false;
-      spy.called.should.equal(false);
-      table._handleSelectRow();
-      spy.called.should.equal(false);
+    it('toggles class "active" on repeat clicks', () => {
+      const row = rows[0];
+      // ensure not active
+      row.getAttribute('class').should.not.include('active');
+
+      // make active
+      Simulate.click(row);
+      row.getAttribute('class').should.include('active');
+
+      // toggle, not active
+      Simulate.click(row);
+      row.getAttribute('class').should.not.include('active');
     });
   });
 

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -234,6 +234,11 @@ describe('Table', () => {
         .findClass('selectable');
     });
 
+    it('is auto applied when "selectedRows" prop is present', () => {
+      render(<Table selectRows={[]} />)
+        .findClass('selectable');
+    });
+
     it('is not auto applied when "onSelectRow" prop is not present', () => {
       it('does not have class "selectable"', () => {
         render(<Table />)

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -190,15 +190,35 @@ describe('Table', () => {
     });
   });
 
-  describe('sortable', () => {
-    describe('with onSortChange prop', () => {
-      it('has class "sortable"', () => {
-        render(<Table onSortChange={_.noop} />)
-          .findClass('sortable');
-      });
+  describe('sort', () => {
+    it('unselects all rows', () => {
+      const tree = render(
+        <Table className='selectable' data={tableData} onSortChange={_.noop}>
+          <TableColumn dataKey={randomDataKey} />
+        </Table>
+      );
+
+      const table = tree.first();
+      const headers = tree.scryClass('sd-table-header');
+      const rows = tree.scryClass('sd-table-row');
+
+      // select a row
+      Simulate.click(rows[0]);
+      table._isRowSelected(0).should.equal(true);
+
+      // sort, assert row unselected
+      Simulate.click(headers[0]);
+      table._isRowSelected(0).should.equal(false);
+    });
+  });
+
+  describe('"sortable" class', () => {
+    it('is auto applied when "onSortChange" prop is present', () => {
+      render(<Table onSortChange={_.noop} />)
+        .findClass('sortable');
     });
 
-    describe('without onSortChange prop', () => {
+    it('is not auto applied when "onSortChange" prop is not present', () => {
       it('does not have class "sortable"', () => {
         render(<Table />)
           .findClass('sd-table')

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -111,21 +111,21 @@ describe('Table', () => {
 
   describe('_isSelectable', () => {
     it('returns true when "selectable" class and "onSelectRow" prop are present', () => {
-      render(<Table className='selectable' onSelectRow={_.noop} data={tableData} />)
+      render(<Table className='selectable' onSelectRow={_.noop} />)
         .first()
         ._isSelectable()
         .should.equal(true);
     });
 
     it('returns false when "selectable" class is omitted', () => {
-      render(<Table onSelectRow={_.noop} data={tableData} />)
+      render(<Table onSelectRow={_.noop} />)
         .first()
         ._isSelectable()
         .should.equal(false);
     });
 
     it('returns false when "onSelectRow" prop is omitted', () => {
-      render(<Table className='selectable' data={tableData} />)
+      render(<Table className='selectable' />)
         .first()
         ._isSelectable()
         .should.equal(false);
@@ -138,7 +138,7 @@ describe('Table', () => {
 
     beforeEach(() => {
       spy = sandbox.spy();
-      table = render(<Table className='selectable' onSelectRow={spy} data={tableData} />).first();
+      table = render(<Table className='selectable' onSelectRow={spy} />).first();
     });
 
     it('calls onSelectRow prop if _isSelectable', () => {
@@ -176,14 +176,14 @@ describe('Table', () => {
   describe('sortable', () => {
     describe('with onSortChange prop', () => {
       it('has class "sortable"', () => {
-        render(<Table data={tableData} onSortChange={_.noop} />)
+        render(<Table onSortChange={_.noop} />)
           .findClass('sortable');
       });
     });
 
     describe('without onSortChange prop', () => {
       it('does not have class "sortable"', () => {
-        render(<Table data={tableData} />)
+        render(<Table />)
           .findClass('sd-table')
           .props.className
           .should.not.include('sortable');

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -50,6 +50,25 @@ describe('Table', () => {
     });
   });
 
+  describe('props', () => {
+    describe('onSelectRow', () => {
+      it('is called with the rowItem and index onClick', () => {
+        const spy = sandbox.spy();
+        const rowItem = {name: 'bob'};
+        const row = render(
+          <Table className='selectable' onSelectRow={spy} data={[rowItem]}>
+            <TableColumn dataKey='name' />
+          </Table>
+        )
+          .scryClass('sd-table-row')[0];
+
+        spy.called.should.equal(false);
+        Simulate.click(row);
+        spy.calledWith(rowItem, 0).should.equal(true);
+      });
+    });
+  });
+
   describe('header', () => {
     it('uses Start Cased column dataKey as the default content', () => {
       render(
@@ -178,23 +197,6 @@ describe('Table', () => {
       spy.called.should.equal(false);
       table._handleSelectRow();
       spy.called.should.equal(false);
-    });
-  });
-
-  describe('select row', () => {
-    it('is called with the rowItem and index onClick', () => {
-      const spy = sandbox.spy();
-      const rowItem = {name: 'bob'};
-      const row = render(
-        <Table className='selectable' onSelectRow={spy} data={[rowItem]}>
-          <TableColumn dataKey='name' />
-        </Table>
-      )
-        .scryClass('sd-table-row')[0];
-
-      spy.called.should.equal(false);
-      Simulate.click(row);
-      spy.calledWith(rowItem, 0).should.equal(true);
     });
   });
 

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -25,6 +25,31 @@ describe('Table', () => {
     randomDataKey = _.sample(_.keys(_.first(tableData)));
   });
 
+  describe('defaultProps', () => {
+    it('should have empty selectedRows', () => {
+      render(<Table />)
+        .first()
+        .props.selectedRows
+        .should.be.empty();
+    });
+  });
+
+  describe('initial state', () => {
+    it('selectedRows should match default selectedRows prop', () => {
+      const {props, state} = render(<Table />).first();
+      state.selectedRows
+        .should.be.equal(props.selectedRows);
+    });
+
+    it('selectedRows should match defined selectedRows prop', () => {
+      const selectedRows = _.times(_.random(1, 20));
+      render(<Table selectedRows={selectedRows} />)
+        .first()
+        .state.selectedRows
+        .should.equal(selectedRows);
+    });
+  });
+
   describe('header', () => {
     it('uses Start Cased column dataKey as the default content', () => {
       render(

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -107,6 +107,29 @@ describe('Table', () => {
     });
   });
 
+  describe('_isSelectable', () => {
+    it('returns true when "selectable" class and "onSelectRow" prop are present', () => {
+      render(<Table className='selectable' onSelectRow={_.noop} data={tableData} />)
+        .first()
+        ._isSelectable()
+        .should.equal(true);
+    });
+
+    it('returns false when "selectable" class is omitted', () => {
+      render(<Table onSelectRow={_.noop} data={tableData} />)
+        .first()
+        ._isSelectable()
+        .should.equal(false);
+    });
+
+    it('returns false when "onSelectRow" prop is omitted', () => {
+      render(<Table className='selectable' data={tableData} />)
+        .first()
+        ._isSelectable()
+        .should.equal(false);
+    });
+  });
+
   describe('sortable', () => {
     describe('with onSortChange prop', () => {
       it('has class "sortable"', () => {

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -154,22 +154,15 @@ describe('Table', () => {
   });
 
   describe('_isSelectable', () => {
-    it('returns true when "selectable" class and "onSelectRow" prop are present', () => {
-      render(<Table className='selectable' onSelectRow={_.noop} />)
+    it('returns true when "selectable" class is present', () => {
+      render(<Table className='selectable' />)
         .first()
         ._isSelectable()
         .should.equal(true);
     });
 
-    it('returns false when "selectable" class is omitted', () => {
-      render(<Table onSelectRow={_.noop} />)
-        .first()
-        ._isSelectable()
-        .should.equal(false);
-    });
-
-    it('returns false when "onSelectRow" prop is omitted', () => {
-      render(<Table className='selectable' />)
+    it('returns false when "selectable" class is not present', () => {
+      render(<Table />)
         .first()
         ._isSelectable()
         .should.equal(false);

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -29,16 +29,17 @@ describe('Table', () => {
     it('should have empty selectedRows', () => {
       render(<Table />)
         .first()
-        .props.selectedRows
-        .should.be.empty();
+        .props.sort
+        .should.deep.equal({key: null, direction: 'descending'});
     });
   });
 
   describe('initial state', () => {
-    it('selectedRows should match default selectedRows prop', () => {
-      const {props, state} = render(<Table />).first();
-      state.selectedRows
-        .should.be.equal(props.selectedRows);
+    it('selectedRows should default to an empty array', () => {
+      render(<Table />)
+        .first()
+        .state.selectedRows
+        .should.deep.equal([]);
     });
 
     it('selectedRows should match defined selectedRows prop', () => {
@@ -218,7 +219,7 @@ describe('Table', () => {
         .findClass('sortable');
     });
 
-    it('is not auto applied when "onSortChange" prop is not present', () => {
+    it('is not auto applied by default', () => {
       it('does not have class "sortable"', () => {
         render(<Table />)
           .findClass('sd-table')
@@ -235,17 +236,15 @@ describe('Table', () => {
     });
 
     it('is auto applied when "selectedRows" prop is present', () => {
-      render(<Table selectRows={[]} />)
+      render(<Table selectedRows={[]} />)
         .findClass('selectable');
     });
 
-    it('is not auto applied when "onSelectRow" prop is not present', () => {
-      it('does not have class "selectable"', () => {
-        render(<Table />)
-          .findClass('sd-table')
-          .props.className
-          .should.not.include('selectable');
-      });
+    it('is not auto applied by default', () => {
+      render(<Table />)
+        .findClass('sd-table')
+        .props.className
+        .should.not.include('selectable');
     });
   });
 });

--- a/webpack.tests.babel.js
+++ b/webpack.tests.babel.js
@@ -50,9 +50,7 @@ module.exports = {
     ],
   },
   resolve: {
-    root: [
-      paths.docsRoot
-    ],
+    root: paths.root,
     modulesDirectories: [
       'node_modules',
       '.'

--- a/webpack.tests.babel.js
+++ b/webpack.tests.babel.js
@@ -51,10 +51,6 @@ module.exports = {
   },
   resolve: {
     root: paths.root,
-    modulesDirectories: [
-      'node_modules',
-      '.'
-    ],
     alias: {
       // When these key names are require()'d, the value will be supplied instead
       jquery: paths.testMocks + '/SemanticjQuery-mock.js',


### PR DESCRIPTION
Semantic UI supports a [`selectable` row table](http://semantic-ui.com/collections/table.html#selectable-row).  This just adds styling to the table.  There is also an [`active` row](http://semantic-ui.com/collections/table.html#active) style.

This PR combines the two, when you click a row (having added the `selectable` table class) the row will be set to `active`.  In addition, a callback prop `onSelectRow` will be called with the row data and the index so you can do what you may with it.  On table sort, the active row will be cleared.

---
- [x] enabled by `className='selectable'` and presence of `onSelectRow` prop
- [x] add onSelectRow callback, called with (rowData, index)
- [x] on select:
  - [x] clear active on all rows
  - [x] apply active to clicked row
- [x] toggle to deselect
- [x] accept a `selectedRows={[...index]}`
- [x] clear selectedRows on sort
