### PR TITLE
Remove eslint-loader, for performance

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -117,16 +117,7 @@ webpackConfig.module.noParse = [
 // ------------------------------------
 // Pre-Loaders
 // ------------------------------------
-webpackConfig.module.preLoaders = [{
-  test: /\.js$/,
-  loader: 'eslint',
-  exclude: /node_modules/,
-}]
-
-webpackConfig.eslint = {
-  configFile: paths.base('.eslintrc'),
-  emitWarning: __DEV__,
-}
+webpackConfig.module.preLoaders = []
 
 // ------------------------------------
 // Loaders

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "enzyme": "^2.2.0",
     "eslint": "^1.5.1",
     "eslint-config-ta": "^4.1.0",
-    "eslint-loader": "^1.0.0",
     "eslint-plugin-mocha": "^1.0.0",
     "eslint-plugin-react": "^4.2.3",
     "express": "^4.13.4",


### PR DESCRIPTION
Build times are insane right now.  _Mostly_ due to `eslint-loader`:

With: `webpack built in 38492ms`
Without: `webpack built in 13282ms`

:scream: 65% reduction in build times without it!
