### PR TITLE
Support full dropdown functionality

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
+++ b/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
@@ -1,0 +1,48 @@
+import _ from 'lodash'
+import cx from 'classnames'
+import faker from 'faker'
+import React, { Component } from 'react'
+import { Button, Dropdown } from 'stardust'
+
+const getOptions = () => _.times(3, () => {
+  const name = faker.name.findName()
+  return { text: name, value: _.snakeCase(name) }
+})
+
+export default class DropdownAsyncOptions extends Component {
+  state = { isFetching: false, value: [], options: [] }
+
+  handleChange = value => this.setState({ value })
+
+  // fake api call
+  fetchOptions = () => {
+    this.setState({ isFetching: true })
+
+    setTimeout(() => {
+      this.setState({ isFetching: false, options: getOptions() })
+      this.selectRandom()
+    }, 500)
+  }
+
+  selectRandom = () => this.setState({ value: _.sample(this.state.options).value })
+
+  render() {
+    const { options, isFetching, value } = this.state
+    const classes = cx('search selection multiple', { 'disabled loading': isFetching })
+
+    return (
+      <div>
+        <Button onClick={this.fetchOptions}>Fetch</Button>
+        <Button onClick={this.selectRandom} disabled={_.isEmpty(options)}>Random</Button>
+        <Dropdown
+          defaultText='Add Users'
+          className={classes}
+          options={options}
+          value={value}
+          onChange={this.handleChange}
+        />
+        <pre>{JSON.stringify(this.state, null, 2)}</pre>
+      </div>
+    )
+  }
+}

--- a/docs/app/Examples/modules/Dropdown/Content/Content.js
+++ b/docs/app/Examples/modules/Dropdown/Content/Content.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+export default class DropdownContentExamples extends Component {
+  render() {
+    return (
+      <ExampleSection title='Content'>
+        <ComponentExample
+          title='Async Options'
+          description="A dropdown's options can change over time"
+          examplePath='modules/Dropdown/Content/AsyncOptions'
+        />
+      </ExampleSection>
+    )
+  }
+}

--- a/docs/app/Examples/modules/Dropdown/DropdownExamples.js
+++ b/docs/app/Examples/modules/Dropdown/DropdownExamples.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react'
+import Types from './Types/Types'
+import Content from './Content/Content'
+import States from './States/States'
+
+export default class DropdownExamples extends Component {
+  render() {
+    return (
+      <div>
+        <Types />
+        <Content />
+        <States />
+      </div>
+    )
+  }
+}

--- a/docs/app/Examples/modules/Dropdown/States/Disabled.js
+++ b/docs/app/Examples/modules/Dropdown/States/Disabled.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react'
+import { Dropdown } from 'stardust'
+
+export default class DropdownDisabledExample extends Component {
+  render() {
+    return (
+      <Dropdown className='disabled' text='Dropdown'>
+        <Dropdown.Menu>
+          <Dropdown.Item text='Choice 1' />
+          <Dropdown.Item text='Choice 2' />
+          <Dropdown.Item text='Choice 3' />
+        </Dropdown.Menu>
+      </Dropdown>
+    )
+  }
+}

--- a/docs/app/Examples/modules/Dropdown/States/States.js
+++ b/docs/app/Examples/modules/Dropdown/States/States.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+export default class DropdownStatesExamples extends Component {
+  render() {
+    return (
+      <ExampleSection title='States'>
+        <ComponentExample
+          title='Disabled'
+          description='A disabled dropdown menu or item does not allow user interaction'
+          examplePath='modules/Dropdown/States/Disabled'
+        />
+      </ExampleSection>
+    )
+  }
+}

--- a/docs/app/Examples/modules/Dropdown/Types/Dropdown.js
+++ b/docs/app/Examples/modules/Dropdown/Types/Dropdown.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react'
+import { Dropdown } from 'stardust'
+
+export default class DropdownDropdownExample extends Component {
+  render() {
+    return (
+      <Dropdown text='File' action='hide'>
+        <Dropdown.Item text='New' />
+        <Dropdown.Item text='Open...' description='ctrl + o' />
+        <Dropdown.Item text='Save as...' description='ctrl + s' />
+        <Dropdown.Item text='Rename' description='ctrl + r' />
+        <Dropdown.Item text='Make a copy' />
+        <Dropdown.Item icon='trash' text='Move to trash' />
+        <Dropdown.Divider />
+        <Dropdown.Item text='Download As...' />
+        <Dropdown.Item text='Publish To Web'>
+          <Dropdown.Menu>
+            <Dropdown.Item text='Google Docs' />
+            <Dropdown.Item text='Google Drive' />
+            <Dropdown.Item text='Dropbox' />
+            <Dropdown.Item text='Adobe Creative Cloud' />
+            <Dropdown.Item text='Private FTP' />
+            <Dropdown.Item text='Another Service...' />
+          </Dropdown.Menu>
+        </Dropdown.Item>
+        {/* item text can also be defined as children */}
+        <Dropdown.Item>E-mail Collaborators</Dropdown.Item>
+      </Dropdown>
+    )
+  }
+}

--- a/docs/app/Examples/modules/Dropdown/Types/Types.js
+++ b/docs/app/Examples/modules/Dropdown/Types/Types.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+import { Message } from 'stardust'
+
+export default class DropdownTypesExamples extends Component {
+  render() {
+    return (
+      <ExampleSection title='Types'>
+        <ComponentExample
+          title='Dropdown'
+          description='A dropdown'
+          examplePath='modules/Dropdown/Types/Dropdown'
+        >
+          <Message>
+            Dropdown <code>children</code> are automatically wrapped in a
+            {' '}<code>{`<Dropdown.Menu />`}</code> for convenience.
+          </Message>
+        </ComponentExample>
+      </ExampleSection>
+    )
+  }
+}

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1,143 +1,203 @@
 import _ from 'lodash'
 import $ from 'jquery'
-import classNames from 'classnames'
+import cx from 'classnames'
 import React, { Component, PropTypes } from 'react'
-import META from '../../utils/Meta'
-import getUnhandledProps from '../../utils/getUnhandledProps'
 
-/* eslint react/jsx-sort-prop-types:0 */
+import META from '../../utils/Meta'
+import { getPluginProps, getComponentProps } from '../../utils/propUtils'
+import { customPropTypes } from '../../utils/propUtils'
+
+import DropdownDivider from './DropdownDivider'
+import DropdownItem from './DropdownItem'
+import DropdownMenu from './DropdownMenu'
+
+const pluginPropTypes = {
+  // Settings
+  action: PropTypes.string,
+  allowAdditions: PropTypes.bool,
+  allowCategorySelection: PropTypes.bool,
+  apiSettings: PropTypes.object,
+  fields: PropTypes.object,
+  forceSelection: PropTypes.bool,
+  glyphWidth: PropTypes.number,
+  label: PropTypes.object,
+  match: PropTypes.string,
+  maxSelections: PropTypes.number,
+  on: PropTypes.string,
+  placeholder: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+  ]),
+  saveRemoteData: PropTypes.bool,
+  useLabels: PropTypes.bool,
+
+  // Additional Settings
+  allowTab: PropTypes.bool,
+  context: PropTypes.object,
+  delay: PropTypes.object,
+  direction: PropTypes.string,
+  duration: PropTypes.number,
+  fullTextSearch: PropTypes.bool,
+  keepOnScreen: PropTypes.bool,
+  keys: PropTypes.object,
+  preserveHTML: PropTypes.bool,
+  showOnFocus: PropTypes.bool,
+  sortSelect: PropTypes.bool,
+  transition: PropTypes.string,
+
+  // Callbacks
+  onAdd: PropTypes.func,
+  onChange: PropTypes.func,
+  onHide: PropTypes.func,
+  onRemove: PropTypes.func,
+  onShow: PropTypes.func,
+  onLabelSelect: PropTypes.func,
+  onLabelRemove: PropTypes.func,
+  onLabelCreate: PropTypes.func,
+  onNoResults: PropTypes.func,
+}
+
 export default class Dropdown extends Component {
   static propTypes = {
-    // Settings
-    action: PropTypes.string,
-    allowAdditions: PropTypes.bool,
-    allowCategorySelection: PropTypes.bool,
-    apiSettings: PropTypes.object,
+    ...pluginPropTypes,
+    text: PropTypes.string,
+    defaultText: PropTypes.string,
     className: PropTypes.string,
-    fields: PropTypes.object,
-    forceSelection: PropTypes.bool,
-    glyphWidth: PropTypes.number,
-    label: PropTypes.object,
-    match: PropTypes.string,
-    maxSelections: PropTypes.number,
-    on: PropTypes.string,
-    options: PropTypes.arrayOf(PropTypes.shape({
-      value: PropTypes.string,
-      text: PropTypes.string,
-    })),
-    placeholder: PropTypes.oneOf([
+    children: customPropTypes.mutuallyExclusive(['options']),
+    icon: PropTypes.string,
+    defaultValue: PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.bool,
+      PropTypes.number,
+      PropTypes.arrayOf([
+        PropTypes.string,
+        PropTypes.number,
+      ]),
     ]),
-    saveRemoteData: PropTypes.bool,
-    useLabels: PropTypes.bool,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.arrayOf([
+        PropTypes.string,
+        PropTypes.number,
+      ]),
+    ]),
+    options: PropTypes.arrayOf(PropTypes.shape({
+      value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+      ]),
+      text: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+      ]),
+    })),
+  }
 
-    // Additional Settings
-    direction: PropTypes.string,
-    keepOnScreen: PropTypes.bool,
-    context: PropTypes.object,
-    fullTextSearch: PropTypes.bool,
-    preserveHTML: PropTypes.bool,
-    sortSelect: PropTypes.bool,
-    showOnFocus: PropTypes.bool,
-    allowTab: PropTypes.bool,
-    transition: PropTypes.string,
-    duration: PropTypes.number,
-    keys: PropTypes.object,
-    delay: PropTypes.object,
-
-    // Callbacks
-    onChange: PropTypes.func,
-    onShow: PropTypes.func,
-    onHide: PropTypes.func,
-    onNoResults: PropTypes.func,
-    onLabelSelect: PropTypes.func,
-    onLabelRemove: PropTypes.func,
-    onLabelCreate: PropTypes.func,
-    onAdd: PropTypes.func,
-    onRemove: PropTypes.func,
-  };
+  static defaultProps = {
+    icon: 'dropdown',
+  }
 
   componentDidMount() {
-    this.element = $(this.refs.select)
-    this.element.dropdown({
-      // Settings
-      action: this.props.action,
-      allowAdditions: this.props.allowAdditions,
-      allowCategorySelection: this.props.allowCategorySelection,
-      apiSettings: this.props.apiSettings,
-      fields: this.props.fields,
-      forceSelection: this.props.forceSelection,
-      glyphWidth: this.props.glyphWidth,
-      label: this.props.label,
-      match: this.props.match,
-      maxSelections: this.props.maxSelections,
-      on: this.props.on,
-      placeholder: this.props.placeholder,
-      saveRemoveData: this.props.saveRemoteData,
-      useLabels: this.props.useLabels,
-
-      // Additional Settings
-      direction: this.props.delay,
-      keepOnScreen: this.props.keys,
-      context: this.props.duration,
-      fullTextSearch: this.props.transition,
-      preserveHTML: this.props.allowTab,
-      sortSelect: this.props.showOnFocus,
-      showOnFocus: this.props.sortSelect,
-      allowTab: this.props.preserveHTML,
-      transition: this.props.fullTextSearch,
-      duration: this.props.context,
-      keys: this.props.keepOnScreen,
-      delay: this.props.direction,
-
-      // Callbacks
-      onChange: this.props.onChange,
-      onHide: this.props.onHide,
-      onShow: this.props.onShow,
-      onNoResults: this.props.onNoResults,
-      onLabelSelect: this.props.onLabelSelect,
-      onLabelRemove: this.props.onLabelRemove,
-      onLabelCreate: this.props.onLabelCreate,
-      onAdd: this.props.onAdd,
-      onRemove: this.props.onRemove,
+    this.element = $(this.refs.element).dropdown({
+      ...getPluginProps(this.props, pluginPropTypes),
+      onAdd: this.handleAdd,
+      onChange: this.handleChange,
+      onRemove: this.handleRemove,
     })
   }
 
   componentDidUpdate(prevProps, prevState) {
     this.element.dropdown('refresh')
+    const isDOMInSync = _.isEqual(this.props.value, this.getValue())
+    if (!isDOMInSync && this.isSelection()) this._syncFromProps()
   }
 
   componentWillUnmount() {
     this.element.off()
   }
 
+  handleAdd = (value) => {
+    if (this._isSyncing) return
+    if (this.props.onAdd) this.props.onAdd(value) // eslint-disable-line
+  }
+
+  handleChange = () => {
+    if (this._isSyncing) return
+    // callback with the appropriate value type
+    if (this.props.onChange) this.props.onChange(this.getValue()) // eslint-disable-line
+  }
+
+  handleRemove = (value) => {
+    if (this._isSyncing) return
+    if (this.props.onRemove) this.props.onRemove(value) // eslint-disable-line
+  }
+
+  // dropdown values are stored in a hidden input value (string)
+  // multiselect dropdown values should be arrays since they accept array values
+  // empty values should not be empty strings ""
+  getValue = () => {
+    const value = this.element.dropdown('get value')
+    if (value) {
+      // multiselect dropdown values are delimited strings
+      return this.isMultiselect() ? value.split(Dropdown._DELIMITER) : value
+    }
+
+    // sensible empty values
+    return this.isMultiselect() ? [] : undefined
+  }
+
+  // sync's the jQuery module to the React props
+  _syncFromProps = () => {
+    // flag that we are syncing so we don't call back on React -> DOM syncing changes
+    this._isSyncing = true
+    const { value } = this.props
+    this.setValue(value)
+    this._isSyncing = false
+  }
+
+  static _DELIMITER = ','
   static _meta = {
     library: META.library.semanticUI,
     name: 'Dropdown',
     type: META.type.module,
-  };
-
-  plugin() {
-    return this.element.dropdown(...arguments)
   }
+  static Divider = DropdownDivider
+  static Item = DropdownItem
+  static Menu = DropdownMenu
+
+  isMultiselect = () => _.includes(this.props.className, 'multiple')
+  isSelection = () => _.includes(this.props.className, 'selection')
+  setValue = (value) => this.element.dropdown('set exactly', value)
 
   render() {
-    const options = _.map(this.props.options, (opt, i) => {
-      return <option key={`${opt.value}-${i}`} value={opt.value}>{opt.text}</option>
-    })
-    const classes = classNames(
+    const { children, className, defaultText, defaultValue, icon, options, text } = this.props
+    const classes = cx(
       'sd-dropdown',
       'ui',
-      this.props.className,
+      className,
       'dropdown'
     )
-    const props = getUnhandledProps(this)
-
+    const iconClasses = cx(
+      'sd-dropdown-icon',
+      icon,
+      'icon'
+    )
+    const items = _.map(options, (opt, i) => (
+      <DropdownItem key={`${opt.value}-${i}`} data-text={opt.text} data-value={opt.value}>
+        {opt.text}
+      </DropdownItem>
+    ))
+    const componentProps = getComponentProps(this.props, pluginPropTypes)
     return (
-      <select {...props} className={classes} ref='select'>
-        {options}
-      </select>
+      <div {...componentProps} className={classes} ref='element'>
+        {this.isSelection() && <input type='hidden' defaultValue={defaultValue} />}
+        {text && <div className='text'>{text}</div>}
+        {icon && <i className={iconClasses} />}
+        {defaultText && <div className='default text'>{defaultText}</div>}
+        <DropdownMenu>
+          {children || items}
+        </DropdownMenu>
+      </div>
     )
   }
 }

--- a/src/modules/Dropdown/DropdownDivider.js
+++ b/src/modules/Dropdown/DropdownDivider.js
@@ -1,0 +1,21 @@
+import React, { Component, PropTypes } from 'react'
+import META from '../../utils/Meta'
+
+class DropdownDivider extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+  }
+
+  static _meta = {
+    library: META.library.semanticUI,
+    name: 'DropdownDivider',
+    parent: 'Dropdown',
+    type: META.type.module,
+  }
+
+  render() {
+    return <div className='sd-dropdown-divider divider' {...this.props} />
+  }
+}
+
+export default DropdownDivider

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -1,0 +1,56 @@
+import React, { Children, Component, PropTypes } from 'react'
+import cx from 'classnames'
+import META from '../../utils/Meta'
+
+export default class DropdownItem extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    description: PropTypes.string,
+    icon: PropTypes.string,
+    text: PropTypes.string,
+    value: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
+  };
+
+  static _meta = {
+    library: META.library.semanticUI,
+    name: 'DropdownItem',
+    parent: 'Dropdown',
+    type: META.type.module,
+  }
+
+  render() {
+    const { children, className, description, icon, text, value, ...rest } = this.props
+    const classes = cx(
+      'sd-dropdown-item',
+      'item',
+      className
+    )
+
+    // add default dropdown icon if item contains another menu
+    let iconName = icon
+    if (!icon) {
+      Children.map(children, (child) => {
+        iconName = child.type && child.type.name === 'DropdownMenu' && 'dropdown'
+      })
+    }
+
+    const iconClasses = cx(
+      'sd-dropdown-item-icon',
+      iconName,
+      'icon'
+    )
+
+    return (
+      <div className={classes} data-value={value} data-text={text} {...rest}>
+        {description && <span className='description'>{description}</span>}
+        {iconName && <i className={iconClasses} />}
+        {text}
+        {children}
+      </div>
+    )
+  }
+}

--- a/src/modules/Dropdown/DropdownMenu.js
+++ b/src/modules/Dropdown/DropdownMenu.js
@@ -1,0 +1,21 @@
+import React, { Component, PropTypes } from 'react'
+import META from '../../utils/Meta'
+
+class DropdownMenu extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+  }
+
+  static _meta = {
+    library: META.library.semanticUI,
+    name: 'DropdownMenu',
+    parent: 'Dropdown',
+    type: META.type.module,
+  }
+
+  render() {
+    return <div className='sd-dropdown-menu menu' {...this.props} />
+  }
+}
+
+export default DropdownMenu

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -2,14 +2,14 @@ import React from 'react'
 import { Dropdown } from 'stardust'
 
 describe('Dropdown', () => {
-  it('has a default value', () => {
+  it('accepts a default value', () => {
     const options = [
       { value: '', text: 'Please select a role' },
       { value: 'admin', text: 'Admin' },
       { value: 'editor', text: 'Editor' },
     ]
-    render(<Dropdown label='Roles' defaultValue='admin' options={options} />)
-      .findTag('select')
+    render(<Dropdown className='selection' defaultValue='admin' options={options} />)
+      .findTag('input')
       .value.should.equal('admin')
   })
   it('has assigned amount of options', () => {
@@ -21,11 +21,12 @@ describe('Dropdown', () => {
       { value: 'purple', text: 'purple' },
       { value: 'blue', text: 'blue' },
     ]
-    render(<Dropdown options={options} />)
-      .scryTag('option')
-      .map((opt, i) => {
-        opt.text.should.equal(options[i].text)
-        opt.value.should.equal(options[i].value)
-      })
+    const items = render(<Dropdown options={options} />)
+      .scryClass('sd-dropdown-item')
+    items.should.have.a.lengthOf(6)
+    items.map((item, i) => {
+      item.textContent.should.equal(options[i].text)
+      item.getAttribute('data-value').should.equal(options[i].value)
+    })
   })
 })


### PR DESCRIPTION
### [Try It](http://deweybot.taplatform.net/qa/src/stardust/feature/dynamic-dropdown-options/#Dropdown-Types-Dropdown)

There are **3 examples** written.  More will be added in other PRs later.
### Not as large as it looks

This PR includes 3 primary things:
1. Doc Site Examples
2. Test updates
3. Dropdown rewrite
### Done

Fixes #4 supporting all dropdown permutations.  Also fixes #149 supporting dynamic options.
- [x] add dropdown menu, item, and divider sub components
- [x] support icons
- [x] support item text/value/descriptions
- [x] add extended dropdown example using dropdown subcomponents
- [x] handle regular dropdowns (menu only style)
- [x] handle selection dropdowns, with hidden input for values
- [x] separate component / plugin prop types
- [x] componentDidUpdate
- [x] add async options example
