### PR TITLE
Component utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "rimraf": "^2.5.2",
     "sass-loader": "^3.2.0",
     "semantic-ui-css": "^2.1.8",
+    "simulant": "^0.2.1",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "style-loader": "^0.13.1",

--- a/src/utils/childrenUtils.js
+++ b/src/utils/childrenUtils.js
@@ -16,9 +16,17 @@ export const someChild = (children, iteratee) => _.some(Children.toArray(childre
  * _.find for props.children.
  * @param {Object} children The children prop of a component.
  * @param {Array|Function|Object|string} iteratee The function invoked per iteration.
- * @returns {*|ReactElement}
+ * @returns {undefined|Object}
  */
 export const findChild = (children, iteratee) => _.find(Children.toArray(children), iteratee)
+
+/**
+ * _.filter for props.children.
+ * @param {Object} children The children prop of a component.
+ * @param {Array|Function|Object|string} iteratee The function invoked per iteration.
+ * @returns {Array}
+ */
+export const filterChildren = (children, iteratee) => _.filter(Children.toArray(children), iteratee)
 
 // ----------------------------------------
 // By Type
@@ -35,6 +43,15 @@ export const someChildType = (children, type) => someChild(children, { type })
  * Find child by type.
  * @param {Object} children The children prop of a component.
  * @param {string|Function} type An html tag name string or React component.
- * @returns {*|ReactElement}
+ * @returns {undefined|Object}
  */
 export const findChildType = (children, type) => findChild(children, { type })
+
+/**
+ * _.map over children of a specific type.
+ * @param {Object} children The children prop of a component.
+ * @param {string|Function} type An html tag name string or React component.
+ * @param {Array|Function|Object|string} iteratee The function invoked per iteration.
+ * @returns {Array}
+ */
+export const mapChildType = (children, type, iteratee) => _.map(filterChildren(children, { type }), iteratee)

--- a/test/utils/domEvent.js
+++ b/test/utils/domEvent.js
@@ -1,0 +1,35 @@
+import simulant from 'simulant'
+
+// ----------------------------------------
+// Simulate DOM Events on real DOM nodes
+// ----------------------------------------
+
+/**
+ * Generic method for dispatching an event on a DOM node.
+ * @param {String|Object} node A querySelector string or DOM node.
+ * @param {String} eventType A DOMString
+ * @param {Object} [data] Additional event data.
+ * @returns {Object} The event
+ */
+export const fire = (node, eventType, data = {}) => {
+  const DOMNode = typeof node === 'string' ? document.querySelector(node) : node
+  const event = simulant(eventType, data)
+
+  return simulant.fire(DOMNode, event)
+}
+
+/**
+ * Dispatch a 'keydown' event on a DOM node.
+ * @param {String|Object} node A querySelector string or DOM node.
+ * @param {Object} [data] Additional event data.
+ * @returns {Object} The event
+ */
+export const keyDown = (node, data) => fire(node, 'keydown', data)
+
+/**
+ * Dispatch a 'click' event on a DOM node.
+ * @param {String|Object} node A querySelector string or DOM node.
+ * @param {Object} [data] Additional event data.
+ * @returns {Object} The event
+ */
+export const click = (node, data) => fire(node, 'click', data)

--- a/test/utils/syntheticEvent.js
+++ b/test/utils/syntheticEvent.js
@@ -1,0 +1,187 @@
+/**
+ * Synthetic Event
+ *
+ * Names of all synthetic events and their event shape.
+ * Methods are also included for comparing and validated event objects.
+ *
+ * https://facebook.github.io/react/docs/events.html
+ */
+
+const noop = () => undefined
+
+const baseShape = {
+  bubbles: null,
+  cancelable: null,
+  currentTarget: null,
+  defaultPrevented: null,
+  eventPhase: null,
+  isTrusted: null,
+  nativeEvent: null,
+  persist: noop,
+  preventDefault: noop,
+  isDefaultPrevented: noop,
+  stopPropagation: noop,
+  isPropagationStopped: noop,
+  target: null,
+  timeStamp: null,
+  type: null,
+}
+
+// ------------------------------------
+// Event Types
+// ------------------------------------
+export const types = {
+  clipboard: {
+    listeners: ['onCopy', 'onCut', 'onPaste'],
+    eventShape: { ...baseShape, clipboardData: null },
+  },
+  composition: {
+    listeners: ['onCompositionEnd', 'onCompositionStart', 'onCompositionUpdate'],
+    eventShape: { ...baseShape, data: null },
+  },
+  keyboard: {
+    listeners: ['onKeyDown', 'onKeyPress', 'onKeyUp'],
+    eventShape: {
+      ...baseShape,
+      altKey: null,
+      charCode: null,
+      ctrlKey: null,
+      getModifierState: noop,
+      key: null,
+      keyCode: null,
+      locale: null,
+      location: null,
+      metaKey: null,
+      repeat: null,
+      shiftKey: null,
+      which: null,
+    },
+  },
+  focus: {
+    listeners: ['onFocus', 'onBlur'],
+    eventShape: { ...baseShape, relatedTarget: null },
+  },
+  form: {
+    listeners: ['onChange', 'onInput', 'onSubmit'],
+    eventShape: { ...baseShape },
+  },
+  mouse: {
+    listeners: [
+      'onClick',
+      'onContextMenu',
+      'onDoubleClick',
+      'onDrag',
+      'onDragEnd',
+      'onDragEnter',
+      'onDragExit',
+      'onDragLeave',
+      'onDragOver',
+      'onDragStart',
+      'onDrop',
+      'onMouseDown',
+      'onMouseEnter',
+      'onMouseLeave',
+      'onMouseMove',
+      'onMouseOut',
+      'onMouseOver',
+      'onMouseUp',
+    ],
+    eventShape: {
+      ...baseShape,
+      altKey: null,
+      button: null,
+      buttons: null,
+      clientX: null,
+      clientY: null,
+      ctrlKey: null,
+      getModifierState: noop,
+      metaKey: null,
+      pageX: null,
+      pageY: null,
+      relatedTarget: null,
+      screenX: null,
+      screenY: null,
+      shiftKey: null,
+    },
+  },
+  selection: {
+    listeners: ['onSelect'],
+    eventShape: { ...baseShape },
+  },
+  touch: {
+    listeners: ['onTouchCancel', 'onTouchEnd', 'onTouchMove', 'onTouchStart'],
+    eventShape: {
+      ...baseShape,
+      altKey: null,
+      changedTouches: null,
+      ctrlKey: null,
+      getModifierState: noop,
+      metaKey: null,
+      shiftKey: null,
+      targetTouches: null,
+      touches: null,
+    },
+  },
+  ui: {
+    listeners: ['onScroll'],
+    eventShape: { ...baseShape, detail: null, view: null },
+  },
+  wheel: {
+    listeners: ['onWheel'],
+    eventShape: { ...baseShape, deltaMode: null, deltaX: null, deltaY: null, deltaZ: null },
+  },
+  media: {
+    listeners: [
+      'onAbort',
+      'onCanPlay',
+      'onCanPlayThrough',
+      'onDurationChange',
+      'onEmptied',
+      'onEncrypted',
+      'onEnded',
+      'onError',
+      'onLoadedData',
+      'onLoadedMetadata',
+      'onLoadStart',
+      'onPause',
+      'onPlay',
+      'onPlaying',
+      'onProgress',
+      'onRateChange',
+      'onSeeked',
+      'onSeeking',
+      'onStalled',
+      'onSuspend',
+      'onTimeUpdate',
+      'onVolumeChange',
+      'onWaiting',
+    ],
+    eventShape: { ...baseShape },
+  },
+  image: {
+    listeners: ['onLoad', 'onError'],
+    eventShape: { ...baseShape },
+  },
+  animation: {
+    listeners: ['onAnimationStart', 'onAnimationEnd', 'onAnimationIteration'],
+    eventShape: { ...baseShape, animationName: null, pseudoElement: null, elapsedTime: null },
+  },
+  transition: {
+    listeners: ['onTransitionEnd'],
+    eventShape: { ...baseShape, propertyName: null, pseudoElement: null, elapsedTime: null },
+  },
+}
+// ------------------------------------
+// Methods
+// ------------------------------------
+
+/**
+ * Determine if an event object has the shape of the event type specified.
+ * @param {Object} event The event object to test.
+ * @param {String|Object} type The string name of the event shape or actual event shape to compare against.
+ * @returns {Boolean}
+ */
+export const hasShape = (event, type) => {
+  const shape = typeof type === 'string' ? types[type].shape : type
+  return Object.keys(event).every(key => key in shape)
+}


### PR DESCRIPTION
This PR is a breakout of #206.  It adds utils that facilitate writing and testing components without Semantic UI jQuery plugins.

The source is well annotated so I'm skipping comment annotations on this one.  Here is the summary:

**childrenUtils**

With our transition, we also are implementing our [v.1.0 component API](https://github.com/TechnologyAdvice/stardust/issues/208).  This means no more `className` use for component behavior and styling.  We extend child utils to facilitate some of this.

**domEvent**

With jQuery out of the picture we now need to handle events.  Both creating and dispatching them in tests.  Simulant gives a cross browser way to create real browser events (we're in phantomjs).  `domEvent` is our wrapper implementation of `simulant`.

**syntheticEvent**

Real browser events alone won't do, our tests rely on React's synthetic events.  This util is just that, basically an enum of synthetic events and their shape.  These are used to test component events.
