### PR TITLE
fix(Checkbox): render required empty labels

### DIFF
--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -161,7 +161,11 @@ export default class Checkbox extends Component {
           tabIndex={0}
           value={value}
         />
-        {label && <label>{label}</label>}
+        {/*
+         Heads Up!
+         Do not remove empty labels, they are required by SUI CSS
+         */}
+        <label>{label}</label>
       </ElementType>
     )
   }

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -126,9 +126,12 @@ describe('Checkbox', () => {
   })
 
   describe('label', () => {
-    it('is not present by default', () => {
+    // Heads Up!
+    // This is required for SUI CSS
+    it('is present when not defined', () => {
       shallow(<Checkbox />)
-        .should.not.have.descendants('label')
+        .should.have.descendants('label')
+        .and.have.text('')
     })
 
     it('adds the "fitted" class when not present', () => {


### PR DESCRIPTION
Empty labels in Checkbox were removed from the render function recently.  They are required by SUI CSS for other checkbox types.

---

![image](https://cloud.githubusercontent.com/assets/5067638/17989797/df74d90e-6ae4-11e6-9e60-e7c8c06884fe.png)
