### PR TITLE
Dropdown: Pass 'options' objects as props to Dropdown.Item

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -46,20 +46,11 @@ export default class Dropdown extends Component {
       PropTypes.string,
     ]),
 
-    /** Array of `{ text: '', value: '' }` options */
+    /** Array of Dropdown.Item props e.g. `{ text: '', value: '' }` */
     options: customPropTypes.every([
       customPropTypes.disallow(['children']),
       customPropTypes.demand(['selection']),
-      PropTypes.arrayOf(PropTypes.shape({
-        value: PropTypes.oneOfType([
-          PropTypes.string,
-          PropTypes.number,
-        ]).isRequired,
-        text: PropTypes.oneOfType([
-          PropTypes.string,
-          PropTypes.number,
-        ]),
-      })),
+      PropTypes.arrayOf(PropTypes.shape(DropdownItem.propTypes)),
     ]),
 
     /** Controls whether or not the dropdown menu is displayed. */
@@ -792,8 +783,7 @@ export default class Dropdown extends Component {
         active={isActive(opt.value)}
         onClick={this.handleItemClick}
         selected={selectedIndex === i}
-        text={opt.text}
-        value={opt.value}
+        {...opt}
       />
     ))
   }

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 
 import {
   childrenUtils,
+  customPropTypes,
   META,
   useKeyOnly,
 } from '../../lib'
@@ -57,7 +58,10 @@ DropdownItem.propTypes = {
   active: PropTypes.bool,
 
   /** Primary content. */
-  children: PropTypes.node,
+  children: customPropTypes.every([
+    customPropTypes.disallow(['text']),
+    PropTypes.node,
+  ]),
 
   /** Additional className. */
   className: PropTypes.string,
@@ -75,7 +79,13 @@ DropdownItem.propTypes = {
   selected: PropTypes.bool,
 
   /** Display text. */
-  text: PropTypes.string,
+  text: customPropTypes.every([
+    customPropTypes.disallow(['children']),
+    PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
+  ]),
 
   /** Stored value */
   value: PropTypes.oneOfType([

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -754,7 +754,7 @@ describe('Dropdown Component', () => {
   describe('options', () => {
     it('adds the onClick handler to all items', () => {
       wrapperShallow(<Dropdown options={options} selection />)
-        .children('DropdownItem')
+        .find('DropdownItem')
         .everyWhere(item => item.should.have.prop('onClick'))
     })
     it('calls handleItemClick when an item is clicked', () => {
@@ -804,6 +804,17 @@ describe('Dropdown Component', () => {
 
       newItem.should.have.prop('text', 'bar')
       newItem.should.have.prop('value', 'bar')
+    })
+
+    it('passes options as props', () => {
+      const customOptions = [
+        { text: 'abra', value: 'abra', 'data-foo': 'someValue' },
+        { text: 'cadabra', value: 'cadabra', 'data-foo': 'someValue' },
+        { text: 'bang', value: 'bang', 'data-foo': 'someValue' },
+      ]
+      wrapperShallow(<Dropdown options={customOptions} selection />)
+        .find('DropdownItem')
+        .everyWhere(item => item.should.have.prop('data-foo', 'someValue'))
     })
   })
 


### PR DESCRIPTION
When specifying options on a dropdown, previously only 'text' and 'value' were being passed to `<Dropdown.Item>`. This makes it so the entire object is passed as props.

cc #416
