### PR TITLE
feat(Tab): Add component

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Once you change the flag, you need to refresh your browser to see the changes in
 | ✓ Loader        |                 |                 |   Shape         |                    |
 | ✓ Rail          |                 |                 | ✓ Sidebar       |                    |
 | ✓ Reveal        |                 |                 |   Sticky        |                    |
-| ✓ Segment       |                 |                 |   Tab           |                    |
+| ✓ Segment       |                 |                 | ✓ Tab           |                    |
 | ✓ Step          |                 |                 |   Transition    |                    |
 
 ## Our Principles

--- a/docs/app/Examples/modules/Tab/MenuVariations/TabExampleAttachedBottom.js
+++ b/docs/app/Examples/modules/Tab/MenuVariations/TabExampleAttachedBottom.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane attached='top'>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane attached='top'>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane attached='top'>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExampleAttachedBottom = () => (
+  <Tab menu={{ attached: 'bottom' }} panes={panes} />
+)
+
+export default TabExampleAttachedBottom

--- a/docs/app/Examples/modules/Tab/MenuVariations/TabExampleAttachedFalse.js
+++ b/docs/app/Examples/modules/Tab/MenuVariations/TabExampleAttachedFalse.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane attached={false}>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane attached={false}>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane attached={false}>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExampleAttachedFalse = () => (
+  <Tab menu={{ attached: false }} panes={panes} />
+)
+
+export default TabExampleAttachedFalse

--- a/docs/app/Examples/modules/Tab/MenuVariations/TabExampleBorderless.js
+++ b/docs/app/Examples/modules/Tab/MenuVariations/TabExampleBorderless.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane attached={false}>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane attached={false}>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane attached={false}>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExampleBorderless = () => (
+  <Tab menu={{ borderless: true, attached: false, tabular: false }}panes={panes} />
+)
+
+export default TabExampleBorderless

--- a/docs/app/Examples/modules/Tab/MenuVariations/TabExampleColored.js
+++ b/docs/app/Examples/modules/Tab/MenuVariations/TabExampleColored.js
@@ -1,0 +1,41 @@
+import _ from 'lodash'
+import React, { Component } from 'react'
+import { Divider, Tab } from 'semantic-ui-react'
+
+const colors = [
+  'red', 'orange', 'yellow', 'olive', 'green', 'teal',
+  'blue', 'violet', 'purple', 'pink', 'brown', 'grey',
+]
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane attached={false}>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane attached={false}>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane attached={false}>Tab 3 Content</Tab.Pane> },
+]
+
+class TabExampleColored extends Component {
+  state = { color: colors[0] }
+
+  handleColorChange = e => this.setState({ color: e.target.value })
+
+  render() {
+    const { color } = this.state
+
+    return (
+      <div>
+        <select onChange={this.handleColorChange}>
+          {_.map(colors, c => <option key={c} value={c}>{_.startCase(c)}</option>)}
+        </select>
+
+        <Divider hidden />
+
+        <Tab
+          menu={{ color, attached: false, tabular: false }}
+          panes={panes}
+        />
+      </div>
+    )
+  }
+}
+
+export default TabExampleColored

--- a/docs/app/Examples/modules/Tab/MenuVariations/TabExampleColoredInverted.js
+++ b/docs/app/Examples/modules/Tab/MenuVariations/TabExampleColoredInverted.js
@@ -1,0 +1,41 @@
+import _ from 'lodash'
+import React, { Component } from 'react'
+import { Divider, Tab } from 'semantic-ui-react'
+
+const colors = [
+  'red', 'orange', 'yellow', 'olive', 'green', 'teal',
+  'blue', 'violet', 'purple', 'pink', 'brown', 'grey',
+]
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane attached={false}>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane attached={false}>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane attached={false}>Tab 3 Content</Tab.Pane> },
+]
+
+class TabExampleColoredInverted extends Component {
+  state = { color: colors[0] }
+
+  handleColorChange = e => this.setState({ color: e.target.value })
+
+  render() {
+    const { color } = this.state
+
+    return (
+      <div>
+        <select onChange={this.handleColorChange}>
+          {_.map(colors, c => <option key={c} value={c}>{_.startCase(c)}</option>)}
+        </select>
+
+        <Divider hidden />
+
+        <Tab
+          menu={{ color, inverted: true, attached: false, tabular: false }}
+          panes={panes}
+        />
+      </div>
+    )
+  }
+}
+
+export default TabExampleColoredInverted

--- a/docs/app/Examples/modules/Tab/MenuVariations/TabExampleTabularFalse.js
+++ b/docs/app/Examples/modules/Tab/MenuVariations/TabExampleTabularFalse.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane attached={false}>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane attached={false}>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane attached={false}>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExampleTabularFalse = () => (
+  <Tab menu={{ attached: false, tabular: false }} panes={panes} />
+)
+
+export default TabExampleTabularFalse

--- a/docs/app/Examples/modules/Tab/MenuVariations/index.js
+++ b/docs/app/Examples/modules/Tab/MenuVariations/index.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+import { Message } from 'semantic-ui-react'
+
+const TabMenuVariationsExamples = () => (
+  <ExampleSection title='Menu Variations'>
+    <ComponentExample
+      title='Attached'
+      description='A tab menu can be attached on bottom.'
+      examplePath='modules/Tab/MenuVariations/TabExampleAttachedBottom'
+    />
+    <ComponentExample
+      description='A tab menu can remove its attached appearance.'
+      examplePath='modules/Tab/MenuVariations/TabExampleAttachedFalse'
+    />
+    <ComponentExample
+      title='Not Tabular'
+      description='A tab menu can disable its tabular appearance.'
+      examplePath='modules/Tab/MenuVariations/TabExampleTabularFalse'
+    />
+    <ComponentExample
+      title='Borderless'
+      description='A tab menu can remove its borders.'
+      examplePath='modules/Tab/MenuVariations/TabExampleBorderless'
+    />
+    <ComponentExample
+      title='Colored'
+      description='A tab menu can be colored.'
+      examplePath='modules/Tab/MenuVariations/TabExampleColored'
+    >
+      <Message
+        info
+        content='Color only applies to the menu, not the pane, so they look best not attached.'
+      />
+    </ComponentExample>
+    <ComponentExample
+      description='A tab menu can invert its colors.'
+      examplePath='modules/Tab/MenuVariations/TabExampleColoredInverted'
+    />
+  </ExampleSection>
+)
+
+export default TabMenuVariationsExamples

--- a/docs/app/Examples/modules/Tab/States/TabExampleLoading.js
+++ b/docs/app/Examples/modules/Tab/States/TabExampleLoading.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane loading>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExampleLoading = () => (
+  <Tab panes={panes} />
+)
+
+export default TabExampleLoading

--- a/docs/app/Examples/modules/Tab/States/index.js
+++ b/docs/app/Examples/modules/Tab/States/index.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const TabStatesExamples = () => (
+  <ExampleSection title='States'>
+    <ComponentExample
+      title='Loading'
+      description='A tab can display a loading indicator.'
+      examplePath='modules/Tab/States/TabExampleLoading'
+    />
+  </ExampleSection>
+)
+
+export default TabStatesExamples

--- a/docs/app/Examples/modules/Tab/Types/TabExampleBasic.js
+++ b/docs/app/Examples/modules/Tab/Types/TabExampleBasic.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExampleBasic = () => (
+  <Tab panes={panes} />
+)
+
+export default TabExampleBasic

--- a/docs/app/Examples/modules/Tab/Types/TabExamplePointing.js
+++ b/docs/app/Examples/modules/Tab/Types/TabExamplePointing.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane attached={false}>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane attached={false}>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane attached={false}>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExamplePointing = () => (
+  <Tab menu={{ pointing: true }} panes={panes} />
+)
+
+export default TabExamplePointing

--- a/docs/app/Examples/modules/Tab/Types/TabExampleSecondary.js
+++ b/docs/app/Examples/modules/Tab/Types/TabExampleSecondary.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane attached={false}>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane attached={false}>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane attached={false}>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExampleSecondary = () => (
+  <Tab menu={{ secondary: true }} panes={panes} />
+)
+
+export default TabExampleSecondary

--- a/docs/app/Examples/modules/Tab/Types/TabExampleSecondaryPointing.js
+++ b/docs/app/Examples/modules/Tab/Types/TabExampleSecondaryPointing.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane attached={false}>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane attached={false}>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane attached={false}>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExampleSecondaryPointing = () => (
+  <Tab menu={{ secondary: true, pointing: true }} panes={panes} />
+)
+
+export default TabExampleSecondaryPointing

--- a/docs/app/Examples/modules/Tab/Types/TabExampleText.js
+++ b/docs/app/Examples/modules/Tab/Types/TabExampleText.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane attached={false}>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane attached={false}>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane attached={false}>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExampleText = () => (
+  <Tab menu={{ text: true }} panes={panes} />
+)
+
+export default TabExampleText

--- a/docs/app/Examples/modules/Tab/Types/index.js
+++ b/docs/app/Examples/modules/Tab/Types/index.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const TabTypesExamples = () => (
+  <ExampleSection title='Types'>
+    <ComponentExample
+      title='Basic'
+      description='A basic tab'
+      examplePath='modules/Tab/Types/TabExampleBasic'
+    />
+    <ComponentExample
+      title='Pointing Menu'
+      description='A tab menu can point to its tab panes.'
+      examplePath='modules/Tab/Types/TabExamplePointing'
+    />
+    <ComponentExample
+      examplePath='modules/Tab/Types/TabExampleSecondaryPointing'
+    />
+    <ComponentExample
+      title='Secondary Menu'
+      description='A tab menu can adjust its appearance to de-emphasize its contents.'
+      examplePath='modules/Tab/Types/TabExampleSecondary'
+    />
+    <ComponentExample
+      title='Text Menu'
+      description='A tab menu can be formatted for text content.'
+      examplePath='modules/Tab/Types/TabExampleText'
+    />
+  </ExampleSection>
+)
+
+export default TabTypesExamples

--- a/docs/app/Examples/modules/Tab/Usage/TabExampleActiveIndex.js
+++ b/docs/app/Examples/modules/Tab/Usage/TabExampleActiveIndex.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane>Tab 3 Content</Tab.Pane> },
+]
+
+class TabExampleActiveIndex extends Component {
+  state = { activeIndex: 1 }
+
+  handleChange = e => this.setState({ activeIndex: e.target.value })
+
+  render() {
+    const { activeIndex } = this.state
+
+    return (
+      <div>
+        <div>activeIndex: {activeIndex}</div>
+        <input type='range' max='2' value={activeIndex} onChange={this.handleChange} />
+        <Tab panes={panes} activeIndex={activeIndex} />
+      </div>
+    )
+  }
+}
+
+export default TabExampleActiveIndex

--- a/docs/app/Examples/modules/Tab/Usage/TabExampleDefaultActiveIndex.js
+++ b/docs/app/Examples/modules/Tab/Usage/TabExampleDefaultActiveIndex.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane>Tab 3 Content</Tab.Pane> },
+]
+
+const TabExampleDefaultActiveIndex = () => (
+  <Tab panes={panes} defaultActiveIndex={2} />
+)
+
+export default TabExampleDefaultActiveIndex

--- a/docs/app/Examples/modules/Tab/Usage/TabExampleOnTabChange.js
+++ b/docs/app/Examples/modules/Tab/Usage/TabExampleOnTabChange.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react'
+import { Segment, Tab } from 'semantic-ui-react'
+
+const panes = [
+  { menuItem: 'Tab 1', render: () => <Tab.Pane>Tab 1 Content</Tab.Pane> },
+  { menuItem: 'Tab 2', render: () => <Tab.Pane>Tab 2 Content</Tab.Pane> },
+  { menuItem: 'Tab 3', render: () => <Tab.Pane>Tab 3 Content</Tab.Pane> },
+]
+
+class TabExampleOnTabChange extends Component {
+  state = {}
+
+  handleChange = (e, data) => this.setState(data)
+
+  render() {
+    return (
+      <div>
+        <Tab panes={panes} onTabChange={this.handleChange} />
+        <Segment tertiary>
+          <pre>{JSON.stringify(this.state, null, 2)}</pre>
+        </Segment>
+      </div>
+    )
+  }
+}
+
+export default TabExampleOnTabChange

--- a/docs/app/Examples/modules/Tab/Usage/index.js
+++ b/docs/app/Examples/modules/Tab/Usage/index.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const TabUsageExamples = () => (
+  <ExampleSection title='Usage'>
+    <ComponentExample
+      title='Active Index'
+      description='A tab can be a controlled component.'
+      examplePath='modules/Tab/Usage/TabExampleActiveIndex'
+    />
+    <ComponentExample
+      title='Default Active Index'
+      description='A tab can define which pane is active by default.'
+      examplePath='modules/Tab/Usage/TabExampleDefaultActiveIndex'
+    />
+    <ComponentExample
+      title='On Tab Change'
+      description='You can capture the tab change event.'
+      examplePath='modules/Tab/Usage/TabExampleOnTabChange'
+    />
+  </ExampleSection>
+)
+
+export default TabUsageExamples

--- a/docs/app/Examples/modules/Tab/index.js
+++ b/docs/app/Examples/modules/Tab/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import Types from './Types'
+import States from './States'
+import MenuVariations from './MenuVariations'
+import Usage from './Usage'
+
+const TabExamples = () => (
+  <div>
+    <Types />
+    <States />
+    <MenuVariations />
+    <Usage />
+  </div>
+)
+
+export default TabExamples

--- a/src/collections/Menu/Menu.d.ts
+++ b/src/collections/Menu/Menu.d.ts
@@ -12,7 +12,7 @@ export interface MenuProps {
   as?: any;
 
   /** Index of the currently active item. */
-  activeIndex?: number;
+  activeIndex?: number | string;
 
   /** A menu may be attached to other content segments. */
   attached?: boolean | 'bottom' | 'top';
@@ -33,7 +33,7 @@ export interface MenuProps {
   compact?: boolean;
 
   /** Initial activeIndex value. */
-  defaultActiveIndex?: number;
+  defaultActiveIndex?: number | string;
 
   /** A menu can be fixed to a side of its context. */
   fixed?: 'left'| 'right'| 'bottom'| 'top';

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -6,6 +6,7 @@ import React from 'react'
 import {
   AutoControlledComponent as Component,
   customPropTypes,
+  createShorthandFactory,
   getElementType,
   getUnhandledProps,
   META,
@@ -220,5 +221,7 @@ class Menu extends Component {
     )
   }
 }
+
+Menu.create = createShorthandFactory(Menu, items => ({ items }))
 
 export default Menu

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -29,7 +29,10 @@ class Menu extends Component {
     as: customPropTypes.as,
 
     /** Index of the currently active item. */
-    activeIndex: PropTypes.number,
+    activeIndex: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
 
     /** A menu may be attached to other content segments. */
     attached: PropTypes.oneOfType([
@@ -53,7 +56,10 @@ class Menu extends Component {
     compact: PropTypes.bool,
 
     /** Initial activeIndex value. */
-    defaultActiveIndex: PropTypes.number,
+    defaultActiveIndex: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
 
     /** A menu can be fixed to a side of its context. */
     fixed: PropTypes.oneOf(['left', 'right', 'bottom', 'top']),
@@ -151,7 +157,7 @@ class Menu extends Component {
 
     return _.map(items, (item, index) => MenuItem.create(item, {
       defaultProps: {
-        active: activeIndex === index,
+        active: parseInt(activeIndex, 10) === index,
         index,
       },
       overrideProps: this.handleItemOverrides,

--- a/src/collections/Message/Message.d.ts
+++ b/src/collections/Message/Message.d.ts
@@ -9,7 +9,7 @@ import { default as MessageList } from './MessageList';
 export interface MessageProps {
   [key: string]: any;
 
-	/** An element type to render as (string or function). */
+  /** An element type to render as (string or function). */
   as?: any;
 
   /** A message can be formatted to attach itself to other content. */

--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,9 @@ export { default as Sidebar } from './modules/Sidebar'
 export { default as SidebarPushable } from './modules/Sidebar/SidebarPushable'
 export { default as SidebarPusher } from './modules/Sidebar/SidebarPusher'
 
+export { default as Tab } from './modules/Tab'
+export { default as TabPane } from './modules/Tab/TabPane'
+
 // Views
 export { default as Advertisement } from './views/Advertisement'
 

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -282,7 +282,6 @@ export const contentShorthand = (...args) => every([
 export const itemShorthand = (...args) => every([
   disallow(['children']),
   PropTypes.oneOfType([
-    PropTypes.array,
     PropTypes.node,
     PropTypes.object,
   ]),

--- a/src/modules/Tab/Tab.d.ts
+++ b/src/modules/Tab/Tab.d.ts
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { default as TabPane } from './TabPane';
+
+export interface TabProps {
+  [key: string]: any;
+
+  /** An element type to render as (string or function). */
+  as?: any;
+
+  /** The initial activeIndex. */
+  defaultActiveIndex?: number | string;
+
+  /** Index of the currently active tab. */
+  activeIndex?: number | string;
+
+  /** Shorthand props for the Menu. */
+  menu?: any;
+
+  /**
+   * Called on tab change.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - The proposed new Tab.Pane.
+   * @param {object} data.activeIndex - The new proposed activeIndex.
+   * @param {object} data.panes - Props of the new proposed active pane.
+   */
+  onTabChange?: (event: React.MouseEvent<HTMLDivElement>, data: TabProps) => void;
+
+  /** Shorthand props for the Menu. */
+  panes?: any;
+}
+
+interface TabComponent extends React.ComponentClass<TabProps> {
+  Pane: typeof TabPane;
+}
+
+declare const Tab: TabComponent;
+
+export default Tab;

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -1,0 +1,117 @@
+import _ from 'lodash'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import {
+  AutoControlledComponent as Component,
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
+import Menu from '../../collections/Menu/Menu'
+import TabPane from './TabPane'
+
+/**
+ * A Tab is a hidden section of content activated by a Menu.
+ * @see Menu
+ * @see Segment
+ */
+class Tab extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
+
+    /** The initial activeIndex. */
+    defaultActiveIndex: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
+
+    /** Index of the currently active tab. */
+    activeIndex: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
+
+    /** Shorthand props for the Menu. */
+    menu: PropTypes.object,
+
+    /**
+     * Called on tab change.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props and proposed new activeIndex.
+     * @param {object} data.activeIndex - The new proposed activeIndex.
+     */
+    onTabChange: PropTypes.func,
+
+    /**
+     * Array of objects describing each Menu.Item and Tab.Pane:
+     * {
+     *   menuItem: 'Home',
+     *   render: () => <Tab.Pane>Welcome!</Tab.Pane>
+     * }
+     */
+    panes: PropTypes.arrayOf(PropTypes.shape({
+      menuItem: PropTypes.string.isRequired,
+      render: PropTypes.func.isRequired,
+    })),
+  }
+
+  static autoControlledProps = [
+    'activeIndex',
+  ]
+
+  static defaultProps = {
+    menu: { attached: true, tabular: true },
+  }
+
+  static _meta = {
+    name: 'Tab',
+    type: META.TYPES.MODULE,
+  }
+
+  static Pane = TabPane
+
+  state = {
+    activeIndex: 0,
+  }
+
+  handleItemClick = (e, { index }) => {
+    _.invoke(this.props, 'onTabChange', e, { activeIndex: index, ...this.props })
+    this.trySetState({ activeIndex: index })
+  }
+
+  renderMenu() {
+    const { menu, panes } = this.props
+    const { activeIndex } = this.state
+
+    return Menu.create(menu, {
+      overrideProps: {
+        items: _.map(panes, 'menuItem'),
+        onItemClick: this.handleItemClick,
+        activeIndex,
+      },
+    })
+  }
+
+  render() {
+    const { panes } = this.props
+    const { activeIndex } = this.state
+
+    const menu = this.renderMenu()
+    const rest = getUnhandledProps(Tab, this.props)
+    const ElementType = getElementType(Tab, this.props)
+
+    return (
+      <ElementType {...rest}>
+        {menu.props.attached !== 'bottom' && menu}
+        {_.invoke(_.get(panes, `[${activeIndex}]`), 'render', this.props)}
+        {menu.props.attached === 'bottom' && menu}
+      </ElementType>
+    )
+  }
+}
+
+export default Tab

--- a/src/modules/Tab/TabPane.d.ts
+++ b/src/modules/Tab/TabPane.d.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+export interface TabPaneProps {
+  [key: string]: any;
+
+  /** An element type to render as (string or function). */
+  as?: any;
+
+  /** Primary content. */
+  children?: React.ReactNode;
+
+  /** Additional classes. */
+  className?: string;
+
+  /** A Tab.Pane can display a loading indicator. */
+  loading?: boolean;
+}
+
+declare const TabPane: React.StatelessComponent<TabPaneProps>;
+
+export default TabPane;

--- a/src/modules/Tab/TabPane.js
+++ b/src/modules/Tab/TabPane.js
@@ -1,0 +1,67 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import {
+  createShorthandFactory,
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+  useKeyOnly,
+} from '../../lib'
+import Segment from '../../elements/Segment/Segment'
+
+/**
+ * A tab pane holds the content of a tab.
+ */
+function TabPane(props) {
+  const { children, className, loading } = props
+
+  const classes = cx(
+    useKeyOnly(loading, 'loading'),
+    'active tab',
+    className
+  )
+  const rest = getUnhandledProps(TabPane, props)
+  const ElementType = getElementType(TabPane, props)
+
+  const calculatedDefaultProps = {}
+  if (ElementType === Segment) {
+    calculatedDefaultProps.attached = 'bottom'
+  }
+
+  return (
+    <ElementType {...calculatedDefaultProps} {...rest} className={classes} loading={loading}>
+      {children}
+    </ElementType>
+  )
+}
+
+TabPane._meta = {
+  name: 'TabPane',
+  parent: 'Tab',
+  type: META.TYPES.MODULE,
+}
+
+TabPane.defaultProps = {
+  as: Segment,
+}
+
+TabPane.propTypes = {
+  /** An element type to render as (string or function). */
+  as: customPropTypes.as,
+
+  /** Primary content. */
+  children: PropTypes.string,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+
+  /** A Tab.Pane can display a loading indicator. */
+  loading: PropTypes.bool,
+}
+
+TabPane.create = createShorthandFactory(TabPane, children => ({ children }))
+
+export default TabPane

--- a/src/modules/Tab/index.d.ts
+++ b/src/modules/Tab/index.d.ts
@@ -1,0 +1,1 @@
+export { default, TabProps } from './Tab';

--- a/src/modules/Tab/index.js
+++ b/src/modules/Tab/index.js
@@ -1,0 +1,1 @@
+export default from './Tab'

--- a/test/specs/collections/Menu/Menu-test.js
+++ b/test/specs/collections/Menu/Menu-test.js
@@ -71,6 +71,13 @@ describe('Menu', () => {
         .at(1)
         .should.have.prop('active', true)
     })
+
+    it('works as a string', () => {
+      mount(<Menu items={items} activeIndex={1} />)
+        .find('MenuItem')
+        .at(1)
+        .should.have.prop('active', true)
+    })
   })
 
   describe('items', () => {

--- a/test/specs/modules/Tab/Tab-test.js
+++ b/test/specs/modules/Tab/Tab-test.js
@@ -1,0 +1,127 @@
+import React from 'react'
+
+import Tab from 'src/modules/Tab/Tab'
+import TabPane from 'src/modules/Tab/TabPane'
+import * as common from 'test/specs/commonTests'
+import { sandbox } from 'test/utils'
+
+describe('Tab', () => {
+  common.isConformant(Tab)
+  common.hasSubComponents(Tab, [TabPane])
+
+  const panes = [
+    { menuItem: 'Tab 1', render: () => <Tab.Pane>Tab 1 Content</Tab.Pane> },
+    { menuItem: 'Tab 2', render: () => <Tab.Pane>Tab 2 Content</Tab.Pane> },
+    { menuItem: 'Tab 3', render: () => <Tab.Pane>Tab 3 Content</Tab.Pane> },
+  ]
+
+  describe('menu', () => {
+    it('defaults to an attached tabular menu', () => {
+      Tab.defaultProps
+        .should.have.property('menu')
+        .which.deep.equals({ attached: true, tabular: true })
+    })
+
+    it('passes the props to the Menu', () => {
+      shallow(<Tab menu={{ 'data-foo': 'bar' }} />)
+        .find('Menu')
+        .should.have.props({ 'data-foo': 'bar' })
+    })
+
+    it('has an item for every menuItem in panes', () => {
+      const items = shallow(<Tab panes={panes} />)
+        .find('Menu')
+        .shallow()
+        .find('MenuItem')
+
+      items.should.have.lengthOf(3)
+      items.at(0).shallow().should.contain.text('Tab 1')
+      items.at(1).shallow().should.contain.text('Tab 2')
+      items.at(2).shallow().should.contain.text('Tab 3')
+    })
+
+    it('renders above the pane by default', () => {
+      const wrapper = shallow(<Tab panes={panes} />)
+
+      wrapper.childAt(0).should.match('Menu')
+      wrapper.childAt(1).shallow().should.match('Segment')
+    })
+
+    it("renders below the pane when attached='bottom'", () => {
+      const wrapper = shallow(<Tab menu={{ attached: 'bottom' }} panes={panes} />)
+
+      wrapper.childAt(0).shallow().should.match('Segment')
+      wrapper.childAt(1).should.match('Menu')
+    })
+  })
+
+  describe('activeIndex', () => {
+    it('is passed to the Menu', () => {
+      const wrapper = mount(<Tab panes={panes} activeIndex={123} />)
+
+      wrapper
+        .find('Menu')
+        .should.have.prop('activeIndex', 123)
+    })
+
+    it('is set when clicking an item', () => {
+      const wrapper = mount(<Tab panes={panes} />)
+
+      wrapper
+        .find('.active.tab')
+        .should.contain.text('Tab 1 Content')
+
+      wrapper
+        .find('MenuItem')
+        .at(1)
+        .simulate('click')
+
+      wrapper
+        .find('.active.tab')
+        .should.contain.text('Tab 2 Content')
+    })
+
+    it('can be set via props', () => {
+      const wrapper = mount(<Tab panes={panes} activeIndex={1} />)
+
+      wrapper
+        .find('.active.tab')
+        .should.contain.text('Tab 2 Content')
+
+      wrapper
+        .setProps({ activeIndex: 2 })
+        .find('.active.tab')
+        .should.contain.text('Tab 3 Content')
+    })
+
+    it('determines which pane render method is called', () => {
+      const activeIndex = 1
+      const props = { activeIndex, panes }
+      sandbox.spy(panes[activeIndex], 'render')
+
+      shallow(<Tab {...props} />)
+
+      panes[activeIndex].render.should.have.been.calledOnce()
+      panes[activeIndex].render.should.have.been.calledWithMatch(props)
+    })
+  })
+
+  describe('onTabChange', () => {
+    it('is called with (e, { activeIndex, ...props }) a menu item is clicked', () => {
+      const activeIndex = 1
+      const spy = sandbox.spy()
+      const event = { fake: 'event' }
+      const props = { onTabChange: spy, panes }
+
+      mount(<Tab {...props} />)
+        .find('MenuItem')
+        .at(activeIndex)
+        .simulate('click', event)
+
+      // Since React will have generated a key the returned tab won't match
+      // exactly so match on the props instead.
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(event, { activeIndex, ...props })
+    })
+  })
+})

--- a/test/specs/modules/Tab/TabPane-test.js
+++ b/test/specs/modules/Tab/TabPane-test.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import TabPane from 'src/modules/Tab/TabPane'
+import * as common from 'test/specs/commonTests'
+
+describe('TabPane', () => {
+  common.isConformant(TabPane)
+  common.propKeyOnlyToClassName(TabPane, 'loading')
+
+  it('renders a Segment by default', () => {
+    shallow(<TabPane />).should.match('Segment')
+  })
+})


### PR DESCRIPTION
Fixes #199. This PR adds the Tab component.  There are a number of ways we could go with the API.  I'll post an API proposal soon.

Considering a Tab component is simply a `tabular menu` followed by some `tab segment`s, I think we may create very a simple Tab API.  More complicated use of Tabs could use an actual Menu and Segments with manual wiring of the click handlers and `active` class.
### Simple Tabs

![image](https://cloud.githubusercontent.com/assets/5067638/17921037/c1c8849a-698c-11e6-88fb-142e65367016.png)

``` jsx
<Tab>
  <Tab.Pane name='First'>
    First
  </Tab.Pane>
  <Tab.Pane name='Second'>
    Second
  </Tab.Pane>
  <Tab.Pane name='Third'>
    Third
  </Tab.Pane>
</Tab>
```
### Custom Tabs

This type of customization requires a full definition of the Menu component (icons, right sub menu, etc).  I think at this point, the user should just wire in their click handlers to render tab Segments manually.  An API for doing this will make the simple use case obtuse.

Open to suggestions on how to accomplish both with a clean and concise API.

![image](https://cloud.githubusercontent.com/assets/5067638/17921092/0fbd845c-698d-11e6-8eef-cc84d9f4eb14.png)
### Considerations

This component doesn't lend itself well to an array shorthand prop such as `panes` since the content is bound to be much more than just text.  Because of this children will be used often.  It is difficult and unreliable to loop/filter children to add click handlers and props for auto controlling things like the `active` Segment (pane).  We are also avoiding React context to do so if at all possible.

Given these points, I'm leaning toward something like the simple tabs markup shown above.  Will come back to this later.  Feedback is much welcomed.
