### PR TITLE
Temporarily bundle jQuery and SUI JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,6 @@ export default class TryStardust extends Component {
 
   <!-- SUI CSS -->
   <link href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/semantic.css" rel="stylesheet">
-
-  <!-- Temporary script dependencies until we're done removing jQuery -->
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/semantic.js"></script>
 </head>
 <body>
   <script src="bundle.js"></script>

--- a/build/karma.conf.babel.js
+++ b/build/karma.conf.babel.js
@@ -1,5 +1,6 @@
 const { argv } = require('yargs')
 const config = require('../config')
+const webpack = require('webpack')
 const webpackConfig = require('./webpack.config')
 
 const { paths } = config
@@ -50,7 +51,13 @@ module.exports = (karmaConfig) => {
           ...webpackConfig.module.loaders,
         ],
       }),
-      plugins: webpackConfig.plugins,
+      plugins: [
+        ...webpackConfig.plugins,
+        // utils/jquery loads real jQuery and semantic-ui-css
+        // we alias jquery and semantic-ui-css to mocks during tests
+        // ignore this module so we can use the mock versions in alias below
+        new webpack.NormalModuleReplacementPlugin(/utils\/jquery/, 'empty'),
+      ],
       resolve: Object.assign({}, webpackConfig.resolve, {
         alias: Object.assign({}, webpackConfig.resolve.alias, {
           jquery: `${paths.test('mocks')}/SemanticjQuery-mock.js`,

--- a/config/_default.js
+++ b/config/_default.js
@@ -64,12 +64,9 @@ config = Object.assign({}, config, {
     'bluebird',
     'classnames',
     'faker',
-    'jquery',
-    'lodash',
     'react',
     'react-dom',
     'react-highlight',
-    'semantic-ui-css/semantic.js',
   ],
   compiler_stats: {
     hash: false,            // the hash of the compilation

--- a/docs/app/Components/Root.js
+++ b/docs/app/Components/Root.js
@@ -1,4 +1,3 @@
-import 'semantic-ui-css/semantic.js'
 import 'semantic-ui-css/semantic.css'
 import 'highlight.js/styles/github.css'
 import _ from 'lodash'

--- a/docs/app/Examples/collections/Form/Validation/FormValidationExamples.js
+++ b/docs/app/Examples/collections/Form/Validation/FormValidationExamples.js
@@ -16,7 +16,7 @@ export default class FormValidationExamples extends Component {
           title='Validating on Blur and other Events'
           description={`
             Validation messages can also appear inline.
-            UI Forms automatically format labels with the class name <code>prompt</code>.
+            UI Forms automatically format labels with the class name "prompt".
             These validation prompts are also set to appear on input change instead of form submission.
           `}
           examplePath='collections/Form/Validation/FormValidatingOnBlurAndOtherEventsExample'

--- a/docs/app/index.ejs
+++ b/docs/app/index.ejs
@@ -7,9 +7,6 @@
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/<%= htmlWebpackPlugin.options.versions.highlightjs %>/styles/github.min.css">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/<%= htmlWebpackPlugin.options.versions.sui %>/semantic.min.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/Faker/<%= htmlWebpackPlugin.options.versions.faker %>/faker.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/<%= htmlWebpackPlugin.options.versions.jquery %>/jquery.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/<%= htmlWebpackPlugin.options.versions.lodash %>/lodash.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/<%= htmlWebpackPlugin.options.versions.sui %>/semantic.min.js"></script>
   <title>Stardust</title>
   <script>
     // Apply gh-pages SPA redirect that was applied in 404.html

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "bluebird": "^3.3.4",
     "classnames": "^2.1.5",
     "debug": "^2.2.0",
-    "lodash": "^4.6.1"
+    "jquery": "^3.1.0",
+    "lodash": "^4.6.1",
+    "semantic-ui-css": "^2.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
@@ -116,7 +118,6 @@
     "require-dir": "^0.3.0",
     "rimraf": "^2.5.2",
     "sass-loader": "^3.2.0",
-    "semantic-ui-css": "^2.1.8",
     "simulant": "^0.2.1",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
@@ -130,7 +131,6 @@
     "yargs": "^4.3.2"
   },
   "peerDependencies": {
-    "jquery": "^2.1.4",
     "react": ">=0.14.0 <= 15",
     "react-dom": ">=0.14.0 <= 15"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import './utils/jquery'
 import { deprecateComponent } from './utils/deprecate'
 
 // ----------------------------------------

--- a/src/utils/jquery.js
+++ b/src/utils/jquery.js
@@ -1,0 +1,31 @@
+/**
+ * Ensure the user's app only uses our one copy of jQuery and SUI jQuery plugins.
+ */
+import _ from 'lodash'
+import { makeDebugger } from './debug'
+
+const debug = makeDebugger('jquery')
+
+let jQuery
+if (window.jQuery) jQuery = window.jQuery
+else if (_.get(window, '$.prototype.jquery')) jQuery = window.$
+
+if (jQuery) {
+  throw new Error([
+    'Do not load jQuery, it is bundled with Stardust.',
+    'Stardust will soon be jQuery free: https://github.com/TechnologyAdvice/stardust/issues/247.',
+  ].join(' '))
+}
+
+debug('Loading jQuery')
+// load jQuery, then load SUI jQuery
+window.jQuery = window.$ = require('jquery')
+
+debug('Loading SUI Checkbox plugin')
+require('semantic-ui-css/components/checkbox')
+
+debug('Loading SUI Form plugin')
+require('semantic-ui-css/components/form')
+
+debug('Loading SUI Progress plugin')
+require('semantic-ui-css/components/progress')


### PR DESCRIPTION
Fixes #326.  This PR address the issue of two copies of jQuery being loaded.  One on the the window via script tag, and another via the webpack bundle.

To simplify things for users for now, we simply bundle jQuery and SUI JS with Stardust.  This is only temporary as we are moving quickly to remove jQuery in #247.
