### PR TITLE
Add subcomponents

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentExample.js
+++ b/docs/app/Components/ComponentDoc/ComponentExample.js
@@ -1,5 +1,5 @@
 import React, { Component, createElement, PropTypes } from 'react'
-import { Grid, Column, Button } from 'stardust'
+import { Grid, Button } from 'stardust'
 import Highlight from 'react-highlight'
 import exampleContext from 'docs/app/utils/ExampleContext'
 
@@ -38,11 +38,11 @@ export default class ComponentExample extends Component {
 
   render() {
     const code = (
-      <Column>
+      <Grid.Column>
         <Highlight className='language-javascript'>
           {this.fileContents}
         </Highlight>
-      </Column>
+      </Grid.Column>
     )
 
     const linkIconStyle = {
@@ -50,13 +50,13 @@ export default class ComponentExample extends Component {
       marginLeft: '0.25em',
     }
 
-    const children = <Column>{this.props.children}</Column>
+    const children = <Grid.Column>{this.props.children}</Grid.Column>
 
     return (
       <Grid className='one column' style={{ marginBottom: '4em' }} id={this.anchor}>
-        <Column>
+        <Grid.Column>
           <Grid>
-            <Column width={12}>
+            <Grid.Column width={12}>
               <h3
                 className='ui header'
                 style={{ marginBottom: 0 }}
@@ -69,19 +69,19 @@ export default class ComponentExample extends Component {
                 </a>
               </h3>
               <p>{this.props.description}</p>
-            </Column>
-            <Column width={4} className='right aligned'>
+            </Grid.Column>
+            <Grid.Column width={4} className='right aligned'>
               <Button className='basic mini labeled icon' onClick={this.toggleShowCode}>
                 code
                 <i className='code icon' />
               </Button>
-            </Column>
+            </Grid.Column>
           </Grid>
-        </Column>
+        </Grid.Column>
         {this.props.children && children}
-        <Column>
+        <Grid.Column>
           {createElement(this.component)}
-        </Column>
+        </Grid.Column>
         {this.state.showCode && code}
       </Grid>
     )

--- a/docs/app/Components/ComponentDoc/ComponentProps.js
+++ b/docs/app/Components/ComponentDoc/ComponentProps.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import React, { Component, PropTypes } from 'react'
-import { Header, Segment, Table, TableColumn } from 'stardust'
+import { Header, Segment, Table } from 'stardust'
 
 const DOCBLOCK_DESCRIPTION_DEFAULTS = {
   children: 'Body of the component.',
@@ -65,10 +65,10 @@ export default class ComponentProps extends Component {
       <Segment className='basic vertical'>
         <Header.H2 className='ui header'>Props</Header.H2>
         <Table data={content} className='very basic'>
-          <TableColumn dataKey='name' cellRenderer={this.nameRenderer} />
-          <TableColumn dataKey='type' />
-          <TableColumn dataKey='defaultValue' cellRenderer={this.defaultValueRenderer} />
-          <TableColumn dataKey='description' />
+          <Table.Column dataKey='name' cellRenderer={this.nameRenderer} />
+          <Table.Column dataKey='type' />
+          <Table.Column dataKey='defaultValue' cellRenderer={this.defaultValueRenderer} />
+          <Table.Column dataKey='description' />
         </Table>
       </Segment>
     )

--- a/docs/app/Components/Sidebar/Sidebar.js
+++ b/docs/app/Components/Sidebar/Sidebar.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import React, { Component } from 'react'
-import stardust, { Menu, MenuItem, Input } from 'stardust'
+import stardust, { Menu, Input } from 'stardust'
 import META from 'src/utils/Meta'
 
 export default class Sidebar extends Component {
@@ -23,7 +23,7 @@ export default class Sidebar extends Component {
       .sortBy((component, name) => name)
       .map(component => {
         const name = component._meta.name
-        return <MenuItem key={name} name={name} href={`#${name}`} />
+        return <Menu.Item key={name} name={name} href={`#${name}`} />
       })
       .value()
 
@@ -45,7 +45,7 @@ export default class Sidebar extends Component {
 
     return (
       <Menu className='inverted secondary vertical fluid' style={{ margin: 0 }}>
-        <MenuItem>
+        <Menu.Item>
           <Input
             className='transparent inverted icon'
             icon='search'
@@ -53,7 +53,7 @@ export default class Sidebar extends Component {
             iconClass='search link icon'
             onChange={this.handleSearchChange}
           />
-        </MenuItem>
+        </Menu.Item>
         {elements}
         {collections}
         {views}

--- a/docs/app/DocsApp.js
+++ b/docs/app/DocsApp.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { render } from 'react-dom'
-import stardust, { Grid, Column } from 'stardust'
+import stardust, { Grid } from 'stardust'
 
 import ComponentDoc from 'docs/app/Components/ComponentDoc/ComponentDoc'
 import DocsMenu from 'Components/Sidebar/Sidebar'
@@ -21,9 +21,9 @@ class DocsApp extends Component {
         </div>
         <div style={style.main}>
           <Grid className='padded'>
-            <Column>
+            <Grid.Column>
               {components}
-            </Column>
+            </Grid.Column>
           </Grid>
         </div>
       </div>

--- a/docs/app/Examples/collections/Table/Variations/TableSelectableExample.js
+++ b/docs/app/Examples/collections/Table/Variations/TableSelectableExample.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import faker from 'faker'
 import React, { Component } from 'react'
-import { Table, TableColumn, Segment } from 'stardust'
+import { Table, Segment } from 'stardust'
 
 const data = _.times(5, n => ({
   name: faker.name.findName(),
@@ -24,9 +24,9 @@ export default class TableSelectableExample extends Component {
     return (
       <div>
         <Table className='selectable' data={data} onSelectRow={this.handleSelectRow}>
-          <TableColumn dataKey='name' />
-          <TableColumn dataKey='phone' />
-          <TableColumn dataKey='state' />
+          <Table.Column dataKey='name' />
+          <Table.Column dataKey='phone' />
+          <Table.Column dataKey='state' />
         </Table>
         <Segment className='secondary' heading='Selected:'>
           <pre>Index: {selectedIndex}{'\n'}Item: {selectedItem}</pre>

--- a/docs/app/Examples/elements/Divider/Types/DividerVerticalExample.js
+++ b/docs/app/Examples/elements/Divider/Types/DividerVerticalExample.js
@@ -1,27 +1,27 @@
 import React, { Component } from 'react'
-import { Grid, Column, Segment, Divider } from 'stardust'
+import { Grid, Segment, Divider } from 'stardust'
 
 export default class DividerVerticalExample extends Component {
   render() {
     return (
       <Grid className='three column relaxed'>
-        <Column>
+        <Grid.Column>
           <Segment className='basic'>
             Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio.
           </Segment>
-        </Column>
+        </Grid.Column>
         <Divider className='vertical'>Or</Divider>
-        <Column>
+        <Grid.Column>
           <Segment className='basic'>
             Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio.
           </Segment>
-        </Column>
+        </Grid.Column>
         <Divider className='vertical'>And</Divider>
-        <Column>
+        <Grid.Column>
           <Segment className='basic'>
             Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio.
           </Segment>
-        </Column>
+        </Grid.Column>
       </Grid>
     )
   }

--- a/docs/app/Examples/elements/List/Content/ListDescriptionExample.js
+++ b/docs/app/Examples/elements/List/Content/ListDescriptionExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem } from 'stardust'
+import { List } from 'stardust'
 
 export default class ListDescriptionExample extends Component {
   render() {
@@ -7,8 +7,16 @@ export default class ListDescriptionExample extends Component {
 
     return (
       <List>
-        <ListItem icon={mapIcon} header='Chicago' description='This city is located in the state of Illinois' />
-        <ListItem icon={mapIcon} header='Nashville' description='This city is located in the state of Tennessee' />
+        <List.Item
+          icon={mapIcon}
+          header='Chicago'
+          description='This city is located in the state of Illinois'
+        />
+        <List.Item
+          icon={mapIcon}
+          header='Nashville'
+          description='This city is located in the state of Tennessee'
+        />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Content/ListHeaderExample.js
+++ b/docs/app/Examples/elements/List/Content/ListHeaderExample.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react'
-import { List, ListItem } from 'stardust'
+import { List } from 'stardust'
 
 export default class ListHeaderExample extends Component {
   render() {
     return (
       <List>
-        <ListItem header='Chapter 1' description='The chapter in which we meet the characters' />
-        <ListItem header='Chapter 2' description='The chapter in which the bad guy is introduced' />
-        <ListItem header='Chapter 3' description='Spoiler alert: The chapter in which the good guy wins!'/>
+        <List.Item header='Chapter 1' description='The chapter in which we meet the characters' />
+        <List.Item header='Chapter 2' description='The chapter in which the bad guy is introduced' />
+        <List.Item header='Chapter 3' description='Spoiler alert: The chapter in which the good guy wins!'/>
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Content/ListIconExample.js
+++ b/docs/app/Examples/elements/List/Content/ListIconExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem } from 'stardust'
+import { List } from 'stardust'
 
 export default class ListIconExample extends Component {
   render() {
@@ -8,19 +8,19 @@ export default class ListIconExample extends Component {
 
     return (
       <List>
-        <ListItem
+        <List.Item
           icon={helpIcon}
           header='Floated Icon'
           description='This text will always have a left margin so it sits alongside the icon'
         />
-        <ListItem
+        <List.Item
           icon={triangleIcon}
           header='Icon Alignment'
           description='Floated icons are by default top aligned'
         />
-        <ListItem icon={helpIcon}>
+        <List.Item icon={helpIcon}>
           This item uses <code>child</code> text, check the code.
-        </ListItem>
+        </List.Item>
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Content/ListImageExample.js
+++ b/docs/app/Examples/elements/List/Content/ListImageExample.js
@@ -1,6 +1,6 @@
 import faker from 'faker'
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 
 export default class ListImageExample extends Component {
   render() {
@@ -9,9 +9,9 @@ export default class ListImageExample extends Component {
     const danielAvatar = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List>
-        <ListItem image={helenAvatar} header='Helen' />
-        <ListItem image={christianAvatar} header='Christian' />
-        <ListItem image={danielAvatar} header='Daniel' />
+        <List.Item image={helenAvatar} header='Helen' />
+        <List.Item image={christianAvatar} header='Christian' />
+        <List.Item image={danielAvatar} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Content/ListItemExample.js
+++ b/docs/app/Examples/elements/List/Content/ListItemExample.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react'
-import { List, ListItem } from 'stardust'
+import { List } from 'stardust'
 
 export default class ListItemExample extends Component {
   render() {
     return (
       <List>
-        <ListItem description='1' />
-        <ListItem description='2' />
-        <ListItem description='3' />
+        <List.Item description='1' />
+        <List.Item description='2' />
+        <List.Item description='3' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Content/ListLinkExample.js
+++ b/docs/app/Examples/elements/List/Content/ListLinkExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem } from 'stardust'
+import { List } from 'stardust'
 
 export default class ListLinkExample extends Component {
   render() {
@@ -8,9 +8,9 @@ export default class ListLinkExample extends Component {
     const link3 = <a>Where is our office located?</a>
     return (
       <List>
-        <ListItem description={link1} />
-        <ListItem description={link2} />
-        <ListItem description={link3} />
+        <List.Item description={link1} />
+        <List.Item description={link2} />
+        <List.Item description={link3} />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Types/ListBulletedExample.js
+++ b/docs/app/Examples/elements/List/Types/ListBulletedExample.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react'
-import { List, ListItem } from 'stardust'
+import { List } from 'stardust'
 
 export default class ListBulletedExample extends Component {
   render() {
     return (
       <List className='bulleted'>
-        <ListItem description='Apples' />
-        <ListItem description='Pears' />
-        <ListItem description='Oranges' />
+        <List.Item description='Apples' />
+        <List.Item description='Pears' />
+        <List.Item description='Oranges' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Types/ListLinkExample.js
+++ b/docs/app/Examples/elements/List/Types/ListLinkExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem } from 'stardust'
+import { List } from 'stardust'
 
 export default class ListLinkExample extends Component {
   render() {
@@ -9,10 +9,10 @@ export default class ListLinkExample extends Component {
     const link4 = <a>Careers</a>
     return (
       <List className='link'>
-        <ListItem className='active' description={link1} />
-        <ListItem description={link2} />
-        <ListItem description={link3} />
-        <ListItem description={link4} />
+        <List.Item className='active' description={link1} />
+        <List.Item description={link2} />
+        <List.Item description={link3} />
+        <List.Item description={link4} />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Types/ListListExample.js
+++ b/docs/app/Examples/elements/List/Types/ListListExample.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react'
-import { List, ListItem } from 'stardust'
+import { List } from 'stardust'
 
 export default class ListListExample extends Component {
   render() {
     return (
       <List>
-        <ListItem description='Apples' />
-        <ListItem description='Pears' />
-        <ListItem description='Oranges' />
+        <List.Item description='Apples' />
+        <List.Item description='Pears' />
+        <List.Item description='Oranges' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Types/ListOrderedExample.js
+++ b/docs/app/Examples/elements/List/Types/ListOrderedExample.js
@@ -1,19 +1,19 @@
 import React, { Component } from 'react'
-import { List, ListItem } from 'stardust'
+import { List } from 'stardust'
 
 export default class ListOrderedExample extends Component {
   render() {
     return (
       <List className='ordered'>
-        <ListItem description='Apples'>
+        <List.Item description='Apples'>
           <List>
-            <ListItem description='Fuji' />
-            <ListItem description='Granny Smith' />
-            <ListItem description='Honeycrisp' />
+            <List.Item description='Fuji' />
+            <List.Item description='Granny Smith' />
+            <List.Item description='Honeycrisp' />
           </List>
-        </ListItem>
-        <ListItem description='Pears' />
-        <ListItem description='Oranges' />
+        </List.Item>
+        <List.Item description='Pears' />
+        <List.Item description='Oranges' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListAnimatedExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListAnimatedExample.js
@@ -1,6 +1,6 @@
 import faker from 'faker'
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 
 export default class ListAnimatedExample extends Component {
   render() {
@@ -9,9 +9,9 @@ export default class ListAnimatedExample extends Component {
     const avatar3 = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='middle aligned animated'>
-        <ListItem image={avatar1} header='Helen' />
-        <ListItem image={avatar2} header='Christian' />
-        <ListItem image={avatar3} header='Daniel' />
+        <List.Item image={avatar1} header='Helen' />
+        <List.Item image={avatar2} header='Christian' />
+        <List.Item image={avatar3} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListCelledExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListCelledExample.js
@@ -1,6 +1,6 @@
 import faker from 'faker'
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 
 export default class ListCelledExample extends Component {
   render() {
@@ -9,9 +9,9 @@ export default class ListCelledExample extends Component {
     const avatar3 = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='celled'>
-        <ListItem image={avatar1} header='Helen' />
-        <ListItem image={avatar2} header='Christian' />
-        <ListItem image={avatar3} header='Daniel' />
+        <List.Item image={avatar1} header='Helen' />
+        <List.Item image={avatar2} header='Christian' />
+        <List.Item image={avatar3} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListDividedExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListDividedExample.js
@@ -1,6 +1,6 @@
 import faker from 'faker'
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 
 export default class ListDividedExample extends Component {
   render() {
@@ -9,9 +9,9 @@ export default class ListDividedExample extends Component {
     const avatar3 = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='middle aligned divided'>
-        <ListItem image={avatar1} header='Helen' />
-        <ListItem image={avatar2} header='Christian' />
-        <ListItem image={avatar3} header='Daniel' />
+        <List.Item image={avatar1} header='Helen' />
+        <List.Item image={avatar2} header='Christian' />
+        <List.Item image={avatar3} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListHorizontalExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListHorizontalExample.js
@@ -1,6 +1,6 @@
 import faker from 'faker'
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 
 export default class ListHorizontalExample extends Component {
   render() {
@@ -9,9 +9,9 @@ export default class ListHorizontalExample extends Component {
     const image3 = <Image className='avatar' src={faker.image.city(100, 100)} />
     return (
       <List className='horizontal'>
-        <ListItem image={image1} header='Chicago' description='This city is located in the state of Illinois' />
-        <ListItem image={image2} header='Indianapolis' description='This city is located in the state of Indiana' />
-        <ListItem image={image3} header='Nashville' description='This city is located in the state of Tennessee' />
+        <List.Item image={image1} header='Chicago' description='This city is located in the state of Illinois' />
+        <List.Item image={image2} header='Indianapolis' description='This city is located in the state of Indiana' />
+        <List.Item image={image3} header='Nashville' description='This city is located in the state of Tennessee' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListInvertedExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListInvertedExample.js
@@ -1,14 +1,14 @@
 import React, { Component } from 'react'
-import { Segment, List, ListItem } from 'stardust'
+import { Segment, List } from 'stardust'
 
 export default class ListInvertedExample extends Component {
   render() {
     return (
       <Segment className='inverted'>
         <List className='inverted relaxed divided'>
-          <ListItem header='Chicago' description='Located in the state of Illinois' />
-          <ListItem header='Indianapolis' description='Located in the state of Indiana' />
-          <ListItem header='Nashville' description='Located in the state of Tennessee' />
+          <List.Item header='Chicago' description='Located in the state of Illinois' />
+          <List.Item header='Indianapolis' description='Located in the state of Indiana' />
+          <List.Item header='Nashville' description='Located in the state of Tennessee' />
         </List>
       </Segment>
     )

--- a/docs/app/Examples/elements/List/Variations/ListRelaxedExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListRelaxedExample.js
@@ -1,6 +1,6 @@
 import faker from 'faker'
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 
 export default class ListRelaxedExample extends Component {
   render() {
@@ -9,9 +9,9 @@ export default class ListRelaxedExample extends Component {
     const avatar3 = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='relaxed'>
-        <ListItem image={avatar1} header='Helen' />
-        <ListItem image={avatar2} header='Christian' />
-        <ListItem image={avatar3} header='Daniel' />
+        <List.Item image={avatar1} header='Helen' />
+        <List.Item image={avatar2} header='Christian' />
+        <List.Item image={avatar3} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListSelectionExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListSelectionExample.js
@@ -1,6 +1,6 @@
 import faker from 'faker'
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 
 export default class ListSelectionExample extends Component {
   render() {
@@ -9,9 +9,9 @@ export default class ListSelectionExample extends Component {
     const avatar3 = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='selection'>
-        <ListItem image={avatar1} header='Helen' />
-        <ListItem image={avatar2} header='Christian' />
-        <ListItem image={avatar3} header='Daniel' />
+        <List.Item image={avatar1} header='Helen' />
+        <List.Item image={avatar2} header='Christian' />
+        <List.Item image={avatar3} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListSizeBigExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListSizeBigExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 import faker from 'faker'
 
 export default class ListSizeBigExample extends Component {
@@ -9,9 +9,9 @@ export default class ListSizeBigExample extends Component {
     const danielAvatar = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='big horizontal divided'>
-        <ListItem image={helenAvatar} header='Helen' />
-        <ListItem image={christianAvatar} header='Christian' />
-        <ListItem image={danielAvatar} header='Daniel' />
+        <List.Item image={helenAvatar} header='Helen' />
+        <List.Item image={christianAvatar} header='Christian' />
+        <List.Item image={danielAvatar} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListSizeHugeExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListSizeHugeExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 import faker from 'faker'
 
 export default class ListSizeHugeExample extends Component {
@@ -9,9 +9,9 @@ export default class ListSizeHugeExample extends Component {
     const danielAvatar = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='huge horizontal divided'>
-        <ListItem image={helenAvatar} header='Helen' />
-        <ListItem image={christianAvatar} header='Christian' />
-        <ListItem image={danielAvatar} header='Daniel' />
+        <List.Item image={helenAvatar} header='Helen' />
+        <List.Item image={christianAvatar} header='Christian' />
+        <List.Item image={danielAvatar} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListSizeLargeExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListSizeLargeExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 import faker from 'faker'
 
 export default class ListSizeLargeExample extends Component {
@@ -9,9 +9,9 @@ export default class ListSizeLargeExample extends Component {
     const danielAvatar = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='large horizontal divided'>
-        <ListItem image={helenAvatar} header='Helen' />
-        <ListItem image={christianAvatar} header='Christian' />
-        <ListItem image={danielAvatar} header='Daniel' />
+        <List.Item image={helenAvatar} header='Helen' />
+        <List.Item image={christianAvatar} header='Christian' />
+        <List.Item image={danielAvatar} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListSizeMassiveExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListSizeMassiveExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 import faker from 'faker'
 
 export default class ListSizeMassiveExample extends Component {
@@ -9,9 +9,9 @@ export default class ListSizeMassiveExample extends Component {
     const danielAvatar = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='massive horizontal divided'>
-        <ListItem image={helenAvatar} header='Helen' />
-        <ListItem image={christianAvatar} header='Christian' />
-        <ListItem image={danielAvatar} header='Daniel' />
+        <List.Item image={helenAvatar} header='Helen' />
+        <List.Item image={christianAvatar} header='Christian' />
+        <List.Item image={danielAvatar} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListSizeMiniExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListSizeMiniExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 import faker from 'faker'
 
 export default class ListSizeMiniExample extends Component {
@@ -9,9 +9,9 @@ export default class ListSizeMiniExample extends Component {
     const danielAvatar = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='mini horizontal divided'>
-        <ListItem image={helenAvatar} header='Helen' />
-        <ListItem image={christianAvatar} header='Christian' />
-        <ListItem image={danielAvatar} header='Daniel' />
+        <List.Item image={helenAvatar} header='Helen' />
+        <List.Item image={christianAvatar} header='Christian' />
+        <List.Item image={danielAvatar} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListSizeSmallExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListSizeSmallExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 import faker from 'faker'
 
 export default class ListSizeSmallExample extends Component {
@@ -9,9 +9,9 @@ export default class ListSizeSmallExample extends Component {
     const danielAvatar = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='small horizontal divided'>
-        <ListItem image={helenAvatar} header='Helen' />
-        <ListItem image={christianAvatar} header='Christian' />
-        <ListItem image={danielAvatar} header='Daniel' />
+        <List.Item image={helenAvatar} header='Helen' />
+        <List.Item image={christianAvatar} header='Christian' />
+        <List.Item image={danielAvatar} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListSizeTinyExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListSizeTinyExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 import faker from 'faker'
 
 export default class ListSizeTinyExample extends Component {
@@ -9,9 +9,9 @@ export default class ListSizeTinyExample extends Component {
     const danielAvatar = <Image className='avatar' src={faker.image.avatar()} />
     return (
       <List className='tiny horizontal divided'>
-        <ListItem image={helenAvatar} header='Helen' />
-        <ListItem image={christianAvatar} header='Christian' />
-        <ListItem image={danielAvatar} header='Daniel' />
+        <List.Item image={helenAvatar} header='Helen' />
+        <List.Item image={christianAvatar} header='Christian' />
+        <List.Item image={danielAvatar} header='Daniel' />
       </List>
     )
   }

--- a/docs/app/Examples/elements/List/Variations/ListVeryRelaxedExample.js
+++ b/docs/app/Examples/elements/List/Variations/ListVeryRelaxedExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { List, ListItem, Image } from 'stardust'
+import { List, Image } from 'stardust'
 import faker from 'faker'
 
 export default class ListVeryRelaxedExample extends Component {
@@ -10,9 +10,9 @@ export default class ListVeryRelaxedExample extends Component {
 
     return (
       <List className='very relaxed'>
-        <ListItem image={avatar1} header='Helen' />
-        <ListItem image={avatar2} header='Christian' />
-        <ListItem image={avatar3} header='Daniel' />
+        <List.Item image={avatar1} header='Helen' />
+        <List.Item image={avatar2} header='Christian' />
+        <List.Item image={avatar3} header='Daniel' />
       </List>
     )
   }

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -4,7 +4,7 @@ import React, { Component, PropTypes } from 'react'
 import classNames from 'classnames'
 import META from '../../utils/Meta'
 import { getPluginProps, getComponentProps } from '../../utils/propUtils'
-import * as deprecate from '../../utils/deprecate'
+import { deprecateProps } from '../../utils/deprecate'
 
 const pluginPropTypes = {
   // form settings
@@ -47,7 +47,7 @@ export default class Form extends Component {
 
   constructor(props, context) {
     super(props, context)
-    deprecate.props(this, {
+    deprecateProps(this, {
       settings: 'Use a separate prop for each setting.',
     })
   }

--- a/src/collections/Grid/Grid.js
+++ b/src/collections/Grid/Grid.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames'
 import React, { Component, PropTypes } from 'react'
 import META from '../../utils/Meta'
+import Column from './Column'
+import Row from './Row'
 
 export default class Grid extends Component {
   static propTypes = {
@@ -13,6 +15,9 @@ export default class Grid extends Component {
     name: 'Grid',
     type: META.type.collection,
   };
+
+  static Column = Column;
+  static Row = Row;
 
   render() {
     const classes = classNames(

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react'
 import classNames from 'classnames'
 import META from '../../utils/Meta'
 import getUnhandledProps from '../../utils/getUnhandledProps'
+import MenuItem from './MenuItem'
 
 export default class Menu extends Component {
   static propTypes = {
@@ -21,6 +22,8 @@ export default class Menu extends Component {
     name: 'Menu',
     type: META.type.collection,
   };
+
+  static Item = MenuItem;
 
   render() {
     const classes = classNames(

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -3,6 +3,7 @@ import React, { Children, Component, PropTypes } from 'react'
 import classNames from 'classnames'
 import { customPropTypes } from '../../utils/propUtils'
 import META from '../../utils/Meta'
+import TableColumn from './TableColumn'
 
 export default class Table extends Component {
   static propTypes = {
@@ -36,6 +37,8 @@ export default class Table extends Component {
     // React cannot render objects, stringify them instead
     return _.isObject(content) ? JSON.stringify(content) : content
   }
+
+  static Column = TableColumn;
 
   _isRowSelected(index) {
     return _.includes(this.state.selectedRows, index)

--- a/src/elements/List/List.js
+++ b/src/elements/List/List.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import classNames from 'classnames'
 import META from '../../utils/Meta'
+import ListItem from './ListItem'
 
 export default class List extends Component {
   static propTypes = {
@@ -13,6 +14,8 @@ export default class List extends Component {
     name: 'List',
     type: META.type.element,
   };
+
+  static Item = ListItem;
 
   render() {
     const classes = classNames(

--- a/src/index.js
+++ b/src/index.js
@@ -50,12 +50,10 @@ const stardust = {
   Textarea,
 
   // Collections
-  Column,
   Field,
   Fields,
   Form,
   Grid,
-  Row,
   Menu,
   Message,
   Table,
@@ -85,12 +83,14 @@ const stardust = {
 }
 
 deprecateComponents(stardust, [
+  [Column, `Use "Grid.Column" instead.`],
   [TableColumn, `Use "Table.Column" instead.`],
   [ListItem, `Use "List.Item" instead.`],
   [MenuItem, `Use "List.Item" instead.`],
   [ModalContent, `Use "Modal.Content" instead.`],
   [ModalFooter, `Use "Modal.Footer" instead.`],
   [ModalHeader, `Use "Modal.Header" instead.`],
+  [Row, `Use "Grid.Row" instead.`],
 ])
 
 export default stardust

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { deprecateSubComponents } from './utils/deprecate'
+import { deprecateComponents } from './utils/deprecate'
 
 // Addons
 import Confirm from './addons/Confirm/Confirm'
@@ -90,12 +90,12 @@ const stardust = {
   Statistic,
 }
 
-deprecateSubComponents(stardust, [
-  TableColumn,
-  ListItem,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-])
+deprecateComponents(stardust, {
+  TableColumn: `Use "Table.Column" instead.`,
+  ListItem: `Use "List.Item" instead.`,
+  ModalContent: `Use "Modal.Content" instead.`,
+  ModalFooter: `Use "Modal.Footer" instead.`,
+  ModalHeader: `Use "Modal.Header" instead.`,
+})
 
 export default stardust

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import { deprecateSubComponents } from './utils/deprecate'
+
 // Addons
 import Confirm from './addons/Confirm/Confirm'
 import Textarea from './addons/Textarea/Textarea'
@@ -87,5 +89,13 @@ const stardust = {
   Items,
   Statistic,
 }
+
+deprecateSubComponents(stardust, [
+  TableColumn,
+  ListItem,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+])
 
 export default stardust

--- a/src/index.js
+++ b/src/index.js
@@ -57,10 +57,8 @@ const stardust = {
   Grid,
   Row,
   Menu,
-  MenuItem,
   Message,
   Table,
-  TableColumn,
 
   // Elements
   Button,
@@ -71,7 +69,6 @@ const stardust = {
   Image,
   Input,
   List,
-  ListItem,
   Segment,
   Segments,
 
@@ -79,9 +76,6 @@ const stardust = {
   Checkbox,
   Dropdown,
   Modal,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
   Progress,
 
   // Views

--- a/src/index.js
+++ b/src/index.js
@@ -90,12 +90,13 @@ const stardust = {
   Statistic,
 }
 
-deprecateComponents(stardust, {
-  TableColumn: `Use "Table.Column" instead.`,
-  ListItem: `Use "List.Item" instead.`,
-  ModalContent: `Use "Modal.Content" instead.`,
-  ModalFooter: `Use "Modal.Footer" instead.`,
-  ModalHeader: `Use "Modal.Header" instead.`,
-})
+deprecateComponents(stardust, [
+  [TableColumn, `Use "Table.Column" instead.`],
+  [ListItem, `Use "List.Item" instead.`],
+  [MenuItem, `Use "List.Item" instead.`],
+  [ModalContent, `Use "Modal.Content" instead.`],
+  [ModalFooter, `Use "Modal.Footer" instead.`],
+  [ModalHeader, `Use "Modal.Header" instead.`],
+])
 
 export default stardust

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -1,6 +1,9 @@
 import React, { Component, PropTypes } from 'react'
 import classNames from 'classnames'
 import META from '../../utils/Meta'
+import ModalContent from './ModalContent'
+import ModalHeader from './ModalHeader'
+import ModalFooter from './ModalFooter'
 
 export default class Modal extends Component {
   static propTypes = {
@@ -15,6 +18,10 @@ export default class Modal extends Component {
   };
 
   state = { isShown: false };
+
+  static Content = ModalContent;
+  static Header = ModalHeader;
+  static Footer = ModalFooter;
 
   showModal = () => {
     this.setState({ isShown: true })

--- a/src/utils/deprecate.js
+++ b/src/utils/deprecate.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import _ from 'lodash'
 
 /**
@@ -7,12 +8,28 @@ import _ from 'lodash'
  *   The component name and "is deprecated" is automatically added.
  *   Only add help messages as values.
  */
-export const props = (context, deprecated) => {
+export const deprecateProps = (context, deprecated) => {
   if (process.env.NODE_ENV === 'production') return
   const warnings = _.pick(deprecated, _.keys(context.props))
   _.each(warnings, (val, key) => {
-    /* eslint-disable no-console */
     console.warn(`Stardust ${context.constructor.name} prop "${key}" is deprecated. ${val}`)
-    /* eslint-enable no-console */
+  })
+}
+
+/**
+ * Show a deprecated warning for sub components.
+ * @param {object} stardust A reference to Stardust.
+ * @param {React.Component[]} subComponents The components to deprecate.
+ */
+export const deprecateSubComponents = (stardust, subComponents) => {
+  subComponents.forEach(SubComponent => {
+    const name = SubComponent.prototype.constructor.name
+    const newName = _.words(name).join('.')
+    Object.defineProperty(stardust, name, {
+      get() {
+        console.warn(`Stardust component "${name}" is deprecated. Use "${newName}" instead.`)
+        return SubComponent
+      },
+    })
   })
 }

--- a/src/utils/deprecate.js
+++ b/src/utils/deprecate.js
@@ -19,16 +19,17 @@ export const deprecateProps = (context, deprecated) => {
 /**
  * Show a deprecated warning for Stardust components.
  * @param {object} stardust A reference to Stardust.
- * @param {object} deprecated Keys/values are deprecated components/warning messages.
+ * @param {array} deprecated Two dimensional array.
+ *   Elements in second dimension are deprecated components/warning messages.
  *   The component name and "is deprecated" is automatically added.
  *   Only add help messages as values.
  */
 export const deprecateComponents = (stardust, deprecated) => {
-  _.each(deprecated, (warning, componentName) => {
-    const component = stardust[componentName]
-    Object.defineProperty(stardust, componentName, {
+  _.each(deprecated, ([component, warning]) => {
+    const name = component.prototype.constructor.name
+    Object.defineProperty(stardust, name, {
       get() {
-        console.warn(`Stardust component "${componentName}" is deprecated. ${warning}`)
+        console.warn(`Stardust component "${name}" is deprecated. ${warning}`)
         return component
       },
     })

--- a/src/utils/deprecate.js
+++ b/src/utils/deprecate.js
@@ -17,18 +17,19 @@ export const deprecateProps = (context, deprecated) => {
 }
 
 /**
- * Show a deprecated warning for sub components.
+ * Show a deprecated warning for Stardust components.
  * @param {object} stardust A reference to Stardust.
- * @param {React.Component[]} subComponents The components to deprecate.
+ * @param {object} deprecated Keys/values are deprecated components/warning messages.
+ *   The component name and "is deprecated" is automatically added.
+ *   Only add help messages as values.
  */
-export const deprecateSubComponents = (stardust, subComponents) => {
-  subComponents.forEach(SubComponent => {
-    const name = SubComponent.prototype.constructor.name
-    const newName = _.words(name).join('.')
-    Object.defineProperty(stardust, name, {
+export const deprecateComponents = (stardust, deprecated) => {
+  _.each(deprecated, (warning, componentName) => {
+    const component = stardust[componentName]
+    Object.defineProperty(stardust, componentName, {
       get() {
-        console.warn(`Stardust component "${name}" is deprecated. Use "${newName}" instead.`)
-        return SubComponent
+        console.warn(`Stardust component "${componentName}" is deprecated. ${warning}`)
+        return component
       },
     })
   })

--- a/test/specs/collections/Menu/Menu-test.js
+++ b/test/specs/collections/Menu/Menu-test.js
@@ -1,7 +1,7 @@
 import faker from 'faker'
 import React from 'react'
 import { Simulate } from 'react-addons-test-utils'
-import { Menu, MenuItem } from 'stardust'
+import { Menu } from 'stardust'
 
 let string
 describe('Menu', () => {
@@ -15,23 +15,23 @@ describe('Menu', () => {
       .assertText(string)
   })
 
-  describe('MenuItem', () => {
+  describe('Menu.Item', () => {
     it('uses the name prop as text', () => {
-      render(<MenuItem name='This is an item' />)
+      render(<Menu.Item name='This is an item' />)
         .assertText('This is an item')
     })
     it('should not have a label by default', () => {
-      render(<MenuItem name='item' />)
+      render(<Menu.Item name='item' />)
         .scryClass('sd-menu-label')
         .should.have.length(0)
     })
     it('should not have active class by default', () => {
-      render(<MenuItem name='item' />)
+      render(<Menu.Item name='item' />)
         .scryClass('active')
         .should.have.length(0)
     })
     it('should render a label if prop given', () => {
-      render(<MenuItem name='item' label='37' />)
+      render(<Menu.Item name='item' label='37' />)
         .findClass('sd-menu-label')
         .textContent
         .should.equal('37')
@@ -39,8 +39,8 @@ describe('Menu', () => {
     it('should have active class if first child', () => {
       const [firstItem, secondItem] = render(
         <Menu>
-          <MenuItem name='item1' />
-          <MenuItem name='item2' />
+          <Menu.Item name='item1' />
+          <Menu.Item name='item2' />
         </Menu>
       ).scryClass('sd-menu-item')
 
@@ -55,8 +55,8 @@ describe('Menu', () => {
     it('should have active class after click', () => {
       const [firstItem, secondItem] = render(
         <Menu>
-          <MenuItem name='item1' />
-          <MenuItem name='item2' />
+          <Menu.Item name='item1' />
+          <Menu.Item name='item2' />
         </Menu>
       ).scryClass('sd-menu-item')
 

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import faker from 'faker'
 import React from 'react'
 import { Simulate } from 'react-addons-test-utils'
-import { Table, TableColumn } from 'stardust'
+import { Table } from 'stardust'
 import sandbox from 'test/utils/Sandbox-util'
 
 describe('Table', () => {
@@ -58,7 +58,7 @@ describe('Table', () => {
         const rowItem = { name: 'bob' }
         const row = render(
           <Table className='selectable' onSelectRow={spy} data={[rowItem]}>
-            <TableColumn dataKey='name' />
+            <Table.Column dataKey='name' />
           </Table>
         )
           .scryClass('sd-table-row')[0]
@@ -74,7 +74,7 @@ describe('Table', () => {
     it('uses Start Cased column dataKey as the default content', () => {
       render(
         <Table data={tableData}>
-          <TableColumn dataKey='firstName' />
+          <Table.Column dataKey='firstName' />
         </Table>
       )
         .findClass('sd-table-header')
@@ -84,7 +84,7 @@ describe('Table', () => {
     it('renders contents with headerRenderer', () => {
       render(
         <Table data={tableData}>
-          <TableColumn dataKey={randomDataKey} headerRenderer={() => 'YO!'} />
+          <Table.Column dataKey={randomDataKey} headerRenderer={() => 'YO!'} />
         </Table>
       )
         .findClass('sd-table-header')
@@ -96,7 +96,7 @@ describe('Table', () => {
     it('uses object values as default contents', () => {
       render(
         <Table data={tableData}>
-          <TableColumn dataKey={randomDataKey} />
+          <Table.Column dataKey={randomDataKey} />
         </Table>
       )
         .scryClass('sd-table-cell')
@@ -110,7 +110,7 @@ describe('Table', () => {
     it('renders contents with the cellRenderer', () => {
       render(
         <Table data={tableData}>
-          <TableColumn dataKey={randomDataKey} cellRenderer={() => 'REDACTED'} />
+          <Table.Column dataKey={randomDataKey} cellRenderer={() => 'REDACTED'} />
         </Table>
       )
         .scryClass('sd-table-cell')
@@ -123,7 +123,7 @@ describe('Table', () => {
       // use the permissions key here as it is an object
       render(
         <Table data={tableData}>
-          <TableColumn dataKey='permissions' />
+          <Table.Column dataKey='permissions' />
         </Table>
       )
         .scryClass('sd-table-cell')
@@ -137,7 +137,7 @@ describe('Table', () => {
     it('only contains cells that were defined in TableColumns', () => {
       render(
         <Table data={tableData}>
-          <TableColumn dataKey={randomDataKey} />
+          <Table.Column dataKey={randomDataKey} />
         </Table>
       )
         .scryClass('sd-table-cell')
@@ -160,7 +160,7 @@ describe('Table', () => {
     beforeEach(() => {
       rows = render(
         <Table className='selectable' data={[{ row: 1 }, { row: 2 }]}>
-          <TableColumn dataKey='row' />
+          <Table.Column dataKey='row' />
         </Table>
       )
         .scryClass('sd-table-row')
@@ -195,7 +195,7 @@ describe('Table', () => {
     it('unselects all rows', () => {
       const tree = render(
         <Table className='selectable' data={tableData} onSortChange={_.noop}>
-          <TableColumn dataKey={randomDataKey} />
+          <Table.Column dataKey={randomDataKey} />
         </Table>
       )
 


### PR DESCRIPTION
Fixes #99. Refactors to subcomponents, i.e. `TableColumn` => `Table.Column`.

Also adds deprecation warnings when using the old components:

![image](https://cloud.githubusercontent.com/assets/5067638/13001494/3bbb26fa-d11b-11e5-8311-fc745c010279.png)

Grid components were also made into sub components:

![image](https://cloud.githubusercontent.com/assets/5067638/13001969/a0d8b986-d11f-11e5-9a09-5b9e14c7fec7.png)
