### PR TITLE
Update doc examples

### DIFF
--- a/docs/app/Examples/collections/Form/Validation/FormSpecifyingValidationRulesExample.js
+++ b/docs/app/Examples/collections/Form/Validation/FormSpecifyingValidationRulesExample.js
@@ -32,7 +32,7 @@ const FormSpecifyingValidationRulesExample = (props) => (
         <Input placeholder='First Name' name='name' type='text' />
       </Form.Field>
       <Form.Field label='Gender'>
-        <Dropdown className='selection' name='gender' options={genderOptions} />
+        <Dropdown selection name='gender' options={genderOptions} />
       </Form.Field>
     </Form.Fields>
     <Form.Fields evenlyDivided>
@@ -44,7 +44,7 @@ const FormSpecifyingValidationRulesExample = (props) => (
       </Form.Field>
     </Form.Fields>
     <Form.Field label='Skills'>
-      <Dropdown className='selection multiple' name='skills' options={skillsOptions} />
+      <Dropdown selection multiple name='skills' options={skillsOptions} />
     </Form.Field>
     <Form.Field className='inline'>
       <Checkbox name='terms' className='hidden' label='I agree to the terms and conditions' />

--- a/docs/app/Examples/elements/Button/Types/ButtonLabeledExample.js
+++ b/docs/app/Examples/elements/Button/Types/ButtonLabeledExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Button, Icon } from 'stardust'
+import { Button, Icon, Label } from 'stardust'
 
 export default class ButtonLabeledExample extends Component {
   render() {
@@ -9,9 +9,9 @@ export default class ButtonLabeledExample extends Component {
           <Icon className='heart' /> Like
         </Button>
         {/* TODO: See issue #46 - button needs to render as a div */}
-        <a className='ui basic label'>
+        <Label basic link>
           3,000
-        </a>
+        </Label>
       </Button>
     )
   }

--- a/docs/app/Examples/elements/Input/Variations/InputActionExample.js
+++ b/docs/app/Examples/elements/Input/Variations/InputActionExample.js
@@ -4,12 +4,13 @@ import { Button, Dropdown, Input } from 'stardust'
 export default class InputActionExample extends Component {
   render() {
     const options = [
+      { value: 'all', text: 'All' },
       { value: 'articles', text: 'Articles' },
       { value: 'products', text: 'Products' },
     ]
     return (
       <Input className='left icon action' icon='search' placeholder='Search...'>
-        <Dropdown className='compact selection' options={options} />
+        <Dropdown compact selection options={options} defaultValue='articles' />
         <Button type='submit'>Search</Button>
       </Input>
     )

--- a/docs/app/Examples/elements/Input/Variations/InputActionExtraExample.js
+++ b/docs/app/Examples/elements/Input/Variations/InputActionExtraExample.js
@@ -5,7 +5,7 @@ export default class InputActionExtraExample extends Component {
   render() {
     return (
       <Input className='left action' placeholder='$23.43'>
-        <Button className='ui teal labeled icon button'>
+        <Button className='teal labeled icon'>
           <Icon className='cart' />
           Checkout
         </Button>

--- a/docs/app/Examples/elements/Input/Variations/InputLabeledExample.js
+++ b/docs/app/Examples/elements/Input/Variations/InputLabeledExample.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react'
-import { Input } from 'stardust'
+import { Input, Label } from 'stardust'
 
 export default class InputLabeledExample extends Component {
   render() {
     return (
       <Input className='labeled' placeholder='mysite.com'>
-        <div className='ui label'>http://</div>
+        <Label>http://</Label>
       </Input>
     )
   }

--- a/docs/app/Examples/elements/Input/Variations/InputRightLabeledExample.js
+++ b/docs/app/Examples/elements/Input/Variations/InputRightLabeledExample.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react'
-import { Input } from 'stardust'
+import { Input, Label } from 'stardust'
 
 export default class InputRightLabeledExample extends Component {
   render() {
     return (
       <Input className='right labeled' placeholder='mysite.com'>
-        <div className='ui label'>http://</div>
+        <Label>http://</Label>
       </Input>
     )
   }

--- a/docs/app/Examples/modules/Dropdown/States/Disabled.js
+++ b/docs/app/Examples/modules/Dropdown/States/Disabled.js
@@ -4,13 +4,7 @@ import { Dropdown } from 'stardust'
 export default class DropdownDisabledExample extends Component {
   render() {
     return (
-      <Dropdown className='disabled' text='Dropdown'>
-        <Dropdown.Menu>
-          <Dropdown.Item text='Choice 1' />
-          <Dropdown.Item text='Choice 2' />
-          <Dropdown.Item text='Choice 3' />
-        </Dropdown.Menu>
-      </Dropdown>
+      <Dropdown disabled text='Dropdown' options={[]} />
     )
   }
 }


### PR DESCRIPTION
The input action docs were broken due to deprecated use of the Dropdown component (className use).  This PR updates those along with the Label usages.
