### PR TITLE
Label allow bool corner prop

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "consistent-return": 0,
     "no-confusing-arrow": 0,
     "react/sort-comp": 1,
-    "valid-jsdoc": 0
+    "valid-jsdoc": 0,
+    "react/jsx-curly-spacing": 0
   }
 }

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -36,7 +36,7 @@ function Label(props) {
     useKeyOnly(horizontal, 'horizontal'),
     useKeyOnly(tag, 'tag'),
     useValueAndKey(attached, 'attached'),
-    useValueAndKey(corner, 'corner'),
+    useKeyOrValueAndKey(corner, 'corner'),
     useKeyOrValueAndKey(pointing, 'pointing'),
     useKeyOrValueAndKey(ribbon, 'ribbon'),
     circular && (children && 'circular' || 'empty circular'),
@@ -98,7 +98,10 @@ Label.propTypes = {
   color: PropTypes.oneOf(Label._meta.props.colors),
 
   /** Place the label in one of the upper corners . */
-  corner: PropTypes.oneOf(Label._meta.props.corner),
+  corner: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.oneOf(Label._meta.props.corner),
+  ]),
 
   /** Additional text with less emphasis. */
   detail: PropTypes.string,

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -5,5 +5,8 @@
     "shallow": false,
     "render": false,
     "mount": false
+  },
+  "rules": {
+    "react/jsx-curly-spacing": 0
   }
 }

--- a/test/specs/elements/Label/Label-test.js
+++ b/test/specs/elements/Label/Label-test.js
@@ -20,8 +20,8 @@ describe('Label Component', () => {
   common.propValueOnlyToClassName(Label, 'size')
 
   common.propKeyAndValueToClassName(Label, 'attached')
-  common.propKeyAndValueToClassName(Label, 'corner')
 
+  common.propKeyOrValueToClassName(Label, 'corner')
   common.propKeyOrValueToClassName(Label, 'pointing')
   common.propKeyOrValueToClassName(Label, 'ribbon')
 


### PR DESCRIPTION
Fixes #292.  These two are forms of markup are synonymous and both supported in SUI:

``` html
<div class="ui corner label"></div>
<div class="ui right corner label"></div>
```

This PR allows `<Label corner />` where we previously required `corner='left|right'`.
