### PR TITLE
feat(Dropdown): add custom noResultsMessage

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -120,6 +120,9 @@ export default class Dropdown extends Component {
     /** Label prefixed to an option added by a user. */
     additionLabel: PropTypes.string,
 
+    /** Message to display when there are no results. */
+    noResultsMessage: PropTypes.string,
+
     // ------------------------------------
     // Callbacks
     // ------------------------------------
@@ -197,6 +200,7 @@ export default class Dropdown extends Component {
   static defaultProps = {
     icon: 'dropdown',
     additionLabel: 'Add:',
+    noResultsMessage: 'No results found.',
   }
 
   static autoControlledProps = [
@@ -770,12 +774,12 @@ export default class Dropdown extends Component {
   }
 
   renderOptions = () => {
-    const { multiple, search } = this.props
+    const { multiple, search, noResultsMessage } = this.props
     const { selectedIndex, value } = this.state
     const options = this.getMenuOptions()
 
     if (search && _.isEmpty(options)) {
-      return <div className='message'>No results found.</div>
+      return <div className='message'>{noResultsMessage}</div>
     }
 
     const isActive = multiple

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1010,6 +1010,42 @@ describe('Dropdown Component', () => {
         .find('.message')
         .should.not.be.present()
     })
+
+    it('uses default noResultsMessage', () => {
+      const search = wrapperMount(<Dropdown options={options} selection search />)
+        .find('input.search')
+
+      // search for something we know will not exist
+      search.simulate('change', { target: { value: '_________________' } })
+
+      wrapper
+        .find('.message')
+        .should.have.text('No results found.')
+    })
+
+    it('uses custom noResultsMessage', () => {
+      const search = wrapperMount(<Dropdown options={options} selection search noResultsMessage='Something custom' />)
+        .find('input.search')
+
+      // search for something we know will not exist
+      search.simulate('change', { target: { value: '_________________' } })
+
+      wrapper
+        .find('.message')
+        .should.have.text('Something custom')
+    })
+
+    it('uses no noResultsMessage', () => {
+      const search = wrapperMount(<Dropdown options={options} selection search noResultsMessage='' />)
+        .find('input.search')
+
+      // search for something we know will not exist
+      search.simulate('change', { target: { value: '_________________' } })
+
+      wrapper
+        .find('.message')
+        .should.have.text('')
+    })
   })
 
   describe('placeholder', () => {


### PR DESCRIPTION
Addresses one of the points references in an issue I opened (#416), allowing customization of the message that shows up when no results are found.
