### PR TITLE
Add babel-plugin-lodash for smaller bundles

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,8 @@
     "es2015",
     "react",
     "stage-1"
+  ],
+  "plugins": [
+    "lodash"
   ]
 }

--- a/docs/app/Components/Sidebar/Sidebar.js
+++ b/docs/app/Components/Sidebar/Sidebar.js
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import _ from 'lodash/fp'
 import React, { Component } from 'react'
 import * as stardust from 'stardust'
 import META from 'src/utils/Meta'
@@ -11,23 +11,23 @@ export default class Sidebar extends Component {
   handleSearchChange = e => this.setState({ query: e.target.value })
 
   getComponentsByQuery() {
-    return _.filter(stardust, component => {
+    return _.filter(component => {
       const name = component._meta.name
       const isParent = META.isParent(component)
       const isQueryMatch = new RegExp(this.state.query, 'i').test(name)
       return isParent && isQueryMatch
-    })
+    }, stardust)
   }
 
   getComponentsByType = type => {
-    const items = _(this.getComponentsByQuery())
-      .filter(component => META.isType(component, type))
-      .sortBy((component, name) => name)
-      .map(component => {
+    const items = _.flow(
+      _.filter(component => META.isType(component, type)),
+      _.sortBy((component, name) => name),
+      _.map(component => {
         const name = component._meta.name
         return <Menu.Item key={name} name={name} href={`#${name}`} />
       })
-      .value()
+    )(this.getComponentsByQuery())
 
     return _.isEmpty(items) ? [] : (
       <div className='item'>

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-core": "^6.5.2",
     "babel-eslint": "^4.1.6",
     "babel-loader": "^6.2.0",
+    "babel-plugin-lodash": "^2.3.0",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",


### PR DESCRIPTION
Instead of importing the entire lodash lib (>300 funcs) [babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash) transforms our imports to only include the functions we actually use.
