### PR TITLE
Publish the production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "lint:watch": "watch 'npm run lint --silent' docs gulp src test",
-    "prepublish": "npm run build:dist",
+    "prepublish": "NODE_ENV=production npm run build:dist",
     "release:major": "ta-script npm/release.sh major",
     "release:minor": "ta-script npm/release.sh minor",
     "release:patch": "ta-script npm/release.sh patch",


### PR DESCRIPTION
Fixes #264.  HMR was being included in the published build because NODE_ENV was not set on prepublish.

I confirmed the built `dist/` no longer includes references to HMR after running the prepublish script.
