### PR TITLE
Add ability to remove dropdown items on backspace

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -222,12 +222,14 @@ export default class Dropdown extends Component {
       } else {
         document.addEventListener('keydown', this.moveSelectionOnKeyDown)
         document.addEventListener('keydown', this.selectItemOnEnter)
+        document.addEventListener('keydown', this.removeItemOnBackspace)
       }
     } else if (prevState.focus && !this.state.focus) {
       document.removeEventListener('keydown', this.openOnArrow)
       document.removeEventListener('keydown', this.openOnSpace)
       document.removeEventListener('keydown', this.moveSelectionOnKeyDown)
       document.removeEventListener('keydown', this.selectItemOnEnter)
+      document.removeEventListener('keydown', this.removeItemOnBackspace)
     }
 
     // opened / closed
@@ -236,6 +238,7 @@ export default class Dropdown extends Component {
       document.addEventListener('keydown', this.closeOnEscape)
       document.addEventListener('keydown', this.moveSelectionOnKeyDown)
       document.addEventListener('keydown', this.selectItemOnEnter)
+      document.addEventListener('keydown', this.removeItemOnBackspace)
       document.addEventListener('click', this.closeOnDocumentClick)
       document.removeEventListener('keydown', this.openOnArrow)
       document.removeEventListener('keydown', this.openOnSpace)
@@ -244,6 +247,7 @@ export default class Dropdown extends Component {
       document.removeEventListener('keydown', this.closeOnEscape)
       document.removeEventListener('keydown', this.moveSelectionOnKeyDown)
       document.removeEventListener('keydown', this.selectItemOnEnter)
+      document.removeEventListener('keydown', this.removeItemOnBackspace)
       document.removeEventListener('click', this.closeOnDocumentClick)
     }
   }
@@ -254,6 +258,7 @@ export default class Dropdown extends Component {
     document.removeEventListener('keydown', this.openOnSpace)
     document.removeEventListener('keydown', this.moveSelectionOnKeyDown)
     document.removeEventListener('keydown', this.selectItemOnEnter)
+    document.removeEventListener('keydown', this.removeItemOnBackspace)
     document.removeEventListener('keydown', this.closeOnEscape)
     document.removeEventListener('click', this.closeOnDocumentClick)
   }
@@ -333,6 +338,25 @@ export default class Dropdown extends Component {
       this.onChange(e, value)
       this.close()
     }
+  }
+
+  removeItemOnBackspace = (e) => {
+    debug('removeItemOnBackspace()')
+    debug(keyboardKey.getName(e))
+    if (keyboardKey.getCode(e) !== keyboardKey.Backspace) return
+
+    const { multiple, search } = this.props
+    const { searchQuery, value } = this.state
+
+    if (searchQuery || !search || !multiple || _.isEmpty(value)) return
+
+    e.preventDefault()
+
+    // remove most recent value
+    const newValue = _.dropRight(value)
+
+    this.setValue(newValue)
+    this.onChange(e, newValue)
   }
 
   closeOnDocumentClick = (e) => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -620,6 +620,80 @@ describe('Dropdown Component', () => {
     })
   })
 
+  describe('removing items on backspace', () => {
+    let spy
+    beforeEach(() => {
+      spy = sandbox.spy()
+    })
+
+    it('does nothing without selected items', () => {
+      wrapperMount(<Dropdown {...requiredProps} multiple search onChange={spy} />)
+
+      // open
+      wrapper.simulate('click')
+
+      domEvent.keyDown(document, { key: 'Backspace' })
+
+      spy.should.not.have.been.called()
+    })
+    it('removes the last item when there is no search query', () => {
+      const value = _.map(options, 'value')
+      const expected = _.dropRight(value)
+      wrapperMount(<Dropdown {...requiredProps} value={value} multiple search onChange={spy} />)
+
+      // open
+      wrapper.simulate('click')
+
+      domEvent.keyDown(document, { key: 'Backspace' })
+
+      spy.should.have.been.calledOnce()
+      spy.firstCall.args[1].should.deep.equal(expected)
+    })
+    it('removes the last item when there is no search query when uncontrolled', () => {
+      const value = _.map(options, 'value')
+      const expected = _.dropRight(value)
+      wrapperMount(<Dropdown {...requiredProps} defaultValue={value} multiple search onChange={spy} />)
+
+      // open
+      wrapper.simulate('click')
+
+      domEvent.keyDown(document, { key: 'Backspace' })
+
+      spy.should.have.been.calledOnce()
+      spy.firstCall.args[1].should.deep.equal(expected)
+
+      wrapper
+        .state('value')
+        .should.deep.equal(expected)
+    })
+    it('does not remove the last item when there is a search query', () => {
+      // search for random item
+      const searchQuery = _.sample(options).text
+      const value = _.map(options, 'value')
+      wrapperMount(<Dropdown {...requiredProps} value={value} multiple search onChange={spy} />)
+
+      // open and simulate search
+      wrapper
+        .simulate('click')
+        .setState({ searchQuery })
+
+      domEvent.keyDown(document, { key: 'Backspace' })
+
+      spy.should.not.have.been.called()
+    })
+    it('does not remove items for multiple dropdowns without search', () => {
+      const value = _.map(options, 'value')
+      wrapperMount(<Dropdown {...requiredProps} value={value} multiple onChange={spy} />)
+
+      // open
+      wrapper.simulate('click')
+
+      domEvent.keyDown(document, { key: 'Backspace' })
+
+      spy.should.not.have.been.called()
+    })
+  })
+
   describe('onChange', () => {
     let spy
     beforeEach(() => {


### PR DESCRIPTION
Fairly simple change that only affects dropdowns with `search` and `multiple`. If the dropdown is focused, the search query is empty and backspace is pressed, the most recently selected item will be removed.
