### PR TITLE
Remove babel-polyfill

### DIFF
--- a/build/karma.conf.babel.js
+++ b/build/karma.conf.babel.js
@@ -13,10 +13,16 @@ module.exports = (karmaConfig) => {
     singleRun: !argv.watch,
     reporters: ['mocha'],
     files: [
-      require.resolve('babel-polyfill/browser'),
       './test/tests.bundle.js',
     ],
-    frameworks: ['mocha'],
+    frameworks: [
+      'phantomjs-shim',
+      'mocha',
+    ],
+    phantomjsLauncher: {
+      // exit on ResourceError, useful if karma exits without killing phantom
+      exitOnResourceError: true,
+    },
     preprocessors: {
       '**/*.bundle.js': ['webpack'],
     },

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -35,7 +35,6 @@ const webpackHotMiddlewareEntry = 'webpack-hot-middleware/client?' + _.map({
 }, (val, key) => `&${key}=${val}`).join('')
 
 const APP_ENTRY = [
-  require.resolve('babel-polyfill'),
   paths.docsSrc('DocsApp.js'),
 ]
 
@@ -45,7 +44,6 @@ webpackConfig.entry = {
     : [...APP_ENTRY],
   vendor: [
     webpackHotMiddlewareEntry,
-    'babel-polyfill',
     ...config.compiler_vendor,
   ],
 }

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 
 machine:
   node:
-    version: 6
+    version: 5
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 
 machine:
   node:
-    version: 5
+    version: 6
 
 dependencies:
   pre:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "docs": "gulp",
     "build": "npm run build:dist && npm run build:docs",
-    "build:dist": "rimraf dist && babel src -d dist",
+    "build:dist": "rm -rf dist && babel src -d dist",
     "build:docs": "gulp docs",
     "clean": "while read line; do rm -rf $line; done < .gitignore",
     "predeploy:docs": "npm run build:docs",
@@ -105,7 +105,6 @@
     "react-transform-hmr": "^1.0.4",
     "redbox-react": "^1.2.2",
     "require-dir": "^0.3.0",
-    "rimraf": "^2.5.2",
     "sass-loader": "^3.2.0",
     "semantic-ui-css": "^2.1.8",
     "simulant": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "docs": "gulp",
     "build": "npm run build:dist && npm run build:docs",
-    "build:dist": "rm -rf dist && babel src -d dist",
+    "prebuild:dist": "rimraf dist",
+    "build:dist": "babel src -d dist",
     "build:docs": "gulp docs",
     "clean": "while read line; do rm -rf $line; done < .gitignore",
     "predeploy:docs": "npm run build:docs",
@@ -105,6 +106,7 @@
     "react-transform-hmr": "^1.0.4",
     "redbox-react": "^1.2.2",
     "require-dir": "^0.3.0",
+    "rimraf": "^2.5.2",
     "sass-loader": "^3.2.0",
     "semantic-ui-css": "^2.1.8",
     "simulant": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "karma-mocha": "^0.2.2",
     "karma-mocha-reporter": "^2.0.0",
     "karma-phantomjs-launcher": "^1.0.0",
+    "karma-phantomjs-shim": "github:technologyadvice/karma-phantomjs-shim",
     "karma-webpack-with-fast-source-maps": "^1.9.2",
     "mocha": "^2.3.3",
     "mocha-loader": "^0.7.1",


### PR DESCRIPTION
As noted in #206, this PR removes the `babel-polyfill` for it's size and global namespace pollution.  We don't want to drop this on our consumers.
