### PR TITLE
List item prop renderers

### DIFF
--- a/src/elements/List/ListItem.js
+++ b/src/elements/List/ListItem.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from 'react'
 import cx from 'classnames'
+
 import META from '../../utils/Meta'
+import { iconPropRenderer, imagePropRenderer } from '../../utils/propUtils'
 
 export default class ListItem extends Component {
   static propTypes = {
@@ -23,18 +25,23 @@ export default class ListItem extends Component {
     const { children, className, description, header, icon, image, ...rest } = this.props
     const classes = cx('sd-list-item', className, 'item')
 
-    const content = !header ? description : (
-      <div className='content'>
-        <div className='header'>{header}</div>
-        {description && <div className='description'>{description}</div>}
-      </div>
+    const media = iconPropRenderer(icon) || imagePropRenderer(image)
+    const _description = description || children
+
+    let content = header ? [
+      header && <div key='header' className='header'>{header}</div>,
+      _description && <div key='description' className='description'>{_description}</div>,
+    ] : (
+      _description
     )
+
+    // wrap content for icon/image layouts
+    if (media) content = <div className='content'>{content}</div>
 
     return (
       <div {...rest} className={classes}>
-        {image || icon}
+        {media}
         {content}
-        {children}
       </div>
     )
   }


### PR DESCRIPTION
Breakout of #206, makes fixes to the list item component.

**Prop renderers**

Our [`propRenderers`](https://github.com/TechnologyAdvice/stardust/blob/master/src/utils/propUtils.js#L67) util gives us consistent intelligent handling of prop values.  In this case, `icon` and `image` props.  You can pass either a string or a component.  See link above.

In the case of a string value, a component will be created for you.  `icon='user'` would create an `<Icon />` with the `user` class.  `image='//placehold.it` would create an `<Image />` with the `src` attr set to the placehold.it url.
