### PR TITLE
Support Dropdown sub component markup

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Types/Dropdown.js
+++ b/docs/app/Examples/modules/Dropdown/Types/Dropdown.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react'
+import { Dropdown } from 'stardust'
+
+export default class DropdownExample extends Component {
+  render() {
+    return (
+      <Dropdown text='File'>
+        <Dropdown.Menu>
+          <Dropdown.Item text='New' />
+          <Dropdown.Item text='Open...' description='ctrl + o' />
+          <Dropdown.Item text='Save as...' description='ctrl + s' />
+          <Dropdown.Item text='Rename' description='ctrl + r' />
+          <Dropdown.Item text='Make a copy' />
+          <Dropdown.Item icon='trash' text='Move to trash' />
+          <Dropdown.Divider />
+          <Dropdown.Item text='Download As...' />
+          <Dropdown.Item text='Publish To Web' />
+          {/* item text can also be defined as children */}
+          <Dropdown.Item>E-mail Collaborators</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    )
+  }
+}

--- a/docs/app/Examples/modules/Dropdown/Types/index.js
+++ b/docs/app/Examples/modules/Dropdown/Types/index.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+export default class DropdownTypesExamples extends Component {
+  render() {
+    return (
+      <ExampleSection title='Types'>
+        <ComponentExample
+          title='Dropdown'
+          description='A dropdown menu'
+          examplePath='modules/Dropdown/Types/Dropdown'
+        />
+      </ExampleSection>
+    )
+  }
+}

--- a/docs/app/Examples/modules/Dropdown/index.js
+++ b/docs/app/Examples/modules/Dropdown/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import Types from './Types'
 import Content from './Content'
 import States from './States'
 
@@ -6,6 +7,7 @@ export default class DropdownExamples extends Component {
   render() {
     return (
       <div>
+        <Types />
         <Content />
         <States />
       </div>

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1,11 +1,9 @@
-/* eslint-disable react/sort-comp */
-
 import _ from 'lodash'
 import cx from 'classnames'
-import React, { PropTypes } from 'react'
+import React, { cloneElement, PropTypes } from 'react'
 
 import META from '../../utils/Meta'
-import { getUnhandledProps, useKeyOnly, useKeyOrValueAndKey } from '../../utils/propUtils'
+import { customPropTypes, getUnhandledProps, useKeyOnly, useKeyOrValueAndKey } from '../../utils/propUtils'
 import keyboardKey from '../../utils/keyboardKey'
 import { makeDebugger } from '../../utils/debug'
 import { objectDiff } from '../../utils/utils'
@@ -53,7 +51,7 @@ export default class Dropdown extends Component {
       text: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,
-      ]).isRequired,
+      ]),
     })),
 
     /** Controls whether or not the dropdown menu is displayed. */
@@ -61,6 +59,12 @@ export default class Dropdown extends Component {
 
     /** Initial value of open. */
     defaultOpen: PropTypes.bool,
+
+    /** A Dropdown can contain a single <Dropdown.Menu /> child. */
+    children: customPropTypes.all([
+      React.PropTypes.element,
+      customPropTypes.ofComponentTypes(['DropdownMenu']),
+    ]),
 
     /** Current value or value array if multiple. Creates a controlled component. */
     value: PropTypes.oneOfType([
@@ -328,7 +332,6 @@ export default class Dropdown extends Component {
 
     // prevent selecting null if there was no selected item value
     if (!value) return
-
 
     // notify the onChange prop that the user is trying to change value
     if (multiple) {
@@ -715,11 +718,25 @@ export default class Dropdown extends Component {
     ))
   }
 
+  renderMenu = () => {
+    const { children } = this.props
+    const { menuClasses } = this.state
+
+    // single menu child
+    if (children) return cloneElement(children, { className: menuClasses })
+
+    return (
+      <DropdownMenu className={menuClasses}>
+        {this.renderOptions()}
+      </DropdownMenu>
+    )
+  }
+
   render() {
     debug('render()')
     debug('props', this.props)
     debug('state', this.state)
-    const { dropdownClasses, menuClasses } = this.state
+    const { dropdownClasses } = this.state
 
     const {
       button,
@@ -792,9 +809,7 @@ export default class Dropdown extends Component {
         {this.renderSearchInput()}
         {this.renderText()}
         <Icon name={'dropdown'} />
-        <DropdownMenu className={menuClasses} ref='menu'>
-          {this.renderOptions()}
-        </DropdownMenu>
+        {this.renderMenu()}
       </div>
     )
   }

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -21,7 +21,7 @@ function DropdownItem(props) {
   } = props
 
   const handleClick = (e) => {
-    onClick(e, value)
+    if (onClick) onClick(e, value)
   }
 
   const classes = cx(

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -9,7 +9,7 @@ import sandbox from 'test/utils/Sandbox-util'
 
 let attachTo
 let options
-let requiredProps
+let optionsProp
 let wrapper
 
 // ----------------------------------------
@@ -57,7 +57,7 @@ describe('Dropdown Component', () => {
     attachTo = undefined
     wrapper = undefined
     options = getOptions()
-    requiredProps = { options }
+    optionsProp = { options }
   })
 
   afterEach(() => {
@@ -65,15 +65,15 @@ describe('Dropdown Component', () => {
     if (attachTo) document.body.removeChild(attachTo)
   })
 
-  common.isConformant(Dropdown, requiredProps)
-  common.hasUIClassName(Dropdown, requiredProps)
-  common.isTabbable(Dropdown, requiredProps)
-  common.propKeyOnlyToClassName(Dropdown, 'multiple', requiredProps)
-  common.propKeyOnlyToClassName(Dropdown, 'search', requiredProps)
-  common.propKeyOnlyToClassName(Dropdown, 'selection', requiredProps)
+  common.isConformant(Dropdown, optionsProp)
+  common.hasUIClassName(Dropdown, optionsProp)
+  common.isTabbable(Dropdown, optionsProp)
+  common.propKeyOnlyToClassName(Dropdown, 'multiple', optionsProp)
+  common.propKeyOnlyToClassName(Dropdown, 'search', optionsProp)
+  common.propKeyOnlyToClassName(Dropdown, 'selection', optionsProp)
 
   it('does not add a hidden input by default', () => {
-    wrapperMount(<Dropdown {...requiredProps} />)
+    wrapperMount(<Dropdown {...optionsProp} />)
       .find('input[type="hidden"]')
       .should.not.be.present()
   })
@@ -105,7 +105,7 @@ describe('Dropdown Component', () => {
 
   describe('selected item', () => {
     it('defaults to the first item', () => {
-      wrapperShallow(<Dropdown {...requiredProps} />)
+      wrapperShallow(<Dropdown {...optionsProp} />)
         .find('DropdownItem')
         .first()
         .should.have.prop('selected', true)
@@ -114,14 +114,14 @@ describe('Dropdown Component', () => {
       // random item, skip the first as its selected by default
       const randomIndex = 1 + _.random(options.length - 2)
 
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
         .find('DropdownItem')
         .at(randomIndex)
         .simulate('click')
         .should.have.prop('selected', true)
     })
     it('moves down on arrow down when open', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       // open
       wrapper.simulate('click')
@@ -142,7 +142,7 @@ describe('Dropdown Component', () => {
         .should.have.prop('selected', true)
     })
     it('moves up on arrow up when open', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       // open
       wrapper
@@ -240,7 +240,7 @@ describe('Dropdown Component', () => {
       )
     })
     it('becomes active on enter when open', () => {
-      const item = wrapperMount(<Dropdown {...requiredProps} />)
+      const item = wrapperMount(<Dropdown {...optionsProp} />)
         .simulate('click')
         .find('DropdownItem')
         .at(1)
@@ -256,7 +256,7 @@ describe('Dropdown Component', () => {
       item.should.have.prop('active', true)
     })
     it('closes the menu', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
         .simulate('click')
 
       dropdownMenuIsOpen()
@@ -271,7 +271,7 @@ describe('Dropdown Component', () => {
     it('sets the corresponding item to active', () => {
       const value = _.sample(options).value
 
-      wrapperShallow(<Dropdown {...requiredProps} value={value} />)
+      wrapperShallow(<Dropdown {...optionsProp} value={value} />)
         .find('DropdownItem')
         .find({ value, active: true })
         .should.be.present()
@@ -280,7 +280,7 @@ describe('Dropdown Component', () => {
     it('sets the corresponding item text', () => {
       const { text, value } = _.sample(options)
 
-      wrapperShallow(<Dropdown value={value} {...requiredProps} />)
+      wrapperShallow(<Dropdown value={value} {...optionsProp} />)
         .find('DropdownItem')
         .find({ value, text })
         .should.be.present()
@@ -291,7 +291,7 @@ describe('Dropdown Component', () => {
       let next
       while (!next || next === value) next = _.sample(options).value
 
-      wrapperShallow(<Dropdown value={value} {...requiredProps} />)
+      wrapperShallow(<Dropdown value={value} {...optionsProp} />)
 
       // initial active item
       wrapper
@@ -314,7 +314,7 @@ describe('Dropdown Component', () => {
       const initialItem = _.sample(options)
       const nextItem = _.sample(_.without(options, initialItem))
 
-      wrapperMount(<Dropdown {...requiredProps} value={initialItem.value} />)
+      wrapperMount(<Dropdown {...optionsProp} value={initialItem.value} />)
         .find('.text')
         .should.contain.text(initialItem.text)
 
@@ -329,14 +329,14 @@ describe('Dropdown Component', () => {
     it('sets the display text', () => {
       const text = faker.hacker.phrase()
 
-      wrapperRender(<Dropdown {...requiredProps} text={text} />)
+      wrapperRender(<Dropdown {...optionsProp} text={text} />)
         .find('.text')
         .should.contain.text(text)
     })
     it('prevents updates on item click if defined', () => {
       const text = faker.hacker.phrase()
 
-      wrapperMount(<Dropdown {...requiredProps} text={text} />)
+      wrapperMount(<Dropdown {...optionsProp} text={text} />)
         .simulate('click')
         .find('DropdownItem')
         .at(_.random(options.length - 1))
@@ -347,7 +347,7 @@ describe('Dropdown Component', () => {
         .should.contain.text(text)
     })
     it('is updated on item click if not already defined', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       // open
       wrapper.simulate('click')
@@ -373,7 +373,7 @@ describe('Dropdown Component', () => {
     // https://github.com/facebook/react/issues/5043
 
     it('opens on dropdown click', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       dropdownMenuIsClosed()
       wrapper.simulate('click')
@@ -381,7 +381,7 @@ describe('Dropdown Component', () => {
     })
 
     it('opens on arrow down when focused', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       dropdownMenuIsClosed()
       wrapper.simulate('focus')
@@ -390,7 +390,7 @@ describe('Dropdown Component', () => {
     })
 
     it('opens on arrow up when focused', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       dropdownMenuIsClosed()
       wrapper.simulate('focus')
@@ -399,7 +399,7 @@ describe('Dropdown Component', () => {
     })
 
     it('opens on space when focused and closed', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       dropdownMenuIsClosed()
       wrapper.simulate('focus')
@@ -408,7 +408,7 @@ describe('Dropdown Component', () => {
     })
 
     it('does not call open on space if already open', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       const instance = wrapper.instance()
       sandbox.spy(instance, 'open')
@@ -432,7 +432,7 @@ describe('Dropdown Component', () => {
     })
 
     it('does not open on arrow down when not focused', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       dropdownMenuIsClosed()
       domEvent.keyDown(document, { key: 'ArrowDown' })
@@ -440,7 +440,7 @@ describe('Dropdown Component', () => {
     })
 
     it('does not open on space when not focused', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       dropdownMenuIsClosed()
       domEvent.keyDown(document, { key: ' ' })
@@ -448,7 +448,7 @@ describe('Dropdown Component', () => {
     })
 
     it('closes on menu item click', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
       const item = wrapper
         .find('DropdownItem')
         .at(_.random(options.length - 1))
@@ -463,7 +463,7 @@ describe('Dropdown Component', () => {
     })
 
     it('closes on click outside', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       // open
       wrapper.simulate('click')
@@ -475,7 +475,7 @@ describe('Dropdown Component', () => {
     })
 
     it('closes on esc key', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       // open
       wrapper
@@ -491,28 +491,28 @@ describe('Dropdown Component', () => {
 
   describe('open', () => {
     it('defaultOpen opens the menu when true', () => {
-      wrapperShallow(<Dropdown {...requiredProps} defaultOpen />)
+      wrapperShallow(<Dropdown {...optionsProp} defaultOpen />)
       dropdownMenuIsOpen()
     })
     it('defaultOpen closes the menu when false', () => {
-      wrapperShallow(<Dropdown {...requiredProps} defaultOpen={false} />)
+      wrapperShallow(<Dropdown {...optionsProp} defaultOpen={false} />)
       dropdownMenuIsClosed()
     })
     it('opens the menu when true', () => {
-      wrapperShallow(<Dropdown {...requiredProps} open />)
+      wrapperShallow(<Dropdown {...optionsProp} open />)
       dropdownMenuIsOpen()
     })
     it('closes the menu when false', () => {
-      wrapperShallow(<Dropdown {...requiredProps} open={false} />)
+      wrapperShallow(<Dropdown {...optionsProp} open={false} />)
       dropdownMenuIsClosed()
     })
     it('closes the menu when toggled from true to false', () => {
-      wrapperShallow(<Dropdown {...requiredProps} open />)
+      wrapperShallow(<Dropdown {...optionsProp} open />)
         .setProps({ open: false })
       dropdownMenuIsOpen()
     })
     it('opens the menu when toggled from false to true', () => {
-      wrapperShallow(<Dropdown {...requiredProps} open={false} />)
+      wrapperShallow(<Dropdown {...optionsProp} open={false} />)
         .setProps({ open: true })
       dropdownMenuIsClosed()
     })
@@ -520,7 +520,7 @@ describe('Dropdown Component', () => {
 
   describe('multiple', () => {
     it('does not close the menu on item selection with enter', () => {
-      wrapperMount(<Dropdown {...requiredProps} multiple />)
+      wrapperMount(<Dropdown {...optionsProp} multiple />)
         .simulate('click')
 
       dropdownMenuIsOpen()
@@ -532,7 +532,7 @@ describe('Dropdown Component', () => {
     })
     it('does not close the menu on clicking on an item', () => {
       const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }
-      wrapperMount(<Dropdown {...requiredProps} multiple />)
+      wrapperMount(<Dropdown {...optionsProp} multiple />)
         .simulate('click', nativeEvent)
         .find('DropdownItem')
         .at(_.random(options.length - 1))
@@ -543,13 +543,13 @@ describe('Dropdown Component', () => {
     it('filters active options out of the list', () => {
       // make all the items active, expect to see none in the list
       const value = _.map(options, 'value')
-      wrapperShallow(<Dropdown {...requiredProps} value={value} multiple />)
+      wrapperShallow(<Dropdown {...optionsProp} value={value} multiple />)
         .should.not.have.descendants('DropdownItem')
     })
     it('displays a label for active items', () => {
       // select a random item, expect a label with the item's text
       const activeItem = _.sample(options)
-      wrapperShallow(<Dropdown {...requiredProps} value={[activeItem.value]} multiple />)
+      wrapperShallow(<Dropdown {...optionsProp} value={[activeItem.value]} multiple />)
         .should.have.descendants('Label')
 
       wrapper
@@ -559,7 +559,7 @@ describe('Dropdown Component', () => {
     it('keeps the selection within the range of remaining options', () => {
       // items are removed as they are made active
       // the selection should move if the last item is made active
-      wrapperMount(<Dropdown {...requiredProps} multiple />)
+      wrapperMount(<Dropdown {...optionsProp} multiple />)
 
       // open
       wrapper.simulate('click')
@@ -592,7 +592,7 @@ describe('Dropdown Component', () => {
     it('has labels with delete icons', () => {
       // add a value so we have a label
       const value = [_.head(options).value]
-      wrapperRender(<Dropdown {...requiredProps} value={value} multiple />)
+      wrapperRender(<Dropdown {...optionsProp} value={value} multiple />)
         .should.have.descendants('.label')
 
       wrapper
@@ -607,7 +607,7 @@ describe('Dropdown Component', () => {
         const randomValue = value[randomIndex]
         const expected = _.without(value, randomValue)
         const spy = sandbox.spy()
-        wrapperMount(<Dropdown {...requiredProps} value={value} multiple onChange={spy} />)
+        wrapperMount(<Dropdown {...optionsProp} value={value} multiple onChange={spy} />)
 
         wrapper
           .find('.delete.icon')
@@ -627,7 +627,7 @@ describe('Dropdown Component', () => {
     })
 
     it('does nothing without selected items', () => {
-      wrapperMount(<Dropdown {...requiredProps} multiple search onChange={spy} />)
+      wrapperMount(<Dropdown {...optionsProp} multiple search onChange={spy} />)
 
       // open
       wrapper.simulate('click')
@@ -639,7 +639,7 @@ describe('Dropdown Component', () => {
     it('removes the last item when there is no search query', () => {
       const value = _.map(options, 'value')
       const expected = _.dropRight(value)
-      wrapperMount(<Dropdown {...requiredProps} value={value} multiple search onChange={spy} />)
+      wrapperMount(<Dropdown {...optionsProp} value={value} multiple search onChange={spy} />)
 
       // open
       wrapper.simulate('click')
@@ -652,7 +652,7 @@ describe('Dropdown Component', () => {
     it('removes the last item when there is no search query when uncontrolled', () => {
       const value = _.map(options, 'value')
       const expected = _.dropRight(value)
-      wrapperMount(<Dropdown {...requiredProps} defaultValue={value} multiple search onChange={spy} />)
+      wrapperMount(<Dropdown {...optionsProp} defaultValue={value} multiple search onChange={spy} />)
 
       // open
       wrapper.simulate('click')
@@ -670,7 +670,7 @@ describe('Dropdown Component', () => {
       // search for random item
       const searchQuery = _.sample(options).text
       const value = _.map(options, 'value')
-      wrapperMount(<Dropdown {...requiredProps} value={value} multiple search onChange={spy} />)
+      wrapperMount(<Dropdown {...optionsProp} value={value} multiple search onChange={spy} />)
 
       // open and simulate search
       wrapper
@@ -683,7 +683,7 @@ describe('Dropdown Component', () => {
     })
     it('does not remove items for multiple dropdowns without search', () => {
       const value = _.map(options, 'value')
-      wrapperMount(<Dropdown {...requiredProps} value={value} multiple onChange={spy} />)
+      wrapperMount(<Dropdown {...optionsProp} value={value} multiple onChange={spy} />)
 
       // open
       wrapper.simulate('click')
@@ -703,7 +703,7 @@ describe('Dropdown Component', () => {
     it('is called with event and value on item click', () => {
       const randomIndex = _.random(options.length - 1)
       const randomValue = options[randomIndex].value
-      wrapperMount(<Dropdown {...requiredProps} onChange={spy} />)
+      wrapperMount(<Dropdown {...optionsProp} onChange={spy} />)
         .simulate('click')
         .find('DropdownItem')
         .at(randomIndex)
@@ -714,7 +714,7 @@ describe('Dropdown Component', () => {
     })
     it('is called with event and value when pressing enter on a selected item', () => {
       const firstValue = options[0].value
-      wrapperMount(<Dropdown {...requiredProps} onChange={spy} />)
+      wrapperMount(<Dropdown {...optionsProp} onChange={spy} />)
         .simulate('click')
 
       domEvent.keyDown(document, { key: 'Enter' })
@@ -726,7 +726,7 @@ describe('Dropdown Component', () => {
       const value = _.sample(options).value
       const next = _.sample(_.without(options, value)).value
 
-      wrapperMount(<Dropdown {...requiredProps} value={value} onChange={spy} />)
+      wrapperMount(<Dropdown {...optionsProp} value={value} onChange={spy} />)
         .setProps({ value: next })
 
       spy.should.not.have.been.called()
@@ -735,12 +735,12 @@ describe('Dropdown Component', () => {
 
   describe('options', () => {
     it('adds the onClick handler to all items', () => {
-      wrapperShallow(<Dropdown {...requiredProps} />)
+      wrapperShallow(<Dropdown {...optionsProp} />)
         .children('DropdownItem')
         .everyWhere(item => item.should.have.prop('onClick'))
     })
     it('calls handleItemClick when an item is clicked', () => {
-      wrapperMount(<Dropdown {...requiredProps} />)
+      wrapperMount(<Dropdown {...optionsProp} />)
 
       const instance = wrapper.instance()
       sandbox.spy(instance, 'handleItemClick')
@@ -763,7 +763,7 @@ describe('Dropdown Component', () => {
 
   describe('selection', () => {
     it('adds a hidden input', () => {
-      wrapperRender(<Dropdown {...requiredProps} selection />)
+      wrapperRender(<Dropdown {...optionsProp} selection />)
         .find('input[type="hidden"]')
         .should.be.present()
     })
@@ -771,17 +771,17 @@ describe('Dropdown Component', () => {
 
   describe('search', () => {
     it('does not add a search input when not defined', () => {
-      wrapperShallow(<Dropdown {...requiredProps} />)
+      wrapperShallow(<Dropdown {...optionsProp} />)
         .should.not.have.descendants('input.search')
     })
 
     it('adds a search input when present', () => {
-      wrapperRender(<Dropdown {...requiredProps} search />)
+      wrapperRender(<Dropdown {...optionsProp} search />)
         .should.have.descendants('input.search')
     })
 
     it('sets focus to the search input on open', () => {
-      wrapperMount(<Dropdown {...requiredProps} search />)
+      wrapperMount(<Dropdown {...optionsProp} search />)
         .simulate('click')
 
       const activeElement = document.activeElement
@@ -792,12 +792,12 @@ describe('Dropdown Component', () => {
     })
 
     it('removes Dropdown tabIndex', () => {
-      wrapperShallow(<Dropdown {...requiredProps} search />)
+      wrapperShallow(<Dropdown {...optionsProp} search />)
         .should.not.have.prop('tabIndex')
     })
 
     it('has a search input with a tabIndex of 0', () => {
-      wrapperShallow(<Dropdown {...requiredProps} search />)
+      wrapperShallow(<Dropdown {...optionsProp} search />)
         .find('input.search')
         .should.have.prop('tabIndex', '0')
     })
@@ -806,7 +806,7 @@ describe('Dropdown Component', () => {
       // search for random item
       const searchQuery = _.sample(options).text
 
-      wrapperMount(<Dropdown {...requiredProps} search />)
+      wrapperMount(<Dropdown {...optionsProp} search />)
 
       // open and simulate search
       wrapper
@@ -824,7 +824,7 @@ describe('Dropdown Component', () => {
     })
 
     it('opens the menu on change if there is a query and not already open', () => {
-      wrapperMount(<Dropdown {...requiredProps} search />)
+      wrapperMount(<Dropdown {...optionsProp} search />)
 
       dropdownMenuIsClosed()
 
@@ -838,7 +838,7 @@ describe('Dropdown Component', () => {
 
     it('does not call onChange on query change', () => {
       const onChangeSpy = sandbox.spy()
-      wrapperMount(<Dropdown {...requiredProps} search onChange={onChangeSpy} />)
+      wrapperMount(<Dropdown {...optionsProp} search onChange={onChangeSpy} />)
 
       // simulate search
       wrapper
@@ -849,7 +849,7 @@ describe('Dropdown Component', () => {
     })
 
     it('filters the items based on display text', () => {
-      const search = wrapperMount(<Dropdown {...requiredProps} search />)
+      const search = wrapperMount(<Dropdown {...optionsProp} search />)
         .find('input.search')
 
       // search for value yields 0 results
@@ -868,7 +868,7 @@ describe('Dropdown Component', () => {
     })
 
     it('sets the selected item to the first search result', () => {
-      const search = wrapperMount(<Dropdown {...requiredProps} search />)
+      const search = wrapperMount(<Dropdown {...optionsProp} search />)
         .find('input.search')
 
       // the first item is selected by default
@@ -883,7 +883,7 @@ describe('Dropdown Component', () => {
 
     it('still allows moving selection after blur/focus', () => {
       // open, first item is selected
-      const search = wrapperMount(<Dropdown {...requiredProps} search />)
+      const search = wrapperMount(<Dropdown {...optionsProp} search />)
         .find('input.search')
         .simulate('focus')
 
@@ -931,7 +931,7 @@ describe('Dropdown Component', () => {
 
   describe('no results message', () => {
     it('is shown when a search yields no results', () => {
-      const search = wrapperMount(<Dropdown {...requiredProps} search />)
+      const search = wrapperMount(<Dropdown {...optionsProp} search />)
         .find('input.search')
 
       wrapper
@@ -949,7 +949,7 @@ describe('Dropdown Component', () => {
     it('is not shown on multiple dropdowns with no remaining items', () => {
       // make all the items active so there are no remaining options
       const value = _.map(options, 'value')
-      wrapperMount(<Dropdown {...requiredProps} value={value} multiple />)
+      wrapperMount(<Dropdown {...optionsProp} value={value} multiple />)
 
       // open the menu
       wrapper.simulate('click')
@@ -968,23 +968,23 @@ describe('Dropdown Component', () => {
 
   describe('placeholder', () => {
     it('is present when defined', () => {
-      wrapperShallow(<Dropdown {...requiredProps} placeholder='hi' />)
+      wrapperShallow(<Dropdown {...optionsProp} placeholder='hi' />)
         .should.have.descendants('.default.text')
     })
     it('is not present when not defined', () => {
-      wrapperShallow(<Dropdown {...requiredProps} />)
+      wrapperShallow(<Dropdown {...optionsProp} />)
         .should.not.have.descendants('.default.text')
     })
     it('is not present when there is a value', () => {
-      wrapperShallow(<Dropdown {...requiredProps} value='hi' placeholder='hi' />)
+      wrapperShallow(<Dropdown {...optionsProp} value='hi' placeholder='hi' />)
         .should.not.have.descendants('.default.text')
     })
     it('is present on a multiple dropdown with an empty value array', () => {
-      wrapperShallow(<Dropdown {...requiredProps} value={[]} multiple placeholder='hi' />)
+      wrapperShallow(<Dropdown {...optionsProp} value={[]} multiple placeholder='hi' />)
         .should.have.descendants('.default.text')
     })
     it('has a filtered className when there is a search query', () => {
-      wrapperShallow(<Dropdown {...requiredProps} search placeholder='hi' />)
+      wrapperShallow(<Dropdown {...optionsProp} search placeholder='hi' />)
         .setState({ searchQuery: 'a' })
         .should.have.descendants('.default.text.filtered')
     })
@@ -992,7 +992,7 @@ describe('Dropdown Component', () => {
 
   describe('render', () => {
     it('calls renderText', () => {
-      wrapperShallow(<Dropdown {...requiredProps} />)
+      wrapperShallow(<Dropdown {...optionsProp} />)
 
       const instance = wrapper.instance()
       sandbox.spy(instance, 'renderText')
@@ -1004,6 +1004,33 @@ describe('Dropdown Component', () => {
 
       instance.renderText
         .should.have.been.called()
+    })
+  })
+
+  describe('Dropdown.Menu child', () => {
+    it('renders child passed', () => {
+      wrapperShallow(
+        <Dropdown>
+          <Dropdown.Menu data-find-me />
+        </Dropdown>
+      )
+        .should.contain.descendants('DropdownMenu')
+
+      wrapper
+        .find('DropdownMenu')
+        .should.have.prop('data-find-me', true)
+    })
+
+    it('opens on click', () => {
+      wrapperMount(
+        <Dropdown>
+          <Dropdown.Menu />
+        </Dropdown>
+      )
+
+      dropdownMenuIsClosed()
+      wrapper.simulate('click')
+      dropdownMenuIsOpen()
     })
   })
 })


### PR DESCRIPTION
See #346 for more information.  This PR enables support for Dropdown markup via sub components.  Currently we only support an array of `options` to configure the Dropdown.  Now we support this:

``` jsx
<Dropdown text='File'>
  <Dropdown.Menu>
    <Dropdown.Item text='New' />
    <Dropdown.Item text='Open...' description='ctrl + o' />
    <Dropdown.Item text='Save as...' description='ctrl + s' />
    <Dropdown.Item text='Rename' description='ctrl + r' />
    <Dropdown.Item text='Make a copy' />
    <Dropdown.Item icon='trash' text='Move to trash' />
    <Dropdown.Divider />
    <Dropdown.Item text='Download As...' />
    <Dropdown.Item text='Publish To Web' />
    {/* item text can also be defined as children */}
    <Dropdown.Item>E-mail Collaborators</Dropdown.Item>
  </Dropdown.Menu>
</Dropdown>
```

![image](https://cloud.githubusercontent.com/assets/5067638/17079325/61f4d642-50c1-11e6-9c43-45e8adc4798b.png)

There are known limitations.  Sub menus are not supported.  Fixes #346 
