### PR TITLE
Update docs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,15 @@
   "extends": [
     "ta",
     "ta/frontend"
-  ]
+  ],
+  "rules": {
+    "react/sort-comp": 1
+  },
+  "globals": {
+    "__DEV__": false,
+    "__DEBUG__": false,
+    "__STAGING__": false,
+    "__TEST__": false,
+    "__PROD__": false
+  }
 }

--- a/docs/app/Components/ComponentDoc/ComponentDoc.js
+++ b/docs/app/Components/ComponentDoc/ComponentDoc.js
@@ -1,31 +1,31 @@
-import React, { Component, PropTypes } from 'react'
-import { Segment } from 'stardust'
+import React, { PropTypes } from 'react'
 
 import ComponentDescription from './ComponentDescription'
 import ComponentExamples from './ComponentExamples'
 import ComponentProps from './ComponentProps'
 import getComponentDocInfo from 'docs/app/utils/getComponentDocInfo'
 
-export default class ComponentDoc extends Component {
-  static propTypes = {
-    meta: PropTypes.object,
-  };
+const ComponentDoc = ({ _meta }) => {
+  // TODO remove util in favor of separate docgen.json in each component directory
+  // this util just parses out a single docgen file based on component path name
+  // our current docgen gulp task concats these into one, only for us to split it back out
+  const doc = getComponentDocInfo(_meta)
 
-  render() {
-    const doc = getComponentDocInfo(this.props.meta)
-
-    return (
-      <Segment id={doc.name}>
-        <ComponentDescription
-          path={doc.path}
-          name={doc.name}
-          parent={doc.parent}
-          type={doc.type}
-          description={doc.docBlock.description}
-        />
-        <ComponentProps props={doc.props} />
-        <ComponentExamples name={doc.name} />
-      </Segment>
-    )
-  }
+  return (
+    <div>
+      <ComponentDescription
+        _meta={_meta}
+        docgen={doc.docgen}
+        docPath={doc.docPath}
+      />
+      <ComponentProps props={doc.docgen.props} />
+      <ComponentExamples name={_meta.name} />
+    </div>
+  )
 }
+
+ComponentDoc.propTypes = {
+  _meta: PropTypes.object,
+}
+
+export default ComponentDoc

--- a/docs/app/Components/ComponentDoc/ComponentExamples.js
+++ b/docs/app/Components/ComponentDoc/ComponentExamples.js
@@ -1,30 +1,25 @@
-import React, { Component, PropTypes } from 'react'
-import { Segment } from 'stardust'
+import React, { Component, createElement, PropTypes } from 'react'
+
 import exampleContext from 'docs/app/utils/ExampleContext'
+import { Divider, Header } from 'stardust'
 
 export default class ComponentExamples extends Component {
   static propTypes = {
     name: PropTypes.string,
-  };
+  }
 
   render() {
+    const { name } = this.props
+
     const examples = exampleContext.keys()
-      .filter(path => path.includes(`/${this.props.name}Examples.js`))
-      .map((path, i) => {
-        const Example = exampleContext(path).default
-        return <Example key={i} />
-      })
+      .filter(path => path.includes(`/${name}Examples.js`))
+      .map((path, i) => createElement(exampleContext(path).default, { key: i }))
 
-    const content = (
-      <Segment className='basic vertical'>
-        <h2 className='ui header'>Examples</h2>
+    return !examples.length ? null : (
+      <div>
+        <Header.H2>Examples</Header.H2>
         {examples}
-      </Segment>
-    )
-
-    return (
-      <div className='stardust-examples'>
-        {!!examples.length && content}
+        <Divider className='hidden section' />
       </div>
     )
   }

--- a/docs/app/Components/ComponentDoc/ComponentProps.js
+++ b/docs/app/Components/ComponentDoc/ComponentProps.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import React, { Component, PropTypes } from 'react'
-import { Header, Segment, Table } from 'stardust'
+import { Divider, Header, Table } from 'stardust'
 
 const DOCBLOCK_DESCRIPTION_DEFAULTS = {
   children: 'Body of the component.',
@@ -62,15 +62,16 @@ export default class ComponentProps extends Component {
     })
 
     return (
-      <Segment className='basic vertical'>
-        <Header.H2 className='ui header'>Props</Header.H2>
-        <Table data={content} className='very basic'>
+      <div>
+        <Header.H2>Props</Header.H2>
+        <Table data={content} className='very basic compact'>
           <Table.Column dataKey='name' cellRenderer={this.nameRenderer} />
           <Table.Column dataKey='type' />
           <Table.Column dataKey='defaultValue' cellRenderer={this.defaultValueRenderer} />
           <Table.Column dataKey='description' />
         </Table>
-      </Segment>
+        <Divider className='hidden section' />
+      </div>
     )
   }
 }

--- a/docs/app/Components/Sidebar/Sidebar.js
+++ b/docs/app/Components/Sidebar/Sidebar.js
@@ -6,9 +6,9 @@ import META from 'src/utils/Meta'
 const { Menu, Input } = stardust
 
 export default class Sidebar extends Component {
-  state = { query: '' };
+  state = { query: '' }
 
-  handleSearchChange = e => this.setState({ query: e.target.value });
+  handleSearchChange = e => this.setState({ query: e.target.value })
 
   getComponentsByQuery() {
     return _.filter(stardust, component => {
@@ -29,17 +29,16 @@ export default class Sidebar extends Component {
       })
       .value()
 
-    const subMenu = (
+    return _.isEmpty(items) ? [] : (
       <div className='item'>
         <div className='header'>{_.capitalize(type)}s</div>
         <div className='menu'>{items}</div>
       </div>
     )
-
-    return items && subMenu
-  };
+  }
 
   render() {
+    const addons = this.getComponentsByType(META.type.addon)
     const elements = this.getComponentsByType(META.type.element)
     const collections = this.getComponentsByType(META.type.collection)
     const views = this.getComponentsByType(META.type.view)
@@ -56,6 +55,7 @@ export default class Sidebar extends Component {
             onChange={this.handleSearchChange}
           />
         </Menu.Item>
+        {addons}
         {elements}
         {collections}
         {views}

--- a/docs/app/DocsApp.js
+++ b/docs/app/DocsApp.js
@@ -1,6 +1,7 @@
 import 'semantic-ui-css/semantic.js'
 import 'semantic-ui-css/semantic.css'
 import 'highlight.js/styles/github.css'
+import _ from 'lodash'
 import React, { Component } from 'react'
 import { render } from 'react-dom'
 
@@ -10,15 +11,23 @@ import ComponentDoc from './Components/ComponentDoc/ComponentDoc'
 import DocsMenu from './Components/Sidebar/Sidebar'
 import style from './Style'
 
-const { Grid } = stardust
+const { Grid, Segment } = stardust
 
 class DocsApp extends Component {
   state = { menuSearch: '' };
 
   render() {
-    const components = Object.keys(stardust)
-      .sort()
-      .map(name => <ComponentDoc key={name} meta={stardust[name]._meta} />)
+    const components = _.map(stardust, '_meta')
+      .sort(({ name }) => name)
+      .map(_meta => (
+        <Grid.Row key={_meta.name} id={_meta.name}>
+          <Grid.Column>
+            <Segment className='basic'>
+              <ComponentDoc _meta={_meta} />
+            </Segment>
+          </Grid.Column>
+        </Grid.Row>
+      ))
 
     return (
       <div style={style.container}>
@@ -26,10 +35,8 @@ class DocsApp extends Component {
           <DocsMenu />
         </div>
         <div style={style.main}>
-          <Grid className='padded'>
-            <Grid.Column>
-              {components}
-            </Grid.Column>
+          <Grid className='vertically divided padded'>
+            {components}
           </Grid>
         </div>
       </div>

--- a/docs/app/utils/SemanticTypes.js
+++ b/docs/app/utils/SemanticTypes.js
@@ -1,9 +1,0 @@
-const SEMANTIC_TYPES = {
-  global: 'global',
-  collection: 'collection',
-  element: 'element',
-  view: 'view',
-  module: 'module',
-}
-
-export default SEMANTIC_TYPES

--- a/docs/app/utils/StardustTypes.js
+++ b/docs/app/utils/StardustTypes.js
@@ -1,5 +1,0 @@
-const STARDUST_TYPES = {
-  addon: 'addon',
-}
-
-export default STARDUST_TYPES

--- a/docs/app/utils/getComponentDocInfo.js
+++ b/docs/app/utils/getComponentDocInfo.js
@@ -9,14 +9,7 @@ import docgenInfo from '../docgenInfo.json'
  */
 export default (_meta) => {
   const docPath = _.find(_.keys(docgenInfo), path => path.includes(`/${_meta.name}.js`))
-  const definition = docgenInfo[docPath]
+  const docgen = docgenInfo[docPath]
 
-  return {
-    name: _meta.name,
-    path: docPath,
-    parent: _meta.parent,
-    type: _meta.type,
-    docBlock: definition.docBlock,
-    props: definition.props,
-  }
+  return { docPath, docgen }
 }

--- a/src/utils/Meta.js
+++ b/src/utils/Meta.js
@@ -1,60 +1,88 @@
 import _ from 'lodash'
+import * as stardust from 'stardust'
+
+const LIBRARIES = {
+  semanticUI: 'Semantic UI',
+  stardust: 'Stardust',
+}
+
+const TYPES = {
+  addon: 'addon',
+  global: 'global',
+  collection: 'collection',
+  element: 'element',
+  view: 'view',
+  module: 'module',
+}
+
+const LIBRARY_VALUES = _.values(LIBRARIES)
+const TYPE_VALUES = _.values(TYPES)
+const NAME_VALUES = _.keys(stardust)
+
+/**
+ * Determine if an object qualifies as a META object.
+ * It must have the required keys and valid values.
+ * @private
+ * @param {Object} _meta A proposed Stardust _meta object.
+ * @returns {Boolean}
+ */
+const isMeta = (_meta) => (
+  _.includes(LIBRARY_VALUES, _.get(_meta, 'library')) &&
+  _.includes(TYPE_VALUES, _.get(_meta, 'type')) &&
+  _.includes(NAME_VALUES, _.get(_meta, 'name'))
+)
+
+/**
+ * Extract the Stardust _meta object and optional key.
+ * Handles literal _meta objects, classes with _meta, objects with _meta
+ * @private
+ * @param {function|object} arg A class, a component instance, or meta object..
+ * @param {string} [key] A key to pluck from the _meta object.
+ * @returns {object|string|undefined}
+ */
+const getMeta = (arg, key) => {
+  let _meta = {}
+
+  // literal
+  if (isMeta(arg)) _meta = arg
+
+  // from prop
+  else if (isMeta(_.get(arg, '_meta'))) _meta = arg._meta
+
+  // from class
+  else if (isMeta(_.get(arg, 'constructor._meta'))) _meta = arg.constructor._meta
+
+  // default values
+  return key ? _meta[key] : _meta
+}
 
 /**
  * Component meta information.  Used to declaratively classify and identify components.
  * @type {{}}
  */
 const META = {
-  library: {
-    semanticUI: 'Semantic UI',
-    stardust: 'Stardust',
-  },
-
-  type: {
-    addon: 'addon',
-    global: 'global',
-    collection: 'collection',
-    element: 'element',
-    view: 'view',
-    module: 'module',
-  },
+  library: LIBRARIES,
+  type: TYPES,
 
   // library
-  isSemanticUI: ({ _meta }) => _meta.library === META.library.semanticUI,
-  isStardust: ({ _meta }) => _meta.library === META.library.stardust,
+  isSemanticUI: (arg) => getMeta(arg, 'library') === META.library.semanticUI,
+  isStardust: (arg) => getMeta(arg, 'library') === META.library.stardust,
 
   // type
-  isAddon: ({ _meta }) => _meta.type === META.type.addon,
-  isGlobal: ({ _meta }) => _meta.type === META.type.global,
-  isCollection: ({ _meta }) => _meta.type === META.type.collection,
-  isElement: ({ _meta }) => _meta.type === META.type.element,
-  isView: ({ _meta }) => _meta.type === META.type.view,
-  isModule: ({ _meta }) => _meta.type === META.type.module,
-  isType: ({ _meta }, type) => _meta.type === type,
+  isAddon: (arg) => getMeta(arg, 'type') === META.type.addon,
+  isGlobal: (arg) => getMeta(arg, 'type') === META.type.global,
+  isCollection: (arg) => getMeta(arg, 'type') === META.type.collection,
+  isElement: (arg) => getMeta(arg, 'type') === META.type.element,
+  isView: (arg) => getMeta(arg, 'type') === META.type.view,
+  isModule: (arg) => getMeta(arg, 'type') === META.type.module,
+  isType: (arg, type) => getMeta(arg, 'type') === type,
 
   // parent
-  isParent: (component) => (
-    // has no 'parent' or 'parent' is self
-    !_.has(component, '_meta.parent') || _.get(component, '_meta.parent') === component._meta.name
-  ),
-  isChild: component => !META.isParent(component),
+  isParent: (arg) => !getMeta(arg, 'parent'),
+  isChild: (arg) => !!getMeta(arg, 'parent'),
 
   // other
-  /**
-   * Components whose constructor begins with an "_" are private.
-   * This helper handles strings, classes, and instances and returns true if the
-   * name or class definition begins with an "_".
-   * @param {string|class|object} component A class, an instance, or constructor name.
-   * @returns {boolean}
-   */
-  isPrivate: component => {
-    // handle component names from a string, a class, or an instance
-    const name = _.isString(component) && component
-      || _.get(component, '_meta.name')
-      || _.get(component, '.constructor._meta.name')
-
-    return _.startsWith(name, '_')
-  },
+  isPrivate: (arg) => _.startsWith(getMeta(arg, 'name'), '_'),
 }
 
 export default META


### PR DESCRIPTION
This PR is a breakout of #206.  Several issues were addressed:
1. Robust `_meta` util
   
   > Used to define / identify our components in tests and docs.
2. Show `addons` in the sidebar.
   
   > These are Stardust components added to the SUI framework.
3. Show related components
   
   > The jsdoc `@see` tag now links to related components.  Used to relate Dropdown -> Select in the coming PR merge.
4. Fix the sidebar filtering.
   
   > Sections are no longer shown if there is no matching search.

---

**Blocked by**

~~https://github.com/TechnologyAdvice/stardust/pull/221~~
