### PR TITLE
Support multiple dropdown type

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
+++ b/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
@@ -12,7 +12,7 @@ export default class DropdownAsyncOptions extends Component {
   componentWillMount() {
     const options = getOptions()
     const value = _.sample(options).value
-    this.setState({ isFetching: false, search: true, value, options })
+    this.setState({ isFetching: false, search: true, multiple: true, value, options })
   }
 
   handleChange = value => this.setState({ value })
@@ -29,29 +29,36 @@ export default class DropdownAsyncOptions extends Component {
 
   selectRandom = () => this.setState({ value: _.sample(this.state.options).value })
   toggleSearch = (e) => this.setState({ search: e.target.checked })
+  toggleMultiple = (e) => this.setState({ multiple: e.target.checked })
 
   render() {
-    const { options, isFetching, search, value } = this.state
+    const { multiple, options, isFetching, search, value } = this.state
 
     return (
       <div>
-        <Button onClick={this.fetchOptions}>Fetch</Button>
-        <Button onClick={this.selectRandom} disabled={_.isEmpty(options)}>Random</Button>
+        <p>
+          <Button onClick={this.fetchOptions}>Fetch</Button>
+          <Button onClick={this.selectRandom} disabled={_.isEmpty(options)}>Random</Button>
+          <label>
+            <input type='checkbox' checked={search} onChange={this.toggleSearch} /> Search
+          </label>
+          {' '}
+          <label>
+            <input type='checkbox' checked={multiple} onChange={this.toggleMultiple} /> Multiple
+          </label>
+        </p>
         <Dropdown
           options={options}
           value={value}
           placeholder='Add Users'
+          multiple={multiple}
           search={search}
           selection
+          fluid
           onChange={this.handleChange}
           disabled={isFetching}
           loading={isFetching}
         />
-        {' '}
-        <label>
-          <input type='checkbox' checked={search} onChange={this.toggleSearch} />
-          {' '}Search
-        </label>
         <pre>{JSON.stringify(this.state, null, 2)}</pre>
       </div>
     )

--- a/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
+++ b/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
@@ -11,7 +11,7 @@ const getOptions = () => _.times(5, () => {
 export default class DropdownAsyncOptions extends Component {
   componentWillMount() {
     const options = getOptions()
-    const value = [_.sample(options).value]
+    const value = []
     this.setState({ isFetching: false, search: true, multiple: true, value, options })
   }
 

--- a/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
+++ b/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
@@ -11,11 +11,11 @@ const getOptions = () => _.times(5, () => {
 export default class DropdownAsyncOptions extends Component {
   componentWillMount() {
     const options = getOptions()
-    const value = _.sample(options).value
+    const value = [_.sample(options).value]
     this.setState({ isFetching: false, search: true, multiple: true, value, options })
   }
 
-  handleChange = value => this.setState({ value })
+  handleChange = (e, value) => this.setState({ value })
 
   // fake api call
   fetchOptions = () => {

--- a/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
+++ b/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
@@ -26,7 +26,11 @@ export default class DropdownAsyncOptions extends Component {
     }, 500)
   }
 
-  selectRandom = () => this.setState({ value: _.sample(this.state.options).value })
+  selectRandom = () => {
+    const { multiple, options } = this.state
+    const value = _.sample(options).value
+    this.setState({ value: multiple ? [value] : value })
+  }
   toggleSearch = (e) => this.setState({ search: e.target.checked })
   toggleMultiple = (e) => {
     const { value } = this.state

--- a/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
+++ b/docs/app/Examples/modules/Dropdown/Content/AsyncOptions.js
@@ -11,8 +11,7 @@ const getOptions = () => _.times(5, () => {
 export default class DropdownAsyncOptions extends Component {
   componentWillMount() {
     const options = getOptions()
-    const value = []
-    this.setState({ isFetching: false, search: true, multiple: true, value, options })
+    this.setState({ isFetching: false, search: true, multiple: true, value: [], options })
   }
 
   handleChange = (e, value) => this.setState({ value })
@@ -29,7 +28,12 @@ export default class DropdownAsyncOptions extends Component {
 
   selectRandom = () => this.setState({ value: _.sample(this.state.options).value })
   toggleSearch = (e) => this.setState({ search: e.target.checked })
-  toggleMultiple = (e) => this.setState({ multiple: e.target.checked })
+  toggleMultiple = (e) => {
+    const { value } = this.state
+    // convert the value to/from an array
+    const newValue = e.target.checked ? _.compact([value]) : value[0]
+    this.setState({ multiple: e.target.checked, value: newValue })
+  }
 
   render() {
     const { multiple, options, isFetching, search, value } = this.state

--- a/docs/app/Examples/modules/Dropdown/DropdownExamples.js
+++ b/docs/app/Examples/modules/Dropdown/DropdownExamples.js
@@ -2,16 +2,10 @@ import React, { Component } from 'react'
 import Content from './Content/Content'
 import States from './States/States'
 
-import { Label, Message } from 'stardust'
-
 export default class DropdownExamples extends Component {
   render() {
     return (
       <div>
-        <Message className='info'>
-          For predictability and simplicity between multiple and single type Dropdowns
-          {' '}<code>value</code> is <b>always and array.</b>
-        </Message>
         <Content />
         <States />
       </div>

--- a/docs/app/Examples/modules/Dropdown/DropdownExamples.js
+++ b/docs/app/Examples/modules/Dropdown/DropdownExamples.js
@@ -2,10 +2,16 @@ import React, { Component } from 'react'
 import Content from './Content/Content'
 import States from './States/States'
 
+import { Label, Message } from 'stardust'
+
 export default class DropdownExamples extends Component {
   render() {
     return (
       <div>
+        <Message className='info'>
+          For predictability and simplicity between multiple and single type Dropdowns
+          {' '}<code>value</code> is <b>always and array.</b>
+        </Message>
         <Content />
         <States />
       </div>

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -1,12 +1,12 @@
-/* eslint-disable valid-jsdoc, complexity */
 import cx from 'classnames'
-import React, { createElement, PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 import createFragment from 'react-addons-create-fragment'
 
 import META from '../../utils/Meta'
 import * as sui from '../../utils/semanticUtils'
 import { someChildType } from '../../utils/childrenUtils'
 import {
+  getUnhandledProps,
   iconPropRenderer,
   imagePropRenderer,
   useKeyOnly,
@@ -21,16 +21,13 @@ import Image from '../Image/Image'
  */
 function Label(props) {
   const {
-    attached, children, color, corner, className, circular, detail, detailLink, floating, horizontal, icon,
-    image, link, onClick, onClickDetail, onClickRemove, pointing, removable, ribbon, size, tag, text,
-    ...rest,
+    attached, children, color, corner, className, circular, detail, detailLink, floating, horizontal,
+    icon, image, link, onClick, onDetailClick, onRemove, pointing, removable, ribbon, size, tag, text,
   } = props
 
   const handleClick = e => onClick && onClick(e, props)
-  const handleClickRemove = e => onClickRemove && onClickRemove(e, props)
-  const handleClickDetail = e => onClickDetail && onClickDetail(e, props)
-
-  const _component = image || link || onClick ? 'a' : 'div'
+  const handleRemove = e => onRemove && onRemove(e, props)
+  const handleDetailClick = e => onDetailClick && onDetailClick(e, props)
 
   const classes = cx('sd-label ui',
     size,
@@ -49,27 +46,29 @@ function Label(props) {
     className
   )
 
-  const _props = {
-    className: classes,
-    onClick: handleClick,
-    ...rest,
-  }
-
-  const _detail = detail || detailLink
-  const detailComponent = (detailLink || onClickDetail) && 'a' || detail && 'div'
+  const DetailComponent = (detailLink || onDetailClick) && 'a' || 'div'
 
   const _children = createFragment({
     icon: iconPropRenderer(icon),
     image: imagePropRenderer(image),
     text,
     children,
-    detail: _detail && createElement(detailComponent, { className: 'detail', onClick: handleClickDetail }, _detail),
-    remove: (removable || onClickRemove) && <Icon className='delete' onClick={handleClickRemove} />,
+    detail: detail && (
+      <DetailComponent className='detail' onClick={handleDetailClick}>{detail}</DetailComponent>
+    ),
+    remove: (removable || onRemove) && (
+      <Icon className='delete' onClick={handleRemove} />
+    ),
   })
 
-  // Do not destructure createElement import
-  // react-docgen only recognizes a stateless component when React.createElement is returned
-  return React.createElement(_component, _props, _children)
+  const LabelComponent = image || link || onClick ? 'a' : 'div'
+  const rest = getUnhandledProps(Label, props)
+
+  return (
+    <LabelComponent className={classes} onClick={handleClick} {...rest}>
+      {_children}
+    </LabelComponent>
+  )
 }
 
 Label._meta = {
@@ -106,7 +105,7 @@ Label.propTypes = {
   /** Additional text with less emphasis. */
   detail: PropTypes.string,
 
-  /** Same as detail but formatted as a link. */
+  /** Format the detail as a link. */
   detailLink: PropTypes.string,
 
   /** Format a label to align better alongside text. */
@@ -136,13 +135,13 @@ Label.propTypes = {
   /** Adds the link style when present, called with (event, props). */
   onClick: PropTypes.func,
 
-  /** Click callback for detail, called with (event, props). */
-  onClickDetail: PropTypes.func,
+  /** Click callback for detail, called with (event, props). Formats the detail as a link. */
+  onDetailClick: PropTypes.func,
 
   /** Adds an "x" icon, called with (event, props) when "x" is clicked. */
-  onClickRemove: PropTypes.func,
+  onRemove: PropTypes.func,
 
-  /** Add an "x" icon that calls onClickRemove when clicked. */
+  /** Add an "x" icon that calls onRemove when clicked. */
   removable: PropTypes.bool,
 
   /** Point to content next to it. */

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -195,6 +195,7 @@ export default class Dropdown extends Component {
       // in development, validate value type matches dropdown type
       const isNextValueArray = Array.isArray(nextProps.value)
 
+      /* eslint-disable no-console */
       if (nextProps.multiple && !isNextValueArray) {
         console.error(
           'Dropdown `value` must be an array when `multiple` is set.' +
@@ -206,6 +207,7 @@ export default class Dropdown extends Component {
           ' Either set `multiple={true}` or use a string or number value.'
         )
       }
+      /* eslint-enable no-console */
     }
 
     if (!_.isEqual(nextProps.value, this.state.value)) {
@@ -305,8 +307,6 @@ export default class Dropdown extends Component {
   }
 
   openOnSpace = (e) => {
-    console.log('openOnSpace')
-    console.log('open:', this.state.open)
     if (keyboardKey.getCode(e) !== keyboardKey.Spacebar) return
     if (this.state.open) return
     e.preventDefault()

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -683,7 +683,7 @@ export default class Dropdown extends Component {
         key={item.value}
         text={item.text}
         value={item.value}
-        onClickRemove={this.handleLabelRemove}
+        onRemove={this.handleLabelRemove}
         link
       />
     ))

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -240,6 +240,7 @@ export default class Dropdown extends Component {
 
     // opened / closed
     if (!prevState.open && this.state.open) {
+      this.open()
       document.addEventListener('keydown', this.closeOnEscape)
       document.addEventListener('keydown', this.moveSelectionOnKeyDown)
       document.addEventListener('keydown', this.selectItemOnEnter)
@@ -247,6 +248,7 @@ export default class Dropdown extends Component {
       document.removeEventListener('keydown', this.openOnArrow)
       document.removeEventListener('keydown', this.openOnSpace)
     } else if (prevState.open && !this.state.open) {
+      this.close()
       document.removeEventListener('keydown', this.closeOnEscape)
       document.removeEventListener('keydown', this.moveSelectionOnKeyDown)
       document.removeEventListener('keydown', this.selectItemOnEnter)
@@ -303,16 +305,22 @@ export default class Dropdown extends Component {
   }
 
   openOnSpace = (e) => {
+    console.log('openOnSpace')
+    console.log('open:', this.state.open)
     if (keyboardKey.getCode(e) !== keyboardKey.Spacebar) return
+    if (this.state.open) return
     e.preventDefault()
-    this.open()
+    // TODO open/close should only change state, open/closeMenu should be called on did update
+    this.trySetState({ open: true })
   }
 
   openOnArrow = (e) => {
     const code = keyboardKey.getCode(e)
     if (!_.includes([keyboardKey.ArrowDown, keyboardKey.ArrowUp], code)) return
+    if (this.state.open) return
     e.preventDefault()
-    this.open()
+    // TODO open/close should only change state, open/closeMenu should be called on did update
+    this.trySetState({ open: true })
   }
 
   selectItemOnEnter = (e) => {
@@ -560,8 +568,8 @@ export default class Dropdown extends Component {
     debug.groupCollapsed('open()')
     debug(`dropdown is ${this.state.open ? 'already' : 'not yet'} open`)
     debug.groupEnd()
-    if (this.state.open) return
-    if (this.props.search) this.refs.search.focus()
+    const { search } = this.props
+    if (search) this.refs.search.focus()
 
     this.trySetState({
       open: true,

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -505,8 +505,6 @@ export default class Dropdown extends Component {
       newState.selectedIndex = this.getMenuItemIndexByValue(value)
     }
 
-    this.trySetState({ value }, { selectedIndex })
-
     this.trySetState({ value }, newState)
   }
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -179,14 +179,15 @@ export default class Dropdown extends Component {
 
   componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(nextProps)
-    debug.groupCollapsed('componentDidUpdate()')
+    debug.groupCollapsed('componentWillReceiveProps()')
     // TODO objectDiff still runs in prod, stop it
     debug('changed props:', objectDiff(nextProps, this.props))
-    debug.groupEnd()
 
     if (!_.isEqual(nextProps.value, this.state.value)) {
+      debug('value changed, setting', nextProps.value)
       this.setValue(nextProps.value)
     }
+    debug.groupEnd()
   }
 
   componentDidUpdate(prevProps, prevState) { // eslint-disable-line complexity
@@ -243,12 +244,12 @@ export default class Dropdown extends Component {
 
   // onChange needs to receive a value
   // can't rely on props.value if we are controlled
-  onChange = (value) => {
+  onChange = (e, value) => {
     debug.groupCollapsed('onChange()')
     debug(value)
     debug.groupEnd()
     const { onChange } = this.props
-    if (onChange) onChange(value)
+    if (onChange) onChange(e, value)
   }
 
   closeOnEscape = (e) => {

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -66,16 +66,16 @@ export default class Dropdown extends Component {
      * Current value, creates a controlled component.
      * This is always an array for simplicity between single and multiple dropdown types.
      */
-    value: PropTypes.arrayOf([
+    value: PropTypes.arrayOf(PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
-    ]),
+    ])),
 
     /** Initial value or value array if multiple. */
-    defaultValue: PropTypes.arrayOf([
+    defaultValue: PropTypes.arrayOf(PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
-    ]),
+    ])),
 
     /** Placeholder text. */
     placeholder: PropTypes.string,
@@ -587,7 +587,7 @@ export default class Dropdown extends Component {
     const { placeholder, search } = this.props
     const { searchQuery, value } = this.state
 
-    if (value || !placeholder) return null
+    if (!_.isEmpty(value) || !placeholder) return null
     const classes = cx('default text', search && searchQuery && 'filtered')
 
     return <div className={classes}>{placeholder}</div>

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -168,16 +168,9 @@ export default class Dropdown extends Component {
   componentWillMount() {
     if (super.componentWillMount) super.componentWillMount()
     debug('componentWillMount()')
-    const { multiple, options } = this.props
     const { open, value } = this.state
 
-    // Select the currently active item, if none, use the first item.
-    // Multiple selects remove active items from the list,
-    // their initial selected index should be 0.
-    const selectedIndex = multiple ? 0 : this.getMenuItemIndexByValue(value || _.get(options, '[0].value'))
-
-    this.trySetState({ value }, { selectedIndex })
-
+    this.setValue(value)
     if (open) this.open()
   }
 
@@ -495,7 +488,12 @@ export default class Dropdown extends Component {
     }
 
     // update the selected index
-    if (multiple) {
+    if (!selectedIndex) {
+      // Select the currently active item, if none, use the first item.
+      // Multiple selects remove active items from the list,
+      // their initial selected index should be 0.
+      newState.selectedIndex = multiple ? 0 : this.getMenuItemIndexByValue(value || _.get(options, '[0].value'))
+    } else if (multiple) {
       // multiple selects remove options from the menu as they are made active
       // keep the selected index within range of the remaining items
       if (selectedIndex >= options.length - 1) {
@@ -506,6 +504,8 @@ export default class Dropdown extends Component {
       // set the selected index to the currently active item
       newState.selectedIndex = this.getMenuItemIndexByValue(value)
     }
+
+    this.trySetState({ value }, { selectedIndex })
 
     this.trySetState({ value }, newState)
   }

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -5,7 +5,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import META from '../../utils/Meta'
-import { useKeyOnly, useKeyOrValueAndKey } from '../../utils/propUtils'
+import { getUnhandledProps, useKeyOnly, useKeyOrValueAndKey } from '../../utils/propUtils'
 import keyboardKey from '../../utils/keyboardKey'
 import { makeDebugger } from '../../utils/debug'
 import { objectDiff } from '../../utils/utils'
@@ -734,9 +734,6 @@ export default class Dropdown extends Component {
       error,
       disabled,
       scrolling,
-      // TODO: not all our props have been destructured, `rest` includes some of our props here
-      // we should only spread user props
-      ...rest,
     } = this.props
 
     // Classes
@@ -773,6 +770,12 @@ export default class Dropdown extends Component {
       tabIndex: 0,
     }
 
+    const rest = getUnhandledProps(Dropdown, this.props)
+    {/*
+     TODO onChange needs to be handled transparently
+     we should allow all changes to bubble, and not go into setValue loops
+     */
+    }
     return (
       <div
         {...rest}

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -600,13 +600,18 @@ export default class Dropdown extends Component {
   // ----------------------------------------
 
   renderText = () => {
-    const { multiple, search, text } = this.props
+    const { multiple, placeholder, search, text } = this.props
     const { searchQuery, value } = this.state
+    const hasValue = multiple ? !_.isEmpty(value) : !!value
 
     if (multiple) return
 
-    const classes = cx('text', search && searchQuery && 'filtered')
-    let _text
+    const classes = cx(
+      placeholder && !hasValue && 'default',
+      'text',
+      search && searchQuery && 'filtered'
+    )
+    let _text = placeholder
     if (text && !searchQuery) {
       _text = text
     } else if (searchQuery) {
@@ -616,17 +621,6 @@ export default class Dropdown extends Component {
     }
 
     return <div className={classes}>{_text}</div>
-  }
-
-  renderPlaceholder = () => {
-    const { multiple, placeholder, search } = this.props
-    const { searchQuery, value } = this.state
-    const hasValue = multiple ? !_.isEmpty(value) : !!value
-
-    if (hasValue || !placeholder) return null
-    const classes = cx('default text', search && searchQuery && 'filtered')
-
-    return <div className={classes}>{placeholder}</div>
   }
 
   // TODO hidden input only exists for backwards compatibility with SUI jQuery plugins
@@ -641,7 +635,7 @@ export default class Dropdown extends Component {
     debug.groupEnd()
     if (!selection) return null
 
-    const _value = multiple ? value.join(',') : value
+    const _value = multiple ? (value || []).join(',') : value
 
     return <input type='hidden' name={name} value={_value} />
   }
@@ -794,11 +788,10 @@ export default class Dropdown extends Component {
         className={classes}
       >
         {this.renderHiddenInput()}
-        <Icon className={'dropdown'} />
         {this.renderLabels()}
         {this.renderSearchInput()}
         {this.renderText()}
-        {this.renderPlaceholder()}
+        <Icon className={'dropdown'} />
         <DropdownMenu className={menuClasses} ref='menu'>
           {this.renderOptions()}
         </DropdownMenu>

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -469,7 +469,7 @@ export default class Dropdown extends Component {
   getMenuItemIndexByValue = (value) => {
     const options = this.getMenuOptions()
 
-    return _.findIndex(options, opt => opt.value === value)
+    return _.findIndex(options, ['value', value])
   }
 
   // ----------------------------------------
@@ -668,10 +668,10 @@ export default class Dropdown extends Component {
     debug('selectedItems', selectedItems)
     debug.groupEnd()
 
-    return _.map(selectedItems, (item) => {
-      // if no item could be found for a given state value the selected item will be undefined
-      // prevent cannot read property foo of undefined errors
-      return _.isUndefined(item) ? null : (
+    // if no item could be found for a given state value the selected item will be undefined
+    // compact the selectedItems so we only have actual objects left
+    return _.map(_.compact(selectedItems), (item) => {
+      return (
         <Label
           key={item.value}
           text={item.text}

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -774,11 +774,6 @@ export default class Dropdown extends Component {
 
     const rest = getUnhandledProps(Dropdown, this.props)
 
-    /*
-     TODO onChange needs to be handled transparently
-     we should allow all changes to bubble, and not go into setValue loops
-     */
-
     return (
       <div
         {...rest}

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -602,8 +602,6 @@ export default class Dropdown extends Component {
     const { searchQuery, value } = this.state
     const hasValue = multiple ? !_.isEmpty(value) : !!value
 
-    if (multiple) return
-
     const classes = cx(
       placeholder && !hasValue && 'default',
       'text',
@@ -614,7 +612,7 @@ export default class Dropdown extends Component {
       _text = text
     } else if (searchQuery) {
       _text = null
-    } else if (value) {
+    } else if (hasValue) {
       _text = _.get(this.getItemByValue(value), 'text')
     }
 

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -53,9 +53,6 @@ DropdownItem._meta = {
 }
 
 DropdownItem.propTypes = {
-  // TODO: filter private methods out of docs or support @private tags
-  __onClick: PropTypes.func,
-
   /** Style as the currently chosen item. */
   active: PropTypes.bool,
 

--- a/test/specs/elements/Label/Label-test.js
+++ b/test/specs/elements/Label/Label-test.js
@@ -75,23 +75,9 @@ describe('Label Component', () => {
     })
 
     it('renders detail as an a tag', () => {
-      shallow(<Label detailLink={faker.hacker.noun()} />)
+      shallow(<Label detail={faker.hacker.noun()} detailLink />)
         .find('.detail')
         .should.have.tagName('a')
-    })
-
-    it('adds a detail last child', () => {
-      shallow(<Label detailLink={faker.hacker.noun()}><br /></Label>)
-        .children()
-        .last()
-        .should.match('.detail')
-    })
-
-    it('adds the value as the detail text', () => {
-      const detailLink = faker.hacker.noun()
-      shallow(<Label detailLink={detailLink} />)
-        .find('.detail')
-        .should.contain.text(detailLink)
     })
   })
 
@@ -186,14 +172,14 @@ describe('Label Component', () => {
     })
   })
 
-  describe('onClickRemove', () => {
+  describe('onRemove', () => {
     it('has no delete icon when not defined', () => {
       shallow(<Label />)
         .should.not.have.descendants('.delete')
     })
 
     it('adds a delete icon as last child', () => {
-      shallow(<Label onClickRemove={() => {}}><br /></Label>)
+      shallow(<Label onRemove={() => {}}><br /></Label>)
         .children()
         .last()
         .should.match('.delete')
@@ -201,7 +187,7 @@ describe('Label Component', () => {
 
     it('is called when delete icon is clicked', () => {
       const props = {
-        onClickRemove: sandbox.spy(),
+        onRemove: sandbox.spy(),
       }
 
       // mount to get click event to propagate on click
@@ -209,21 +195,20 @@ describe('Label Component', () => {
         .find('.delete')
         .simulate('click')
 
-      props.onClickRemove.should.have.been.calledOnce()
+      props.onRemove.should.have.been.calledOnce()
     })
   })
 
-  describe('onClickDetail', () => {
+  describe('onDetailClick', () => {
     it('renders detail as an a tag', () => {
-      shallow(<Label detail={faker.hacker.noun()} onClickDetail={() => {}} />)
-        .find('.detail')
-        .should.have.tagName('a')
+      shallow(<Label detail={faker.hacker.noun()} onDetailClick={() => {}} />)
+        .should.have.descendants('a.detail')
     })
 
     it('is called when detail is clicked', () => {
       const props = {
         detail: faker.hacker.noun(),
-        onClickDetail: sandbox.spy(),
+        onDetailClick: sandbox.spy(),
       }
 
       // mount to get click event to propagate on click
@@ -231,7 +216,7 @@ describe('Label Component', () => {
         .find('.detail')
         .simulate('click')
 
-      props.onClickDetail.should.have.been.calledOnce()
+      props.onDetailClick.should.have.been.calledOnce()
     })
   })
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -271,7 +271,7 @@ describe('Dropdown Component', () => {
     it('sets the corresponding item to active', () => {
       const value = _.sample(options).value
 
-      wrapperShallow(<Dropdown {...requiredProps} value={[value]} />)
+      wrapperShallow(<Dropdown {...requiredProps} value={value} />)
         .find('DropdownItem')
         .find({ value, active: true })
         .should.be.present()
@@ -291,7 +291,7 @@ describe('Dropdown Component', () => {
       let next
       while (!next || next === value) next = _.sample(options).value
 
-      wrapperShallow(<Dropdown value={[value]} {...requiredProps} />)
+      wrapperShallow(<Dropdown value={value} {...requiredProps} />)
 
       // initial active item
       wrapper
@@ -301,7 +301,7 @@ describe('Dropdown Component', () => {
 
       // change value
       wrapper
-        .setProps({ value: [next] })
+        .setProps({ value: next })
 
       // next active item
       wrapper
@@ -314,12 +314,12 @@ describe('Dropdown Component', () => {
       const initialItem = _.sample(options)
       const nextItem = _.sample(_.without(options, initialItem))
 
-      wrapperMount(<Dropdown {...requiredProps} value={[initialItem.value]} />)
+      wrapperMount(<Dropdown {...requiredProps} value={initialItem.value} />)
         .find('.text')
         .should.contain.text(initialItem.text)
 
       wrapper
-        .setProps({ value: [nextItem.value] })
+        .setProps({ value: nextItem.value })
         .find('.text')
         .should.contain.text(nextItem.text)
     })
@@ -611,7 +611,7 @@ describe('Dropdown Component', () => {
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[1].should.deep.equal([randomValue])
+      spy.firstCall.args[1].should.deep.equal(randomValue)
     })
     it('is called with event and value when pressing enter on a selected item', () => {
       const firstValue = options[0].value
@@ -621,7 +621,7 @@ describe('Dropdown Component', () => {
       domEvent.keyDown(document, { key: 'Enter' })
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[1].should.deep.equal([firstValue])
+      spy.firstCall.args[1].should.deep.equal(firstValue)
     })
     it('is not called when updating the value prop', () => {
       const value = [_.sample(options).value]
@@ -668,6 +668,10 @@ describe('Dropdown Component', () => {
       wrapperRender(<Dropdown {...requiredProps} selection />)
         .find('input[type="hidden"]')
         .should.be.present()
+    })
+
+    it('does not allow a null item', () => {
+
     })
   })
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -280,7 +280,7 @@ describe('Dropdown Component', () => {
     it('sets the corresponding item text', () => {
       const { text, value } = _.sample(options)
 
-      wrapperShallow(<Dropdown value={[value]} {...requiredProps} />)
+      wrapperShallow(<Dropdown value={value} {...requiredProps} />)
         .find('DropdownItem')
         .find({ value, text })
         .should.be.present()
@@ -653,9 +653,8 @@ describe('Dropdown Component', () => {
       spy.firstCall.args[1].should.deep.equal(firstValue)
     })
     it('is not called when updating the value prop', () => {
-      const value = [_.sample(options).value]
-      let next
-      while (!next || next === value) next = [_.sample(options).value]
+      const value = _.sample(options).value
+      const next = _.sample(_.without(options, value)).value
 
       wrapperMount(<Dropdown {...requiredProps} value={value} onChange={spy} />)
         .setProps({ value: next })
@@ -697,10 +696,6 @@ describe('Dropdown Component', () => {
       wrapperRender(<Dropdown {...requiredProps} selection />)
         .find('input[type="hidden"]')
         .should.be.present()
-    })
-
-    it('does not allow a null item', () => {
-
     })
   })
 
@@ -911,7 +906,7 @@ describe('Dropdown Component', () => {
         .should.not.have.descendants('.default.text')
     })
     it('is not present when there is a value', () => {
-      wrapperShallow(<Dropdown {...requiredProps} value={['hi']} placeholder='hi' />)
+      wrapperShallow(<Dropdown {...requiredProps} value='hi' placeholder='hi' />)
         .should.not.have.descendants('.default.text')
     })
     it('has a filtered className when there is a search query', () => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -493,6 +493,35 @@ describe('Dropdown Component', () => {
     })
   })
 
+  describe('open', () => {
+    it('defaultOpen opens the menu when true', () => {
+      wrapperShallow(<Dropdown {...requiredProps} defaultOpen />)
+      dropdownMenuIsOpen()
+    })
+    it('defaultOpen closes the menu when false', () => {
+      wrapperShallow(<Dropdown {...requiredProps} defaultOpen={false} />)
+      dropdownMenuIsClosed()
+    })
+    it('closes the menu when true', () => {
+      wrapperShallow(<Dropdown {...requiredProps} open />)
+      dropdownMenuIsOpen()
+    })
+    it('closes the menu when false', () => {
+      wrapperShallow(<Dropdown {...requiredProps} open={false} />)
+      dropdownMenuIsClosed()
+    })
+    it('closes the menu when toggled from true to false', () => {
+      wrapperShallow(<Dropdown {...requiredProps} open />)
+        .setProps({ open: false })
+      dropdownMenuIsOpen()
+    })
+    it('closes the menu when toggled from false to true', () => {
+      wrapperShallow(<Dropdown {...requiredProps} open={false} />)
+        .setProps({ open: true })
+      dropdownMenuIsClosed()
+    })
+  })
+
   describe('multiple', () => {
     it('does not close the menu on item selection with enter', () => {
       wrapperMount(<Dropdown {...requiredProps} multiple />)

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -9,7 +9,7 @@ import sandbox from 'test/utils/Sandbox-util'
 
 let attachTo
 let options
-let defaultProps
+let requiredProps
 let wrapper
 
 // ----------------------------------------
@@ -57,7 +57,7 @@ describe('Dropdown Component', () => {
     attachTo = undefined
     wrapper = undefined
     options = getOptions()
-    defaultProps = { options }
+    requiredProps = { options }
   })
 
   afterEach(() => {
@@ -65,15 +65,15 @@ describe('Dropdown Component', () => {
     if (attachTo) document.body.removeChild(attachTo)
   })
 
-  common.isConformant(Dropdown, defaultProps)
-  common.hasUIClassName(Dropdown, defaultProps)
-  common.isTabbable(Dropdown, defaultProps)
-  common.propKeyOnlyToClassName(Dropdown, 'multiple', defaultProps)
-  common.propKeyOnlyToClassName(Dropdown, 'search', defaultProps)
-  common.propKeyOnlyToClassName(Dropdown, 'selection', defaultProps)
+  common.isConformant(Dropdown, requiredProps)
+  common.hasUIClassName(Dropdown, requiredProps)
+  common.isTabbable(Dropdown, requiredProps)
+  common.propKeyOnlyToClassName(Dropdown, 'multiple', requiredProps)
+  common.propKeyOnlyToClassName(Dropdown, 'search', requiredProps)
+  common.propKeyOnlyToClassName(Dropdown, 'selection', requiredProps)
 
   it('does not add a hidden input by default', () => {
-    wrapperMount(<Dropdown {...defaultProps} />)
+    wrapperMount(<Dropdown {...requiredProps} />)
       .find('input[type="hidden"]')
       .should.not.be.present()
   })
@@ -105,7 +105,7 @@ describe('Dropdown Component', () => {
 
   describe('selected item', () => {
     it('defaults to the first item', () => {
-      wrapperShallow(<Dropdown {...defaultProps} />)
+      wrapperShallow(<Dropdown {...requiredProps} />)
         .find('DropdownItem')
         .first()
         .should.have.prop('selected', true)
@@ -114,14 +114,14 @@ describe('Dropdown Component', () => {
       // random item, skip the first as its selected by default
       const randomIndex = 1 + _.random(options.length - 2)
 
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
         .find('DropdownItem')
         .at(randomIndex)
         .simulate('click')
         .should.have.prop('selected', true)
     })
     it('moves down on arrow down when open', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       // open
       wrapper.simulate('click')
@@ -142,7 +142,7 @@ describe('Dropdown Component', () => {
         .should.have.prop('selected', true)
     })
     it('moves up on arrow up when open', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       // open
       wrapper
@@ -240,7 +240,7 @@ describe('Dropdown Component', () => {
       )
     })
     it('becomes active on enter when open', () => {
-      const item = wrapperMount(<Dropdown {...defaultProps} />)
+      const item = wrapperMount(<Dropdown {...requiredProps} />)
         .simulate('click')
         .find('DropdownItem')
         .at(1)
@@ -256,7 +256,7 @@ describe('Dropdown Component', () => {
       item.should.have.prop('active', true)
     })
     it('closes the menu', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
         .simulate('click')
 
       dropdownMenuIsOpen()
@@ -271,7 +271,7 @@ describe('Dropdown Component', () => {
     it('sets the corresponding item to active', () => {
       const { value } = _.sample(options)
 
-      wrapperShallow(<Dropdown {...defaultProps} value={value} />)
+      wrapperShallow(<Dropdown {...requiredProps} value={value} />)
         .children()
         .find({ value })
         .should.have.prop('active', true)
@@ -280,7 +280,7 @@ describe('Dropdown Component', () => {
     it('sets the corresponding item text', () => {
       const { text, value } = _.sample(options)
 
-      wrapperShallow(<Dropdown value={value} {...defaultProps} />)
+      wrapperShallow(<Dropdown value={value} {...requiredProps} />)
         .children()
         .find({ value })
         .should.have.prop('text', text)
@@ -291,7 +291,7 @@ describe('Dropdown Component', () => {
       let next
       while (!next || next === value) next = _.sample(options).value
 
-      wrapperShallow(<Dropdown value={value} {...defaultProps} />)
+      wrapperShallow(<Dropdown value={value} {...requiredProps} />)
 
       // initial active item
       wrapper
@@ -315,7 +315,7 @@ describe('Dropdown Component', () => {
       let next
       while (!next || next === sample) next = _.sample(options)
 
-      wrapperMount(<Dropdown {...defaultProps} value={sample.value} />)
+      wrapperMount(<Dropdown {...requiredProps} value={sample.value} />)
         .find('.text')
         .should.contain.text(sample.text)
 
@@ -330,14 +330,14 @@ describe('Dropdown Component', () => {
     it('sets the display text', () => {
       const text = faker.hacker.phrase()
 
-      wrapperRender(<Dropdown {...defaultProps} text={text} />)
+      wrapperRender(<Dropdown {...requiredProps} text={text} />)
         .find('.text')
         .should.contain.text(text)
     })
     it('prevents updates on item click if defined', () => {
       const text = faker.hacker.phrase()
 
-      wrapperMount(<Dropdown {...defaultProps} text={text} />)
+      wrapperMount(<Dropdown {...requiredProps} text={text} />)
         .simulate('click')
         .find('DropdownItem')
         .at(_.random(options.length - 1))
@@ -348,7 +348,7 @@ describe('Dropdown Component', () => {
         .should.contain.text(text)
     })
     it('is updated on item click if not already defined', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       // open
       wrapper.simulate('click')
@@ -364,6 +364,10 @@ describe('Dropdown Component', () => {
         .find('.text')
         .should.contain.text(item.text())
     })
+    it('is not present on multiple dropdowns', () => {
+      wrapperShallow(<Dropdown {...requiredProps} multiple />)
+        .should.not.have.descendants('.text')
+    })
   })
 
   describe('menu', () => {
@@ -374,7 +378,7 @@ describe('Dropdown Component', () => {
     // https://github.com/facebook/react/issues/5043
 
     it('opens on dropdown click', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       dropdownMenuIsClosed()
       wrapper.simulate('click')
@@ -382,7 +386,7 @@ describe('Dropdown Component', () => {
     })
 
     it('opens on arrow down when focused', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       dropdownMenuIsClosed()
       wrapper.simulate('focus')
@@ -391,7 +395,7 @@ describe('Dropdown Component', () => {
     })
 
     it('opens on arrow up when focused', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       dropdownMenuIsClosed()
       wrapper.simulate('focus')
@@ -400,7 +404,7 @@ describe('Dropdown Component', () => {
     })
 
     it('opens on space when focused and closed', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       dropdownMenuIsClosed()
       wrapper.simulate('focus')
@@ -409,7 +413,7 @@ describe('Dropdown Component', () => {
     })
 
     it('does not call open on space if already open', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       const instance = wrapper.instance()
       sandbox.spy(instance, 'open')
@@ -433,7 +437,7 @@ describe('Dropdown Component', () => {
     })
 
     it('does not open on arrow down when not focused', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       dropdownMenuIsClosed()
       domEvent.keyDown(document, { key: 'ArrowDown' })
@@ -441,7 +445,7 @@ describe('Dropdown Component', () => {
     })
 
     it('does not open on space when not focused', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       dropdownMenuIsClosed()
       domEvent.keyDown(document, { key: ' ' })
@@ -449,7 +453,7 @@ describe('Dropdown Component', () => {
     })
 
     it('closes on menu item click', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
       const item = wrapper
         .find('DropdownItem')
         .at(_.random(options.length - 1))
@@ -464,7 +468,7 @@ describe('Dropdown Component', () => {
     })
 
     it('closes on click outside', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       // open
       wrapper.simulate('click')
@@ -476,7 +480,7 @@ describe('Dropdown Component', () => {
     })
 
     it('closes on esc key', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       // open
       wrapper
@@ -492,7 +496,7 @@ describe('Dropdown Component', () => {
 
   describe('multiple', () => {
     it('does not close the menu on item selection with enter', () => {
-      wrapperMount(<Dropdown {...defaultProps} multiple />)
+      wrapperMount(<Dropdown {...requiredProps} multiple />)
         .simulate('click')
 
       dropdownMenuIsOpen()
@@ -503,13 +507,63 @@ describe('Dropdown Component', () => {
       dropdownMenuIsOpen()
     })
     it('does not close the menu on clicking on an item', () => {
-      wrapperMount(<Dropdown {...defaultProps} multiple />)
-        .simulate('click')
+      const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }
+      wrapperMount(<Dropdown {...requiredProps} multiple />)
+        .simulate('click', nativeEvent)
         .find('DropdownItem')
         .at(_.random(options.length - 1))
-        .simulate('click')
+        .simulate('click', nativeEvent)
 
       dropdownMenuIsOpen()
+    })
+    it('filters active options out of the list', () => {
+      // make all the items active, expect to see none in the list
+      const value = _.map(requiredProps.options, 'value').join(',')
+      wrapperShallow(<Dropdown {...requiredProps} value={value} multiple />)
+        .should.not.have.descendants('DropdownItem')
+    })
+    it('displays a label for active items', () => {
+      // select a random item, expect a label with the item's text
+      const activeItem = _.sample(requiredProps.options)
+      wrapperShallow(<Dropdown {...requiredProps} value={activeItem.value} multiple />)
+        .should.have.descendants('Label')
+
+      wrapper
+        .find('Label')
+        .should.have.prop('text', activeItem.text)
+    })
+    it('keeps the selection within the range of remaining options', () => {
+      // items are removed as they are made active
+      // the selection should move if the last item is made active
+      wrapperMount(<Dropdown {...requiredProps} multiple />)
+
+      // open
+      wrapper.simulate('click')
+      dropdownMenuIsOpen()
+
+      // activate the last item
+      domEvent.keyDown(document, { key: 'ArrowUp' })
+
+      wrapper
+        .find('DropdownItem')
+        .last()
+        .should.have.prop('selected', true)
+
+      domEvent.keyDown(document, { key: 'Enter' })
+
+      // expect selection to have moved from last, to one from last
+      // activating items in multiple selects removes them from the list
+      // we use at() to ensure we're targeting the exact indexes we expect
+      // (ie the last() item will vary)
+      wrapper
+        .find('DropdownItem')
+        .at(requiredProps.options.length - 1)
+        .should.not.have.prop('selected', true)
+
+      wrapper
+        .find('DropdownItem')
+        .at(requiredProps.options.length - 2)
+        .should.have.prop('selected', true)
     })
   })
 
@@ -517,13 +571,8 @@ describe('Dropdown Component', () => {
     let spy
     beforeEach(() => (spy = sandbox.spy()))
 
-    it('is a prop on the hidden input', () => {
-      wrapperShallow(<Dropdown {...defaultProps} selection onChange={spy} />)
-        .find('input[type="hidden"]')
-        .should.have.prop('onChange')
-    })
     it('is called on item click', () => {
-      wrapperMount(<Dropdown {...defaultProps} onChange={spy} />)
+      wrapperMount(<Dropdown {...requiredProps} onChange={spy} />)
         .simulate('click')
         .find('DropdownItem')
         .at(_.random(options.length - 1))
@@ -532,7 +581,7 @@ describe('Dropdown Component', () => {
       spy.should.have.been.called()
     })
     it('is called when pressing enter on a selected item', () => {
-      wrapperMount(<Dropdown {...defaultProps} onChange={spy} />)
+      wrapperMount(<Dropdown {...requiredProps} onChange={spy} />)
         .simulate('click')
 
       domEvent.keyDown(document, { key: 'ArrowDown' })
@@ -545,7 +594,7 @@ describe('Dropdown Component', () => {
       let next
       while (!next || next === value) next = _.sample(options).value
 
-      wrapperMount(<Dropdown {...defaultProps} value={value} onChange={spy} />)
+      wrapperMount(<Dropdown {...requiredProps} value={value} onChange={spy} />)
         .setProps({ value: next })
 
       spy.should.not.have.been.called()
@@ -554,12 +603,12 @@ describe('Dropdown Component', () => {
 
   describe('options', () => {
     it('adds the onClick handler to all items', () => {
-      wrapperShallow(<Dropdown {...defaultProps} />)
+      wrapperShallow(<Dropdown {...requiredProps} />)
         .children('DropdownItem')
         .everyWhere(item => item.should.have.prop('onClick'))
     })
     it('calls handleItemClick when an item is clicked', () => {
-      wrapperMount(<Dropdown {...defaultProps} />)
+      wrapperMount(<Dropdown {...requiredProps} />)
 
       const instance = wrapper.instance()
       sandbox.spy(instance, 'handleItemClick')
@@ -582,7 +631,7 @@ describe('Dropdown Component', () => {
 
   describe('selection', () => {
     it('adds a hidden input', () => {
-      wrapperRender(<Dropdown {...defaultProps} selection />)
+      wrapperRender(<Dropdown {...requiredProps} selection />)
         .find('input[type="hidden"]')
         .should.be.present()
     })
@@ -590,17 +639,17 @@ describe('Dropdown Component', () => {
 
   describe('search', () => {
     it('does not add a search input when not defined', () => {
-      wrapperShallow(<Dropdown {...defaultProps} />)
+      wrapperShallow(<Dropdown {...requiredProps} />)
         .should.not.have.descendants('input.search')
     })
 
     it('adds a search input when present', () => {
-      wrapperRender(<Dropdown {...defaultProps} search />)
+      wrapperRender(<Dropdown {...requiredProps} search />)
         .should.have.descendants('input.search')
     })
 
     it('sets focus to the search input on open', () => {
-      wrapperMount(<Dropdown {...defaultProps} search />)
+      wrapperMount(<Dropdown {...requiredProps} search />)
         .simulate('click')
 
       const activeElement = document.activeElement
@@ -611,12 +660,12 @@ describe('Dropdown Component', () => {
     })
 
     it('removes Dropdown tabIndex', () => {
-      wrapperShallow(<Dropdown {...defaultProps} search />)
+      wrapperShallow(<Dropdown {...requiredProps} search />)
         .should.not.have.prop('tabIndex')
     })
 
     it('has a search input with a tabIndex of 0', () => {
-      wrapperShallow(<Dropdown {...defaultProps} search />)
+      wrapperShallow(<Dropdown {...requiredProps} search />)
         .find('input.search')
         .should.have.prop('tabIndex', '0')
     })
@@ -625,7 +674,7 @@ describe('Dropdown Component', () => {
       // search for random item
       const searchQuery = _.sample(options).text
 
-      wrapperMount(<Dropdown {...defaultProps} search />)
+      wrapperMount(<Dropdown {...requiredProps} search />)
 
       // open and simulate search
       wrapper
@@ -643,7 +692,7 @@ describe('Dropdown Component', () => {
     })
 
     it('opens the menu on change if there is a query and not already open', () => {
-      wrapperMount(<Dropdown {...defaultProps} search />)
+      wrapperMount(<Dropdown {...requiredProps} search />)
 
       dropdownMenuIsClosed()
 
@@ -657,7 +706,7 @@ describe('Dropdown Component', () => {
 
     it('does not call onChange on query change', () => {
       const onChangeSpy = sandbox.spy()
-      wrapperMount(<Dropdown {...defaultProps} search onChange={onChangeSpy} />)
+      wrapperMount(<Dropdown {...requiredProps} search onChange={onChangeSpy} />)
 
       // simulate search
       wrapper
@@ -668,7 +717,7 @@ describe('Dropdown Component', () => {
     })
 
     it('filters the items based on display text', () => {
-      const search = wrapperMount(<Dropdown {...defaultProps} search />)
+      const search = wrapperMount(<Dropdown {...requiredProps} search />)
         .find('input.search')
 
       // search for value yields 0 results
@@ -687,7 +736,7 @@ describe('Dropdown Component', () => {
     })
 
     it('sets the selected item to the first search result', () => {
-      const search = wrapperMount(<Dropdown {...defaultProps} search />)
+      const search = wrapperMount(<Dropdown {...requiredProps} search />)
         .find('input.search')
 
       // the first item is selected by default
@@ -700,25 +749,9 @@ describe('Dropdown Component', () => {
       wrapper.should.have.state('selectedIndex', 0)
     })
 
-    it('shows a message when there are no results', () => {
-      const search = wrapperMount(<Dropdown {...defaultProps} search />)
-        .find('input.search')
-
-      wrapper
-        .find('.message')
-        .should.not.be.present()
-
-      // search for something we know will not exist
-      search.simulate('change', { target: { value: '_________________' } })
-
-      wrapper
-        .find('.message')
-        .should.be.present()
-    })
-
     it('still allows moving selection after blur/focus', () => {
       // open, first item is selected
-      const search = wrapperMount(<Dropdown {...defaultProps} search />)
+      const search = wrapperMount(<Dropdown {...requiredProps} search />)
         .find('input.search')
         .simulate('focus')
 
@@ -764,9 +797,46 @@ describe('Dropdown Component', () => {
     })
   })
 
+  describe('no results message', () => {
+    it('is shown when a search yields no results', () => {
+      const search = wrapperMount(<Dropdown {...requiredProps} search />)
+        .find('input.search')
+
+      wrapper
+        .find('.message')
+        .should.not.be.present()
+
+      // search for something we know will not exist
+      search.simulate('change', { target: { value: '_________________' } })
+
+      wrapper
+        .find('.message')
+        .should.be.present()
+    })
+
+    it('is not shown on multiple dropdowns with no remaining items', () => {
+      // make all the items active so there are no remaining options
+      const value = _.map(requiredProps.options, 'value').join(',')
+      wrapperMount(<Dropdown {...requiredProps} value={value} multiple />)
+
+      // open the menu
+      wrapper.simulate('click')
+      dropdownMenuIsOpen()
+
+      // confirm there are no items
+      wrapper
+        .should.not.have.descendants('DropdownItem')
+
+      // expect no message
+      wrapper
+        .find('.message')
+        .should.not.be.present()
+    })
+  })
+
   describe('render', () => {
     it('calls renderText', () => {
-      wrapperShallow(<Dropdown {...defaultProps} />)
+      wrapperShallow(<Dropdown {...requiredProps} />)
 
       const instance = wrapper.instance()
       sandbox.spy(instance, 'renderText')
@@ -781,7 +851,7 @@ describe('Dropdown Component', () => {
     })
 
     it('calls renderPlaceholder', () => {
-      wrapperShallow(<Dropdown {...defaultProps} />)
+      wrapperShallow(<Dropdown {...requiredProps} />)
 
       const instance = wrapper.instance()
       sandbox.spy(instance, 'renderPlaceholder')

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -311,18 +311,17 @@ describe('Dropdown Component', () => {
     })
 
     it('updates text when value changed', () => {
-      const sample = _.sample(options)
-      let next
-      while (!next || next === sample) next = _.sample(options)
+      const initialItem = _.sample(options)
+      const nextItem = _.sample(_.without(options, initialItem))
 
-      wrapperMount(<Dropdown {...requiredProps} value={sample.value} />)
+      wrapperMount(<Dropdown {...requiredProps} value={[initialItem.value]} />)
         .find('.text')
-        .should.contain.text(sample.text)
+        .should.contain.text(initialItem.text)
 
       wrapper
-        .setProps({ value: next.value })
+        .setProps({ value: [nextItem.value] })
         .find('.text')
-        .should.contain.text(next.text)
+        .should.contain.text(nextItem.text)
     })
   })
 
@@ -518,14 +517,14 @@ describe('Dropdown Component', () => {
     })
     it('filters active options out of the list', () => {
       // make all the items active, expect to see none in the list
-      const value = _.map(requiredProps.options, 'value').join(',')
+      const value = _.map(requiredProps.options, 'value')
       wrapperShallow(<Dropdown {...requiredProps} value={value} multiple />)
         .should.not.have.descendants('DropdownItem')
     })
     it('displays a label for active items', () => {
       // select a random item, expect a label with the item's text
       const activeItem = _.sample(requiredProps.options)
-      wrapperShallow(<Dropdown {...requiredProps} value={activeItem.value} multiple />)
+      wrapperShallow(<Dropdown {...requiredProps} value={[activeItem.value]} multiple />)
         .should.have.descendants('Label')
 
       wrapper
@@ -567,7 +566,7 @@ describe('Dropdown Component', () => {
     })
     it('has labels with delete icons', () => {
       // add a value so we have a label
-      const value = _.head(requiredProps.options).value
+      const value = [_.head(requiredProps.options).value]
       wrapperRender(<Dropdown {...requiredProps} value={value} multiple />)
         .should.have.descendants('.label')
 
@@ -577,7 +576,7 @@ describe('Dropdown Component', () => {
     })
     it('calls handleLabelRemove on label delete icon click', () => {
       // add a value so we have a label
-      const value = _.head(requiredProps.options).value
+      const value = [_.head(requiredProps.options).value]
       wrapperMount(<Dropdown {...requiredProps} value={value} multiple />)
 
       const instance = wrapper.instance()
@@ -844,7 +843,7 @@ describe('Dropdown Component', () => {
 
     it('is not shown on multiple dropdowns with no remaining items', () => {
       // make all the items active so there are no remaining options
-      const value = _.map(requiredProps.options, 'value').join(',')
+      const value = _.map(requiredProps.options, 'value')
       wrapperMount(<Dropdown {...requiredProps} value={value} multiple />)
 
       // open the menu

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -363,10 +363,6 @@ describe('Dropdown Component', () => {
         .find('.text')
         .should.contain.text(item.text())
     })
-    it('is not present on multiple dropdowns', () => {
-      wrapperShallow(<Dropdown {...requiredProps} multiple />)
-        .should.not.have.descendants('.text')
-    })
   })
 
   describe('menu', () => {
@@ -909,8 +905,12 @@ describe('Dropdown Component', () => {
       wrapperShallow(<Dropdown {...requiredProps} value='hi' placeholder='hi' />)
         .should.not.have.descendants('.default.text')
     })
+    it('is present on a multiple dropdown with an empty value array', () => {
+      wrapperShallow(<Dropdown {...requiredProps} value={[]} multiple placeholder='hi' />)
+        .should.have.descendants('.default.text')
+    })
     it('has a filtered className when there is a search query', () => {
-      wrapperMount(<Dropdown {...requiredProps} search placeholder='hi' />)
+      wrapperShallow(<Dropdown {...requiredProps} search placeholder='hi' />)
         .setState({ searchQuery: 'a' })
         .should.have.descendants('.default.text.filtered')
     })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -936,20 +936,5 @@ describe('Dropdown Component', () => {
       instance.renderText
         .should.have.been.called()
     })
-
-    it('calls renderPlaceholder', () => {
-      wrapperShallow(<Dropdown {...requiredProps} />)
-
-      const instance = wrapper.instance()
-      sandbox.spy(instance, 'renderPlaceholder')
-
-      instance.renderPlaceholder
-        .should.not.have.been.called()
-
-      instance.render()
-
-      instance.renderPlaceholder
-        .should.have.been.called()
-    })
   })
 })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -502,7 +502,7 @@ describe('Dropdown Component', () => {
       wrapperShallow(<Dropdown {...requiredProps} defaultOpen={false} />)
       dropdownMenuIsClosed()
     })
-    it('closes the menu when true', () => {
+    it('opens the menu when true', () => {
       wrapperShallow(<Dropdown {...requiredProps} open />)
       dropdownMenuIsOpen()
     })
@@ -515,7 +515,7 @@ describe('Dropdown Component', () => {
         .setProps({ open: false })
       dropdownMenuIsOpen()
     })
-    it('closes the menu when toggled from false to true', () => {
+    it('opens the menu when toggled from false to true', () => {
       wrapperShallow(<Dropdown {...requiredProps} open={false} />)
         .setProps({ open: true })
       dropdownMenuIsClosed()

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -861,6 +861,26 @@ describe('Dropdown Component', () => {
     })
   })
 
+  describe('placeholder', () => {
+    it('is present when defined', () => {
+      wrapperShallow(<Dropdown {...requiredProps} placeholder='hi' />)
+        .should.have.descendants('.default.text')
+    })
+    it('is not present when not defined', () => {
+      wrapperShallow(<Dropdown {...requiredProps} />)
+        .should.not.have.descendants('.default.text')
+    })
+    it('is not present when there is a value', () => {
+      wrapperShallow(<Dropdown {...requiredProps} value={['hi']} placeholder='hi' />)
+        .should.not.have.descendants('.default.text')
+    })
+    it('has a filtered className when there is a search query', () => {
+      wrapperMount(<Dropdown {...requiredProps} search placeholder='hi' />)
+        .setState({ searchQuery: 'a' })
+        .should.have.descendants('.default.text.filtered')
+    })
+  })
+
   describe('render', () => {
     it('calls renderText', () => {
       wrapperShallow(<Dropdown {...requiredProps} />)

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -565,6 +565,34 @@ describe('Dropdown Component', () => {
         .at(requiredProps.options.length - 2)
         .should.have.prop('selected', true)
     })
+    it('has labels with delete icons', () => {
+      // add a value so we have a label
+      const value = _.head(requiredProps.options).value
+      wrapperRender(<Dropdown {...requiredProps} value={value} multiple />)
+        .should.have.descendants('.label')
+
+      wrapper
+        .find('.label')
+        .should.have.descendants('.delete.icon')
+    })
+    it('calls handleLabelRemove on label delete icon click', () => {
+      // add a value so we have a label
+      const value = _.head(requiredProps.options).value
+      wrapperMount(<Dropdown {...requiredProps} value={value} multiple />)
+
+      const instance = wrapper.instance()
+      sandbox.spy(instance, 'handleLabelRemove')
+
+      wrapper
+        .find('.delete.icon')
+        .simulate('click')
+
+      // TODO why do we need to timeout here in order to wait for the call?
+      setTimeout(() => {
+        instance.handleLabelRemove
+          .should.have.been.calledOnce()
+      }, 0)
+    })
   })
 
   describe('onChange', () => {


### PR DESCRIPTION
This PR adds support for the `multiple` dropdown type.  A multiple dropdown:
- accepts an array for the `value` (opposed to string/number)
- logs errors when !production if value is wrong type for the given dropdown type
- does not close when selecting a value
- allows removing values by clicking the &times; icon on the label for a value

Other updates and fixes:
- calls onChange with (e, value)
- only show "no results" message if `search`
