### PR TITLE
Add "all" custom prop type and fix issues

### DIFF
--- a/docs/app/Examples/elements/Header/Variations/HeaderColoredExample.js
+++ b/docs/app/Examples/elements/Header/Variations/HeaderColoredExample.js
@@ -13,7 +13,7 @@ export default class HeaderColoredExample extends Component {
         <Header.H4 color='teal'>Teal</Header.H4>
         <Header.H4 color='blue'>Blue</Header.H4>
         <Header.H4 color='purple'>Purple</Header.H4>
-        <Header.H4 color='violent'>Violent</Header.H4>
+        <Header.H4 color='violet'>Violet</Header.H4>
         <Header.H4 color='pink'>Pink</Header.H4>
         <Header.H4 color='brown'>Brown</Header.H4>
         <Header.H4 color='grey'>Grey</Header.H4>

--- a/docs/app/Examples/elements/Header/Variations/HeaderInvertedExample.js
+++ b/docs/app/Examples/elements/Header/Variations/HeaderInvertedExample.js
@@ -13,7 +13,7 @@ export default class HeaderInvertedExample extends Component {
         <Header.H4 inverted color='teal'>Teal</Header.H4>
         <Header.H4 inverted color='blue'>Blue</Header.H4>
         <Header.H4 inverted color='purple'>Purple</Header.H4>
-        <Header.H4 inverted color='violent'>Violent</Header.H4>
+        <Header.H4 inverted color='violet'>Violet</Header.H4>
         <Header.H4 inverted color='pink'>Pink</Header.H4>
         <Header.H4 inverted color='brown'>Brown</Header.H4>
         <Header.H4 inverted color='grey'>Grey</Header.H4>

--- a/src/elements/Header/_Header.js
+++ b/src/elements/Header/_Header.js
@@ -77,7 +77,7 @@ _Header.propTypes = {
   ]),
 
   /** Color of the header. */
-  color: PropTypes.oneOf(_Header._meta.props.colors),
+  color: PropTypes.oneOf(_Header._meta.props.color),
 
   /** Align header content */
   aligned: PropTypes.oneOf(_Header._meta.props.aligned),

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -22,7 +22,10 @@ export default class Accordion extends AutoControlledComponent {
     activeIndex: PropTypes.number,
 
     /** Accordion.Title and Accordion.Content components.  Mutually exclusive with the panels prop. */
-    children: customPropTypes.mutuallyExclusive('panels'),
+    children: customPropTypes.all([
+      customPropTypes.mutuallyExclusive(['panels']),
+      PropTypes.node,
+    ]),
 
     /** Classes to add to the Accordion className. */
     className: PropTypes.string,
@@ -44,11 +47,15 @@ export default class Accordion extends AutoControlledComponent {
      * Object can optionally define an `active` key to open/close the panel.
      * Mutually exclusive with children.
      */
-    panels: PropTypes.arrayOf(PropTypes.shape({
-      active: PropTypes.bool,
-      title: PropTypes.string,
-      content: PropTypes.string,
-    })),
+    panels: customPropTypes.all([
+      customPropTypes.mutuallyExclusive(['children']),
+      PropTypes.arrayOf(PropTypes.shape({
+        active: PropTypes.bool,
+        title: PropTypes.string,
+        content: PropTypes.string,
+        onClick: PropTypes.func,
+      })),
+    ]),
 
     /** Adds some basic styling to accordion panels. */
     styled: PropTypes.bool,

--- a/src/utils/propUtils.js
+++ b/src/utils/propUtils.js
@@ -16,7 +16,7 @@ export const customPropTypes = {
   ofComponentTypes: (allowedTypes) => {
     return (props, propName, componentName) => {
       if (propName !== 'children') {
-        throw new Error(`ofComponentTypes can only be used on the \`children\` prop, not ${propName}`)
+        throw new Error(`ofComponentTypes can only be used on the \`children\` prop, not ${propName}.`)
       }
       if (!_.isArray(allowedTypes)) {
         throw new Error([
@@ -73,9 +73,9 @@ export const customPropTypes = {
     return (props, propName, componentName) => {
       if (!_.isArray(validators)) {
         throw new Error([
-          'Invalid argument supplied to all, expected an instance of array.'
-            ` See ${componentName} prop \`${propName}\`.`,
-        ].join(''))
+          'Invalid argument supplied to all, expected an instance of array.',
+          `See ${componentName} prop \`${propName}\`.`,
+        ].join(' '))
       }
 
       const errors = _.compact(_.map(validators, validator => {

--- a/src/utils/propUtils.js
+++ b/src/utils/propUtils.js
@@ -10,36 +10,83 @@ import Image from '../elements/Image/Image'
 // ===============================================================
 export const customPropTypes = {
   /**
-   * Ensures children are of a set of types.
-   * Similar to `oneOfType` built-in validator
-   * @param {String[]} allowedTypes Collection of allowed Stardust component types
+   * Ensures children are of a set of types. Matches are made against the component _meta.name property.
+   * @param {String[]} allowedTypes Collection of allowed component types.
    */
   ofComponentTypes: (allowedTypes) => {
     return (props, propName, componentName) => {
-      const { children } = props
-      const disallowed = Children.map(children, child => {
+      if (propName !== 'children') {
+        throw new Error(`ofComponentTypes can only be used on the \`children\` prop, not ${propName}`)
+      }
+      if (!_.isArray(allowedTypes)) {
+        throw new Error([
+          'Invalid argument supplied to ofComponentTypes, expected an instance of array.'
+            ` See ${componentName} prop \`${propName}\`.`,
+        ].join(''))
+      }
+      const disallowed = _.compact(Children.map(props.children, child => {
         return _.includes(allowedTypes, _.get(child, 'type._meta.name')) ? null : child
-      })
-      if (disallowed && disallowed.length !== 0) {
+      }))
+      if (!_.isEmpty(disallowed)) {
         return new Error(
           `\`${componentName}\` should only have children of type \`${allowedTypes}\`.`
         )
       }
     }
   },
+
   /**
-   * Verifies exclusivity of a given prop
-   * @param {string} exclusives property used for exclusivity check
+   * Verifies exclusivity of a given prop.
+   * @param {string[]} exclusives An array of props that cannot be used with this prop.
    */
   mutuallyExclusive: exclusives => {
     return (props, propName, componentName) => {
-      _.forEach(exclusives, exclusiveProp => {
-        if (props[propName] && props[exclusiveProp]) {
-          return new Error(
-            `\`${componentName}\` should only have one of type \`${propName}\` or \`${exclusiveProp}\` not both.`
-          )
+      if (!_.isArray(exclusives)) {
+        throw new Error([
+          'Invalid argument supplied to mutuallyExclusive, expected an instance of array.'
+            ` See ${componentName} prop \`${propName}\`.`,
+        ].join(''))
+      }
+
+      // mutually exclusive
+      const disallowed = _.transform(exclusives, (acc, exclusive) => {
+        if (_.has(props, propName) && _.has(props, exclusive)) {
+          return acc.push(exclusive)
         }
-      })
+        return acc
+      }, [])
+
+      if (!_.isEmpty(disallowed)) {
+        return new Error([
+          `\`${componentName}\` prop \`${propName}\` conflicts with props: \`${disallowed.join('`, `')}\`.`,
+          'They cannot be defined together, choose one or the other.',
+        ].join(' '))
+      }
+    }
+  },
+
+  /**
+   * Ensure a prop adherers to multiple prop type validators.
+   * @param {function[]} validators An array of propType functions.
+   */
+  all: (validators) => {
+    return (props, propName, componentName) => {
+      if (!_.isArray(validators)) {
+        throw new Error([
+          'Invalid argument supplied to all, expected an instance of array.'
+            ` See ${componentName} prop \`${propName}\`.`,
+        ].join(''))
+      }
+
+      const errors = _.compact(_.map(validators, validator => {
+        if (!_.isFunction(validator)) {
+          throw new Error(`all() "validators" functions, received: ${typeof validator}.`)
+        }
+        return validator(props, propName, componentName)
+      }))
+
+      // we can only return one error at a time
+      return errors[0]
     }
   },
 }

--- a/src/utils/propUtils.js
+++ b/src/utils/propUtils.js
@@ -49,9 +49,9 @@ export const customPropTypes = {
       }
 
       // mutually exclusive
-      const disallowed = _.transform(exclusives, (acc, exclusive) => {
+      const disallowed = exclusives.reduce((acc, exclusive) => {
         if (_.has(props, propName) && _.has(props, exclusive)) {
-          return acc.push(exclusive)
+          return [...acc, exclusive]
         }
         return acc
       }, [])

--- a/src/views/Item/Item.js
+++ b/src/views/Item/Item.js
@@ -8,10 +8,16 @@ import ItemItems from './ItemItems'
 
 export default class Item extends Component {
   static propTypes = {
-    children: PropTypes.node,
+    children: customPropTypes.all([
+      customPropTypes.mutuallyExclusive(['description']),
+      PropTypes.node,
+    ]),
     className: PropTypes.string,
     contentClassName: PropTypes.string,
-    description: customPropTypes.mutuallyExclusive(['children']),
+    description: customPropTypes.all([
+      customPropTypes.mutuallyExclusive(['children']),
+      PropTypes.node,
+    ]),
     extra: PropTypes.node,
     header: PropTypes.node,
     image: PropTypes.node,


### PR DESCRIPTION
This PR adds the `all()` custom prop type.  This allows passing multiple prop type checkers.  It is needed in #321 and elsewhere to validate mutually exclusive props.

I also fixed a number of prop type issues and updated components using mutuallyExclusive.
