### PR TITLE
fix(Header): correct shorthand props API

### DIFF
--- a/docs/app/Examples/elements/Header/Content/HeaderIconPropExample.js
+++ b/docs/app/Examples/elements/Header/Content/HeaderIconPropExample.js
@@ -2,9 +2,7 @@ import React from 'react'
 import { Header } from 'stardust'
 
 const HeaderIconExample = () => (
-  <Header as='h2' icon='plug'>
-    Is Your Electricity Truly Electrifying?
-  </Header>
+  <Header as='h2' icon='plug' content='Uptime Guarantee' />
 )
 
 export default HeaderIconExample

--- a/docs/app/Examples/elements/Header/Content/HeaderImageExample.js
+++ b/docs/app/Examples/elements/Header/Content/HeaderImageExample.js
@@ -1,12 +1,10 @@
-import faker from 'faker'
 import React from 'react'
 import { Header, Image } from 'stardust'
 
-const image = <Image className='circular' src={faker.image.city(120, 120)} />
-
 const HeaderImageExample = () => (
-  <Header as='h2' image={image}>
-    Welcome to Our City!
+  <Header as='h2'>
+    <Image shape='circular' src='http://semantic-ui.com/images/avatar2/large/patrick.png' />
+    {' '}Patrick
   </Header>
 )
 

--- a/docs/app/Examples/elements/Header/Content/HeaderImagePropExample.js
+++ b/docs/app/Examples/elements/Header/Content/HeaderImagePropExample.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Header } from 'stardust'
+
+const HeaderImageExample = () => (
+  <Header
+    as='h2'
+    image='http://semantic-ui.com/images/icons/school.png'
+    content='Learn More'
+  />
+)
+
+export default HeaderImageExample

--- a/docs/app/Examples/elements/Header/Content/HeaderPlugIconExample.js
+++ b/docs/app/Examples/elements/Header/Content/HeaderPlugIconExample.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Header, Icon } from 'stardust'
+
+const HeaderIconExample = () => (
+  <Header as='h2'>
+    <Icon name='plug' />
+    <Header.Content>
+      Uptime Guarantee
+    </Header.Content>
+  </Header>
+)
+
+export default HeaderIconExample

--- a/docs/app/Examples/elements/Header/Content/HeaderSettingsIconExample.js
+++ b/docs/app/Examples/elements/Header/Content/HeaderSettingsIconExample.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Header, Icon } from 'stardust'
+
+const HeaderIconExample = () => (
+  <Header as='h2'>
+    <Icon name='settings' />
+    <Header.Content>
+      Account Settings
+      <Header.Subheader>
+        Manage your preferences
+      </Header.Subheader>
+    </Header.Content>
+  </Header>
+)
+
+export default HeaderIconExample

--- a/docs/app/Examples/elements/Header/Content/index.js
+++ b/docs/app/Examples/elements/Header/Content/index.js
@@ -10,9 +10,20 @@ const HeaderContentExamples = () => (
       examplePath='elements/Header/Content/HeaderImageExample'
     />
     <ComponentExample
+      description='You can also define an image with props'
+      examplePath='elements/Header/Content/HeaderImagePropExample'
+    />
+    <ComponentExample
       title='Icon'
       description='A header may contain an icon'
-      examplePath='elements/Header/Content/HeaderIconExample'
+      examplePath='elements/Header/Content/HeaderPlugIconExample'
+    />
+    <ComponentExample
+      examplePath='elements/Header/Content/HeaderSettingsIconExample'
+    />
+    <ComponentExample
+      description='You can also define an icon with props'
+      examplePath='elements/Header/Content/HeaderIconPropExample'
     />
     <ComponentExample
       title='Subheader'

--- a/docs/app/Examples/elements/Header/Types/HeaderSettingsIconHeaderExample.js
+++ b/docs/app/Examples/elements/Header/Types/HeaderSettingsIconHeaderExample.js
@@ -1,8 +1,9 @@
 import React from 'react'
-import { Header } from 'stardust'
+import { Header, Icon } from 'stardust'
 
 const HeaderIconHeadersExample = () => (
-  <Header as='h2' icon='settings'>
+  <Header as='h2' icon>
+    <Icon name='settings' />
     Account Settings
     <Header.Subheader>
       Manage your account settings and set e-mail preferences.

--- a/docs/app/Examples/elements/Header/Types/HeaderUsersIconHeaderExample.js
+++ b/docs/app/Examples/elements/Header/Types/HeaderUsersIconHeaderExample.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Header, Icon, Image } from 'stardust'
+
+const HeaderIconHeadersExample = () => (
+  <div>
+    <Header as='h2' icon textAlign='center'>
+      <Icon name='users' circular />
+      <Header.Content>
+        Friends
+      </Header.Content>
+    </Header>
+    <Image centered size='large' src='http://semantic-ui.com/images/wireframe/centered-paragraph.png' />
+  </div>
+)
+
+export default HeaderIconHeadersExample

--- a/docs/app/Examples/elements/Header/Types/index.js
+++ b/docs/app/Examples/elements/Header/Types/index.js
@@ -26,7 +26,10 @@ const HeaderTypesExamples = () => (
     <ComponentExample
       title='Icon Headers'
       description='A header can be formatted to emphasize an icon'
-      examplePath='elements/Header/Types/HeaderIconHeadersExample'
+      examplePath='elements/Header/Types/HeaderSettingsIconHeaderExample'
+    />
+    <ComponentExample
+      examplePath='elements/Header/Types/HeaderUsersIconHeaderExample'
     />
     <ComponentExample
       title='Sub Headers'

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -12,7 +12,7 @@ const names = [
   'bhutan', 'bv', 'bouvet island', 'bw', 'botswana', 'by', 'belarus', 'bz', 'belize', 'ca', 'canada', 'cc',
   'cocos islands', 'cd', 'congo', 'cf', 'central african republic', 'cg', 'congo brazzaville', 'ch', 'switzerland',
   'ci', 'cote divoire', 'ck', 'cook islands', 'cl', 'chile', 'cm', 'cameroon', 'cn', 'china', 'co', 'colombia', 'cr',
-  'costa rica', 'cs', 'serbia', 'cu', 'cuba', 'cv', 'cape verde', 'cx', 'christmas island', 'cy', 'cyprus', 'cz',
+  'costa rica', 'cs', 'cu', 'cuba', 'cv', 'cape verde', 'cx', 'christmas island', 'cy', 'cyprus', 'cz',
   'czech republic', 'de', 'germany', 'dj', 'djibouti', 'dk', 'denmark', 'dm', 'dominica', 'do', 'dominican republic',
   'dz', 'algeria', 'ec', 'ecuador', 'ee', 'estonia', 'eg', 'egypt', 'eh', 'western sahara', 'er', 'eritrea', 'es',
   'spain', 'et', 'ethiopia', 'eu', 'european union', 'fi', 'finland', 'fj', 'fiji', 'fk', 'falkland islands', 'fm',

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -14,6 +14,7 @@ import {
 } from '../../lib'
 import { createIcon, createImage } from '../../factories'
 import HeaderSubheader from './HeaderSubheader'
+import HeaderContent from './HeaderContent'
 
 function Header(props) {
   const {
@@ -23,9 +24,9 @@ function Header(props) {
 
   const classes = cx(
     'ui',
-    icon && 'icon',
     size,
     color,
+    useKeyOnly(icon === true, 'icon'),
     useKeyOnly(sub, 'sub'),
     useKeyOnly(dividing, 'dividing'),
     useKeyOnly(block, 'block'),
@@ -41,16 +42,24 @@ function Header(props) {
   const ElementType = getElementType(Header, props)
   const rest = getUnhandledProps(Header, props)
 
-  if (children) {
-    return <ElementType {...rest} className={classes}>{children}</ElementType>
+  if (icon && typeof icon !== 'boolean') {
+    return (
+      <ElementType className={classes} {...rest}>
+        {createIcon(icon)}
+        {content && <HeaderContent>{content}</HeaderContent>}
+      </ElementType>
+    )
   }
 
-  return (
-    <ElementType className={classes} {...rest}>
-      {createIcon(icon) || createImage(image)}
-      <div className='content'>{content}</div>
-    </ElementType>
-  )
+  if (image) {
+    return (
+      <ElementType className={classes} {...rest}>
+        {createImage(image)} {content}
+      </ElementType>
+    )
+  }
+
+  return <ElementType {...rest} className={classes}>{children || content}</ElementType>
 }
 
 Header._meta = {
@@ -77,8 +86,12 @@ Header.propTypes = {
 
   /** Primary content */
   children: customPropTypes.every([
-    customPropTypes.disallow(['icon', 'image']),
     PropTypes.node,
+    customPropTypes.disallow(['image']),
+    customPropTypes.givenProps(
+      { icon: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.object]) },
+      customPropTypes.disallow(['icon']),
+    ),
   ]),
 
   /** Primary content.  Mutually exclusive with children. */
@@ -89,12 +102,15 @@ Header.propTypes = {
 
   /** Add an icon by icon name or pass an <Icon /.> */
   icon: customPropTypes.every([
-    customPropTypes.disallow(['children', 'image']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.element,
-      PropTypes.object,
-    ]),
+    customPropTypes.disallow(['image']),
+    customPropTypes.givenProps(
+      { children: PropTypes.node.isRequired },
+      PropTypes.bool,
+    ),
+    customPropTypes.givenProps(
+      { icon: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.object]) },
+      customPropTypes.disallow(['children']),
+    ),
   ]),
 
   /** Add an image by img src or pass an <Image />. */
@@ -138,6 +154,7 @@ Header.propTypes = {
   textAlign: PropTypes.oneOf(Header._meta.props.textAlign),
 }
 
+Header.Content = HeaderContent
 Header.Subheader = HeaderSubheader
 
 export default Header

--- a/src/elements/Header/HeaderContent.js
+++ b/src/elements/Header/HeaderContent.js
@@ -1,0 +1,38 @@
+import cx from 'classnames'
+import React, { PropTypes } from 'react'
+
+import { getElementType, getUnhandledProps, META } from '../../lib'
+
+/**
+ * Header content wraps the main content when there is an adjacent Icon or Image.
+ */
+function HeaderContent(props) {
+  const { className, children } = props
+  const classes = cx(className, 'content')
+  const rest = getUnhandledProps(HeaderContent, props)
+  const ElementType = getElementType(HeaderContent, props)
+
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
+}
+
+HeaderContent._meta = {
+  name: 'HeaderContent',
+  parent: 'Header',
+  type: META.TYPES.VIEW,
+}
+
+HeaderContent.propTypes = {
+  /** An element type to render as (string or function). */
+  as: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+  ]),
+
+  /** Primary content */
+  children: PropTypes.node,
+
+  /** Classes that will be added to the HeaderContent className */
+  className: PropTypes.string,
+}
+
+export default HeaderContent

--- a/test/specs/elements/Header/Header-test.js
+++ b/test/specs/elements/Header/Header-test.js
@@ -1,12 +1,12 @@
-import faker from 'faker'
 import React from 'react'
 import Header from 'src/elements/Header/Header'
-import Subheader from 'src/elements/Header/HeaderSubheader'
+import HeaderContent from 'src/elements/Header/HeaderContent'
+import HeaderSubheader from 'src/elements/Header/HeaderSubheader'
 import * as common from 'test/specs/commonTests'
 
 describe('Header', () => {
   common.hasUIClassName(Header)
-  common.hasSubComponents(Header, [Subheader])
+  common.hasSubComponents(Header, [HeaderContent, HeaderSubheader])
   common.rendersChildren(Header)
 
   common.propKeyOnlyToClassName(Header, 'dividing')
@@ -25,16 +25,44 @@ describe('Header', () => {
   common.implementsImageProp(Header)
   common.implementsTextAlignProp(Header)
 
-  it('has an icon class when adding an icon', () => {
-    const iconClass = faker.hacker.noun()
-    const wrapper = mount(<Header icon={iconClass} />)
-    wrapper.should.have.className('icon')
+  describe('icon', () => {
+    it('adds an icon class when true', () => {
+      shallow(<Header icon />)
+        .should.have.className('icon')
+    })
+    it('does not add an Icon when true', () => {
+      shallow(<Header icon />)
+        .should.not.have.descendants('Icon')
+    })
+    it('adds an Icon when given a name', () => {
+      shallow(<Header icon='user' />)
+        .should.have.descendants('Icon')
+    })
+    it('does not add an icon class given a name', () => {
+      shallow(<Header icon='user' />)
+        .should.not.have.className('icon')
+    })
   })
 
   describe('content', () => {
-    it('renders text', () => {
+    it('adds child text', () => {
       shallow(<Header content='foo' />)
+        .should.have.prop('children', 'foo')
+    })
+    it('adds child text when there is an image', () => {
+      shallow(<Header content='foo' image='foo.png' />)
         .should.contain.text('foo')
+    })
+    it('is wrapped in HeaderContent when there is an icon name', () => {
+      shallow(<Header icon='users' content='Friends' />)
+        .find('HeaderContent')
+        .should.have.prop('children', 'Friends')
+    })
+    it('is not wrapped in HeaderContent when icon is true', () => {
+      const wrapper = shallow(<Header icon content='Friends' />)
+
+      wrapper.should.contain.text('Friends')
+      wrapper.should.not.have.descendants('HeaderContent')
     })
   })
 })

--- a/test/specs/elements/Header/HeaderContent-test.js
+++ b/test/specs/elements/Header/HeaderContent-test.js
@@ -1,0 +1,7 @@
+import HeaderContent from 'src/elements/Header/HeaderContent'
+import * as common from 'test/specs/commonTests'
+
+describe('HeaderContent', () => {
+  common.isConformant(HeaderContent)
+  common.rendersChildren(HeaderContent)
+})


### PR DESCRIPTION
Fixes #454 

The Header did not conform the latest shorthand props API standards.  Namely, it prevented users from accessing the content div and allowed use of icon/image shorthand props along with children.

This PR adds `Header.Content`, docs, tests, and refactors the Header to correctly handle the shorthand props API.
