### PR TITLE
Provide callback for default element type

### DIFF
--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -13,16 +13,15 @@ import {
  * A section sub-component for Breadcrumb component.
  */
 function BreadcrumbSection(props) {
-  const { active, children, className, href, onClick } = props
+  const { active, children, className, href, link, onClick } = props
   const classes = cx(
     useKeyOnly(active, 'active'),
     className,
     'section',
   )
   const rest = getUnhandledProps(BreadcrumbSection, props)
-  const ElementType = getElementType(BreadcrumbSection, props, {
-    link: 'a',
-    onClick: 'a',
+  const ElementType = getElementType(BreadcrumbSection, props, () => {
+    if (link || onClick) return 'a'
   })
 
   const handleClick = (e) => {

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -21,7 +21,7 @@ import ImageGroup from './ImageGroup'
 function Image(props) {
   const {
     verticalAlign, alt, avatar, bordered, centered, className, disabled, floated, fluid,
-    hidden, height, href, inline, shape, size, spaced, src, width, ui,
+    hidden, height, href, inline, shape, size, spaced, src, width, wrapped, ui,
   } = props
 
   const classes = cx(
@@ -45,8 +45,8 @@ function Image(props) {
   const rest = getUnhandledProps(Image, props)
   const rootProps = { className: classes, ...rest }
   const imgTagProps = { src, alt, width, height }
-  const ElementType = getElementType(Image, props, {
-    wrapped: 'div',
+  const ElementType = getElementType(Image, props, () => {
+    if (wrapped) return 'div'
   })
 
   if (ElementType === 'img') {

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -20,7 +20,7 @@ import { Icon, Image } from '../'
 function Label(props) {
   const {
     attached, basic, children, color, corner, className, circular, detail, detailLink, floating, horizontal,
-    icon, image, onClick, onDetailClick, onRemove, pointing, removable, ribbon, size, tag, text,
+    icon, image, link, onClick, onDetailClick, onRemove, pointing, removable, ribbon, size, tag, text,
   } = props
 
   const handleClick = e => onClick && onClick(e, props)
@@ -46,10 +46,8 @@ function Label(props) {
   )
 
   const DetailComponent = (detailLink || onDetailClick) && 'a' || 'div'
-  const ElementType = getElementType(Label, props, {
-    image: 'a',
-    link: 'a',
-    onClick: 'a',
+  const ElementType = getElementType(Label, props, () => {
+    if (image || link || onClick) return 'a'
   })
   const rest = getUnhandledProps(Label, props)
 

--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -34,8 +34,8 @@ function Step(props) {
   const handleClick = (e) => {
     if (onClick) onClick(e)
   }
-  const ElementType = getElementType(Step, props, {
-    onClick: 'a',
+  const ElementType = getElementType(Step, props, () => {
+    if (onClick) return 'a'
   })
 
   return (

--- a/src/lib/getElementType.js
+++ b/src/lib/getElementType.js
@@ -1,30 +1,26 @@
-import _ from 'lodash'
-
 /**
  * Returns a createElement() type based on the props of the Component.
  * Useful for calculating what type a component should render as.
  *
  * @param {function} Component A function or ReactClass.
  * @param {object} props A ReactElement props object
- * @param {object} [typeMap] Maps props (keys) to element types (values).
+ * @param {function} [getDefault] A function that returns a default element type.
  * @returns {string|function} A ReactElement type
  */
-function getElementType(Component, props, typeMap) {
+function getElementType(Component, props, getDefault) {
   const { defaultProps = {} } = Component
 
   // ----------------------------------------
-  // user defined element type
+  // user defined "as" element type
 
   if (props.as && props.as !== defaultProps.as) return props.as
 
   // ----------------------------------------
-  // prop to type mappings
-  if (typeMap) {
-    const mappedType = _.find(typeMap, (type, propName) => {
-      const propValue = props[propName]
-      return !(propValue === undefined || propValue === null || propValue === '')
-    })
-    if (mappedType) return mappedType
+  // computed default element type
+
+  if (getDefault) {
+    const computedDefault = getDefault()
+    if (computedDefault) return computedDefault
   }
 
   // ----------------------------------------

--- a/src/views/Card/Card.js
+++ b/src/views/Card/Card.js
@@ -49,8 +49,8 @@ function Card(props) {
   const handleClick = (e) => {
     if (onClick) onClick(e)
   }
-  const ElementType = getElementType(Card, props, {
-    onClick: 'a',
+  const ElementType = getElementType(Card, props, () => {
+    if (onClick) return 'a'
   })
 
   if (children) {


### PR DESCRIPTION
Currently, we allow mapping props to default element types.  So, if you have a component that should render as an `a` tag when the `link` prop is present:

``` js
const ElementType = getElementType(MyComponent, props, { link: 'a' })
```

Sometimes a component needs to choose the default element based on some logic, like the prop value.  This the case with the Button.  It needs to choose a `button` if type is submit.  You cannot do this with a map of props to types alone.  This PR allows for a callback instead:

``` js
const ElementType = getElementType(Button, props, () => {
  if (type === 'submit') return 'button'
  if (attached) return 'div'
})
```

This is far more flexible allowing not only logic, but also precedence to be controlled by the component.
