### PR TITLE
Fix getComponentDocInfo docPath on windows

### DIFF
--- a/docs/app/utils/getComponentDocInfo.js
+++ b/docs/app/utils/getComponentDocInfo.js
@@ -2,13 +2,15 @@ import _ from 'lodash'
 import docgenInfo from '../docgenInfo.json'
 
 /**
- * This util extracts and formats a doc object from docgenInfo.json for a single `component` and merges it with
- * the component's meta information.
+ * This util extracts and formats a doc object from docgenInfo.json for a single `component`.
  * @param {string} _meta Stardust component _meta object.
  * @returns {{}} Documentation object.
  */
 export default (_meta) => {
-  const docPath = _.find(_.keys(docgenInfo), path => path.includes(`/${_meta.name}.js`))
+  const docPath = _.find(_.keys(docgenInfo), path => {
+    const re = new RegExp(`${_meta.name}.js$`)
+    return re.test(path)
+  })
   const docgen = docgenInfo[docPath]
 
   return { docPath, docgen }


### PR DESCRIPTION
Fixes #304.  This PR removes the `/` in the path check logic.  On Windows this is a `\`.
