### PR TITLE
feat(Grid): add stretched prop

### DIFF
--- a/src/collections/Grid/Grid.js
+++ b/src/collections/Grid/Grid.js
@@ -115,7 +115,7 @@ Grid.propTypes = {
   /** A grid can have its columns stack on-top of each other after reaching mobile breakpoints. */
   stackable: PropTypes.bool,
 
-  /** An can stretch its contents to take up the entire column height. */
+  /** An can stretch its contents to take up the entire grid height. */
   stretched: PropTypes.bool,
 
   /** A grid can specify its text alignment. */

--- a/src/collections/Grid/Grid.js
+++ b/src/collections/Grid/Grid.js
@@ -19,8 +19,8 @@ import GridRow from './GridRow'
 /** A grid is used to harmonize negative space in a layout. */
 function Grid(props) {
   const {
-    children, className, celled, centered, columns, divided, doubling, padded, relaxed, reversed, stackable, textAlign,
-    verticalAlign,
+    children, className, celled, centered, columns, divided, doubling, padded, relaxed, reversed, stackable, stretched,
+    textAlign, verticalAlign,
   } = props
   const classes = cx(
     'ui',
@@ -34,6 +34,7 @@ function Grid(props) {
     useKeyOrValueAndKey(relaxed, 'relaxed'),
     useValueAndKey(reversed, 'reversed'),
     useKeyOnly(stackable, 'stackable'),
+    useKeyOnly(stretched, 'stretched'),
     useTextAlignProp(textAlign),
     useVerticalAlignProp(verticalAlign),
     'grid'
@@ -113,6 +114,9 @@ Grid.propTypes = {
 
   /** A grid can have its columns stack on-top of each other after reaching mobile breakpoints. */
   stackable: PropTypes.bool,
+
+  /** An can stretch its contents to take up the entire column height. */
+  stretched: PropTypes.bool,
 
   /** A grid can specify its text alignment. */
   textAlign: PropTypes.oneOf(Grid._meta.props.textAlign),

--- a/src/collections/Grid/GridColumn.js
+++ b/src/collections/Grid/GridColumn.js
@@ -6,6 +6,7 @@ import {
   getUnhandledProps,
   META,
   SUI,
+  useKeyOnly,
   useTextAlignProp,
   useValueAndKey,
   useVerticalAlignProp,
@@ -14,8 +15,8 @@ import {
 
 function GridColumn(props) {
   const {
-    children, computer, className, color, floated, largeScreen, mobile, only, tablet, textAlign, verticalAlign,
-    widescreen, width,
+    children, computer, className, color, floated, largeScreen, mobile, only, stretched, tablet, textAlign,
+    verticalAlign, widescreen, width,
   } = props
   const classes = cx(
     className,
@@ -25,6 +26,7 @@ function GridColumn(props) {
     useWidthProp(largeScreen, 'wide large screen'),
     useWidthProp(mobile, 'wide mobile'),
     useValueAndKey(only, 'only'),
+    useKeyOnly(stretched, 'stretched'),
     useWidthProp(tablet, 'wide tablet'),
     useTextAlignProp(textAlign),
     useVerticalAlignProp(verticalAlign),
@@ -87,6 +89,9 @@ GridColumn.propTypes = {
 
   /** A column can appear only for a specific device, or screen sizes. */
   only: PropTypes.oneOf(GridColumn._meta.props.only),
+
+  /** An can stretch its contents to take up the entire column height. */
+  stretched: PropTypes.bool,
 
   /** A column can specify a width for a tablet device. */
   tablet: PropTypes.oneOf(GridColumn._meta.props.width),

--- a/src/collections/Grid/GridColumn.js
+++ b/src/collections/Grid/GridColumn.js
@@ -90,7 +90,7 @@ GridColumn.propTypes = {
   /** A column can appear only for a specific device, or screen sizes. */
   only: PropTypes.oneOf(GridColumn._meta.props.only),
 
-  /** An can stretch its contents to take up the entire column height. */
+  /** An can stretch its contents to take up the entire grid or row height. */
   stretched: PropTypes.bool,
 
   /** A column can specify a width for a tablet device. */

--- a/test/specs/collections/Grid/Grid-test.js
+++ b/test/specs/collections/Grid/Grid-test.js
@@ -19,5 +19,6 @@ describe('Grid', () => {
   common.propKeyOrValueToClassName(Grid, 'relaxed')
   common.propKeyAndValueToClassName(Grid, 'reversed')
   common.propKeyOnlyToClassName(Grid, 'stackable')
+  common.propKeyOnlyToClassName(Grid, 'stretched')
   common.rendersChildren(Grid)
 })

--- a/test/specs/collections/Grid/GridColumn-test.js
+++ b/test/specs/collections/Grid/GridColumn-test.js
@@ -26,5 +26,6 @@ describe('GridColumn', () => {
   common.propValueOnlyToClassName(GridColumn, 'color')
   common.propKeyAndValueToClassName(GridColumn, 'floated')
   common.propKeyAndValueToClassName(GridColumn, 'only')
+  common.propKeyOnlyToClassName(GridColumn, 'stretched')
   common.rendersChildren(GridColumn)
 })


### PR DESCRIPTION
This PR addes `stretched` prop to `Grid` and `Grid.Column`. This behavior is missing in SUI docs of `Grid`, but:
- [stretched](https://github.com/Semantic-Org/UI-Grid/blob/master/grid.css#L1246) in `grid.css`;
- `stretched` in [`Menu`](http://semantic-ui.com/collections/menu.html#tabular) docs.
