### PR TITLE
Drop babel-node from build process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,14 @@ CONTRIBUTING
 
 ## Getting Started
 
+Make sure you have at least [Node.js v6][11]:
+
+```sh
+node -v
+
+v6.2.1
+```
+
 ### Clone & Install
 
 Start by cloning this repo and installing dependencies:
@@ -510,3 +518,4 @@ Adding documentation for new components is a bit tedious.  The best way to do th
 [8]: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit
 [9]: http://semantic-ui.com/introduction/glossary.html
 [10]: http://semantic-ui.com/elements/label.html
+[11]: https://nodejs.org/

--- a/build/karma.conf.babel.js
+++ b/build/karma.conf.babel.js
@@ -1,7 +1,6 @@
-import { argv } from 'yargs'
-
-import config from '../config'
-import webpackConfig from './webpack.config'
+const { argv } = require('yargs')
+const config = require('../config')
+const webpackConfig = require('./webpack.config')
 
 const { paths } = config
 
@@ -42,8 +41,7 @@ module.exports = (karmaConfig) => {
     },
     webpack: {
       devtool: 'cheap-module-source-map',
-      module: {
-        ...webpackConfig.module,
+      module: Object.assign({}, webpackConfig.module, {
         loaders: [
           {
             test: /sinon\.js$/,
@@ -51,14 +49,10 @@ module.exports = (karmaConfig) => {
           },
           ...webpackConfig.module.loaders,
         ],
-      },
-      plugins: [
-        ...webpackConfig.plugins,
-      ],
-      resolve: {
-        ...webpackConfig.resolve,
-        alias: {
-          ...webpackConfig.resolve.alias,
+      }),
+      plugins: webpackConfig.plugins,
+      resolve: Object.assign({}, webpackConfig.resolve, {
+        alias: Object.assign({}, webpackConfig.resolve.alias, {
           jquery: `${paths.test('mocks')}/SemanticjQuery-mock.js`,
           sinon: 'sinon/pkg/sinon',
           // These are internal deps specific to React 0.13 required() by enzyme
@@ -69,8 +63,8 @@ module.exports = (karmaConfig) => {
           // this is a React 0.13 dep required by enzyme
           // ignore it since we don't have it
           'react/addons': 'empty/object',
-        },
-      },
+        }),
+      }),
     },
     webpackServer: {
       progress: false,

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -1,9 +1,8 @@
-import config from '../config'
-import webpack from 'webpack'
-import HtmlWebpackPlugin from 'html-webpack-plugin'
-import _ from 'lodash'
-import yargs from 'yargs'
-const { argv } = yargs
+const config = require('../config')
+const webpack = require('webpack')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+const _ = require('lodash')
+const { argv } = require('yargs')
 
 const { paths } = config
 const { __BASE__, __DEV__, __TEST__ } = config.compiler_globals
@@ -27,7 +26,7 @@ const webpackConfig = {
 
 const webpackHotPath = `${config.compiler_public_path}__webpack_hmr`
 
-export const webpackHotMiddlewareEntry = `webpack-hot-middleware/client?${_.map({
+const webpackHotMiddlewareEntry = `webpack-hot-middleware/client?${_.map({
   path: webpackHotPath,   // The path which the middleware is serving the event stream on
   timeout: 2000,          // The time to wait after a disconnection before attempting to reconnect
   overlay: true,          // Set to false to disable the DOM-based client-side overlay.
@@ -36,14 +35,12 @@ export const webpackHotMiddlewareEntry = `webpack-hot-middleware/client?${_.map(
   quiet: false,           // Set to true to disable all console logging.
 }, (val, key) => `&${key}=${val}`).join('')}`
 
-const APP_ENTRY = [
-  paths.docsSrc('index.js'),
-]
+const APP_ENTRY = paths.docsSrc('index.js')
 
 webpackConfig.entry = __DEV__ ? {
   app: [
     webpackHotMiddlewareEntry,
-    ...APP_ENTRY,
+    APP_ENTRY,
   ],
   vendor: [
     webpackHotMiddlewareEntry,
@@ -100,7 +97,7 @@ webpackConfig.plugins = [
 if (__DEV__) {
   webpackConfig.plugins.push(
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin(),
+    new webpack.NoErrorsPlugin()
   )
 } else if (!__TEST__) {
   webpackConfig.plugins.push(
@@ -187,14 +184,11 @@ if (argv.localModules) {
     /semantic-ui-css\/semantic\.js/,
     /semantic-ui-css\/semantic\.css/,
   ]
-
-  webpackConfig.resolve.alias = {
-    ...webpackConfig.resolve.alias,
+  webpackConfig.resolve.alias = Object.assign({}, webpackConfig.resolve.alias, {
     'semantic-ui-css/semantic.js': 'empty',
     'semantic-ui-css/semantic.css': 'empty',
     'highlight.js/styles/github.css': 'empty',
-  }
-
+  })
   webpackConfig.externals = {
     jquery: 'jQuery',
     faker: 'faker',
@@ -202,4 +196,4 @@ if (argv.localModules) {
   }
 }
 
-export default webpackConfig
+module.exports = webpackConfig

--- a/build/webpack.dll.js
+++ b/build/webpack.dll.js
@@ -1,6 +1,6 @@
-import webpack from 'webpack'
+const webpack = require('webpack')
 
-import config from '../config'
+const config = require('../config')
 const webpackDllConfig = { module: {} }
 
 const { paths } = config
@@ -15,12 +15,11 @@ webpackDllConfig.entry = {
 // ------------------------------------
 // Bundle Output
 // ------------------------------------
-webpackDllConfig.output = {
-  ...webpackDllConfig.output,
+webpackDllConfig.output = Object.assign({}, webpackDllConfig.output, {
   path: 'dll',
   filename: `dll.[name].[${config.compiler_hash_type}].js`,
   library: '[name]_[hash]',
-}
+})
 
 // ------------------------------------
 // Plugins
@@ -60,4 +59,4 @@ webpackDllConfig.module.loaders = [{
   loader: 'file',
 }]
 
-export default webpackDllConfig
+module.exports = webpackDllConfig

--- a/config/_default.js
+++ b/config/_default.js
@@ -1,5 +1,7 @@
-import path from 'path'
-import { argv } from 'yargs'
+const path = require('path')
+const yargs = require('yargs')
+
+const { argv } = yargs
 
 const env = process.env.NODE_ENV || 'development'
 const __DEV__ = env === 'development'
@@ -38,8 +40,7 @@ const paths = {
   docsSrc: base.bind(null, config.dir_docs_src),
 }
 
-config = {
-  ...config,
+config = Object.assign({}, config, {
   paths,
 
   // ----------------------------------
@@ -115,6 +116,6 @@ config = {
       dir: 'coverage',
     },
   ],
-}
+})
 
-export default config
+module.exports = config

--- a/config/development.js
+++ b/config/development.js
@@ -1,4 +1,4 @@
-export default (config) => {
+module.exports = (config) => {
   // We use an explicit public path in development to resolve this issue:
   // http://stackoverflow.com/questions/34133808/webpack-ots-parsing-error-loading-fonts/34133809#34133809
   const __BASE__ = `http://${config.server_host}:${config.server_port}/`
@@ -6,9 +6,8 @@ export default (config) => {
   return {
     compiler_devtool: 'eval-cheap-module-source-map',
     compiler_public_path: __BASE__,
-    compiler_globals: {
-      ...config.compiler_globals,
+    compiler_globals: Object.assign({}, config.compiler_globals, {
       __BASE__: JSON.stringify(__BASE__),
-    },
+    }),
   }
 }

--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,6 @@
-import base from './_default'
+const base = require('./_default')
 
-const envConfig = require(`./${base.env}`).default(base)
+const envConfig = require(`./${base.env}`)(base)
 
-export default { ...base, ...envConfig }
+
+module.exports = Object.assign({}, base, envConfig)

--- a/config/production.js
+++ b/config/production.js
@@ -1,12 +1,11 @@
 const __BASE__ = '/stardust/'
 
-export default (config) => ({
+module.exports = (config) => ({
   compiler_fail_on_warning: true,
   compiler_hash_type: 'chunkhash',
   compiler_devtool: false,
   compiler_public_path: __BASE__,
-  compiler_globals: {
-    ...config.compiler_globals,
+  compiler_globals: Object.assign({}, config.compiler_globals, {
     __BASE__: JSON.stringify(__BASE__),
-  },
+  }),
 })

--- a/config/staging.js
+++ b/config/staging.js
@@ -1,6 +1,6 @@
-import config from './production'
+const config = require('./production')
 
 // Enable source-maps in staging
 config.compiler_devtool = 'source-map'
 
-export default config
+module.exports = config

--- a/config/test.js
+++ b/config/test.js
@@ -1,4 +1,4 @@
 // Just use the production configuration
-import production from './production'
+const production = require('./production')
 
-export default production
+module.exports = production

--- a/gulp/tasks/dll.js
+++ b/gulp/tasks/dll.js
@@ -8,7 +8,7 @@ const g = loadPlugins()
 const { log, PluginError } = g.util
 
 task('dll', (cb) => {
-  const webpackDLLConfig = require('../../build/webpack.dll').default
+  const webpackDLLConfig = require('../../build/webpack.dll')
   const compiler = webpack(webpackDLLConfig)
 
   compiler.run((err, stats) => {

--- a/gulp/tasks/docs.js
+++ b/gulp/tasks/docs.js
@@ -31,7 +31,7 @@ task('generate-docs-json', () => {
 })
 
 task('webpack-docs', (cb) => {
-  const webpackConfig = require('../../build/webpack.config').default
+  const webpackConfig = require('../../build/webpack.config')
   const compiler = webpack(webpackConfig)
 
   compiler.run((err, stats) => {

--- a/gulp/tasks/serve.js
+++ b/gulp/tasks/serve.js
@@ -12,7 +12,7 @@ const g = loadPlugins()
 const { log, colors } = g.util
 
 const serve = (cb) => {
-  const webpackConfig = require('../../build/webpack.config').default
+  const webpackConfig = require('../../build/webpack.config')
   const app = express()
   const compiler = webpack(webpackConfig)
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "npm run docs",
     "start:local-modules": "npm run docs -- --local-modules",
     "pretest": "gulp dll",
-    "test": "NODE_ENV=test babel-node $(npm bin)/karma start build/karma.conf.babel.js",
+    "test": "NODE_ENV=test karma start build/karma.conf.babel.js",
     "test:watch": "npm run test --silent -- --watch"
   },
   "repository": {


### PR DESCRIPTION
This PR dials back the build and config syntax to work with vanilla node 6.  This means no more `babel-node` in order to run Karma.

This is good in general because it reduces complexity and deps.  The main reason it was done though was in attempt for Windows compatibility.  See #316, where we were having issues running karma by referencing the npm bin path.  On windows, this needs to be the Windows version which I believe is `karma.cmd`.

Having removed babel-node means we also remove the need to reference the path directly.  Windows _should_ be able to execute the test script now and NPM _should_ do its cross platform magic and run the correct version.

We shall see.
