### PR TITLE
Modal: full feature support with Dimmer and docs

### DIFF
--- a/config.js
+++ b/config.js
@@ -63,7 +63,6 @@ config = Object.assign({}, config, {
   compiler_output_path: paths.base(config.dir_docs_dist),
   compiler_public_path: __BASE__ || '/',
   compiler_vendor: [
-    'bluebird',
     'classnames',
     'faker',
     'react',

--- a/docs/app/Examples/addons/Confirm/Types/ConfirmCallbacksExample.js
+++ b/docs/app/Examples/addons/Confirm/Types/ConfirmCallbacksExample.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+import { Button, Confirm } from 'stardust'
+
+class ConfirmConfirmExample extends Component {
+  state = { active: false }
+
+  show = () => this.setState({ active: true })
+  handleConfirm = () => this.setState({ result: 'confirm', active: false })
+  handleCancel = () => this.setState({ result: 'cancel', active: false })
+
+  render() {
+    const { active, result } = this.state
+
+    return (
+      <div>
+        {result && <p>You chose: <em>{result}</em></p>}
+
+        <Button onClick={this.show}>Show</Button>
+        <Confirm
+          active={active}
+          onCancel={this.handleCancel}
+          onConfirm={this.handleConfirm}
+        />
+      </div>
+    )
+  }
+}
+
+export default ConfirmConfirmExample

--- a/docs/app/Examples/addons/Confirm/Types/ConfirmCallbacksExample.js
+++ b/docs/app/Examples/addons/Confirm/Types/ConfirmCallbacksExample.js
@@ -1,19 +1,19 @@
 import React, { Component } from 'react'
 import { Button, Confirm } from 'stardust'
 
-class ConfirmConfirmExample extends Component {
-  state = { active: false }
+class ConfirmCallbacksExample extends Component {
+  state = { active: false, result: 'show the modal to capture a result' }
 
   show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ result: 'confirm', active: false })
-  handleCancel = () => this.setState({ result: 'cancel', active: false })
+  handleConfirm = () => this.setState({ result: 'confirmed', active: false })
+  handleCancel = () => this.setState({ result: 'cancelled', active: false })
 
   render() {
     const { active, result } = this.state
 
     return (
       <div>
-        {result && <p>You chose: <em>{result}</em></p>}
+        <p>Result: <em>{result}</em></p>
 
         <Button onClick={this.show}>Show</Button>
         <Confirm
@@ -26,4 +26,4 @@ class ConfirmConfirmExample extends Component {
   }
 }
 
-export default ConfirmConfirmExample
+export default ConfirmCallbacksExample

--- a/docs/app/Examples/addons/Confirm/Types/ConfirmConfirmExample.js
+++ b/docs/app/Examples/addons/Confirm/Types/ConfirmConfirmExample.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react'
+import { Button, Header, Image, Modal } from 'stardust'
+
+class ModalModalExample extends Component {
+  state = { active: false }
+
+  show = () => this.setState({ active: true })
+  hide = () => this.setState({ active: false })
+
+  render() {
+    const { active } = this.state
+
+    return (
+      <div>
+        <Button onClick={this.show}>Show Modal</Button>
+
+        <Modal active={active} onHide={this.hide}>
+          <Modal.Header>Select a Photo</Modal.Header>
+          <Modal.Content image>
+            <Image className='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
+            <Modal.Description>
+              <Header>Default Profile Image</Header>
+              <p>We've found the following gravatar image associated with your e-mail address.</p>
+              <p>Is it okay to use this photo?</p>
+            </Modal.Description>
+          </Modal.Content>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+export default ModalModalExample

--- a/docs/app/Examples/addons/Confirm/Types/ConfirmConfirmExample.js
+++ b/docs/app/Examples/addons/Confirm/Types/ConfirmConfirmExample.js
@@ -1,33 +1,25 @@
 import React, { Component } from 'react'
-import { Button, Header, Image, Modal } from 'stardust'
+import { Button, Confirm } from 'stardust'
 
-class ModalModalExample extends Component {
+class ConfirmConfirmExample extends Component {
   state = { active: false }
 
   show = () => this.setState({ active: true })
-  hide = () => this.setState({ active: false })
+  handleConfirm = () => this.setState({ active: false })
+  handleCancel = () => this.setState({ active: false })
 
   render() {
-    const { active } = this.state
-
     return (
       <div>
-        <Button onClick={this.show}>Show Modal</Button>
-
-        <Modal active={active} onHide={this.hide}>
-          <Modal.Header>Select a Photo</Modal.Header>
-          <Modal.Content image>
-            <Image className='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
-            <Modal.Description>
-              <Header>Default Profile Image</Header>
-              <p>We've found the following gravatar image associated with your e-mail address.</p>
-              <p>Is it okay to use this photo?</p>
-            </Modal.Description>
-          </Modal.Content>
-        </Modal>
+        <Button onClick={this.show}>Show</Button>
+        <Confirm
+          active={this.state.active}
+          onCancel={this.handleCancel}
+          onConfirm={this.handleConfirm}
+        />
       </div>
     )
   }
 }
 
-export default ModalModalExample
+export default ConfirmConfirmExample

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmButtonsExample.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmButtonsExample.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react'
+import { Button, Icon, Confirm } from 'stardust'
+
+class ConfirmContentExample extends Component {
+  state = { active: false }
+
+  show = () => this.setState({ active: true })
+  hide = () => this.setState({ active: false })
+
+  render() {
+    const { active, size } = this.state
+
+    return (
+      <div>
+        <Button onClick={this.show}>Small</Button>
+
+        <Confirm size={size} active={active} onHide={this.hide}>
+          <Confirm.Header>
+            Delete Your Account
+          </Confirm.Header>
+          <Confirm.Content>
+            <p>Are you sure you want to delete your account</p>
+          </Confirm.Content>
+          <Confirm.Actions>
+            <Button className='negative'>
+              No
+            </Button>
+            <Button className='positive right labeled icon'>
+              Yes <Icon name='checkmark' />
+            </Button>
+          </Confirm.Actions>
+        </Confirm>
+      </div>
+    )
+  }
+}
+
+export default ConfirmContentExample

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmButtonsExample.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmButtonsExample.js
@@ -1,38 +1,27 @@
 import React, { Component } from 'react'
-import { Button, Icon, Confirm } from 'stardust'
+import { Button, Confirm } from 'stardust'
 
-class ConfirmContentExample extends Component {
+class ConfirmButtonsExample extends Component {
   state = { active: false }
 
   show = () => this.setState({ active: true })
-  hide = () => this.setState({ active: false })
+  handleConfirm = () => this.setState({ active: false })
+  handleCancel = () => this.setState({ active: false })
 
   render() {
-    const { active, size } = this.state
-
     return (
       <div>
-        <Button onClick={this.show}>Small</Button>
-
-        <Confirm size={size} active={active} onHide={this.hide}>
-          <Confirm.Header>
-            Delete Your Account
-          </Confirm.Header>
-          <Confirm.Content>
-            <p>Are you sure you want to delete your account</p>
-          </Confirm.Content>
-          <Confirm.Actions>
-            <Button className='negative'>
-              No
-            </Button>
-            <Button className='positive right labeled icon'>
-              Yes <Icon name='checkmark' />
-            </Button>
-          </Confirm.Actions>
-        </Confirm>
+        <Button onClick={this.show}>Show</Button>
+        <Confirm
+          active={this.state.active}
+          cancelButton='Never mind'
+          confirmButton="Let's do it"
+          onCancel={this.handleCancel}
+          onConfirm={this.handleConfirm}
+        />
       </div>
     )
   }
 }
 
-export default ConfirmContentExample
+export default ConfirmButtonsExample

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmContentExample.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmContentExample.js
@@ -1,40 +1,26 @@
 import React, { Component } from 'react'
-import { Button, Icon, Modal } from 'stardust'
+import { Button, Confirm } from 'stardust'
 
-class ModalSizeExample extends Component {
+class ConfirmButtonsExample extends Component {
   state = { active: false }
 
-  show = (size) => () => this.setState({ size, active: true })
-  hide = () => this.setState({ active: false })
+  show = () => this.setState({ active: true })
+  handleConfirm = () => this.setState({ active: false })
+  handleCancel = () => this.setState({ active: false })
 
   render() {
-    const { active, size } = this.state
-
     return (
       <div>
-        <Button onClick={this.show('small')}>Small</Button>
-        <Button onClick={this.show('large')}>Large</Button>
-        <Button onClick={this.show('fullscreen')}>Fullscreen</Button>
-
-        <Modal size={size} active={active} onHide={this.hide}>
-          <Modal.Header>
-            Delete Your Account
-          </Modal.Header>
-          <Modal.Content>
-            <p>Are you sure you want to delete your account</p>
-          </Modal.Content>
-          <Modal.Actions>
-            <Button className='negative'>
-              No
-            </Button>
-            <Button className='positive right labeled icon'>
-              Yes <Icon name='checkmark' />
-            </Button>
-          </Modal.Actions>
-        </Modal>
+        <Button onClick={this.show}>Show</Button>
+        <Confirm
+          active={this.state.active}
+          content='This is a custom message'
+          onCancel={this.handleCancel}
+          onConfirm={this.handleConfirm}
+        />
       </div>
     )
   }
 }
 
-export default ModalSizeExample
+export default ConfirmButtonsExample

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmContentExample.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmContentExample.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react'
+import { Button, Icon, Modal } from 'stardust'
+
+class ModalSizeExample extends Component {
+  state = { active: false }
+
+  show = (size) => () => this.setState({ size, active: true })
+  hide = () => this.setState({ active: false })
+
+  render() {
+    const { active, size } = this.state
+
+    return (
+      <div>
+        <Button onClick={this.show('small')}>Small</Button>
+        <Button onClick={this.show('large')}>Large</Button>
+        <Button onClick={this.show('fullscreen')}>Fullscreen</Button>
+
+        <Modal size={size} active={active} onHide={this.hide}>
+          <Modal.Header>
+            Delete Your Account
+          </Modal.Header>
+          <Modal.Content>
+            <p>Are you sure you want to delete your account</p>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button className='negative'>
+              No
+            </Button>
+            <Button className='positive right labeled icon'>
+              Yes <Icon name='checkmark' />
+            </Button>
+          </Modal.Actions>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+export default ModalSizeExample

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmHeaderExample.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmHeaderExample.js
@@ -1,38 +1,26 @@
 import React, { Component } from 'react'
-import { Button, Icon, Confirm } from 'stardust'
+import { Button, Confirm } from 'stardust'
 
-class ConfirmContentExample extends Component {
+class ConfirmHeaderExample extends Component {
   state = { active: false }
 
   show = () => this.setState({ active: true })
-  hide = () => this.setState({ active: false })
+  handleConfirm = () => this.setState({ active: false })
+  handleCancel = () => this.setState({ active: false })
 
   render() {
-    const { active, size } = this.state
-
     return (
       <div>
-        <Button onClick={this.show}>Small</Button>
-
-        <Confirm size={size} active={active} onHide={this.hide}>
-          <Confirm.Header>
-            Delete Your Account
-          </Confirm.Header>
-          <Confirm.Content>
-            <p>Are you sure you want to delete your account</p>
-          </Confirm.Content>
-          <Confirm.Actions>
-            <Button className='negative'>
-              No
-            </Button>
-            <Button className='positive right labeled icon'>
-              Yes <Icon name='checkmark' />
-            </Button>
-          </Confirm.Actions>
-        </Confirm>
+        <Button onClick={this.show}>Show</Button>
+        <Confirm
+          active={this.state.active}
+          header='This is a custom header'
+          onCancel={this.handleCancel}
+          onConfirm={this.handleConfirm}
+        />
       </div>
     )
   }
 }
 
-export default ConfirmContentExample
+export default ConfirmHeaderExample

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmHeaderExample.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmHeaderExample.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react'
+import { Button, Icon, Confirm } from 'stardust'
+
+class ConfirmContentExample extends Component {
+  state = { active: false }
+
+  show = () => this.setState({ active: true })
+  hide = () => this.setState({ active: false })
+
+  render() {
+    const { active, size } = this.state
+
+    return (
+      <div>
+        <Button onClick={this.show}>Small</Button>
+
+        <Confirm size={size} active={active} onHide={this.hide}>
+          <Confirm.Header>
+            Delete Your Account
+          </Confirm.Header>
+          <Confirm.Content>
+            <p>Are you sure you want to delete your account</p>
+          </Confirm.Content>
+          <Confirm.Actions>
+            <Button className='negative'>
+              No
+            </Button>
+            <Button className='positive right labeled icon'>
+              Yes <Icon name='checkmark' />
+            </Button>
+          </Confirm.Actions>
+        </Confirm>
+      </div>
+    )
+  }
+}
+
+export default ConfirmContentExample

--- a/docs/app/Examples/addons/Confirm/index.js
+++ b/docs/app/Examples/addons/Confirm/index.js
@@ -2,41 +2,43 @@ import React, { Component } from 'react'
 import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
 import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
 
-export default class ModalExamples extends Component {
+import { Message } from 'stardust'
+
+export default class ConfirmExamples extends Component {
   render() {
     return (
       <div>
+        <Message className='info'>
+          A Confirm is a pre-configured Modal.  You can use all the props of a regular Modal.
+        </Message>
         <ExampleSection title='Types'>
           <ComponentExample
-            title='Modal'
-            description='A standard modal'
-            examplePath='modules/Modal/Types/ModalModalExample'
+            title='Confirm'
+            description='A default confirm'
+            examplePath='addons/Confirm/Types/ConfirmConfirmExample'
           />
           <ComponentExample
-            title='Basic'
-            description='A modal can reduce its complexity'
-            examplePath='modules/Modal/Types/ModalBasicExample'
-          />
-          <ComponentExample
-            title='Scrolling'
-            description={[
-              'When your modal content exceeds the height of the browser the scrollable area will automatically',
-              'expand to include just enough space for scrolling, without scrolling the page below.',
-            ].join(' ')}
-            examplePath='modules/Modal/Types/ModalScrollingExample'
+            title='Callbacks'
+            description='A confirm has callbacks for cancel and confirm actions'
+            examplePath='addons/Confirm/Types/ConfirmCallbacksExample'
           />
         </ExampleSection>
 
         <ExampleSection title='Variations'>
           <ComponentExample
-            title='Size'
-            description='A modal can vary in size'
-            examplePath='modules/Modal/Variations/ModalSizeExample'
+            title='Header'
+            description='A confirm can define a header'
+            examplePath='addons/Confirm/Variations/ConfirmHeaderExample'
           />
           <ComponentExample
-            title='Dimmer Variations'
-            description='A modal can specify dimmer variations'
-            examplePath='modules/Modal/Variations/ModalDimmerExample'
+            title='Content'
+            description='A confirm can define content'
+            examplePath='addons/Confirm/Variations/ConfirmContentExample'
+          />
+          <ComponentExample
+            title='Button Text'
+            description='A confirm can customize button text'
+            examplePath='addons/Confirm/Variations/ConfirmButtonsExample'
           />
         </ExampleSection>
       </div>

--- a/docs/app/Examples/addons/Confirm/index.js
+++ b/docs/app/Examples/addons/Confirm/index.js
@@ -1,0 +1,45 @@
+import React, { Component } from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+export default class ModalExamples extends Component {
+  render() {
+    return (
+      <div>
+        <ExampleSection title='Types'>
+          <ComponentExample
+            title='Modal'
+            description='A standard modal'
+            examplePath='modules/Modal/Types/ModalModalExample'
+          />
+          <ComponentExample
+            title='Basic'
+            description='A modal can reduce its complexity'
+            examplePath='modules/Modal/Types/ModalBasicExample'
+          />
+          <ComponentExample
+            title='Scrolling'
+            description={[
+              'When your modal content exceeds the height of the browser the scrollable area will automatically',
+              'expand to include just enough space for scrolling, without scrolling the page below.',
+            ].join(' ')}
+            examplePath='modules/Modal/Types/ModalScrollingExample'
+          />
+        </ExampleSection>
+
+        <ExampleSection title='Variations'>
+          <ComponentExample
+            title='Size'
+            description='A modal can vary in size'
+            examplePath='modules/Modal/Variations/ModalSizeExample'
+          />
+          <ComponentExample
+            title='Dimmer Variations'
+            description='A modal can specify dimmer variations'
+            examplePath='modules/Modal/Variations/ModalDimmerExample'
+          />
+        </ExampleSection>
+      </div>
+    )
+  }
+}

--- a/docs/app/Examples/modules/Modal/Types/ModalBasicExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalBasicExample.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react'
+import { Button, Header, Icon, Modal } from 'stardust'
+
+class ModalBasicExample extends Component {
+  state = { active: false }
+
+  show = () => this.setState({ active: true })
+  hide = () => this.setState({ active: false })
+
+  render() {
+    const { active } = this.state
+
+    return (
+      <div>
+        <Button onClick={this.show}>Basic Modal</Button>
+
+        <Modal basic size='small' active={active} onHide={this.hide}>
+          <Header icon='archive'>Archive Old Messages</Header>
+          <Modal.Content>
+            <p>Your inbox is getting full, would you like us to enable automatic archiving of old messages?</p>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button className='red basic inverted' onClick={this.hide}>
+              <Icon name='remove' /> No
+            </Button>
+            <Button className='green inverted' onClick={this.hide}>
+              <Icon name='checkmark' /> Yes
+            </Button>
+          </Modal.Actions>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+export default ModalBasicExample

--- a/docs/app/Examples/modules/Modal/Types/ModalModalExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalModalExample.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react'
+import { Button, Header, Image, Modal } from 'stardust'
+
+class ModalModalExample extends Component {
+  state = { active: false }
+
+  show = () => this.setState({ active: true })
+  hide = () => this.setState({ active: false })
+
+  render() {
+    const { active } = this.state
+
+    return (
+      <div>
+        <Button onClick={this.show}>Show Modal</Button>
+
+        <Modal active={active} onHide={this.hide}>
+          <Modal.Header>Select a Photo</Modal.Header>
+          <Modal.Content image>
+            <Image wrapped className='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
+            <Modal.Description>
+              <Header>Default Profile Image</Header>
+              <p>We've found the following gravatar image associated with your e-mail address.</p>
+              <p>Is it okay to use this photo?</p>
+            </Modal.Description>
+          </Modal.Content>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+export default ModalModalExample

--- a/docs/app/Examples/modules/Modal/Types/ModalScrollingExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalScrollingExample.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react'
+import { Button, Header, Icon, Image, Modal } from 'stardust'
+
+class ModalScrollingExample extends Component {
+  state = { active: false }
+
+  show = () => this.setState({ active: true })
+  hide = () => this.setState({ active: false })
+
+  render() {
+    const { active, dimmer } = this.state
+
+    return (
+      <div>
+        <Button onClick={this.show}>Long Modal</Button>
+
+        <Modal dimmer={dimmer} active={active} onHide={this.hide}>
+          <Modal.Header>Profile Picture</Modal.Header>
+          <Modal.Content image>
+            <Image wrapped className='medium' src='http://semantic-ui.com/images/wireframe/image.png' />
+            <Modal.Description>
+              <Header>Modal Header</Header>
+              <p>This is an example of expanded content that will cause the modal's dimmer to scroll</p>
+              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+            </Modal.Description>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button className='primary icon' onClick={this.hide}>
+              Proceed <Icon name='right chevron' />
+            </Button>
+          </Modal.Actions>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+export default ModalScrollingExample
+

--- a/docs/app/Examples/modules/Modal/Variations/ModalDimmerExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalDimmerExample.js
@@ -1,0 +1,45 @@
+import React, { Component } from 'react'
+import { Button, Header, Icon, Image, Modal } from 'stardust'
+
+class ModalDimmerExample extends Component {
+  state = { active: false }
+
+  show = (dimmer) => () => this.setState({ dimmer, active: true })
+  hide = () => this.setState({ active: false })
+
+  render() {
+    const { active, dimmer } = this.state
+
+    return (
+      <div>
+        <Button onClick={this.show(true)}>Default</Button>
+        <Button onClick={this.show('inverted')}>Inverted</Button>
+        <Button onClick={this.show('blurring')}>Blurring</Button>
+        <Button onClick={this.show(false)}>None</Button>
+
+        <Modal dimmer={dimmer} active={active} onHide={this.hide}>
+          <Modal.Header>Select a Photo</Modal.Header>
+          <Modal.Content image>
+            <Image wrapped className='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
+            <Modal.Description>
+              <Header>Default Profile Image</Header>
+              <p>We've found the following gravatar image associated with your e-mail address.</p>
+              <p>Is it okay to use this photo?</p>
+            </Modal.Description>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button className='black' onClick={this.hide}>
+              Nope
+            </Button>
+            <Button className='positive right labeled icon' onClick={this.hide}>
+              Yep, that's me <Icon name='checkmark' />
+            </Button>
+          </Modal.Actions>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+export default ModalDimmerExample
+

--- a/docs/app/Examples/modules/Modal/Variations/ModalSizeExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalSizeExample.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react'
+import { Button, Icon, Modal } from 'stardust'
+
+class ModalSizeExample extends Component {
+  state = { active: false }
+
+  show = (size) => () => this.setState({ size, active: true })
+  hide = () => this.setState({ active: false })
+
+  render() {
+    const { active, size } = this.state
+
+    return (
+      <div>
+        <Button onClick={this.show('small')}>Small</Button>
+        <Button onClick={this.show('large')}>Large</Button>
+        <Button onClick={this.show('fullscreen')}>Fullscreen</Button>
+
+        <Modal size={size} active={active} onHide={this.hide}>
+          <Modal.Header>
+            Delete Your Account
+          </Modal.Header>
+          <Modal.Content>
+            <p>Are you sure you want to delete your account</p>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button className='negative'>
+              No
+            </Button>
+            <Button className='positive right labeled icon'>
+              Yes <Icon name='checkmark' />
+            </Button>
+          </Modal.Actions>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+export default ModalSizeExample

--- a/docs/app/Examples/modules/Modal/index.js
+++ b/docs/app/Examples/modules/Modal/index.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+import { Message } from 'src/collections'
+
+const ModalExamples = () => (
+  <div>
+    <ExampleSection title='Types'>
+      <ComponentExample
+        title='Modal'
+        description='A standard modal'
+        examplePath='modules/Modal/Types/ModalModalExample'
+      />
+      <ComponentExample
+        title='Basic'
+        description='A modal can reduce its complexity'
+        examplePath='modules/Modal/Types/ModalBasicExample'
+      />
+      <ComponentExample
+        title='Scrolling'
+        description={[
+          'When your modal content exceeds the height of the browser the scrollable area will automatically',
+          'expand to include just enough space for scrolling, without scrolling the page below.',
+        ].join(' ')}
+        examplePath='modules/Modal/Types/ModalScrollingExample'
+      >
+        <Message warning>
+          <code>&lt;Modal.Content image /&gt;</code> requires an image
+          with wrapped markup: <code>&lt;Image wrapped /&gt; </code>
+        </Message>
+      </ComponentExample>
+    </ExampleSection>
+
+    <ExampleSection title='Variations'>
+      <ComponentExample
+        title='Size'
+        description='A modal can vary in size'
+        examplePath='modules/Modal/Variations/ModalSizeExample'
+      />
+      <ComponentExample
+        title='Dimmer Variations'
+        description='A modal can specify dimmer variations'
+        examplePath='modules/Modal/Variations/ModalDimmerExample'
+      />
+    </ExampleSection>
+  </div>
+)
+
+export default ModalExamples

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "debug": "^2.2.0",
     "jquery": "^3.1.0",
     "lodash": "^4.6.1",
-    "semantic-ui-css": "^2.2.1"
+    "react-portal": "^2.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
@@ -118,7 +118,8 @@
     "require-dir": "^0.3.0",
     "rimraf": "^2.5.2",
     "sass-loader": "^3.2.0",
-    "simulant": "^0.2.1",
+    "semantic-ui-css": "^2.2.2",
+    "simulant": "^0.2.2",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "style-loader": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "npm": "2 - 4"
   },
   "dependencies": {
-    "bluebird": "^3.3.4",
     "classnames": "^2.1.5",
     "debug": "^2.2.0",
     "jquery": "^3.1.0",

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -1,58 +1,61 @@
-import React, { Component, PropTypes } from 'react'
-import Promise from 'bluebird'
+import React, { PropTypes } from 'react'
 
-import { getUnhandledProps, META } from '../../lib'
+import { Button } from '../../elements'
 import { Modal } from '../../modules'
+import { getUnhandledProps, META } from '../../lib'
 
-export default class Confirm extends Component {
-  static propTypes = {
-    abortLabel: PropTypes.string,
-    confirmLabel: PropTypes.string,
-    header: PropTypes.string,
-  }
+/**
+ * A Confirm modal gives the user a choice to confirm or cancel an action
+ * @see Modal
+ */
+function Confirm(props) {
+  const { active, cancelButton, confirmButton, header, content, onConfirm, onCancel } = props
+  const rest = getUnhandledProps(Confirm, props)
 
-  static defaultProps = {
-    abortLabel: 'Cancel',
-    confirmLabel: 'Yes',
-  }
-
-  state = {
-    message: 'Are you sure?',
-    active: true,
-  }
-
-  show = (message) => new Promise((resolve, reject) => {
-    this.setState({ message })
-
-    this.handleAbort = () => resolve(false)
-    this.handleConfirm = () => resolve(true)
-  })
-    .then(isConfirmed => {
-      this.setState({ active: false })
-      return isConfirmed
-    })
-
-  static _meta = {
-    name: 'Confirm',
-    type: META.TYPES.ADDON,
-  }
-
-  render() {
-    const { header, abortLabel, confirmLabel } = this.props
-    const rest = getUnhandledProps(Confirm, this.props)
-    return (
-      <Modal active={this.state.active} {...rest}>
-        <Modal.Header>
-          {header}
-        </Modal.Header>
-        <Modal.Content>
-          {this.state.message}
-        </Modal.Content>
-        <Modal.Actions>
-          <div className='ui button' onClick={this.handleAbort}>{abortLabel}</div>
-          <div className='ui blue button' onClick={this.handleConfirm}>{confirmLabel}</div>
-        </Modal.Actions>
-      </Modal>
-    )
-  }
+  return (
+    <Modal active={active} size='small' onHide={onCancel} {...rest}>
+      {header && <Modal.Header>{header}</Modal.Header>}
+      {content && <Modal.Content>{content}</Modal.Content>}
+      <Modal.Actions>
+        <Button onClick={onCancel}>{cancelButton}</Button>
+        <Button className='primary' onClick={onConfirm}>{confirmButton}</Button>
+      </Modal.Actions>
+    </Modal>
+  )
 }
+
+Confirm._meta = {
+  name: 'Confirm',
+  type: META.TYPES.ADDON,
+}
+
+Confirm.propTypes = {
+  /** Whether or not the modal is visible */
+  active: PropTypes.bool,
+
+  /** The cancel button text */
+  cancelButton: PropTypes.string,
+
+  /** The OK button text */
+  confirmButton: PropTypes.string,
+
+  /** The ModalHeader text */
+  header: PropTypes.string,
+
+  /** The ModalContent text. Mutually exclusive with children. */
+  content: PropTypes.string,
+
+  /** Called when the OK button is clicked */
+  onConfirm: PropTypes.func,
+
+  /** Called when the Cancel button is clicked */
+  onCancel: PropTypes.func,
+}
+
+Confirm.defaultProps = {
+  cancelButton: 'Cancel',
+  confirmButton: 'OK',
+  content: 'Are you sure?',
+}
+
+export default Confirm

--- a/src/lib/objectDiff.js
+++ b/src/lib/objectDiff.js
@@ -21,11 +21,3 @@ export const objectDiff = (source, target) => _.transform(source, (res, val, key
   // new keys / changed values
   else if (!_.isEqual(val, target[key])) res[key] = target[key]
 }, {})
-
-export const isNodeInRoot = (node, root) => {
-  while (node) {
-    if (node === root) return true
-    node = node.parentNode
-  }
-  return false
-}

--- a/src/lib/objectDiff.js
+++ b/src/lib/objectDiff.js
@@ -21,3 +21,11 @@ export const objectDiff = (source, target) => _.transform(source, (res, val, key
   // new keys / changed values
   else if (!_.isEqual(val, target[key])) res[key] = target[key]
 }, {})
+
+export const isNodeInRoot = (node, root) => {
+  while (node) {
+    if (node === root) return true
+    node = node.parentNode
+  }
+  return false
+}

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -1,61 +1,224 @@
-import React, { PropTypes } from 'react'
+import _ from 'lodash'
+import React, { PropTypes, Component } from 'react'
 import cx from 'classnames'
 
-import { getUnhandledProps, META, useKeyOnly } from '../../lib'
 import ModalHeader from './ModalHeader'
 import ModalContent from './ModalContent'
 import ModalActions from './ModalActions'
+import ModalDescription from './ModalDescription'
+import Portal from 'react-portal'
 
-function Modal(props) {
-  const {
-    children, className,
-    active, basic, size,
-  } = props
+import {
+  getUnhandledProps,
+  keyboardKey,
+  makeDebugger,
+  META,
+  useKeyOnly,
+} from '../../lib'
 
-  const classes = cx('ui',
-    useKeyOnly(active, 'transition visible active'),
-    useKeyOnly(basic, 'basic'),
-    size,
-    'modal',
-    className,
-  )
+const debug = makeDebugger('modal')
 
-  const rest = getUnhandledProps(Modal, props)
-
-  return (
-    <div className={classes} {...rest} >
-      {children}
-    </div>
-  )
-}
-
-Modal._meta = {
+const _meta = {
   name: 'Modal',
   type: META.TYPES.MODULE,
   props: {
     size: ['fullscreen', 'large', 'small'],
+    dimmer: ['inverted', 'blurring'],
   },
 }
 
-Modal.propTypes = {
-  /** Primary content of the modal. Consider using ModalHeader, ModalContent or ModalActions here */
-  children: PropTypes.any,
+/**
+ * A modal displays content that temporarily blocks interactions with the main view of a site
+ * @see Confirm
+ */
+class Modal extends Component {
+  static propTypes = {
+    /** Primary content of the modal. Consider using ModalHeader, ModalContent or ModalActions here */
+    children: PropTypes.node,
 
-  /** Classes to add to the modal className */
-  className: PropTypes.string,
+    /** Classes to add to the modal className */
+    className: PropTypes.string,
 
-  /** An active modal is visible on the page */
-  active: PropTypes.bool,
+    /** An active modal is visible on the page */
+    active: PropTypes.bool,
 
-  /** A modal can reduce its complexity */
-  basic: PropTypes.bool,
+    /** A modal can reduce its complexity */
+    basic: PropTypes.bool,
 
-  /** A modal can vary in size */
-  size: PropTypes.oneOf(Modal._meta.props.size),
+    /** A modal can appear in a dimmer */
+    dimmer: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(_meta.props.dimmer),
+    ]),
+
+    /** A modal can vary in size */
+    size: PropTypes.oneOf(_meta.props.size),
+
+    /** Called when the modal is hidden */
+    onHide: PropTypes.func,
+  }
+
+  static defaultProps = {
+    dimmer: true,
+  }
+
+  static _meta = _meta
+  static Header = ModalHeader
+  static Content = ModalContent
+  static Description = ModalDescription
+  static Actions = ModalActions
+
+  state = {}
+
+  componentDidMount() {
+    debug('componentWillMount()')
+    const { active } = this.props
+
+    if (active) this.handleShow()
+
+    this.setPosition()
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    debug('componentDidUpdate()')
+
+    if (!prevProps.active && this.props.active) {
+      debug('modal changed to shown')
+      this.handleShow()
+    } else if (prevProps.active && !this.props.active) {
+      debug('modal changed to hidden')
+      this.handleHide()
+    }
+  }
+
+  componentWillUnmount() {
+    debug('componentWillUnmount()')
+    this.handleHide()
+  }
+
+  onHide = () => {
+    debug('onHide()')
+    const { onHide } = this.props
+    if (onHide) onHide()
+  }
+
+  handleHide = () => {
+    debug('handleHide()')
+    // Always remove all dimmer classes.
+    // If the dimmer value changes while the modal is open,
+    //   then removing its current value could leave cruft classes previously added.
+    document.body.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
+
+    document.removeEventListener('keydown', this.handleDocumentKeyDown)
+    document.removeEventListener('click', this.handleClickOutside)
+  }
+
+  handleShow = () => {
+    debug('handleShow()')
+    const { dimmer } = this.props
+    if (dimmer) {
+      debug('adding dimmer')
+      document.body.classList.add('dimmable', 'dimmed')
+
+      if (dimmer === 'blurring') {
+        debug('adding blurred dimmer')
+        document.body.classList.add('blurring')
+      }
+    }
+
+    document.addEventListener('keydown', this.handleDocumentKeyDown)
+    document.addEventListener('click', this.handleClickOutside)
+  }
+
+  handleClickOutside = (e) => {
+    // do nothing when clicking inside the modal
+    if (this._modalNode.contains(e.target)) return
+
+    debug('handleDimmerClick()')
+
+    e.stopPropagation()
+    this.onHide()
+  }
+
+  handleDocumentKeyDown = (e) => {
+    const key = keyboardKey.getCode(e)
+    debug('handleDocumentKeyDown()', key)
+
+    switch (key) {
+      case keyboardKey.Escape:
+        this.onHide()
+        break
+      default:
+        break
+    }
+  }
+
+  setPosition = () => {
+    if (this._modalNode) {
+      const { height } = this._modalNode.getBoundingClientRect()
+      const scrolling = height >= window.innerHeight
+
+      const newState = {
+        marginTop: -Math.round(height / 2),
+        scrolling,
+      }
+
+      // add/remove scrolling class on body
+      if (!this.state.scrolling && scrolling) {
+        document.body.classList.add('scrolling')
+      } else if (this.state.scrolling && !scrolling) {
+        document.body.classList.remove('scrolling')
+      }
+
+      if (!_.isEqual(newState, this.state)) {
+        this.setState(newState)
+      }
+    }
+
+    requestAnimationFrame(this.setPosition)
+  }
+
+  render() {
+    const { active, basic, children, className, dimmer, size } = this.props
+    const { marginTop, scrolling } = this.state
+    const classes = cx(
+      'ui',
+      size,
+      useKeyOnly(basic, 'basic'),
+      useKeyOnly(scrolling, 'scrolling'),
+      'modal',
+      useKeyOnly(active, 'transition visible active'),
+      className,
+    )
+    const rest = getUnhandledProps(Modal, this.props)
+
+    let modalJSX = (
+      <div {...rest} className={classes} style={{ marginTop }} ref={c => (this._modalNode = c)}>
+        {children}
+      </div>
+    )
+
+    // wrap dimmer modals
+    const dimmerClasses = !dimmer ? null : cx(
+      'ui',
+      dimmer === 'inverted' && 'inverted',
+      useKeyOnly(active, 'transition visible active'),
+      'page modals dimmer',
+    )
+
+    // Heads up!
+    //
+    // The SUI CSS selector to prevent the modal itself from blurring requires an immediate .dimmer child:
+    // .blurring.dimmed.dimmable>:not(.dimmer) { ... }
+    //
+    // The .blurring.dimmed.dimmable is the body, so that all body content inside is blurred.
+    // We need the immediate child to be the dimmer to :not() blur the modal itself!
+    // Otherwise, the portal div is also blurred, blurring the modal.
+    //
+    // We cannot them wrap the modalJSX in an actual <Dimmer /> instead, we apply the dimmer classes to the <Portal />.
+
+    return <Portal isOpened={active} className={dimmerClasses}>{modalJSX}</Portal>
+  }
 }
-
-Modal.Header = ModalHeader
-Modal.Content = ModalContent
-Modal.Actions = ModalActions
 
 export default Modal

--- a/src/modules/Modal/ModalDescription.js
+++ b/src/modules/Modal/ModalDescription.js
@@ -1,0 +1,37 @@
+import React, { PropTypes } from 'react'
+import cx from 'classnames'
+
+import { getUnhandledProps, META } from '../../lib'
+
+function ModalDescription(props) {
+  const { children, className } = props
+
+  const classes = cx(
+    className,
+    'description'
+  )
+
+  const rest = getUnhandledProps(ModalDescription, props)
+
+  return (
+    <div className={classes} {...rest}>
+      {children}
+    </div>
+  )
+}
+
+ModalDescription._meta = {
+  name: 'ModalDescription',
+  type: META.TYPES.MODULE,
+  parent: 'Modal',
+}
+
+ModalDescription.propTypes = {
+  /** Primary content */
+  children: PropTypes.any,
+
+  /** Classes to add to the className */
+  className: PropTypes.string,
+}
+
+export default ModalDescription

--- a/test/specs/addons/Confirm-test.js
+++ b/test/specs/addons/Confirm-test.js
@@ -1,37 +1,114 @@
 import React from 'react'
 
-import Confirm from 'src/addons/Confirm/Confirm'
-import * as common from '../commonTests'
+import { Confirm } from 'src/addons'
+import { Modal } from 'src/modules'
+import { sandbox } from 'test/utils'
+import * as common from 'test/specs/commonTests'
 
 describe('Confirm', () => {
   common.isConformant(Confirm)
 
-  it('default prop abortLabel should be "Cancel"', () => {
-    Confirm.defaultProps.abortLabel
-      .should.equal('Cancel')
+  it('renders a small Modal', () => {
+    const wrapper = shallow(<Confirm />)
+    wrapper
+      .type()
+      .should.equal(Modal)
+    wrapper
+      .should.have.prop('size', 'small')
   })
-  it('default prop confirmLabel should be "Yes"', () => {
-    Confirm.defaultProps.confirmLabel
-      .should.equal('Yes')
+
+  describe('cancelButton', () => {
+    it('is "Cancel" by default', () => {
+      Confirm.defaultProps.cancelButton
+        .should.equal('Cancel')
+    })
+    it('sets the cancel button text', () => {
+      shallow(<Confirm cancelButton='foo' />)
+        .find('Button')
+        .first()
+        .shallow()
+        .should.have.text('foo')
+    })
   })
-  it('should return true on confirm', () => {
-    const confirm = mount(<Confirm />)
-    confirm
-      .instance()
-      .show()
-      .then(isConfirmed => isConfirmed.should.equal(true))
-    confirm
-      .findWhere(c => c.text() === 'Yes')
-      .simulate('click')
+
+  describe('confirmButton', () => {
+    it('is "OK" by default', () => {
+      Confirm.defaultProps.confirmButton
+        .should.equal('OK')
+    })
+    it('sets the confirm button text', () => {
+      shallow(<Confirm confirmButton='foo' />)
+        .find('Button.primary')
+        .shallow()
+        .should.have.text('foo')
+    })
   })
-  it('should return false on abort', () => {
-    const confirm = mount(<Confirm />)
-    confirm
-      .instance()
-      .show()
-      .then(isConfirmed => isConfirmed.should.equal(false))
-    confirm
-      .findWhere(c => c.text() === 'Cancel')
-      .simulate('click')
+
+  describe('header', () => {
+    it('is not present by default', () => {
+      shallow(<Confirm />)
+        .should.not.have.descendants('ModalHeader')
+    })
+    it('sets the header text', () => {
+      const wrapper = shallow(<Confirm header='foo' />)
+      wrapper
+        .should.have.descendants('ModalHeader')
+      wrapper
+        .find('ModalHeader')
+        .shallow()
+        .should.have.text('foo')
+    })
+  })
+
+  describe('content', () => {
+    it('is "Are you sure?" by default', () => {
+      const wrapper = shallow(<Confirm />)
+      wrapper
+        .should.have.descendants('ModalContent')
+      wrapper
+        .find('ModalContent')
+        .shallow()
+        .should.have.text('Are you sure?')
+    })
+    it('sets the content text', () => {
+      const wrapper = shallow(<Confirm content='foo' />)
+      wrapper
+        .should.have.descendants('ModalContent')
+      wrapper
+        .find('ModalContent')
+        .shallow()
+        .should.have.text('foo')
+    })
+  })
+
+  describe('onCancel', () => {
+    it('is called on Cancel button click', () => {
+      const spy = sandbox.spy()
+      shallow(<Confirm onCancel={spy} />)
+        .find('Button')
+        .first()
+        .simulate('click')
+
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is passed to the Modal onHide prop', () => {
+      const func = () => null
+
+      shallow(<Confirm onCancel={func} />)
+        .find('Modal')
+        .prop('onHide', func)
+    })
+  })
+
+  describe('onConfirm', () => {
+    it('is called on OK button click', () => {
+      const spy = sandbox.spy()
+      shallow(<Confirm onConfirm={spy} />)
+        .find('Button.primary')
+        .simulate('click')
+
+      spy.should.have.been.calledOnce()
+    })
   })
 })

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -1,23 +1,320 @@
+import _ from 'lodash'
 import React from 'react'
+import Portal from 'react-portal'
 
 import Modal from 'src/modules/Modal/Modal'
 import ModalHeader from 'src/modules/Modal/ModalHeader'
 import ModalContent from 'src/modules/Modal/ModalContent'
 import ModalActions from 'src/modules/Modal/ModalActions'
+import ModalDescription from 'src/modules/Modal/ModalDescription'
+
+import { keyboardKey } from 'src/lib'
+import { domEvent, sandbox } from 'test/utils'
 import * as common from 'test/specs/commonTests'
 
+// ----------------------------------------
+// Wrapper
+// ----------------------------------------
+let wrapper
+
+// we need to unmount the modal after every test to remove it from the document
+// wrap the render methods to update a global wrapper that is unmounted after each test
+const wrapperMount = (...args) => (wrapper = mount(...args))
+const wrapperShallow = (...args) => (wrapper = shallow(...args))
+
+const assertInBody = (selector, isPresent = true) => {
+  const didFind = document.body.querySelector(selector) !== null
+  didFind.should.equal(isPresent, `${didFind ? 'Found' : 'Did not find'} "${selector}" in the document.body.`)
+}
+
+const assertBodyClasses = (...rest) => {
+  const hasClasses = typeof rest[rest.length - 1] === 'boolean' ? rest.pop() : true
+
+  rest.forEach(className => {
+    const didFind = document.body.classList.contains(className)
+    const message = [
+      `document.body ${didFind ? 'has' : 'does not have'} class "${className}".`,
+      `It has class="${document.body.classList}"`,
+    ].join(' ')
+
+    didFind.should.equal(hasClasses, message)
+  })
+}
+
 describe('Modal', () => {
-  common.isConformant(Modal)
-  common.hasUIClassName(Modal)
-  common.rendersChildren(Modal)
-  common.hasSubComponents(Modal, [ModalHeader, ModalContent, ModalActions])
+  beforeEach(() => {
+    wrapper = undefined
+  })
 
-  common.propKeyOnlyToClassName(Modal, 'active')
-  common.propKeyOnlyToClassName(Modal, 'basic')
-  common.propValueOnlyToClassName(Modal, 'size')
+  afterEach(() => {
+    if (wrapper && wrapper.unmount) wrapper.unmount()
+  })
 
-  it('renders a <div /> element', () => {
-    shallow(<Modal />)
-      .should.have.tagName('div')
+  common.hasSubComponents(Modal, [ModalHeader, ModalContent, ModalActions, ModalDescription])
+
+  // Heads up!
+  //
+  // Our commonTests do not currently handle wrapped components.
+  // Nor do they handle components rendered to the body with Portal.
+  // The Modal is wrapped in a Portal, so we manually test a few things here.
+
+  it('renders a Portal', () => {
+    wrapperShallow(<Modal active />)
+      .type()
+      .should.equal(Portal)
+  })
+
+  it('renders to the document body', () => {
+    wrapperMount(<Modal active />)
+    assertInBody('.ui.modal')
+  })
+
+  it('renders child text', () => {
+    wrapperMount(<Modal active>child text</Modal>)
+
+    document.querySelector('.ui.modal')
+      .innerText
+      .should.equal('child text')
+  })
+
+  it('renders child components', () => {
+    const child = <div data-child />
+    wrapperMount(<Modal active>{child}</Modal>)
+
+    document
+      .querySelector('.ui.modal')
+      .querySelector('[data-child]')
+      .should.not.equal(null, 'Modal did not render the child component.')
+  })
+
+  describe('active', () => {
+    it('is not active by default', () => {
+      wrapperMount(<Modal />)
+      assertInBody('.ui.modal.active', false)
+    })
+
+    it('is passed to Portal isOpened', () => {
+      shallow(<Modal active />)
+        .find('Portal')
+        .should.have.prop('isOpened', true)
+
+      shallow(<Modal active={false} />)
+        .find('Portal')
+        .should.have.prop('isOpened', false)
+    })
+
+    it('does not show the modal when false', () => {
+      wrapperMount(<Modal active={false} />)
+      assertInBody('.ui.modal', false)
+    })
+
+    it('does not show the dimmer when false', () => {
+      wrapperMount(<Modal active={false} />)
+      assertInBody('.ui.dimmer', false)
+    })
+
+    it('shows the dimmer when true', () => {
+      wrapperMount(<Modal active dimmer />)
+      assertInBody('.ui.dimmer')
+    })
+
+    it('shows the modal when true', () => {
+      wrapperMount(<Modal active />)
+      assertInBody('.ui.modal')
+    })
+
+    it('shows the modal and dimmer on changing from false to true', () => {
+      wrapperMount(<Modal active={false} />)
+      assertInBody('.ui.modal', false)
+      assertInBody('.ui.dimmer', false)
+
+      wrapper.setProps({ active: true })
+
+      assertInBody('.ui.modal')
+      assertInBody('.ui.dimmer')
+    })
+
+    it('hides the modal and dimmer on changing from true to false', () => {
+      wrapperMount(<Modal active />)
+      assertInBody('.ui.modal')
+      assertInBody('.ui.dimmer')
+
+      wrapper.setProps({ active: false })
+
+      assertInBody('.ui.modal', false)
+      assertInBody('.ui.dimmer', false)
+    })
+  })
+
+  describe('basic', () => {
+    it('adds basic to the modal className', () => {
+      wrapperMount(<Modal basic active />)
+      assertInBody('.ui.basic.modal')
+    })
+  })
+
+  describe('size', () => {
+    it('defines prop options in _meta', () => {
+      Modal._meta.props.should.have.any.keys('size')
+      Modal._meta.props.size.should.be.an('array')
+    })
+
+    it('adds the size to the modal className', () => {
+      Modal._meta.props.size.forEach(size => {
+        wrapperMount(<Modal size={size} active />)
+        assertInBody(`.ui.${size}.modal`)
+      })
+    })
+  })
+
+  describe('dimmer', () => {
+    describe('defaults', () => {
+      it('is set to true by default', () => {
+        Modal.defaultProps.dimmer
+          .should.equal(true)
+      })
+
+      it('is present by default', () => {
+        wrapperMount(<Modal active />)
+        assertInBody('.ui.dimmer')
+      })
+    })
+
+    describe('true', () => {
+      it('adds classes "dimmable dimmed" to the body', () => {
+        wrapperMount(<Modal active dimmer />)
+        assertBodyClasses('dimmable', 'dimmed')
+      })
+
+      it('adds a dimmer to the body', () => {
+        wrapperMount(<Modal active dimmer />)
+        assertInBody('.ui.page.modals.dimmer.transition.visible.active')
+      })
+    })
+
+    describe('false', () => {
+      it('does not render a dimmer', () => {
+        wrapperMount(<Modal active dimmer={false} />)
+        assertBodyClasses('dimmable', 'dimmed', 'blurring', false)
+      })
+
+      it('does not add any dimmer classes to the body', () => {
+        wrapperMount(<Modal active dimmer={false} />)
+        assertBodyClasses('dimmable', 'dimmed', 'blurring', false)
+      })
+    })
+
+    describe('blurring', () => {
+      it('adds class "dimmable dimmed blurring" to the body', () => {
+        wrapperMount(<Modal active dimmer='blurring' />)
+        assertBodyClasses('dimmable', 'dimmed', 'blurring')
+      })
+
+      it('adds a dimmer to the body', () => {
+        wrapperMount(<Modal active dimmer='blurring' />)
+        assertInBody('.ui.page.modals.dimmer.transition.visible.active')
+      })
+    })
+
+    describe('inverted', () => {
+      it('adds class "dimmable dimmed" to the body', () => {
+        wrapperMount(<Modal active dimmer='inverted' />)
+        assertBodyClasses('dimmable', 'dimmed')
+        assertBodyClasses('inverted', false)
+      })
+
+      it('adds an inverted dimmer to the body', () => {
+        wrapperMount(<Modal active dimmer='inverted' />)
+        assertInBody('.ui.inverted.page.modals.dimmer.transition.visible.active')
+      })
+    })
+  })
+
+  describe('onHide', () => {
+    let spy
+
+    beforeEach(() => {
+      spy = sandbox.spy()
+      wrapperMount(<Modal onHide={spy} active />)
+    })
+
+    it('is called on dimmer click', () => {
+      domEvent.click('.ui.dimmer')
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is called on click outside of the modal', () => {
+      domEvent.click(document.querySelector('.ui.modal').parentNode)
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is not called on click inside of the modal', () => {
+      domEvent.click(document.querySelector('.ui.modal'))
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is called on body click', () => {
+      domEvent.click('body')
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is called when pressing escape', () => {
+      domEvent.keyDown(document, { key: 'Escape' })
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is not called when pressing a key other than "Escape"', () => {
+      _.each(keyboardKey, (val, key) => {
+        // skip Escape key
+        if (val === keyboardKey.Escape) return
+
+        domEvent.keyDown(document, { key })
+        spy.should.not.have.been.called(`onHide was called when pressing "${key}"`)
+      })
+    })
+
+    it('is not called when the active prop changes to false', () => {
+      wrapper.setProps({ active: false })
+      spy.should.not.have.been.called()
+    })
+  })
+
+  describe('scrolling', () => {
+    afterEach(() => {
+      document.body.classList.remove('scrolling')
+    })
+
+    it('does not add the scrolling class to the body by default', () => {
+      wrapperMount(<Modal active />)
+      assertBodyClasses('scrolling', false)
+    })
+
+    it('adds the scrolling class to the body when taller than the window', (done) => {
+      wrapperMount(<Modal active>foo</Modal>)
+
+      window.innerHeight = 10
+
+      requestAnimationFrame(() => {
+        assertBodyClasses('scrolling')
+        done()
+      })
+    })
+
+    it('removes the scrolling class from the body when the window grows taller', (done) => {
+      assertBodyClasses('scrolling', false)
+
+      wrapperMount(<Modal active>foo</Modal>)
+      window.innerHeight = 10
+
+      requestAnimationFrame(() => {
+        assertBodyClasses('scrolling')
+        window.innerHeight = 10000
+
+        requestAnimationFrame(() => {
+          assertBodyClasses('scrolling', false)
+          done()
+        })
+      })
+    })
   })
 })

--- a/test/specs/modules/Modal/ModalDescription-test.js
+++ b/test/specs/modules/Modal/ModalDescription-test.js
@@ -1,0 +1,7 @@
+import ModalDescription from 'src/modules/Modal/ModalDescription'
+import * as common from 'test/specs/commonTests'
+
+describe('ModalDescription', () => {
+  common.isConformant(ModalDescription)
+  common.rendersChildren(ModalDescription)
+})


### PR DESCRIPTION
An `image content` Modal requires the image to be a `div.ui.image > img`.  However, some components, like the List, require markup of `img.ui.image`.

Image updates in #280 provide a `wrapped` prop for choosing the div wrapped markup variation.
## Updates

Fixes #175 #84.  This PR adds many features and full docs for the Modal.  Added:
- missing ModalDescription
- portal render to body
- optional configurable dimmer
- auto scrolling when height is larger than window
- close on esc (fixes #175)
- close on click outside
- callbacks onHide, onShow
