### PR TITLE
AutoControlledComponent

### DIFF
--- a/build/karma.conf.babel.js
+++ b/build/karma.conf.babel.js
@@ -1,6 +1,9 @@
 import { argv } from 'yargs'
+import webpack from 'webpack'
+
 import config from '../config'
 import webpackConfig from './webpack.config'
+
 const { paths } = config
 
 module.exports = (karmaConfig) => {
@@ -35,6 +38,9 @@ module.exports = (karmaConfig) => {
           ...webpackConfig.module.loaders,
         ],
       },
+      plugins: [
+        new webpack.DefinePlugin(config.compiler_globals),
+      ],
       resolve: {
         ...webpackConfig.resolve,
         alias: {

--- a/src/utils/AutoControlledComponent.js
+++ b/src/utils/AutoControlledComponent.js
@@ -1,0 +1,145 @@
+/* eslint-disable no-console */
+/**
+ * Why choose inheritance over a HOC?  Multiple advantages for this particular use case.
+ * In short, we need identical functionality to setState(), unless there is a prop defined
+ * for the state key.  Also:
+ *
+ * 1. Single Renders
+ *    Calling trySetState() in constructor(), componentWillMount(), or componentWillReceiveProps()
+ *    does not cause two renders. Consumers and tests do not have to wait two renders to get state.
+ *
+ * 2. Simple Testing
+ *    Using a HOC means you must either test the undecorated component or test through the decorator.
+ *    Testing the undecorated component means you must mock the decorator functionality.
+ *    Testing through the HOC means you can not simply shallow render your component.
+ *
+ * 3. Statics
+ *    HOC wrap instances, so statics are no longer accessible.  They can be hoisted, but this is more
+ *    looping over properties and storing references.  We rely heavily on statics for testing and sub
+ *    components.
+ *
+ * 4. Instance Methods
+ *    Some instances methods may be exposed to users via refs.  Again, these are lost with HOC unless
+ *    hoisted and exposed by the HOC.
+ */
+import _ from 'lodash'
+import { Component } from 'react'
+
+const getDefaultPropName = (prop) => `default${prop[0].toUpperCase() + prop.slice(1)}`
+
+export default class AutoControlledComponent extends Component {
+  componentWillMount() {
+    if (super.componentWillMount) super.componentWillMount()
+    const { autoControlledProps } = this.constructor
+
+    // Auto controlled props are copied to state.
+    // Set initial state by copying auto controlled props to state.
+    // Also look for the default prop for any auto controlled props (foo => defaultFoo)
+    // so we can set initial values from defaults.
+    this.state = _.transform(autoControlledProps, (res, prop) => {
+      const defaultPropName = getDefaultPropName(prop)
+
+      // apply default props if they exist
+      res[prop] = this.props[defaultPropName in this.props ? defaultPropName : prop]
+
+      if (!__PROD__) {
+        const { name } = this.constructor
+        // prevent defaultFoo={} along side foo={}
+        if (defaultPropName in this.props && prop in this.props) {
+          console.error(
+            `${name} prop "${prop}" is auto controlled. Specify either ${defaultPropName} or ${prop}, but not both.`
+          )
+        }
+      }
+    }, {})
+
+    if (!__PROD__) {
+      const { defaultProps, name, propTypes } = this.constructor
+      // require static autoControlledProps
+      if (!autoControlledProps) {
+        console.error(`Auto controlled ${name} must specify a static autoControlledProps array.`)
+      }
+
+      // require propTypes
+      _.each(autoControlledProps, (prop) => {
+        const defaultProp = getDefaultPropName(prop)
+        // regular prop
+        if (!_.has(propTypes, defaultProp)) {
+          console.error(`${name} is missing "${defaultProp}" propTypes validation for auto controlled prop "${prop}".`)
+        }
+        // its default prop
+        if (!_.has(propTypes, prop)) {
+          console.error(`${name} is missing propTypes validation for auto controlled prop "${prop}".`)
+        }
+      })
+
+      // prevent autoControlledProps in defaultProps
+      //
+      // When setting state, auto controlled props values always win (so the parent can manage them).
+      // It is not reasonable to decipher the difference between props from the parent and defaultProps.
+      // Allowing defaultProps results in trySetState always deferring to the defaultProp value.
+      // Auto controlled props also listed in defaultProps can never be updated.
+      const illegalDefaults = _.intersection(autoControlledProps, _.keys(defaultProps))
+      if (!_.isEmpty(illegalDefaults)) {
+        console.error([
+          'Do not set defaultProps for autoControlledProps,',
+          'use trySetState() in constructor() or componentWillMount() instead.',
+          `See ${name} props: "${illegalDefaults}".`,
+        ].join(' '))
+      }
+
+      // prevent listing defaultProps in autoControlledProps
+      //
+      // Default props are automatically handled.
+      // Listing defaults in autoControlledProps would result in allowing defaultDefaultValue props.
+      const illegalAutoControlled = _.filter(autoControlledProps, prop => prop.startsWith('default'))
+      if (!_.isEmpty(illegalAutoControlled)) {
+        console.error([
+          'Do not add default props to autoControlledProps.',
+          'Default props are automatically handled.',
+          `See ${name} autoControlledProps: "${illegalAutoControlled}".`,
+        ].join(' '))
+      }
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (super.componentWillReceiveProps) super.componentWillReceiveProps(nextProps)
+
+    // props always win, update state with all auto controlled prop
+    const newState = _.pick(nextProps, this.constructor.autoControlledProps)
+    if (!_.isEmpty(newState)) this.setState(newState)
+  }
+
+  /**
+   * Safely attempt to set state for props that might be controlled by the user.
+   * Second argument is a state object that is always passed to setState.
+   * @param {object} maybeState State that corresponds to controlled props.
+   * @param {object} [state] Actual state, useful when you also need to setState.
+   */
+  trySetState = (maybeState, state) => {
+    // console.debug('trySetState')
+    // console.log('maybe:', maybeState, 'state:', state)
+    const { autoControlledProps } = this.constructor
+    if (!__PROD__) {
+      const { name } = this.constructor
+      // warn about failed attempts to setState for keys not listed in autoControlledProps
+      const illegalKeys = _.difference(_.keys(maybeState), autoControlledProps)
+      if (!_.isEmpty(illegalKeys)) {
+        console.error([
+          `${name} called trySetState() with controlled props: "${illegalKeys}".`,
+          'State will not be set.',
+          'Only props in static autoControlledProps will be set on state.',
+        ].join(' '))
+      }
+    }
+
+    // pick auto controlled props
+    // omit props from parent
+    let newState = _.omit(_.pick(maybeState, autoControlledProps), _.keys(this.props))
+
+    if (state) newState = { ...newState, ...state }
+
+    if (!_.isEmpty(newState)) this.setState(newState)
+  }
+}

--- a/test/specs/utils/AutoControlledComponent-test.js
+++ b/test/specs/utils/AutoControlledComponent-test.js
@@ -1,0 +1,210 @@
+/* eslint-disable no-console */
+import faker from 'faker'
+import _ from 'lodash'
+import React from 'react'
+
+import AutoControlledComponent from 'src/utils/AutoControlledComponent'
+import * as consoleUtil from 'test/utils/consoleUtil.js'
+
+let TestClass
+
+/* eslint-disable */
+const createTestClass = (options = {}) => class Test extends AutoControlledComponent {
+  static autoControlledProps = options.autoControlledProps
+  state = options.state
+  render = () => <div />
+}
+/* eslint-enable */
+
+const toDefaultName = (prop) => `default${prop.slice(0, 1).toUpperCase() + prop.slice(1)}`
+
+const makeProps = () => _.transform(_.times(_.random(3, 10)), (res) => {
+  res[_.camelCase(faker.hacker.noun())] = faker.hacker.verb()
+}, {})
+
+const makeDefaultProps = (props) => _.transform(props, (res, val, key) => {
+  res[toDefaultName(key)] = val
+})
+
+describe('extending AutoControlledComponent', () => {
+  beforeEach(() => {
+    TestClass = createTestClass({ autoControlledProps: [], state: {} })
+  })
+
+  describe('trySetState', () => {
+    it('is an instance method', () => {
+      shallow(<TestClass />)
+        .instance()
+        .trySetState.should.be.a('function')
+    })
+
+    it('sets state for autoControlledProps', () => {
+      const autoControlledProps = _.keys(makeProps())
+      const randomProp = _.sample(autoControlledProps)
+      const randomValue = faker.hacker.verb()
+
+      TestClass = createTestClass({ autoControlledProps })
+      const wrapper = shallow(<TestClass />)
+
+      wrapper
+        .instance()
+        .trySetState({ [randomProp]: randomValue })
+
+      wrapper
+        .should.have.state(randomProp, randomValue)
+    })
+
+    it('does not set state for non autoControlledProps', () => {
+      consoleUtil.disableOnce()
+
+      TestClass = createTestClass({ state: {} })
+      const wrapper = shallow(<TestClass />)
+
+      wrapper
+        .instance()
+        .trySetState({ [faker.hacker.noun()]: faker.hacker.verb() })
+
+      wrapper
+        .state()
+        .should.be.empty()
+    })
+
+    it('does not set state for props defined by the parent', () => {
+      const props = makeProps()
+      const autoControlledProps = _.keys(props)
+
+      const randomProp = _.sample(autoControlledProps)
+      const randomValue = faker.hacker.phrase()
+
+      TestClass = createTestClass({ autoControlledProps, state: {} })
+      const wrapper = shallow(<TestClass {...props} />)
+
+      wrapper
+        .instance()
+        .trySetState({ [randomProp]: randomValue })
+
+      // not updated
+      wrapper
+        .should.not.have.state(randomProp, randomValue)
+
+      // is original value
+      wrapper
+        .should.have.state(randomProp, props[randomProp])
+    })
+  })
+
+  describe('initial state', () => {
+    it('is derived from autoControlledProps in props', () => {
+      const props = makeProps()
+      const autoControlledProps = _.keys(props)
+
+      TestClass = createTestClass({ autoControlledProps, state: {} })
+      shallow(<TestClass {...props} />)
+        .state()
+        .should.deep.equal(props)
+    })
+
+    it('does not include non autoControlledProps', () => {
+      const props = makeProps()
+      const wrapper = shallow(<TestClass {...props} />)
+
+      _.each(props, (val, key) => wrapper.should.not.have.state(key, val))
+    })
+  })
+
+  describe('default props', () => {
+    it('are applied to state for props in autoControlledProps', () => {
+      const props = makeProps()
+      const autoControlledProps = _.keys(props)
+      const defaultProps = makeDefaultProps(props)
+
+      TestClass = createTestClass({ autoControlledProps, state: {} })
+      shallow(<TestClass {...defaultProps} />)
+        .state()
+        .should.deep.equal(props)
+    })
+
+    it('are not applied to state for normal props', () => {
+      const props = makeProps()
+      const defaultProps = makeDefaultProps(props)
+
+      const wrapper = shallow(<TestClass {...defaultProps} />)
+
+      _.each(props, (val, key) => wrapper.should.not.have.state(key, val))
+    })
+
+    it('allows trySetState to work on non-default autoControlledProps', () => {
+      const props = makeProps()
+      const autoControlledProps = _.keys(props)
+      const defaultProps = makeDefaultProps(props)
+
+      const randomProp = _.sample(autoControlledProps)
+      const randomValue = faker.hacker.phrase()
+
+      TestClass = createTestClass({ autoControlledProps, state: {} })
+      const wrapper = shallow(<TestClass {...defaultProps} />)
+
+      wrapper
+        .instance()
+        .trySetState({ [randomProp]: randomValue })
+
+      wrapper
+        .should.have.state(randomProp, randomValue)
+    })
+  })
+
+  describe('changing props', () => {
+    it('sets state for props in autoControlledProps', () => {
+      const props = makeProps()
+      const autoControlledProps = _.keys(props)
+
+      const randomProp = _.sample(autoControlledProps)
+      const randomValue = faker.hacker.phrase()
+
+      TestClass = createTestClass({ autoControlledProps, state: {} })
+      const wrapper = shallow(<TestClass {...props} />)
+
+      wrapper
+        .setProps({ [randomProp]: randomValue })
+
+      wrapper
+        .should.have.state(randomProp, randomValue)
+    })
+
+    it('does not set state for props not in autoControlledProps', () => {
+      consoleUtil.disableOnce()
+      const props = makeProps()
+
+      const randomProp = _.sample(_.keys(props))
+      const randomValue = faker.hacker.phrase()
+
+      TestClass = createTestClass({ state: {} })
+      const wrapper = shallow(<TestClass {...props} />)
+
+      wrapper
+        .setProps({ [randomProp]: randomValue })
+
+      wrapper
+        .should.not.have.state(randomProp, randomValue)
+    })
+
+    it('does not set state for default props when changed', () => {
+      const props = makeProps()
+      const autoControlledProps = _.keys(props)
+      const defaultProps = makeDefaultProps(props)
+
+      const randomPropIndex = _.random(0, autoControlledProps.length)
+      const randomDefaultProp = _.keys(defaultProps)[randomPropIndex]
+      const randomValue = faker.hacker.phrase()
+
+      TestClass = createTestClass({ autoControlledProps, state: {} })
+      const wrapper = shallow(<TestClass {...defaultProps} />)
+
+      wrapper
+        .setProps({ [randomDefaultProp]: randomValue })
+
+      wrapper
+        .should.not.have.state(randomDefaultProp, randomValue)
+    })
+  })
+})


### PR DESCRIPTION
# AutoControlledComponent

This PR is a breakout of #206.  This PR is actually tiny. It is mostly runtime warnings, tests, and comments.  I've committed a "slim" version of the component with no runtime warnings nor comments so it can be reviewed easier.  **It is only 34 SLOC**.  I will remove it before merging.
## Why this thing?

Many of our components have props that are possibly [controlled](https://facebook.github.io/react/docs/forms.html#controlled-components) by the consumer.  Many of those props should also be self managed inside the component if there is no prop given.

Example, `<Dropdown />` has a `value` prop.  This is the `value` of the active item.  When the user clicks on an item, we set the value on state internally.  However, the consumer may have added a value prop to the `<Dropdown />` as well.  Now, when we want to access the value, we need to conditionally choose between which value we retrieve.  The prop or the state?

Also, it would be responsible to never set state for the value if we were passed a value prop.  This saves a render.  Yet, another conditional, if there is no value prop then set state.  This quickly becomes ugly and hard to maintain.
## Community Options

We reviewed and tested other libraries solving this same problem:
- [react-controllables](https://github.com/matthewwithanm/react-controllables)
- [uncontrollable](https://github.com/jquense/uncontrollable) (react-bootstrap)

These didn't work for us for the following:
- dictates a single handler for each prop
- dictates that each handler call back with the new prop value as the first argument to update props
- HOC/decorator pattern causes troubles for our static props/subcomponents
- HOC/decorator pattern cannot set computed props without a double initial render
- Overall too restrictive in the implementation
## Solution

<p align=center>
<br />
What we really want is a smart setState() that submits to controlled props.
<br />
<br />
</p>


This solves all our issues.  AutoControlledComponent is extended by your component, giving it a `trySetState` method and static `autoControlledProps` array.
#### `static autoControlledProps = []`

This array defines which props are auto controlled.

**`props` to `state`**
Auto controlled props are made available on `state`.  The value will automatically defer to prop values if present (controlled) or the internal state value if there is no prop (uncontrolled).
#### `trySetState(maybeState, [state])`

**`maybeState`**
When trying to set maybe state, controlled prop values always win.  Unnecessary renders are also prevented.

**`state`**
Allows setting regular state while simultaneously trying to set state for controlled values.  You often need to set both, this allows a single call to setState and a single render.
## Niceties

**Auto default props `defaultFoo`**

Each auto controlled prop also accepts a `default*` prop.  It works exactly like vanilla React, only applied on first render.

**Runtime Warnings**

The majority of the code is actually run time warnings to ensure proper use of the abstraction.  Warnings are removed in production by dead code elimination.
- prevent defaultFoo={} along side foo={} _(follows vanilla React)_
- require static autoControlledProps
- require propTypes for autoControlledProps
- require propTypes for corresponding default autoControlledProps
- prevent listing defaultProps in autoControlledProps _(automatically added)_
- prevent autoControlledProps in defaultProps _(trySetState on construction instead)_
- prevent trySetState for props that are not auto controlled
