### PR TITLE
Dropdown: fix icon prop

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -14,7 +14,8 @@ import {
   useKeyOnly,
   useKeyOrValueAndKey,
 } from '../../lib'
-import { Icon, Label } from '../../elements'
+import { createIcon } from '../../factories'
+import { Label } from '../../elements'
 import DropdownDivider from './DropdownDivider'
 import DropdownItem from './DropdownItem'
 import DropdownMenu from './DropdownMenu'
@@ -39,7 +40,7 @@ export default class Dropdown extends Component {
     // Behavior
     // ------------------------------------
     /** Add an icon by name or as a component. */
-    icon: PropTypes.oneOf([
+    icon: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.string,
     ]),
@@ -172,6 +173,10 @@ export default class Dropdown extends Component {
     disabled: PropTypes.bool,
 
     scrolling: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    icon: 'dropdown',
   }
 
   static autoControlledProps = [
@@ -807,7 +812,10 @@ export default class Dropdown extends Component {
       useKeyOnly(fluid, 'fluid'),
       useKeyOnly(floating, 'floating'),
       useKeyOnly(inline, 'inline'),
-      useKeyOnly(icon, 'icon'),
+      // TODO: consider augmentation to render Dropdowns as Button/Menu, solves icon/link item issues
+      // https://github.com/TechnologyAdvice/stardust/issues/401#issuecomment-240487229
+      // TODO: the icon class is only required when a dropdown is a button
+      // useKeyOnly(icon, 'icon'),
       useKeyOnly(labeled, 'labeled'),
       // TODO: linkItem is required only when Menu child, add dynamically
       useKeyOnly(linkItem, 'link item'),
@@ -844,7 +852,7 @@ export default class Dropdown extends Component {
         {this.renderSearchInput()}
         {this.renderSearchSizer()}
         {this.renderText()}
-        <Icon name={'dropdown'} />
+        {createIcon(icon)}
         {this.renderMenu()}
       </div>
     )

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -65,6 +65,7 @@ describe('Dropdown Component', () => {
   common.isConformant(Dropdown)
   common.hasUIClassName(Dropdown)
   common.isTabbable(Dropdown)
+  common.implementsIconProp(Dropdown)
   common.propKeyOnlyToClassName(Dropdown, 'multiple')
   common.propKeyOnlyToClassName(Dropdown, 'search')
   common.propKeyOnlyToClassName(Dropdown, 'selection')
@@ -99,6 +100,14 @@ describe('Dropdown Component', () => {
   //
   //   dropdownMenuIsOpen()
   // })
+
+  describe('icon', () => {
+    it('defaults to a dropdown icon', () => {
+      Dropdown.defaultProps.icon.should.equal('dropdown')
+      wrapperRender(<Dropdown />)
+        .should.contain.descendants('.dropdown.icon')
+    })
+  })
 
   describe('selected item', () => {
     it('defaults to the first item', () => {
@@ -1019,7 +1028,7 @@ describe('Dropdown Component', () => {
   describe('Dropdown.Menu child', () => {
     it('renders child passed', () => {
       wrapperShallow(
-        <Dropdown>
+        <Dropdown text='required prop'>
           <Dropdown.Menu data-find-me />
         </Dropdown>
       )
@@ -1032,7 +1041,7 @@ describe('Dropdown Component', () => {
 
     it('opens on click', () => {
       wrapperMount(
-        <Dropdown>
+        <Dropdown text='required prop'>
           <Dropdown.Menu />
         </Dropdown>
       )


### PR DESCRIPTION
Fixes #401.  This PR wires the `icon` prop to the icon factory.  This addresses the most simple use case for setting the Dropdown icon.

Additional Dropdown types (Button, MenuItem) including their icons are being considered in #403.
