### PR TITLE
Fix debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "classnames": "^2.1.5",
+    "debug": "^2.2.0",
     "lodash": "^4.6.1"
   },
   "devDependencies": {
@@ -62,7 +63,6 @@
     "chai-enzyme": "^0.4.1",
     "connect-history-api-fallback": "^1.2.0",
     "css-loader": "^0.23.1",
-    "debug": "^2.2.0",
     "del": "^2.0.2",
     "dirty-chai": "^1.2.2",
     "doctrine": "^1.2.1",


### PR DESCRIPTION
Fixes #296.  This PR moves `debug` from devDeps to deps.

Because we use `debug` in dev and other apps, we have the module.  We also use webpack with dead code elimination for production builds, which strips the `require('debug')` call on production.

However, when we build Stardust for consumption, we only parse it with babel as it is up to the user to then webpack it into their own app.  This means some users can be missing the `debug` module and not webpack with production + dead code elimination and therefore get the error in the linked issue.

I don't like adding more dependencies to the published dist, but in this case it is the shortest path to a solution.
