### PR TITLE
feat(Header): support size prop

### DIFF
--- a/docs/app/Examples/elements/Header/Types/HeaderContentHeadersExample.js
+++ b/docs/app/Examples/elements/Header/Types/HeaderContentHeadersExample.js
@@ -3,21 +3,11 @@ import { Header } from 'stardust'
 
 const HeaderContentHeadersExample = () => (
   <div>
-    <Header size='huge'>
-      Huge Header
-    </Header>
-    <Header size='large'>
-      Large Header
-    </Header>
-    <Header size='medium'>
-      Medium Header
-    </Header>
-    <Header size='small'>
-      Small Header
-    </Header>
-    <Header size='tiny'>
-      Tiny Header
-    </Header>
+    <Header size='huge'>Huge Header</Header>
+    <Header size='large'>Large Header</Header>
+    <Header size='medium'>Medium Header</Header>
+    <Header size='small'>Small Header</Header>
+    <Header size='tiny'>Tiny Header</Header>
   </div>
 )
 

--- a/docs/app/Examples/elements/Header/Types/HeaderPageHeadersExample.js
+++ b/docs/app/Examples/elements/Header/Types/HeaderPageHeadersExample.js
@@ -3,24 +3,12 @@ import { Header } from 'stardust'
 
 const HeaderPageHeadersExamples = () => (
   <div>
-    <Header as='h1'>
-      First Header
-    </Header>
-    <Header as='h2'>
-      Second Header
-    </Header>
-    <Header as='h3'>
-      Third Header
-    </Header>
-    <Header as='h4'>
-      Fourth Header
-    </Header>
-    <Header as='h5'>
-      Fifth Header
-    </Header>
-    <Header as='h6'>
-      Sixth Header
-    </Header>
+    <Header as='h1'>First Header</Header>
+    <Header as='h2'>Second Header</Header>
+    <Header as='h3'>Third Header</Header>
+    <Header as='h4'>Fourth Header</Header>
+    <Header as='h5'>Fifth Header</Header>
+    <Header as='h6'>Sixth Header</Header>
   </div>
 )
 

--- a/docs/app/Examples/elements/Header/Types/index.js
+++ b/docs/app/Examples/elements/Header/Types/index.js
@@ -10,8 +10,8 @@ const HeaderTypesExamples = () => (
       description='Headers may be oriented to give the hierarchy of a section in the context of the page'
       examplePath='elements/Header/Types/HeaderPageHeadersExample'
     >
-      <Message>
-        Page headings are sized using rem and are not affected by surrounding content size.
+      <Message info>
+        Page headings are sized using <code>rem</code> and are not affected by surrounding content size.
       </Message>
     </ComponentExample>
     <ComponentExample
@@ -19,8 +19,8 @@ const HeaderTypesExamples = () => (
       description='Headers may be oriented to give the importance of a section'
       examplePath='elements/Header/Types/HeaderContentHeadersExample'
     >
-      <Message>
-        Content headings are sized with em and are based on the font-size of their container.
+      <Message info>
+        Content headings are sized with <code>em</code> and are based on the font-size of their container.
       </Message>
     </ComponentExample>
     <ComponentExample

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 import {
@@ -16,13 +17,14 @@ import HeaderSubheader from './HeaderSubheader'
 
 function Header(props) {
   const {
-    color, content, dividing, block, attached, floated, inverted, disabled, sub, textAlign,
+    color, content, dividing, block, attached, floated, inverted, disabled, sub, size, textAlign,
     icon, image, children, className,
   } = props
 
   const classes = cx(
     'ui',
     icon && 'icon',
+    size,
     color,
     useKeyOnly(sub, 'sub'),
     useKeyOnly(dividing, 'dividing'),
@@ -57,6 +59,7 @@ Header._meta = {
   props: {
     attached: ['top', 'bottom'],
     color: SUI.COLORS,
+    size: _.without(SUI.SIZES, 'big', 'massive'),
     floated: SUI.FLOATS,
     textAlign: SUI.TEXT_ALIGNMENTS,
   },
@@ -127,6 +130,9 @@ Header.propTypes = {
 
   /** Headers may be formatted to label smaller or de-emphasized content */
   sub: PropTypes.bool,
+
+  /** Content headings are sized with em and are based on the font-size of their container. */
+  size: PropTypes.oneOf(Header._meta.props.size),
 
   /** Align header content */
   textAlign: PropTypes.oneOf(Header._meta.props.textAlign),

--- a/test/specs/elements/Header/Header-test.js
+++ b/test/specs/elements/Header/Header-test.js
@@ -19,6 +19,7 @@ describe('Header', () => {
   common.propKeyOrValueToClassName(Header, 'attached')
 
   common.propValueOnlyToClassName(Header, 'color')
+  common.propValueOnlyToClassName(Header, 'size')
 
   common.implementsIconProp(Header)
   common.implementsImageProp(Header)


### PR DESCRIPTION
This PR adds the `size` prop to the Header. It was somehow overlooked.

We currently have docs for "Content Headers" but no component support.  A content header is a header sized using `size=''`.  It differs from h tag headers in that they are sized using `em` rather than `rem`.

http://semantic-ui.com/elements/header.html#content-headers

http://technologyadvice.github.io/stardust/elements/header#content-headers
