### PR TITLE
Remove unused Input ref

### DIFF
--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -10,7 +10,6 @@ export default class Input extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     icon: PropTypes.string,
-    ref: PropTypes.string,
   }
 
   static defaultProps = {


### PR DESCRIPTION
Fixes #238.

Likely cause by the recent major dependency updates from greenkeeper-bot. The input component had a rogue ref prop that was being spread.  This was a fatal error and prevents the doc site from loading.
