### PR TITLE
Remove _meta.library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,6 @@ Here's an example `_meta` object:
 import META from '../../utils/Meta'
 
 const _meta = {
-  library: META.library.semanticUI,
   name: 'MyComponent',
   type: META.type.module,
   props: {

--- a/docs/app/Components/ComponentDoc/ComponentDescription.js
+++ b/docs/app/Components/ComponentDoc/ComponentDescription.js
@@ -28,7 +28,7 @@ export default class ComponentDescription extends Component {
   renderSemanticDocsLink = () => {
     const { _meta } = this.props
 
-    if (!META.isSemanticUI(_meta)) return null
+    if (META.isAddon(_meta)) return null
 
     const name = META.isParent(_meta) ? _meta.name : _meta.parent
     const url = `http://semantic-ui.com/${_meta.type}s/${name}.html`.toLowerCase()

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -39,7 +39,6 @@ export default class Confirm extends Component {
     })
 
   static _meta = {
-    library: META.library.stardust,
     name: 'Confirm',
     type: META.type.addon,
   }

--- a/src/addons/Radio/Radio.js
+++ b/src/addons/Radio/Radio.js
@@ -14,7 +14,6 @@ function Radio(props) {
 }
 
 Radio._meta = {
-  library: META.library.stardust,
   name: 'Radio',
   type: META.type.addon,
 }

--- a/src/addons/Select/Select.js
+++ b/src/addons/Select/Select.js
@@ -12,7 +12,6 @@ function Select(props) {
 }
 
 Select._meta = {
-  library: META.library.stardust,
   name: 'Select',
   type: META.type.addon,
 }

--- a/src/addons/Textarea/Textarea.js
+++ b/src/addons/Textarea/Textarea.js
@@ -8,7 +8,6 @@ export default class Textarea extends Component {
   }
 
   static _meta = {
-    library: META.library.stardust,
     name: 'Textarea',
     type: META.type.addon,
   }

--- a/src/collections/Breadcrumb/Breadcrumb.js
+++ b/src/collections/Breadcrumb/Breadcrumb.js
@@ -38,7 +38,6 @@ function Breadcrumb(props) {
 }
 
 Breadcrumb._meta = {
-  library: META.library.semanticUI,
   name: 'Breadcrumb',
   type: META.type.collection,
   props: {

--- a/src/collections/Breadcrumb/BreadcrumbDivider.js
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.js
@@ -18,7 +18,6 @@ function BreadcrumbDivider(props) {
 }
 
 BreadcrumbDivider._meta = {
-  library: META.library.semanticUI,
   name: 'BreadcrumbDivider',
   type: META.type.collection,
   parent: 'Breadcrumb',

--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -46,7 +46,6 @@ function BreadcrumbSection(props) {
 }
 
 BreadcrumbSection._meta = {
-  library: META.library.semanticUI,
   name: 'BreadcrumbSection',
   type: META.type.collection,
   parent: 'Breadcrumb',

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -64,7 +64,6 @@ export default class Form extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Form',
     type: META.type.collection,
   }

--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -12,7 +12,6 @@ export default class FormField extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'FormField',
     parent: 'Form',
     type: META.type.collection,

--- a/src/collections/Form/FormFields.js
+++ b/src/collections/Form/FormFields.js
@@ -17,7 +17,6 @@ export default class FormFields extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'FormFields',
     parent: 'Form',
     type: META.type.collection,

--- a/src/collections/Grid/Grid.js
+++ b/src/collections/Grid/Grid.js
@@ -46,7 +46,6 @@ Grid.Column = GridColumn
 Grid.Row = GridRow
 
 Grid._meta = {
-  library: META.library.semanticUI,
   name: 'Grid',
   type: META.type.collection,
   props: {

--- a/src/collections/Grid/GridColumn.js
+++ b/src/collections/Grid/GridColumn.js
@@ -32,7 +32,6 @@ function GridColumn(props) {
 }
 
 GridColumn._meta = {
-  library: META.library.semanticUI,
   name: 'GridColumn',
   parent: 'Grid',
   type: META.type.collection,

--- a/src/collections/Grid/GridRow.js
+++ b/src/collections/Grid/GridRow.js
@@ -32,7 +32,6 @@ function GridRow(props) {
 }
 
 GridRow._meta = {
-  library: META.library.semanticUI,
   name: 'GridRow',
   parent: 'Grid',
   type: META.type.collection,

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -27,7 +27,6 @@ export default class Menu extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Menu',
     type: META.type.collection,
   }

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -25,7 +25,6 @@ function MenuItem({ __onClick, active, children, className, label, name, onClick
 }
 
 MenuItem._meta = {
-  library: META.library.semanticUI,
   name: 'MenuItem',
   type: META.type.collection,
   parent: 'Menu',

--- a/src/collections/Message/Message.js
+++ b/src/collections/Message/Message.js
@@ -24,7 +24,6 @@ export default class Message extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Message',
     type: META.type.collection,
   }

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -133,7 +133,6 @@ export default class Table extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Table',
     type: META.type.collection,
   }

--- a/src/collections/Table/TableColumn.js
+++ b/src/collections/Table/TableColumn.js
@@ -13,7 +13,6 @@ TableColumn.propTypes = {
 }
 
 TableColumn._meta = {
-  library: META.library.semanticUI,
   name: 'TableColumn',
   type: META.type.collection,
   parent: 'Table',

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -13,7 +13,6 @@ export default class Button extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Button',
     type: META.type.element,
   }

--- a/src/elements/Button/Buttons.js
+++ b/src/elements/Button/Buttons.js
@@ -9,7 +9,6 @@ export default class Buttons extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Buttons',
     type: META.type.element,
     parent: 'Button',

--- a/src/elements/Container/Container.js
+++ b/src/elements/Container/Container.js
@@ -23,7 +23,6 @@ function Container(props) {
 }
 
 Container._meta = {
-  library: META.library.semanticUI,
   name: 'Container',
   type: META.type.element,
   props: {

--- a/src/elements/Divider/Divider.js
+++ b/src/elements/Divider/Divider.js
@@ -39,7 +39,6 @@ function Divider(props) {
 }
 
 Divider._meta = {
-  library: META.library.semanticUI,
   name: 'Divider',
   type: META.type.element,
 }

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -57,7 +57,6 @@ function Flag(props) {
 }
 
 Flag._meta = {
-  library: META.library.semanticUI,
   name: 'Flag',
   type: META.type.element,
   props: {

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -16,7 +16,6 @@ function Header(props) {
 }
 
 Header._meta = {
-  library: META.library.semanticUI,
   name: 'Header',
   type: META.type.element,
 }

--- a/src/elements/Header/HeaderH1.js
+++ b/src/elements/Header/HeaderH1.js
@@ -9,7 +9,6 @@ function HeaderH1(props) {
 }
 
 HeaderH1._meta = {
-  library: META.library.semanticUI,
   name: 'HeaderH1',
   parent: 'Header',
   type: META.type.element,

--- a/src/elements/Header/HeaderH2.js
+++ b/src/elements/Header/HeaderH2.js
@@ -9,7 +9,6 @@ function HeaderH2(props) {
 }
 
 HeaderH2._meta = {
-  library: META.library.semanticUI,
   name: 'HeaderH2',
   parent: 'Header',
   type: META.type.element,

--- a/src/elements/Header/HeaderH3.js
+++ b/src/elements/Header/HeaderH3.js
@@ -9,7 +9,6 @@ function HeaderH3(props) {
 }
 
 HeaderH3._meta = {
-  library: META.library.semanticUI,
   name: 'HeaderH3',
   parent: 'Header',
   type: META.type.element,

--- a/src/elements/Header/HeaderH4.js
+++ b/src/elements/Header/HeaderH4.js
@@ -9,7 +9,6 @@ function HeaderH4(props) {
 }
 
 HeaderH4._meta = {
-  library: META.library.semanticUI,
   name: 'HeaderH4',
   parent: 'Header',
   type: META.type.element,

--- a/src/elements/Header/HeaderH5.js
+++ b/src/elements/Header/HeaderH5.js
@@ -9,7 +9,6 @@ function HeaderH5(props) {
 }
 
 HeaderH5._meta = {
-  library: META.library.semanticUI,
   name: 'HeaderH5',
   parent: 'Header',
   type: META.type.element,

--- a/src/elements/Header/HeaderH6.js
+++ b/src/elements/Header/HeaderH6.js
@@ -9,7 +9,6 @@ function HeaderH6(props) {
 }
 
 HeaderH6._meta = {
-  library: META.library.semanticUI,
   name: 'HeaderH6',
   parent: 'Header',
   type: META.type.element,

--- a/src/elements/Header/HeaderSubheader.js
+++ b/src/elements/Header/HeaderSubheader.js
@@ -26,7 +26,6 @@ function HeaderSubheader(props) {
 }
 
 HeaderSubheader._meta = {
-  library: META.library.semanticUI,
   name: 'HeaderSubheader',
   parent: 'Header',
   type: META.type.element,

--- a/src/elements/Header/_Header.js
+++ b/src/elements/Header/_Header.js
@@ -48,7 +48,6 @@ function _Header(props) {
 }
 
 _Header._meta = {
-  library: META.library.semanticUI,
   name: '_Header',
   type: META.type.element,
   props: {

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -47,7 +47,6 @@ function Icon(props) {
 Icon.Group = IconGroup
 
 Icon._meta = {
-  library: META.library.semanticUI,
   name: 'Icon',
   type: META.type.element,
   props: {

--- a/src/elements/Icon/IconGroup.js
+++ b/src/elements/Icon/IconGroup.js
@@ -32,7 +32,6 @@ function IconGroup(props) {
 
 
 IconGroup._meta = {
-  library: META.library.semanticUI,
   name: 'IconGroup',
   parent: 'Icon',
   type: META.type.element,

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -10,7 +10,6 @@ export default class Image extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Image',
     type: META.type.element,
   }

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -18,7 +18,6 @@ export default class Input extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Input',
     type: META.type.element,
   }

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -68,7 +68,6 @@ function Label(props) {
 }
 
 Label._meta = {
-  library: META.library.semanticUI,
   name: 'Label',
   type: META.type.element,
   props: {

--- a/src/elements/List/List.js
+++ b/src/elements/List/List.js
@@ -10,7 +10,6 @@ export default class List extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'List',
     type: META.type.element,
   }

--- a/src/elements/List/ListItem.js
+++ b/src/elements/List/ListItem.js
@@ -15,7 +15,6 @@ export default class ListItem extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'ListItem',
     type: META.type.element,
     parent: 'List',

--- a/src/elements/Loader/Loader.js
+++ b/src/elements/Loader/Loader.js
@@ -25,7 +25,6 @@ function Loader(props) {
 }
 
 Loader._meta = {
-  library: META.library.semanticUI,
   name: 'Loader',
   type: META.type.element,
   props: {

--- a/src/elements/Rail/Rail.js
+++ b/src/elements/Rail/Rail.js
@@ -28,7 +28,6 @@ function Rail(props) {
 }
 
 Rail._meta = {
-  library: META.library.semanticUI,
   name: 'Rail',
   props: {
     close: ['very'],

--- a/src/elements/Segment/Segment.js
+++ b/src/elements/Segment/Segment.js
@@ -22,7 +22,6 @@ export default class Segment extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Segment',
     type: META.type.element,
   }

--- a/src/elements/Segment/SegmentSegments.js
+++ b/src/elements/Segment/SegmentSegments.js
@@ -13,7 +13,6 @@ export default class SegmentSegments extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'SegmentSegments',
     type: META.type.element,
     parent: 'Segment',

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -62,7 +62,6 @@ export default class Accordion extends AutoControlledComponent {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Accordion',
     type: META.type.module,
   }

--- a/src/modules/Accordion/AccordionContent.js
+++ b/src/modules/Accordion/AccordionContent.js
@@ -32,7 +32,6 @@ AccordionContent.propTypes = {
 }
 
 AccordionContent._meta = {
-  library: META.library.semanticUI,
   name: 'AccordionContent',
   type: META.type.module,
   parent: 'Accordion',

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -39,7 +39,6 @@ AccordionTitle.propTypes = {
 }
 
 AccordionTitle._meta = {
-  library: META.library.semanticUI,
   name: 'AccordionTitle',
   type: META.type.module,
   parent: 'Accordion',

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -18,7 +18,6 @@ const typeMap = {
 }
 
 const _meta = {
-  library: META.library.semanticUI,
   name: 'Checkbox',
   type: META.type.module,
   props: {

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -20,7 +20,6 @@ import Label from '../../elements/Label/Label'
 const debug = makeDebugger('dropdown')
 
 const _meta = {
-  library: META.library.semanticUI,
   name: 'Dropdown',
   type: META.type.module,
   props: {

--- a/src/modules/Dropdown/DropdownDivider.js
+++ b/src/modules/Dropdown/DropdownDivider.js
@@ -7,7 +7,6 @@ class DropdownDivider extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'DropdownDivider',
     parent: 'Dropdown',
     type: META.type.module,

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -32,7 +32,7 @@ function DropdownItem(props) {
   )
   // add default dropdown icon if item contains another menu
   const iconName = icon || someChildType(children, 'DropdownMenu') && 'dropdown'
-  const iconClasses = cx('sd-dropdown-item-icon', iconName, 'icon')
+  const iconClasses = cx(iconName, 'icon')
 
   return (
     <div {...rest} className={classes} onClick={handleClick}>

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -45,7 +45,6 @@ function DropdownItem(props) {
 }
 
 DropdownItem._meta = {
-  library: META.library.semanticUI,
   name: 'DropdownItem',
   parent: 'Dropdown',
   type: META.type.module,

--- a/src/modules/Dropdown/DropdownMenu.js
+++ b/src/modules/Dropdown/DropdownMenu.js
@@ -13,7 +13,6 @@ class DropdownMenu extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'DropdownMenu',
     parent: 'Dropdown',
     type: META.type.module,

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -27,7 +27,6 @@ export default class Modal extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Modal',
     type: META.type.module,
   }

--- a/src/modules/Modal/ModalContent.js
+++ b/src/modules/Modal/ModalContent.js
@@ -9,7 +9,6 @@ export default class ModalContent extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'ModalContent',
     type: META.type.module,
     parent: 'Modal',

--- a/src/modules/Modal/ModalFooter.js
+++ b/src/modules/Modal/ModalFooter.js
@@ -9,7 +9,6 @@ export default class ModalFooter extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'ModalFooter',
     type: META.type.module,
     parent: 'Modal',

--- a/src/modules/Modal/ModalHeader.js
+++ b/src/modules/Modal/ModalHeader.js
@@ -9,7 +9,6 @@ export default class ModalHeader extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'ModalHeader',
     type: META.type.module,
     parent: 'Modal',

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -68,7 +68,6 @@ function Progress(props) {
 }
 
 Progress._meta = {
-  library: META.library.semanticUI,
   name: 'Progress',
   type: META.type.module,
   props: {

--- a/src/utils/Meta.js
+++ b/src/utils/Meta.js
@@ -1,20 +1,13 @@
 import _ from 'lodash/fp'
 
-const LIBRARIES = {
-  semanticUI: 'Semantic UI',
-  stardust: 'Stardust',
-}
-
 const TYPES = {
   addon: 'addon',
-  global: 'global',
   collection: 'collection',
   element: 'element',
   view: 'view',
   module: 'module',
 }
 
-const LIBRARY_VALUES = _.values(LIBRARIES)
 const TYPE_VALUES = _.values(TYPES)
 
 /**
@@ -25,7 +18,6 @@ const TYPE_VALUES = _.values(TYPES)
  * @returns {Boolean}
  */
 const isMeta = (_meta) => (
-  _.includes(_.get('library', _meta), LIBRARY_VALUES) &&
   _.includes(_.get('type', _meta), TYPE_VALUES)
 )
 
@@ -49,24 +41,17 @@ const getMeta = (metaArg) => {
 
 const metaHasKeyValue = _.curry((key, val, metaArg) => _.flow(getMeta, _.get(key), _.eq(val))(metaArg))
 const isType = metaHasKeyValue('type')
-const isLibrary = metaHasKeyValue('library')
 
 /**
  * Component meta information.  Used to declaratively classify and identify components.
  * @type {{}}
  */
 const META = {
-  library: LIBRARIES,
   type: TYPES,
-
-  // library
-  isSemanticUI: isLibrary(LIBRARIES.semanticUI),
-  isStardust: isLibrary(LIBRARIES.stardust),
 
   // type
   isType,
   isAddon: isType(TYPES.addon),
-  isGlobal: isType(TYPES.global),
   isCollection: isType(TYPES.collection),
   isElement: isType(TYPES.element),
   isView: isType(TYPES.view),

--- a/src/views/Item/Item.js
+++ b/src/views/Item/Item.js
@@ -29,7 +29,6 @@ export default class Item extends Component {
   }
 
   static _meta = {
-    library: META.library.semanticUI,
     name: 'Item',
     type: META.type.view,
   }

--- a/src/views/Item/ItemItems.js
+++ b/src/views/Item/ItemItems.js
@@ -15,7 +15,6 @@ ItemItems.propTypes = {
 }
 
 ItemItems._meta = {
-  library: META.library.semanticUI,
   name: 'ItemItems',
   type: META.type.view,
   parent: 'Item',

--- a/src/views/Statistic/Statistic.js
+++ b/src/views/Statistic/Statistic.js
@@ -36,7 +36,6 @@ function Statistic(props) {
 }
 
 Statistic._meta = {
-  library: META.library.semanticUI,
   name: 'Statistic',
   type: META.type.view,
   props: {

--- a/src/views/Statistic/StatisticGroup.js
+++ b/src/views/Statistic/StatisticGroup.js
@@ -33,7 +33,6 @@ function StatisticGroup(props) {
 }
 
 StatisticGroup._meta = {
-  library: META.library.semanticUI,
   name: 'StatisticGroup',
   type: META.type.view,
   parent: 'Statistic',

--- a/src/views/Statistic/StatisticLabel.js
+++ b/src/views/Statistic/StatisticLabel.js
@@ -18,7 +18,6 @@ function StatisticLabel(props) {
 }
 
 StatisticLabel._meta = {
-  library: META.library.semanticUI,
   name: 'StatisticLabel',
   parent: 'Statistic',
   type: META.type.view,

--- a/src/views/Statistic/StatisticValue.js
+++ b/src/views/Statistic/StatisticValue.js
@@ -18,7 +18,6 @@ function StatisticValue(props) {
 }
 
 StatisticValue._meta = {
-  library: META.library.semanticUI,
   name: 'StatisticValue',
   parent: 'Statistic',
   type: META.type.view,

--- a/test/specs/commonTests.js
+++ b/test/specs/commonTests.js
@@ -246,21 +246,6 @@ export const isConformant = (Component, requiredProps = {}) => {
   describe('className (common)', () => {
     const isHeader = /(header|h1|h2|h3|h4|h5|h6)/i.test(componentClassName)
 
-    it('does not have an sd-* className', () => {
-      const wrapper = shallow(<Component {...requiredProps} />)
-      const className = wrapper.prop('className')
-      const children = wrapper.children()
-
-      // component itself
-      if (className) className.should.not.contain('sd-')
-
-      // children
-      children.forEach(c => {
-        const childClassName = c.prop('className')
-        if (childClassName) childClassName.should.not.contain('sd-')
-      })
-    })
-
     // TODO: do not exclude headers once their APIs are updated
     if (!isHeader && !META.isAddon(Component)) {
       it(`has the Semantic UI className "${componentClassName}"`, () => {

--- a/test/specs/commonTests.js
+++ b/test/specs/commonTests.js
@@ -211,11 +211,8 @@ export const isConformant = (Component, requiredProps = {}) => {
     })
 
     describe('library', () => {
-      it('is defined', () => {
-        expect(_meta).to.have.any.keys('library')
-      })
-      it('is a META.library', () => {
-        expect(_.values(META.library)).to.contain(_meta.library)
+      it('is not defined', () => {
+        expect(_meta).not.to.have.any.keys('library', 'Remove _meta.library, it is deprecated.')
       })
     })
     describe('name', () => {
@@ -265,7 +262,7 @@ export const isConformant = (Component, requiredProps = {}) => {
     })
 
     // TODO: do not exclude headers once their APIs are updated
-    if (!isHeader && META.isSemanticUI(Component)) {
+    if (!isHeader && !META.isAddon(Component)) {
       it(`has the Semantic UI className "${componentClassName}"`, () => {
         render(<Component {...requiredProps} />)
           .should.have.className(componentClassName)


### PR DESCRIPTION
This repo will soon transfer to [`Semantic-UI-React`](https://github.com/Semantic-Org/Semantic-UI-React).  When that happens, there will be no more "Stardust".

All components will be under one library, SUI-React.  This PR removes the `_meta.library` key in preparation for this transfer.
