### PR TITLE
Docs: use platform path sep

### DIFF
--- a/config.js
+++ b/config.js
@@ -97,6 +97,7 @@ config = Object.assign({}, config, {
     __DEV__,
     __DEBUG__: !!argv.debug,
     __STAGING__,
+    __PATH_SEP__: JSON.stringify(path.sep),
     __TEST__,
     __PROD__,
   },

--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -5,6 +5,7 @@
     "__DEBUG__": false,
     "__STAGING__": false,
     "__TEST__": false,
+    "__PATH_SEP__": false,
     "__PROD__": false
   }
 }

--- a/docs/app/Components/ComponentDoc/ComponentDescription.js
+++ b/docs/app/Components/ComponentDoc/ComponentDescription.js
@@ -13,6 +13,8 @@ const descriptionStyle = {
   fontSize: '1.2em',
 }
 
+const pathSepRegEx = new RegExp(__PATH_SEP__, 'g')
+
 export default class ComponentDescription extends Component {
   static propTypes = {
     /** Stardust component _meta object. */
@@ -44,11 +46,13 @@ export default class ComponentDescription extends Component {
 
   renderSourceLink() {
     const { docPath } = this.props
+    // no matter the OS path separator, use '/' since these link to github
+    const posixPath = docPath.replace(pathSepRegEx, '/')
     return (
       <List.Item icon='github'>
         <code>
-          <a href={`https://github.com/TechnologyAdvice/stardust/blob/master/${docPath}`} target='_blank'>
-            {docPath}
+          <a href={`https://github.com/TechnologyAdvice/stardust/blob/master/${posixPath}`} target='_blank'>
+            {posixPath}
           </a>
         </code>
       </List.Item>

--- a/docs/app/Components/ComponentDoc/ComponentDoc.js
+++ b/docs/app/Components/ComponentDoc/ComponentDoc.js
@@ -12,7 +12,7 @@ const ComponentDoc = ({ _meta }) => {
   // This just parses out a single docgen file based on component path name.
   // Our current docgen gulp task concats these into one, only for us to split it back out.
   // The leading slash in the RegEx is required, some components end with the same name.
-  const docPath = _.find(_.keys(docgenInfo), path => new RegExp(`/${_meta.name}.js$`).test(path))
+  const docPath = _.find(_.keys(docgenInfo), path => new RegExp(`${__PATH_SEP__}${_meta.name}.js$`).test(path))
   const docgen = docgenInfo[docPath]
 
   return (


### PR DESCRIPTION
Fixes #434.  Uses a platform dependent path separator.
