### PR TITLE
Add selectable table example

### DIFF
--- a/docs/app/Examples/collections/Table/TableExamples.js
+++ b/docs/app/Examples/collections/Table/TableExamples.js
@@ -1,0 +1,12 @@
+import React, {Component} from 'react';
+import TableVariationsExamples from './Variations/TableVariationsExamples';
+
+export default class TableExamples extends Component {
+  render() {
+    return (
+      <div>
+        <TableVariationsExamples />
+      </div>
+    );
+  }
+}

--- a/docs/app/Examples/collections/Table/Variations/TableSelectableExample.js
+++ b/docs/app/Examples/collections/Table/Variations/TableSelectableExample.js
@@ -1,0 +1,37 @@
+import _ from 'lodash';
+import faker from 'faker';
+import React, {Component} from 'react';
+import {Table, TableColumn, Segment} from 'stardust';
+
+const data = _.times(5, n => ({
+  name: faker.name.findName(),
+  phone: faker.phone.phoneNumber(),
+  state: faker.address.state(),
+}));
+
+export default class TableSelectableExample extends Component {
+  state = {};
+
+  handleSelectRow = (item, index) => {
+    this.setState({
+      selectedItem: JSON.stringify(item, null, 2),
+      selectedIndex: index,
+    });
+  };
+
+  render() {
+    const {selectedItem, selectedIndex} = this.state;
+    return (
+      <div>
+        <Table className='selectable' data={data} onSelectRow={this.handleSelectRow}>
+          <TableColumn dataKey='name' />
+          <TableColumn dataKey='phone' />
+          <TableColumn dataKey='state' />
+        </Table>
+        <Segment className='secondary' heading='Selected:'>
+          <pre>Index: {selectedIndex}{'\n'}Item: {selectedItem}</pre>
+        </Segment>
+      </div>
+    );
+  }
+}

--- a/docs/app/Examples/collections/Table/Variations/TableVariationsExamples.js
+++ b/docs/app/Examples/collections/Table/Variations/TableVariationsExamples.js
@@ -1,0 +1,17 @@
+import React, {Component} from 'react';
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection';
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample';
+
+export default class TableVariationsExamples extends Component {
+  render() {
+    return (
+      <ExampleSection title='Variations'>
+        <ComponentExample
+          title='Selectable'
+          description='A table can make its rows selectable'
+          examplePath='collections/Table/Variations/TableSelectableExample'
+        />
+      </ExampleSection>
+    );
+  }
+}


### PR DESCRIPTION
This PR adds a selectable table example, from the work in #155

![image](https://cloud.githubusercontent.com/assets/5067638/12669387/f71c5a20-c614-11e5-99d3-7b408c386768.png)
