### PR TITLE
"aligned" prop util and common test

### DIFF
--- a/src/utils/propUtils.js
+++ b/src/utils/propUtils.js
@@ -74,7 +74,7 @@ export const iconPropRenderer = (val) => _.isString(val) ? <Icon className={val}
 export const imagePropRenderer = (val) => _.isString(val) ? <Image src={val} /> : val
 
 // ----------------------------------------
-// Prop To Class Name
+// Prop to className
 //
 // There are 4 prop patterns used to build up the className for a component.
 // Each utility here is meant for use in a classnames() argument.
@@ -121,3 +121,22 @@ export const useValueAndKey = (val, key) => val && val !== true && `${val} ${key
  * <div class="ui left pointing label"></div>
  */
 export const useKeyOrValueAndKey = (val, key) => val && (val === true ? key : `${val} ${key}`)
+
+//
+// Prop to className exceptions
+//
+
+/**
+ * The "aligned" prop follows the useValueAndKey except when the value is "justified'.
+ * In this case, only the class "justified" is used, ignoring the "aligned" class.
+ * @param {*} val The value of the "aligned" prop
+ *
+ * @example
+ * <Container aligned='justified' />
+ * <div class="ui justified container"></div>
+ *
+ * @example
+ * <Container aligned='left' />
+ * <div class="ui left aligned container"></div>
+ */
+export const useAlignedProp = val => val === 'justified' ? 'justified' : useValueAndKey(val, 'aligned')

--- a/test/specs/commonTests.js
+++ b/test/specs/commonTests.js
@@ -361,10 +361,38 @@ const _noClassNameFromBoolProps = (Component, propKey, requiredProps) => {
 }
 
 const _classNamePropValueBeforePropName = (Component, propKey, requiredProps) => {
-  it('adds "${value} ${name}" to className', () => {
-    const sample = _.sample(Component._meta.props[propKey])
-    shallow(createElement(Component, { ...requiredProps, [propKey]: sample }))
-      .should.have.className(`${sample} ${propKey}`)
+  _.each(Component._meta.props[propKey], (propVal) => {
+    it(`adds "${propVal} ${propKey}" to className`, () => {
+      shallow(createElement(Component, { ...requiredProps, [propKey]: propVal }))
+        .should.have.className(`${propVal} ${propKey}`)
+    })
+  })
+}
+
+/**
+ * Assert that a Component correctly implements the "aligned" prop.
+ * @param {React.Component|Function} Component The component to test.
+ * @param {Object} [requiredProps={}] Props required to render the component.
+ */
+export const implementsAlignedProp = (Component, requiredProps = {}) => {
+  describe('aligned (common)', () => {
+    _definesPropOptions(Component, 'aligned')
+    _noDefaultClassNameFromProp(Component, 'aligned')
+    _noClassNameFromBoolProps(Component, 'aligned', requiredProps)
+
+    _.each(Component._meta.props.aligned, (propVal) => {
+      if (propVal === 'justified') {
+        it('adds "justified" without "aligned" to className', () => {
+          shallow(<Component { ...requiredProps } aligned='justified' />)
+            .should.have.className('justified')
+        })
+      } else {
+        it(`adds "${propVal} aligned" to className`, () => {
+          shallow(<Component { ...requiredProps } aligned={propVal} />)
+            .should.have.className(`${propVal} ${'aligned'}`)
+        })
+      }
+    })
   })
 }
 


### PR DESCRIPTION
See [this comment](https://github.com/TechnologyAdvice/stardust/pull/277/files#r68493395) in the Container PR for the background on this PR.

This PR adds a prop util and common test for the `aligned` prop.  This prop breaks the pattern of other props as noted in the comments and doc blocks.

``` js
<i aligned='left' />          // <i class="left aligned" />
<i aligned='right' />         // <i class="right aligned" />
<i aligned='center' />        // <i class="center aligned" />
<i aligned='justified' />     // <i class="justified" />
```

To support the missing `aligned` class only when the value is `justified` we now have `useAlignedProp` in propUtils:

``` js
const { aligned } = this.props

const classes = cx(
  useAlignedProp(aligned)
)
```

In tests, we assure it was implemented correctly like so:

``` js
import Foo from 'src/Foo'

common.implementsAlignedProp(Foo)
```

I tested the util and common test on another component in developing this PR and I'm sure as I can be that it is correct.
