### PR TITLE
Remove keyboard event polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "classnames": "^2.1.5",
-    "keyboardevent-key-polyfill": "github:technologyadvice/keyboardevent-key-polyfill#0eb142e8d6845a90f23d21b468a3c8c8162b5a25",
     "lodash": "^4.6.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,4 @@
-import keyboardeventKeyPolyfill from 'keyboardevent-key-polyfill'
 import { deprecateComponent } from './utils/deprecate'
-
-keyboardeventKeyPolyfill.polyfill()
 
 // ----------------------------------------
 // Addons

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -7,6 +7,7 @@ import React, { PropTypes } from 'react'
 import META from '../../utils/Meta'
 import { useKeyOnly, useKeyOrValueAndKey } from '../../utils/propUtils'
 import { iconPropRenderer } from '../../utils/propUtils'
+import keyboardKey from '../../utils/keyboardKey'
 
 // import as Component so eslint react/prop-types recognizes Dropdown
 import { default as Component } from '../../utils/AutoControlledComponent'
@@ -255,20 +256,20 @@ export default class Dropdown extends Component {
   }
 
   closeOnEscape = (e) => {
-    if (e.key !== 'Escape') return
+    if (keyboardKey.getCode(e) !== keyboardKey.Escape) return
     e.preventDefault()
     this.close()
   }
 
   moveSelectionOnKeyDown = (e) => {
     // console.debug('Dropdown.moveSelectionOnKeyDown()')
-    // console.log(`key: ${e.key}`)
-    switch (e.key) {
-      case 'ArrowDown':
+    // console.log(`key: ${keyboardKey.getCode(e)}`)
+    switch (keyboardKey.getCode(e)) {
+      case keyboardKey.ArrowDown:
         e.preventDefault()
         this.moveSelectionBy(1)
         break
-      case 'ArrowUp':
+      case keyboardKey.ArrowUp:
         e.preventDefault()
         this.moveSelectionBy(-1)
         break
@@ -278,20 +279,21 @@ export default class Dropdown extends Component {
   }
 
   openOnSpace = (e) => {
-    if (e.key !== ' ') return
+    if (keyboardKey.getCode(e) !== keyboardKey.Spacebar) return
     e.preventDefault()
     this.open()
   }
 
   openOnArrow = (e) => {
-    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+    const code = keyboardKey.getCode(e)
+    if (!_.includes([keyboardKey.ArrowDown, keyboardKey.ArrowUp], code)) return
     e.preventDefault()
     this.open()
   }
 
   selectItemOnEnter = (e) => {
     // console.debug('Dropdown.selectItemOnEnter()')
-    if (e.key !== 'Enter') return
+    if (keyboardKey.getCode(e) !== keyboardKey.Enter) return
     e.preventDefault()
     const value = this.getSelectedValue()
     if (!value) return
@@ -350,18 +352,6 @@ export default class Dropdown extends Component {
     // item clicks are circumvented by calling close() here
     // this.close()
     this.setState({ focus: false })
-  }
-
-  handleSearchKeyDown = (e) => {
-    // console.debug('Dropdown.handleSearchKeyDown()')
-    // console.log(e.key)
-    switch (e.key) {
-      case 'ArrowDown':
-        this.open()
-        break
-      default:
-        break
-    }
   }
 
   handleSearchChange = (e) => {
@@ -545,7 +535,6 @@ export default class Dropdown extends Component {
         onBlur={this.handleBlur}
         onChange={this.handleSearchChange}
         onFocus={this.handleFocus}
-        onKeyDown={this.handleSearchKeyDown}
         className='search'
         autoComplete='off'
         tabIndex='0'

--- a/src/utils/keyboardKey.js
+++ b/src/utils/keyboardKey.js
@@ -1,0 +1,298 @@
+/**
+ * All previous KeyboardEvent key identifying properties are deprecated in favor of `key`.
+ * Unfortunately, `key` is not yet fully supported.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+ */
+import _ from 'lodash'
+
+export const codes = {
+  // ----------------------------------------
+  // By Code
+  // ----------------------------------------
+  3: 'Cancel',
+  6: 'Help',
+  8: 'Backspace',
+  9: 'Tab',
+  12: 'Clear',
+  13: 'Enter',
+  16: 'Shift',
+  17: 'Control',
+  18: 'Alt',
+  19: 'Pause',
+  20: 'CapsLock',
+  27: 'Escape',
+  28: 'Convert',
+  29: 'NonConvert',
+  30: 'Accept',
+  31: 'ModeChange',
+  32: ' ',
+  33: 'PageUp',
+  34: 'PageDown',
+  35: 'End',
+  36: 'Home',
+  37: 'ArrowLeft',
+  38: 'ArrowUp',
+  39: 'ArrowRight',
+  40: 'ArrowDown',
+  41: 'Select',
+  42: 'Print',
+  43: 'Execute',
+  44: 'PrintScreen',
+  45: 'Insert',
+  46: 'Delete',
+  48: ['0', ')'],
+  49: ['1', '!'],
+  50: ['2', '@'],
+  51: ['3', '#'],
+  52: ['4', '$'],
+  53: ['5', '%'],
+  54: ['6', '^'],
+  55: ['7', '&'],
+  56: ['8', '*'],
+  57: ['9', '('],
+  91: 'OS',
+  93: 'ContextMenu',
+  144: 'NumLock',
+  145: 'ScrollLock',
+  181: 'VolumeMute',
+  182: 'VolumeDown',
+  183: 'VolumeUp',
+  186: [';', ':'],
+  187: ['=', '+'],
+  188: [',', '<'],
+  189: ['-', '_'],
+  190: ['.', '>'],
+  191: ['/', '?'],
+  192: ['`', '~'],
+  219: ['[', '{'],
+  220: ['\\', '|'],
+  221: [']', '}'],
+  222: ["'", '"'],
+  224: 'Meta',
+  225: 'AltGraph',
+  246: 'Attn',
+  247: 'CrSel',
+  248: 'ExSel',
+  249: 'EraseEof',
+  250: 'Play',
+  251: 'ZoomOut',
+}
+
+// Function Keys (F1-24)
+_.times(24, (i) => codes[112 + i] = `F${i + 1}`)
+
+// Alphabet (a-Z)
+_.times(26, (i) => {
+  const n = i + 65
+  codes[n] = [String.fromCharCode(n + 32), String.fromCharCode(n)]
+})
+
+const keyboardKey = {
+  /**
+   * Get the `keyCode` or `which` value from a keyboard event or `key` name.
+   * @param {string|object} name A keyboard event like object or `key` name.
+   * @param {string} [name.key] If object, it must have one of these keys.
+   * @param {string} [name.keyCode] If object, it must have one of these keys.
+   * @param {string} [name.which] If object, it must have one of these keys.
+   * @returns {*}
+   */
+  getCode(name) {
+    if (_.isObject(name)) {
+      return name.keyCode || name.which || this[name.key]
+    }
+    return this[name]
+  },
+
+  /**
+   * Get the key name from a keyboard event, `keyCode`, or `which` value.
+   * @param {number|object} code A keyboard event like object or key name.
+   * @param {number} [code.keyCode] If object, it must have one of these keys.
+   * @param {number} [code.which] If object, it must have one of these keys.
+   * @param {number} [code.shiftKey] If object, it must have one of these keys.
+   * @returns {*}
+   */
+  getName(code) {
+    const isEvent = _.isObject(code)
+    let name = codes[isEvent ? code.keyCode || code.which : code]
+
+    if (Array.isArray(name)) {
+      if (isEvent) {
+        name = name[code.shiftKey ? 1 : 0]
+      } else {
+        name = name[0]
+      }
+    }
+
+    return name
+  },
+
+  // ----------------------------------------
+  // By Name
+  // ----------------------------------------
+  // declare these manually for static analysis
+  Cancel: 3,
+  Help: 6,
+  Backspace: 8,
+  Tab: 9,
+  Clear: 12,
+  Enter: 13,
+  Shift: 16,
+  Control: 17,
+  Alt: 18,
+  Pause: 19,
+  CapsLock: 20,
+  Escape: 27,
+  Convert: 28,
+  NonConvert: 29,
+  Accept: 30,
+  ModeChange: 31,
+  ' ': 32,
+  PageUp: 33,
+  PageDown: 34,
+  End: 35,
+  Home: 36,
+  ArrowLeft: 37,
+  ArrowUp: 38,
+  ArrowRight: 39,
+  ArrowDown: 40,
+  Select: 41,
+  Print: 42,
+  Execute: 43,
+  PrintScreen: 44,
+  Insert: 45,
+  Delete: 46,
+  '0': 48, ')': 48,
+  '1': 49, '!': 49,
+  '2': 50, '@': 50,
+  '3': 51, '#': 51,
+  '4': 52, $: 52,
+  '5': 53, '%': 53,
+  '6': 54, '^': 54,
+  '7': 55, '&': 55,
+  '8': 56, '*': 56,
+  '9': 57, '(': 57,
+  a: 65, A: 65,
+  b: 66, B: 66,
+  c: 67, C: 67,
+  d: 68, D: 68,
+  e: 69, E: 69,
+  f: 70, F: 70,
+  g: 71, G: 71,
+  h: 72, H: 72,
+  i: 73, I: 73,
+  j: 74, J: 74,
+  k: 75, K: 75,
+  l: 76, L: 76,
+  m: 77, M: 77,
+  n: 78, N: 78,
+  o: 79, O: 79,
+  p: 80, P: 80,
+  q: 81, Q: 81,
+  r: 82, R: 82,
+  s: 83, S: 83,
+  t: 84, T: 84,
+  u: 85, U: 85,
+  v: 86, V: 86,
+  w: 87, W: 87,
+  x: 88, X: 88,
+  y: 89, Y: 89,
+  z: 90, Z: 90,
+  OS: 91,
+  ContextMenu: 93,
+  F1: 112,
+  F2: 113,
+  F3: 114,
+  F4: 115,
+  F5: 116,
+  F6: 117,
+  F7: 118,
+  F8: 119,
+  F9: 120,
+  F10: 121,
+  F11: 122,
+  F12: 123,
+  F13: 124,
+  F14: 125,
+  F15: 126,
+  F16: 127,
+  F17: 128,
+  F18: 129,
+  F19: 130,
+  F20: 131,
+  F21: 132,
+  F22: 133,
+  F23: 134,
+  F24: 135,
+  NumLock: 144,
+  ScrollLock: 145,
+  VolumeMute: 181,
+  VolumeDown: 182,
+  VolumeUp: 183,
+  ';': 186, ':': 186,
+  '=': 187, '+': 187,
+  ',': 188, '<': 188,
+  '-': 189, _: 189,
+  '.': 190, '>': 190,
+  '/': 191, '?': 191,
+  '`': 192, '~': 192,
+  '[': 219, '{': 219,
+  '\\': 220, '\|': 220,
+  ']': 221, '}': 221,
+  "'": 222, '"': 222,
+  Meta: 224,
+  AltGraph: 225,
+  Attn: 246,
+  CrSel: 247,
+  ExSel: 248,
+  EraseEof: 249,
+  Play: 250,
+  ZoomOut: 251,
+}
+
+// ----------------------------------------
+// By Alias
+// ----------------------------------------
+// provide dot-notation accessible keys for all key names
+keyboardKey.Spacebar = keyboardKey[' ']
+keyboardKey.Digit0 = keyboardKey['0']
+keyboardKey.Digit1 = keyboardKey['1']
+keyboardKey.Digit2 = keyboardKey['2']
+keyboardKey.Digit3 = keyboardKey['3']
+keyboardKey.Digit4 = keyboardKey['4']
+keyboardKey.Digit5 = keyboardKey['5']
+keyboardKey.Digit6 = keyboardKey['6']
+keyboardKey.Digit7 = keyboardKey['7']
+keyboardKey.Digit8 = keyboardKey['8']
+keyboardKey.Digit9 = keyboardKey['9']
+keyboardKey.Tilde = keyboardKey['~']
+keyboardKey.GraveAccent = keyboardKey['`']
+keyboardKey.ExclamationPoint = keyboardKey['!']
+keyboardKey.AtSign = keyboardKey['@']
+keyboardKey.PoundSign = keyboardKey['#']
+keyboardKey.PercentSign = keyboardKey['%']
+keyboardKey.Caret = keyboardKey['^']
+keyboardKey.Ampersand = keyboardKey['&']
+keyboardKey.PlusSign = keyboardKey['+']
+keyboardKey.MinusSign = keyboardKey['-']
+keyboardKey.EqualsSign = keyboardKey['=']
+keyboardKey.DivisionSign = keyboardKey['/']
+keyboardKey.MultiplicationSign = keyboardKey['*']
+keyboardKey.Comma = keyboardKey[',']
+keyboardKey.Decimal = keyboardKey['.']
+keyboardKey.Colon = keyboardKey[':']
+keyboardKey.Semicolon = keyboardKey[';']
+keyboardKey.Pipe = keyboardKey['|']
+keyboardKey.BackSlash = keyboardKey['\\']
+keyboardKey.QuestionMark = keyboardKey['?']
+keyboardKey.SingleQuote = keyboardKey['"']
+keyboardKey.DoubleQuote = keyboardKey['"']
+keyboardKey.LeftCurlyBrace = keyboardKey['{']
+keyboardKey.RightCurlyBrace = keyboardKey['}']
+keyboardKey.LeftParenthesis = keyboardKey['(']
+keyboardKey.RightParenthesis = keyboardKey[')']
+keyboardKey.LeftAngleBracket = keyboardKey['<']
+keyboardKey.RightAngleBracket = keyboardKey['>']
+keyboardKey.LeftSquareBracket = keyboardKey['[']
+keyboardKey.RightSquareBracket = keyboardKey[']']
+
+export default keyboardKey

--- a/test/specs/utils/keyboardKey-test.js
+++ b/test/specs/utils/keyboardKey-test.js
@@ -1,0 +1,125 @@
+import _ from 'lodash'
+
+import keyboardKey, { codes } from '../../../src/utils/keyboardKey'
+
+const _wrongReturn = (method, arg, ret) =>
+  `keyboardKey.${method}(${arg}) should return key name "${ret}"\n`
+
+const wrongCode = (...args) => _wrongReturn('getCode', ...args)
+const wrongName = (...args) => _wrongReturn('getName', ...args)
+
+const missingPair = (key, val) => (
+  `keyboardKey is missing property "${key}" with value ${val}\n`
+)
+
+describe('keyboardKey', () => {
+  it('has a key/value for every value/key in codes', () => {
+    _.each(codes, (name, code) => {
+      if (Array.isArray(name)) {
+        String(keyboardKey[name[0]]).should.equal(code, missingPair(name[0], code))
+        String(keyboardKey[name[1]]).should.equal(code, missingPair(name[1], code))
+      } else {
+        String(keyboardKey[name]).should.equal(code, missingPair(name, code))
+      }
+    })
+  })
+
+  describe('getCode', () => {
+    it('is a function', () => {
+      expect(keyboardKey.getCode).to.be.a('function')
+    })
+    it('returns the code for a given key name', () => {
+      keyboardKey.getCode('Enter').should.equal(13, wrongCode('Enter', 13))
+    })
+    it('handles all key names in codes', () => {
+      _.each(codes, (name, code) => {
+        const _code = Number(code)
+
+        if (Array.isArray(name)) {
+          expect(keyboardKey.getCode(name[0])).to.equal(_code, wrongCode(name[0], code))
+          expect(keyboardKey.getCode(name[1])).to.equal(_code, wrongCode(name[1], code))
+        } else {
+          expect(keyboardKey.getCode(name)).to.equal(_code, wrongCode(name, code))
+        }
+      })
+    })
+    it('handles event like objects with `key` prop', () => {
+      _.each(codes, (name, code) => {
+        const _code = Number(code)
+
+        if (Array.isArray(name)) {
+          const key0 = { key: name[0] }
+          const key1 = { key: name[1] }
+          keyboardKey.getCode(key0).should.equal(_code, wrongCode(key0, code))
+          keyboardKey.getCode(key1).should.equal(_code, wrongCode(key1, code))
+        } else {
+          const key = { key: name }
+          expect(keyboardKey.getCode(key)).to.equal(_code, wrongCode(key, code))
+        }
+      })
+    })
+  })
+
+  describe('getName', () => {
+    it('is a function', () => {
+      expect(keyboardKey.getName).to.be.a('function')
+    })
+    it('returns the code for a given key name', () => {
+      keyboardKey.getName(13).should.equal('Enter', wrongName(13, 'Enter'))
+    })
+    it('handles all codes', () => {
+      _.each(codes, (name, code) => {
+        const keyName = keyboardKey.getName(code)
+        if (Array.isArray(name)) {
+          expect(keyName).to.equal(name[0], wrongName(code, name[0]))
+        } else {
+          expect(keyName).to.equal(name, wrongName(code, name))
+        }
+      })
+    })
+    it('handles event like object: { keyCode: code, shiftKey: false }`', () => {
+      _.each(codes, (name, code) => {
+        const keyName = keyboardKey.getName({ keyCode: code, shiftKey: false })
+
+        if (Array.isArray(name)) {
+          expect(keyName).to.equal(name[0], wrongName(code, name[0]))
+        } else {
+          expect(keyName).to.equal(name, wrongName(code, name))
+        }
+      })
+    })
+    it('handles event like object: { keyCode: code, shiftKey: true }`', () => {
+      _.each(codes, (name, code) => {
+        const keyName = keyboardKey.getName({ keyCode: code, shiftKey: true })
+
+        if (Array.isArray(name)) {
+          expect(keyName).to.equal(name[1], wrongName(code, name[1]))
+        } else {
+          expect(keyName).to.equal(name, wrongName(code, name))
+        }
+      })
+    })
+    it('handles event like object: { which: code, shiftKey: false }', () => {
+      _.each(codes, (name, code) => {
+        const keyName = keyboardKey.getName({ which: code, shiftKey: false })
+
+        if (Array.isArray(name)) {
+          expect(keyName).to.equal(name[0], wrongName(code, name[0]))
+        } else {
+          expect(keyName).to.equal(name, wrongName(code, name))
+        }
+      })
+    })
+    it('handles event like object: { which: code, shiftKey: true }', () => {
+      _.each(codes, (name, code) => {
+        const keyName = keyboardKey.getName({ which: code, shiftKey: true })
+
+        if (Array.isArray(name)) {
+          expect(keyName).to.equal(name[1], wrongName(code, name[1]))
+        } else {
+          expect(keyName).to.equal(name, wrongName(code, name))
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
Addresses todo in #206.  Removes the keyboard-event-key-polyfill in favor of a ponyfill util.
