### PR TITLE
Label: fix color propType argument

### DIFF
--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -95,7 +95,7 @@ Label.propTypes = {
   className: PropTypes.string,
 
   /** Color of the label. */
-  color: PropTypes.oneOf(Label._meta.props.colors),
+  color: PropTypes.oneOf(Label._meta.props.color),
 
   /** Place the label in one of the upper corners. */
   corner: PropTypes.oneOfType([


### PR DESCRIPTION
Fixes #368.  This PR corrects the typo in the Label `color` propType function argument.
