### PR TITLE
Checkbox without jQuery

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
     "complexity": [1, 10],
     "consistent-return": 0,
     "no-confusing-arrow": 0,
-    "react/sort-comp": 1,
+    "react/sort-comp": 0,
     "valid-jsdoc": 0,
     "react/jsx-curly-spacing": 0
   }

--- a/docs/app/Components/ComponentDoc/ComponentDescription.js
+++ b/docs/app/Components/ComponentDoc/ComponentDescription.js
@@ -25,10 +25,12 @@ export default class ComponentDescription extends Component {
 
   renderSemanticDocsLink = () => {
     const { _meta } = this.props
-    if (!META.isSemanticUI(_meta) || !META.isParent(_meta)) {
-      return null
-    }
-    const url = `http://semantic-ui.com/${_meta.type}s/${_meta.name}.html`.toLowerCase()
+
+    if (!META.isSemanticUI(_meta)) return null
+
+    const name = META.isParent(_meta) ? _meta.name : _meta.parent
+    const url = `http://semantic-ui.com/${_meta.type}s/${name}.html`.toLowerCase()
+
     return (
       <List.Item icon='book'>
         <a href={url} target='_blank'>

--- a/docs/app/Components/ComponentDoc/ComponentDoc.js
+++ b/docs/app/Components/ComponentDoc/ComponentDoc.js
@@ -21,6 +21,7 @@ const ComponentDoc = ({ _meta }) => {
         docPath={docPath}
       />
       <ComponentProps props={docgen.props} />
+      {docgen.props && <ComponentProps props={docgen.props} />}
       <ComponentExamples name={_meta.name} />
     </div>
   )

--- a/docs/app/Examples/addons/Radio/RadioExamples.js
+++ b/docs/app/Examples/addons/Radio/RadioExamples.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import Types from './Types/Types'
+import States from './States/States'
+import Variations from './Variations/Variations'
+
+const RadioExamples = () => (
+  <div>
+    <Types />
+    <States />
+    <Variations />
+  </div>
+)
+
+export default RadioExamples

--- a/docs/app/Examples/addons/Radio/States/Checked.js
+++ b/docs/app/Examples/addons/Radio/States/Checked.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Radio } from 'stardust'
+
+const RadioCheckedExample = () => (
+  <Radio label='This radio comes prechecked' defaultChecked />
+)
+
+export default RadioCheckedExample

--- a/docs/app/Examples/addons/Radio/States/Disabled.js
+++ b/docs/app/Examples/addons/Radio/States/Disabled.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Form, Radio, Field } from 'stardust'
+
+const RadioDisabledExample = () => (
+  <Form>
+    <Form.Field>
+      <Radio label='Disabled' disabled />
+    </Form.Field>
+    <Form.Field>
+      <Radio type='toggle' label='Disabled' disabled />
+    </Form.Field>
+  </Form>
+)
+
+export default RadioDisabledExample

--- a/docs/app/Examples/addons/Radio/States/RadioRemoteControlExample.js
+++ b/docs/app/Examples/addons/Radio/States/RadioRemoteControlExample.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react'
+import { Button, Radio } from 'stardust'
+
+export default class RadioRemoteControlExample extends Component {
+  state = { checked: false }
+  toggle = () => this.setState({ checked: !this.state.checked })
+
+  render() {
+    return (
+      <div>
+        <Button onClick={this.toggle}>
+          Toggle it
+        </Button>
+        <Radio
+          label='Check this radio'
+          onClick={this.toggle}
+          checked={this.state.checked}
+        />
+      </div>
+    )
+  }
+}

--- a/docs/app/Examples/addons/Radio/States/ReadOnly.js
+++ b/docs/app/Examples/addons/Radio/States/ReadOnly.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Radio } from 'stardust'
+
+const RadioReadOnlyExample = () => (
+  <Radio label='This radio is read-only' readOnly />
+)
+
+export default RadioReadOnlyExample

--- a/docs/app/Examples/addons/Radio/States/States.js
+++ b/docs/app/Examples/addons/Radio/States/States.js
@@ -1,0 +1,41 @@
+import React, { Component } from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+import { Message } from 'stardust'
+
+export default class RadioStatesExamples extends Component {
+  render() {
+    return (
+      <ExampleSection title='States'>
+        <ComponentExample
+          title='Checked'
+          description='A radio can come pre-checked'
+          examplePath='addons/Radio/States/Checked'
+        >
+          <Message>
+            Use{' '}
+            <a href='https://facebook.github.io/react/docs/forms.html#default-value' target='_blank'>
+              <code>defaultChecked</code>
+            </a>
+            {' '}as you normally would to set default form values.
+          </Message>
+        </ComponentExample>
+        <ComponentExample
+          title='Disabled'
+          description='Radioes can be disabled'
+          examplePath='addons/Radio/States/Disabled'
+        />
+        <ComponentExample
+          title='Read Only'
+          description='Make the radio unable to be edited by the user'
+          examplePath='addons/Radio/States/ReadOnly'
+        />
+        <ComponentExample
+          title='Remote Control'
+          description='You can trigger events remotely.'
+          examplePath='addons/Radio/States/RadioRemoteControlExample'
+        />
+      </ExampleSection>
+    )
+  }
+}

--- a/docs/app/Examples/addons/Radio/Types/Radio.js
+++ b/docs/app/Examples/addons/Radio/Types/Radio.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Radio } from 'stardust'
+
+const RadioRadioExample = () => (
+  <Radio label='Make my profile visible' />
+)
+
+export default RadioRadioExample

--- a/docs/app/Examples/addons/Radio/Types/RadioGroup.js
+++ b/docs/app/Examples/addons/Radio/Types/RadioGroup.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react'
+import { Form, Radio } from 'stardust'
+
+export default class RadioGroupExample extends Component {
+  state = {}
+  handleClick = (e, { value }) => this.setState({ value })
+
+  render() {
+    return (
+      <Form>
+        <Form.Field>
+          Selected value: <b>{this.state.value}</b>
+        </Form.Field>
+        <Form.Field>
+          <Radio
+            label='Choose this'
+            name='radioGroup'
+            value='this'
+            checked={this.state.value === 'this'}
+            onClick={this.handleClick}
+          />
+        </Form.Field>
+        <Form.Field>
+          <Radio
+            label='Or that'
+            name='radioGroup'
+            value='that'
+            checked={this.state.value === 'that'}
+            onClick={this.handleClick}
+          />
+        </Form.Field>
+      </Form>
+    )
+  }
+}

--- a/docs/app/Examples/addons/Radio/Types/Slider.js
+++ b/docs/app/Examples/addons/Radio/Types/Slider.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Radio } from 'stardust'
+
+const RadioSliderExample = () => (
+  <Radio type='slider' />
+)
+
+export default RadioSliderExample

--- a/docs/app/Examples/addons/Radio/Types/Toggle.js
+++ b/docs/app/Examples/addons/Radio/Types/Toggle.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Radio } from 'stardust'
+
+const RadioToggleExample = () => (
+  <Radio type='toggle' />
+)
+
+export default RadioToggleExample

--- a/docs/app/Examples/addons/Radio/Types/Types.js
+++ b/docs/app/Examples/addons/Radio/Types/Types.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const RadioTypesExamples = () => (
+  <ExampleSection title='Types'>
+    <ComponentExample
+      title='Radio'
+      description='A radio for checking.'
+      examplePath='addons/Radio/Types/Radio'
+    />
+    <ComponentExample
+      title='Toggle'
+      description='A radio can toggle.'
+      examplePath='addons/Radio/Types/Toggle'
+    />
+    <ComponentExample
+      title='Slider'
+      description='A radio can look like a slider.'
+      examplePath='addons/Radio/Types/Slider'
+    />
+    <ComponentExample
+      title='Radio Group'
+      description='Radios can be part of a group.'
+      examplePath='addons/Radio/Types/RadioGroup'
+    />
+  </ExampleSection>
+)
+
+export default RadioTypesExamples

--- a/docs/app/Examples/addons/Radio/Variations/Fitted.js
+++ b/docs/app/Examples/addons/Radio/Variations/Fitted.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Radio, Segment } from 'stardust'
+
+const RadioFittedExample = () => (
+  <div>
+    <Segment className='compact'>
+      <Radio />
+    </Segment>
+    <Segment className='compact'>
+      <Radio type='slider' />
+    </Segment>
+    <Segment className='compact'>
+      <Radio type='toggle' />
+    </Segment>
+  </div>
+)
+
+export default RadioFittedExample

--- a/docs/app/Examples/addons/Radio/Variations/Variations.js
+++ b/docs/app/Examples/addons/Radio/Variations/Variations.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+import { Message } from 'stardust'
+
+const RadioVariationsExamples = () => (
+  <ExampleSection title='Variations'>
+    <ComponentExample
+      title='Fitted'
+      description='A fitted radio does not leave padding for a label'
+      examplePath='addons/Radio/Variations/Fitted'
+    >
+      <Message>
+        The{' '}
+        <a href='http://semantic-ui.com/modules/checkbox.html#fitted' target='_blank'>
+          <code>fitted</code>
+        </a>
+        {' '}class is automatically applied if there is no <code>label</code> prop.
+      </Message>
+    </ComponentExample>
+  </ExampleSection>
+)
+
+export default RadioVariationsExamples

--- a/docs/app/Examples/modules/Checkbox/States/CheckboxRemoteControlExample.js
+++ b/docs/app/Examples/modules/Checkbox/States/CheckboxRemoteControlExample.js
@@ -2,15 +2,14 @@ import React, { Component } from 'react'
 import { Button, Checkbox } from 'stardust'
 
 export default class CheckboxRemoteControlExample extends Component {
-  toggle = () => {
-    this.refs.checkbox.plugin('toggle')
-  };
+  state = { checked: false }
+  toggle = () => this.setState({ checked: !this.state.checked })
 
   render() {
     return (
       <div>
         <Button onClick={this.toggle}>Toggle it</Button>
-        <Checkbox label='Check this box' ref='checkbox' />
+        <Checkbox label='Check this box' onClick={this.toggle} checked={this.state.checked} />
       </div>
     )
   }

--- a/docs/app/Examples/modules/Checkbox/States/Checked.js
+++ b/docs/app/Examples/modules/Checkbox/States/Checked.js
@@ -3,6 +3,6 @@ import { Checkbox } from 'stardust'
 
 export default CheckboxCheckedExample => {
   return (
-    <Checkbox defaultChecked label='This checkbox comes prechecked' />
+    <Checkbox label='This checkbox comes prechecked' defaultChecked />
   )
 }

--- a/docs/app/Examples/modules/Checkbox/States/Disabled.js
+++ b/docs/app/Examples/modules/Checkbox/States/Disabled.js
@@ -6,10 +6,10 @@ export default class CheckboxDisabledExample extends Component {
     return (
       <Form>
         <Form.Field>
-          <Checkbox className='disabled' label='Disabled' />
+          <Checkbox label='Disabled' disabled />
         </Form.Field>
         <Form.Field>
-          <Checkbox className='toggle' disabled label='Disabled' />
+          <Checkbox type='toggle' label='Disabled' disabled />
         </Form.Field>
       </Form>
     )

--- a/docs/app/Examples/modules/Checkbox/States/ReadOnly.js
+++ b/docs/app/Examples/modules/Checkbox/States/ReadOnly.js
@@ -4,7 +4,7 @@ import { Checkbox } from 'stardust'
 export default class CheckboxReadOnlyExample extends Component {
   render() {
     return (
-      <Checkbox className='read-only' label='This checkbox is read-only' />
+      <Checkbox label='This checkbox is read-only' readOnly />
     )
   }
 }

--- a/docs/app/Examples/modules/Checkbox/States/States.js
+++ b/docs/app/Examples/modules/Checkbox/States/States.js
@@ -13,13 +13,11 @@ export default class CheckboxStatesExamples extends Component {
           examplePath='modules/Checkbox/States/Checked'
         >
           <Message>
-            Use
-            &nbsp;
+            Use{' '}
             <a href='https://facebook.github.io/react/docs/forms.html#default-value' target='_blank'>
               <code>defaultChecked</code>
             </a>
-            &nbsp;
-            as you normally would to set default form values.
+            {' '}as you normally would to set default form values.
           </Message>
         </ComponentExample>
         <ComponentExample
@@ -28,7 +26,7 @@ export default class CheckboxStatesExamples extends Component {
           examplePath='modules/Checkbox/States/Disabled'
         />
         <ComponentExample
-          title='ReadOnly'
+          title='Read Only'
           description='Make the checkbox unable to be edited by the user'
           examplePath='modules/Checkbox/States/ReadOnly'
         />

--- a/docs/app/Examples/modules/Checkbox/Types/Radio.js
+++ b/docs/app/Examples/modules/Checkbox/Types/Radio.js
@@ -4,9 +4,7 @@ import { Checkbox } from 'stardust'
 export default class CheckboxRadioExample extends Component {
   render() {
     return (
-      <div>
-        <Checkbox className='radio' label='Radio choice' />
-      </div>
+      <Checkbox type='radio' label='Radio choice' />
     )
   }
 }

--- a/docs/app/Examples/modules/Checkbox/Types/RadioGroup.js
+++ b/docs/app/Examples/modules/Checkbox/Types/RadioGroup.js
@@ -2,14 +2,34 @@ import React, { Component } from 'react'
 import { Form, Checkbox } from 'stardust'
 
 export default class CheckboxRadioGroupExample extends Component {
+  state = {}
+  handleClick = (e, { value }) => this.setState({ value })
+
   render() {
     return (
       <Form>
         <Form.Field>
-          <Checkbox className='radio' label='Choose this' name='radioGroup' />
+          Selected value: <b>{this.state.value}</b>
         </Form.Field>
         <Form.Field>
-          <Checkbox className='radio' label='Or that' name='radioGroup' />
+          <Checkbox
+            type='radio'
+            label='Choose this'
+            name='checkboxRadioGroup'
+            value='this'
+            checked={this.state.value === 'this'}
+            onClick={this.handleClick}
+          />
+        </Form.Field>
+        <Form.Field>
+          <Checkbox
+            type='radio'
+            label='Or that'
+            name='checkboxRadioGroup'
+            value='that'
+            checked={this.state.value === 'that'}
+            onClick={this.handleClick}
+          />
         </Form.Field>
       </Form>
     )

--- a/docs/app/Examples/modules/Checkbox/Types/Slider.js
+++ b/docs/app/Examples/modules/Checkbox/Types/Slider.js
@@ -4,7 +4,7 @@ import { Checkbox } from 'stardust'
 export default class CheckboxSliderExample extends Component {
   render() {
     return (
-      <Checkbox className='slider' />
+      <Checkbox type='slider' />
     )
   }
 }

--- a/docs/app/Examples/modules/Checkbox/Types/Toggle.js
+++ b/docs/app/Examples/modules/Checkbox/Types/Toggle.js
@@ -4,7 +4,7 @@ import { Checkbox } from 'stardust'
 export default class CheckboxToggleExample extends Component {
   render() {
     return (
-      <Checkbox className='toggle' />
+      <Checkbox type='toggle' />
     )
   }
 }

--- a/docs/app/Examples/modules/Checkbox/Types/Types.js
+++ b/docs/app/Examples/modules/Checkbox/Types/Types.js
@@ -2,10 +2,17 @@ import React, { Component } from 'react'
 import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
 import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
 
+import { Message } from 'stardust'
+
 export default class CheckboxTypesExamples extends Component {
   render() {
     return (
       <ExampleSection title='Types'>
+        <Message className='info'>
+          All checkbox types use an input with type <code>checkbox</code>, except for type <code>radio</code>.
+          {' '}Use <code>inputType</code> if you'd like to mix and match style and behavior.
+          {' '}For instance, type <code>slider</code> with <code>inputType</code> radio for exclusive sliders.
+        </Message>
         <ComponentExample
           title='Checkbox'
           description='A box for checking.'

--- a/docs/app/Examples/modules/Checkbox/Variations/Fitted.js
+++ b/docs/app/Examples/modules/Checkbox/Variations/Fitted.js
@@ -9,10 +9,10 @@ export default class CheckboxFittedExample extends Component {
           <Checkbox />
         </Segment>
         <Segment className='compact'>
-          <Checkbox className='slider' />
+          <Checkbox type='slider' />
         </Segment>
         <Segment className='compact'>
-          <Checkbox className='toggle' />
+          <Checkbox type='toggle' />
         </Segment>
       </div>
     )

--- a/docs/app/Examples/modules/Checkbox/Variations/Variations.js
+++ b/docs/app/Examples/modules/Checkbox/Variations/Variations.js
@@ -13,11 +13,11 @@ export default class CheckboxVariationsExamples extends Component {
           examplePath='modules/Checkbox/Variations/Fitted'
         >
           <Message>
-            The&nbsp;
+            The{' '}
             <a href='http://semantic-ui.com/modules/checkbox.html#fitted' target='_blank'>
               <code>fitted</code>
             </a>
-            &nbsp;class is automatically applied if there is no <code>label</code> prop.
+            {' '}class is automatically applied if there is no <code>label</code> prop.
           </Message>
         </ComponentExample>
       </ExampleSection>

--- a/src/addons/Radio/Radio.js
+++ b/src/addons/Radio/Radio.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import META from '../../utils/Meta'
+import Checkbox from '../../modules/Checkbox/Checkbox'
+
+/**
+ * A <Radio /> is sugar for <Checkbox type='radio' inputType='radio' />.
+ * Useful for exclusive groups of type='slider' or type='toggle'.
+ * @see Checkbox
+ */
+function Radio(props) {
+  return (
+    <Checkbox type='radio' {...props} inputType='radio' />
+  )
+}
+
+Radio._meta = {
+  library: META.library.stardust,
+  name: 'Radio',
+  type: META.type.addon,
+}
+
+export default Radio

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,9 @@ import { deprecateComponent } from './utils/deprecate'
 // Addons
 // ----------------------------------------
 export Confirm from './addons/Confirm/Confirm'
-export Textarea from './addons/Textarea/Textarea'
+export Radio from './addons/Radio/Radio'
 export Select from './addons/Select/Select'
+export Textarea from './addons/Textarea/Textarea'
 
 // ----------------------------------------
 // Collections

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -1,86 +1,151 @@
 import _ from 'lodash'
-import META from '../../utils/Meta'
-import { getUnhandledProps } from '../../utils/propUtils'
-import React, { Component, PropTypes } from 'react'
-import classNames from 'classnames'
-import $ from 'jquery'
+import React, { PropTypes } from 'react'
+import cx from 'classnames'
 
-export default class Checkbox extends Component {
+import AutoControlledComponent from '../../utils/AutoControlledComponent'
+import META from '../../utils/Meta'
+import { makeDebugger } from '../../utils/debug'
+import { getUnhandledProps } from '../../utils/propUtils'
+
+const debug = makeDebugger('checkbox')
+
+// maps checkbox types to input types
+const typeMap = {
+  checkbox: 'checkbox',
+  radio: 'radio',
+  slider: 'checkbox',
+  toggle: 'checkbox',
+}
+
+const _meta = {
+  library: META.library.semanticUI,
+  name: 'Checkbox',
+  type: META.type.module,
+  props: {
+    inputType: [
+      'checkbox',
+      'radio',
+    ],
+    type: [
+      'checkbox',
+      'radio',
+      'slider',
+      'toggle',
+    ],
+  },
+}
+
+/**
+ * A checkbox allows a user to select a value from a small set of options, often binary
+ * @see Radio
+ */
+export default class Checkbox extends AutoControlledComponent {
   static propTypes = {
-    beforeChecked: PropTypes.func,
-    beforeDeterminate: PropTypes.func,
-    beforeIndeterminate: PropTypes.func,
-    beforeUnchecked: PropTypes.func,
     className: PropTypes.string,
+
+    /** Whether or not checkbox is checked. */
+    checked: PropTypes.bool,
+
+    /** The initial value of checked. */
+    defaultChecked: PropTypes.bool,
+
+    /** Removes padding for a label. Auto applied when there is no label. */
+    fitted: PropTypes.bool,
+
+    /** The text of the associated label element. */
     label: PropTypes.string,
+
+    /** HTML input type, either checkbox or radio. */
+    inputType: PropTypes.oneOf(_meta.props.inputType),
+
+    /** Called with (event, { name, value, checked }) when the checkbox or label is clicked. */
+    onClick: PropTypes.func,
+
+    /**
+     * Display as a checkbox, radio, slider, or toggle.
+     * The input type is `checkbox` for both slider and toggle types.
+     * You can set `inputType` separately to mix and match appearance and behavior.
+     */
+    type: PropTypes.oneOf(_meta.props.type),
+
+    /** The HTML input name. */
+    name: PropTypes.string,
+
+    /** The HTML input value. */
+    value: PropTypes.string,
+
+    /** Called with (event, { name, value, checked }) when the user attempts to change the value. */
     onChange: PropTypes.func,
-    onChecked: PropTypes.func,
-    onDeterminate: PropTypes.func,
-    onDisable: PropTypes.func,
-    onEnable: PropTypes.func,
-    onIndeterminate: PropTypes.func,
-    onUnchecked: PropTypes.func,
-    type: PropTypes.string,
   }
 
   static defaultProps = {
     type: 'checkbox',
   }
 
-  componentDidMount() {
-    this.element = $(this.refs.element)
-    this.element.checkbox({
-      onChange: this.props.onChange,
-      onChecked: this.props.onChecked,
-      onIndeterminate: this.props.onIndeterminate,
-      onDeterminate: this.props.onDeterminate,
-      onUnchecked: this.props.onUnchecked,
-      beforeChecked: this.props.beforeChecked,
-      beforeIndeterminate: this.props.beforeIndeterminate,
-      beforeDeterminate: this.props.beforeDeterminate,
-      beforeUnchecked: this.props.beforeUnchecked,
-      onEnable: this.props.onEnable,
-      onDisable: this.props.onDisable,
-    })
-  }
+  static autoControlledProps = [
+    'checked',
+  ]
 
-  componentWillUnmount() {
-    _.invoke(this, 'element.off')
-  }
+  static _meta = _meta
 
-  static _meta = {
-    library: META.library.semanticUI,
-    name: 'Checkbox',
-    type: META.type.module,
-  }
+  state = {}
 
-  handleChange = (e) => {
-    const { onChange } = this.props
-    if (onChange) onChange(e)
-  }
+  handleClick = (e) => {
+    debug('handleClick()')
+    const { disabled, onChange, onClick, name, readOnly, value } = this.props
+    // using a ref here allows us to let the browser manage radio group state for us
+    // this is a special exception where we are reading state from the DOM
+    // otherwise, all radio groups would have to be controlled components
+    const refChecked = _.get(this.refs, 'input.checked')
+    debug(`  name:       ${name}`)
+    debug(`  value:      ${value}`)
+    debug(`  refChecked: ${refChecked}`)
 
-  plugin(...args) {
-    return this.element.checkbox(...args)
+    if (onClick) onClick(e, { name, value, checked: !!refChecked })
+    if (onChange) onChange(e, { name, value, checked: !refChecked })
+
+    if (!disabled && !readOnly) {
+      this.trySetState({ checked: !refChecked })
+    }
   }
 
   render() {
-    let type = this.props.type
-    if (_.includes(this.props.className, 'radio')) {
-      type = 'radio'
-    }
-    const classes = classNames(
+    const { className, inputType, label, name, onChange, type, value } = this.props
+    const { checked } = this.state
+    const classes = cx(
       'ui',
-      this.props.className,
+      // don't add duplicate "checkbox" classes, but add any other type
+      type !== 'checkbox' && type,
       // auto apply fitted class to compact white space when there is no label
       // http://semantic-ui.com/modules/checkbox.html#fitted
-      { fitted: !this.props.label },
-      'checkbox'
+      !label && 'fitted',
+      checked && 'checked',
+      'checkbox',
+      className
     )
-    const props = getUnhandledProps(Checkbox, this.props)
+    const rest = getUnhandledProps(Checkbox, this.props)
+    // Heads Up!
+    // onChange props are never called as the user cannot click on the hidden input.
+    // We call onChange in the onClick handler.
+    // This exists only to prevent React "prop checked without onChange" warnings.
     return (
-      <div className={classes} ref='element'>
-        <input {...props} type={type} onChange={this.handleChange} />
-        <label>{this.props.label}</label>
+      <div
+        {...rest}
+        className={classes}
+        onClick={this.handleClick}
+        onChange={onChange || _.noop}
+      >
+        <input
+          ref='input'
+          type={inputType || typeMap[type]}
+          name={name}
+          onChange={onChange || _.noop}
+          checked={checked}
+          className='hidden'
+          tabIndex={0}
+          value={value}
+        />
+        <label>{label}</label>
       </div>
     )
   }

--- a/src/utils/AutoControlledComponent.js
+++ b/src/utils/AutoControlledComponent.js
@@ -40,8 +40,22 @@ export default class AutoControlledComponent extends Component {
     this.state = _.transform(autoControlledProps, (res, prop) => {
       const defaultPropName = getDefaultPropName(prop)
 
-      // apply default props if they exist
-      res[prop] = this.props[defaultPropName in this.props ? defaultPropName : prop]
+      // try to set initial state in this order:
+      //  - default props
+      //  - then, regular props
+      //  - then, `checked` defaults to false
+      //  - then, `value` defaults to null
+      // React doesn't allow changing from uncontrolled to controlled components
+      // this is why we default checked/value if they are not present.
+      if (_.has(this.props, defaultPropName)) {
+        res[prop] = this.props[defaultPropName]
+      } else if (_.has(this.props, prop)) {
+        res[prop] = this.props[prop]
+      } else if (prop === 'checked') {
+        res[prop] = false
+      } else if (prop === 'value') {
+        res[prop] = ''
+      }
 
       if (process.env.NODE_ENV !== 'production') {
         const { name } = this.constructor

--- a/src/utils/jquery.js
+++ b/src/utils/jquery.js
@@ -21,8 +21,5 @@ debug('Loading jQuery')
 // load jQuery, then load SUI jQuery
 window.jQuery = window.$ = require('jquery')
 
-debug('Loading SUI Checkbox plugin')
-require('semantic-ui-css/components/checkbox')
-
 debug('Loading SUI Form plugin')
 require('semantic-ui-css/components/form')

--- a/test/specs/addons/Radio/Radio-test.js
+++ b/test/specs/addons/Radio/Radio-test.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import Radio from 'src/addons/Radio/Radio'
+import Checkbox from 'src/modules/Checkbox/Checkbox'
+import * as common from 'test/specs/commonTests'
+
+describe('Radio', () => {
+  common.isConformant(Radio)
+
+  it('renders a radio Checkbox', () => {
+    shallow(<Radio />)
+      .first()
+      .should.contain(<Checkbox type='radio' inputType='radio' />)
+  })
+})

--- a/test/specs/commonTests.js
+++ b/test/specs/commonTests.js
@@ -170,7 +170,8 @@ export const isConformant = (Component, requiredProps = {}) => {
 
         handlerSpy.called.should.equal(true,
           `<${constructorName} ${listenerName}={${handlerName}} />\n` +
-          `${leftPad} ^ was not called on "${eventName}"\n`
+          `${leftPad} ^ was not called on "${eventName}".` +
+          'You may need to hoist your event handlers up to the root element.\n'
         )
 
         // TODO: https://github.com/TechnologyAdvice/stardust/issues/218

--- a/test/specs/modules/Accordion/Accordion-test.js
+++ b/test/specs/modules/Accordion/Accordion-test.js
@@ -35,7 +35,7 @@ describe('Accordion', () => {
       titles.at(1).should.have.className('active')
       contents.at(1).should.have.className('active')
     })
-    it('Accordion.Content is active at activeIndex - 1', () => {
+    it('makes Accordion.Content at activeIndex - 1 "active"', () => {
       const contents = shallow(
         <Accordion activeIndex={0}>
           <Accordion.Title />

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -1,27 +1,134 @@
+import _ from 'lodash'
 import React from 'react'
 
 import Checkbox from 'src/modules/Checkbox/Checkbox'
 import * as common from 'test/specs/commonTests'
+import sandbox from 'test/utils/Sandbox-util'
 
 describe('Checkbox', () => {
   common.isConformant(Checkbox)
   common.hasUIClassName(Checkbox)
-  common.rendersChildren(Checkbox)
 
-  it('can be checked by default', () => {
-    shallow(<Checkbox defaultChecked name='firstName' />)
-      .find('input')
-      .should.be.checked()
+  describe('defaultChecked', () => {
+    it('sets the initial checked state', () => {
+      // consoleUtil.disableOnce()
+      shallow(<Checkbox defaultChecked />)
+        .find('input')
+        .should.be.checked()
+    })
   })
-  it('should init the semantic ui plugin', () => {
-    mount(<Checkbox />)
-      .instance()
-      // the component exposes the jQuery element as 'element'
-      // 'checkbox' is the jQuery plugin
-      .element.checkbox.called.should.equal(true)
-  })
-  it('should have a fitted class if no label is given', () => {
+
+  it('adds the "fitted" class if no label is given', () => {
     shallow(<Checkbox name='firstName' />)
       .should.have.className('fitted')
+  })
+
+  describe('disabled', () => {
+    it('cannot be checked', () => {
+      shallow(<Checkbox disabled />)
+        .simulate('click')
+        .find('input')
+        .should.not.be.checked()
+    })
+    it('cannot be unchecked', () => {
+      shallow(<Checkbox disabled defaultChecked />)
+        .simulate('click')
+        .find('input')
+        .should.be.checked()
+    })
+  })
+
+  describe('inputType', () => {
+    it('overrides type', () => {
+      // for every type, override with each inputType
+      _.each(Checkbox._meta.props.type, (type) => {
+        _.each(Checkbox._meta.props.inputType, (inputType) => {
+          shallow(<Checkbox type={type} inputType={inputType} />)
+            .find('input')
+            .should.have.prop('type', inputType)
+        })
+      })
+    })
+  })
+
+  describe('type', () => {
+    it('renders an input of type checkbox when not set', () => {
+      shallow(<Checkbox />)
+        .find('input')
+        .should.have.prop('type', 'checkbox')
+    })
+    it('renders an input of type checkbox when set to slider', () => {
+      shallow(<Checkbox type='slider' />)
+        .find('input')
+        .should.have.prop('type', 'checkbox')
+    })
+    it('renders an input of type checkbox when set to toggle', () => {
+      shallow(<Checkbox type='toggle' />)
+        .find('input')
+        .should.have.prop('type', 'checkbox')
+    })
+    it('renders an input of type radio when set to radio', () => {
+      shallow(<Checkbox type='radio' />)
+        .find('input')
+        .should.have.prop('type', 'radio')
+    })
+    it('it adds the prop value to className, except checkbox', () => {
+      const types = _.without(Checkbox._meta.props.type, 'checkbox')
+      _.each(types, (type) => {
+        shallow(<Checkbox type={type} />)
+          .should.have.className(type)
+      })
+    })
+    it('does not add duplicate checkbox classes when set to "checkbox"', () => {
+      shallow(<Checkbox type='checkbox' />)
+        .prop('className')
+        .match(/checkbox/g)
+        .should.have.length(1)
+    })
+  })
+
+  describe('onClick', () => {
+    it('is called with (event { name, value, checked }) on label click', () => {
+      const spy = sandbox.spy()
+      const expectProps = { name: 'foo', value: 'bar', checked: false }
+      mount(<Checkbox onClick={spy} {...expectProps} />)
+        .find('label')
+        .simulate('click')
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch({}, {})
+      spy.firstCall.args[1]
+        .should.deep.equal(expectProps)
+    })
+  })
+
+  describe('onChange', () => {
+    it('is called with (event { name, value, !checked }) on click', () => {
+      const spy = sandbox.spy()
+      const expectProps = { name: 'foo', value: 'bar', checked: false }
+      mount(<Checkbox onChange={spy} {...expectProps} />)
+        .find('label')
+        .simulate('click')
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch({}, {})
+      spy.firstCall.args[1]
+        .should.deep.equal({ ...expectProps, checked: true })
+    })
+  })
+
+  describe('readOnly', () => {
+    it('cannot be checked', () => {
+      shallow(<Checkbox readOnly />)
+        .simulate('click')
+        .find('input')
+        .should.not.be.checked()
+    })
+    it('cannot be unchecked', () => {
+      shallow(<Checkbox readOnly defaultChecked />)
+        .simulate('click')
+        .find('input')
+        .should.be.checked()
+    })
   })
 })

--- a/test/specs/utils/AutoControlledComponent-test.js
+++ b/test/specs/utils/AutoControlledComponent-test.js
@@ -116,6 +116,22 @@ describe('extending AutoControlledComponent', () => {
 
       _.each(props, (val, key) => wrapper.should.not.have.state(key, val))
     })
+
+    it('defaults "checked" to false if not present', () => {
+      consoleUtil.disableOnce()
+      TestClass.autoControlledProps.push('checked')
+
+      shallow(<TestClass />)
+        .should.have.state('checked', false)
+    })
+
+    it('defaults "value" to an empty string if not present', () => {
+      consoleUtil.disableOnce()
+      TestClass.autoControlledProps.push('value')
+
+      shallow(<TestClass />)
+        .should.have.state('value', '')
+    })
   })
 
   describe('default props', () => {


### PR DESCRIPTION
Addresses the checklist item in #247. This PR updates the Checkbox to our v1 API.  It also removes use of jQuery.
