### PR TITLE
fix(Dropdown): merge Dropdown.Menu className

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import cx from 'classnames'
-import React, { cloneElement, PropTypes } from 'react'
+import React, { Children, cloneElement, PropTypes } from 'react'
 
 import {
   AutoControlledComponent as Component,
@@ -69,7 +69,10 @@ export default class Dropdown extends Component {
     children: customPropTypes.every([
       customPropTypes.disallow(['options', 'selection']),
       customPropTypes.demand(['text']),
-      React.PropTypes.element,
+      customPropTypes.givenProps(
+        { children: PropTypes.any.isRequired },
+        React.PropTypes.element.isRequired,
+      ),
       customPropTypes.ofComponentTypes(['DropdownMenu']),
     ]),
 
@@ -801,7 +804,12 @@ export default class Dropdown extends Component {
     const { menuClasses } = this.state
 
     // single menu child
-    if (children) return cloneElement(children, { className: menuClasses })
+    if (children) {
+      const menuChild = Children.only(children)
+      const className = cx(menuClasses, menuChild.props.className)
+
+      return cloneElement(menuChild, { className })
+    }
 
     return (
       <DropdownMenu className={menuClasses}>

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1125,6 +1125,35 @@ describe('Dropdown Component', () => {
       wrapper.simulate('click')
       dropdownMenuIsOpen()
     })
+
+    it('spreads extra menu props', () => {
+      wrapperShallow(
+        <Dropdown text='required prop'>
+          <Dropdown.Menu data-foo-bar />
+        </Dropdown>
+      )
+        .should.contain.descendants('DropdownMenu')
+
+      wrapper
+        .find('DropdownMenu')
+        .should.have.prop('data-foo-bar', true)
+    })
+
+    it("merges the user's menu className", () => {
+      wrapperShallow(
+        <Dropdown text='required prop'>
+          <Dropdown.Menu className='foo-bar' />
+        </Dropdown>
+      )
+        .should.contain.descendants('DropdownMenu')
+
+      const menu = wrapper
+        .find('DropdownMenu')
+        .shallow()
+
+      menu.should.have.className('menu')
+      menu.should.have.className('foo-bar')
+    })
   })
 
   describe('allowAdditions', () => {


### PR DESCRIPTION
Fixes #448.

The Dropdown clones a Dropdown.Menu child in order to control the open state of the menu by adding the appropriate classes.  We were replacing classes instead of merging classes.  User's classes on Dropdown.Menu were blown away.

This PR merges the open state classes with the user's classes.  It also adds tests to ensure the className and props are properly merged and spread respectively.
