### PR TITLE
Update Menu to v1 API

### DIFF
--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -16,10 +16,10 @@ function MenuItem({ __onClick, active, header, children, className, label, name,
     'item',
   )
 
-  const tag = (!header || rest.href) ? "a" : "div"
+  const tag = (!header || rest.href) ? 'a' : 'div'
 
   return React.createElement(tag,
-            {...rest, className: classes, onClick: handleClick },
+            { ...rest, className: classes, onClick: handleClick },
             name,
             label && <Label>{label}</Label>,
             children)
@@ -35,6 +35,7 @@ MenuItem._meta = {
 MenuItem.propTypes = {
   __onClick: PropTypes.func,
   active: PropTypes.bool,
+  header: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
   label: PropTypes.oneOfType([

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -3,7 +3,7 @@ import cx from 'classnames'
 import META from '../../utils/Meta'
 import Label from '../../elements/Label/Label'
 
-function MenuItem({ __onClick, active, children, className, label, name, onClick, ...rest }) {
+function MenuItem({ __onClick, active, header, children, className, label, name, onClick, ...rest }) {
   const handleClick = (e) => {
     if (__onClick) __onClick(name)
     if (onClick) onClick(name)
@@ -11,17 +11,18 @@ function MenuItem({ __onClick, active, children, className, label, name, onClick
 
   const classes = cx(
     active && 'active',
+    header && 'header',
     className,
     'item',
   )
 
-  return (
-    <a {...rest} className={classes} onClick={handleClick}>
-      {name}
-      {label && <Label>{label}</Label>}
-      {children}
-    </a>
-  )
+  const tag = (!header || rest.href) ? "a" : "div"
+
+  return React.createElement(tag,
+            {...rest, className: classes, onClick: handleClick },
+            name,
+            label && <Label>{label}</Label>,
+            children)
 }
 
 MenuItem._meta = {

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -78,4 +78,19 @@ describe('MenuItem', () => {
         .and.contain.text('37')
     })
   })
+
+  describe('header', () => {
+    it('should be a <div> tag when header is present', () => {
+      shallow(<MenuItem header />)
+        .should.match('div')
+    })
+    it('should be an <a> tag when header not present', () => {
+      shallow(<MenuItem />)
+        .should.match('a')
+    })
+    it('should be an <a> tag when header present and href defined', () => {
+      shallow(<MenuItem header href="link" />)
+        .should.match('a')
+    })
+  })
 })

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -89,7 +89,7 @@ describe('MenuItem', () => {
         .should.match('a')
     })
     it('should be an <a> tag when header present and href defined', () => {
-      shallow(<MenuItem header href="link" />)
+      shallow(<MenuItem header href='link' />)
         .should.match('a')
     })
   })


### PR DESCRIPTION
Semantic-UI allows menu items with the class `header` to be `<div>`. Change behavior to allow `header` property that will then render a `<div>`. If MenuItem has `header` and `href` prop, then, render `<a>` tag.
