### PR TITLE
Hot reload in dev only

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -38,14 +38,18 @@ const APP_ENTRY = [
   paths.docsSrc('DocsApp.js'),
 ]
 
-webpackConfig.entry = {
-  app: __DEV__
-    ? [webpackHotMiddlewareEntry, ...APP_ENTRY]
-    : [...APP_ENTRY],
+webpackConfig.entry = __DEV__ ? {
+  app: [
+    webpackHotMiddlewareEntry,
+    ...APP_ENTRY,
+  ],
   vendor: [
     webpackHotMiddlewareEntry,
     ...config.compiler_vendor,
   ],
+} : {
+  app: APP_ENTRY,
+  vendor: config.compiler_vendor,
 }
 
 // ------------------------------------

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ deployment:
   development:
     branch: /^(?!master).*$/
     commands:
-      - gulp docs
+      - NODE_ENV=production gulp docs
       - $(npm bin)/ta-script aws/stage -d docs/build -r $CIRCLE_PROJECT_REPONAME -b $CIRCLE_BRANCH
   production:
     branch: master
@@ -28,4 +28,4 @@ deployment:
       - git config --global user.email "devteam+deweybot@technologyadvice.com"
       - git config --global user.name "deweybot"
       - $(npm bin)/ta-script circle_ci/create_changelog
-      - npm run deploy:docs
+      - NODE_ENV=production npm run deploy:docs


### PR DESCRIPTION
The doc site has hot reloading for development purposes.  Previously, we were running hot reload in the production doc site as well.  This PR limits HMR to dev only.  It also makes a minified production build for the doc site.
