### PR TITLE
Docs: fix search focus

### DIFF
--- a/docs/app/Components/Sidebar/Sidebar.js
+++ b/docs/app/Components/Sidebar/Sidebar.js
@@ -33,9 +33,10 @@ export default class Sidebar extends Component {
   handleDocumentKeyDown = (e) => {
     const code = keyboardKey.getCode(e)
     const isAZ = code >= 65 && code <= 90
+    const hasModifier = e.altKey || e.ctrlKey || e.metaKey
     const bodyHasFocus = document.activeElement === document.body
 
-    if (isAZ && bodyHasFocus) this._searchInput.focus()
+    if (!hasModifier && isAZ && bodyHasFocus) this._searchInput.focus()
   }
 
   renderItemsByType = (type) => {


### PR DESCRIPTION
Fixes #425.  We no longer focus the docs search input if there is a modifier key present while typing.
