### PR TITLE
feat(Dropdown): Add Header sub-component

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -18,6 +18,7 @@ import { createIcon } from '../../factories'
 import { Label } from '../../elements'
 import DropdownDivider from './DropdownDivider'
 import DropdownItem from './DropdownItem'
+import DropdownHeader from './DropdownHeader'
 import DropdownMenu from './DropdownMenu'
 
 const debug = makeDebugger('dropdown')
@@ -211,6 +212,7 @@ export default class Dropdown extends Component {
 
   static _meta = _meta
   static Divider = DropdownDivider
+  static Header = DropdownHeader
   static Item = DropdownItem
   static Menu = DropdownMenu
 

--- a/src/modules/Dropdown/DropdownHeader.js
+++ b/src/modules/Dropdown/DropdownHeader.js
@@ -1,0 +1,35 @@
+import cx from 'classnames'
+import React, { PropTypes } from 'react'
+
+import { getElementType, getUnhandledProps, META } from '../../lib'
+
+function DropdownHeader(props) {
+  const { className, children } = props
+  const classes = cx('header', className)
+  const rest = getUnhandledProps(DropdownHeader, props)
+  const ElementType = getElementType(DropdownHeader, props)
+
+  return <ElementType className={classes} {...rest}>{children}</ElementType>
+}
+
+DropdownHeader._meta = {
+  name: 'DropdownHeader',
+  parent: 'Dropdown',
+  type: META.TYPES.MODULE,
+}
+
+DropdownHeader.propTypes = {
+  /** An element type to render as (string or function) */
+  as: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+  ]),
+
+  /** Primary content */
+  children: PropTypes.node,
+
+  /** Additional classes */
+  className: PropTypes.node,
+}
+
+export default DropdownHeader

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1,10 +1,14 @@
-import faker from 'faker'
 import _ from 'lodash'
+import faker from 'faker'
 import React from 'react'
 
-import Dropdown from 'src/modules/Dropdown/Dropdown'
 import * as common from 'test/specs/commonTests'
 import { domEvent, sandbox } from 'test/utils'
+import Dropdown from 'src/modules/Dropdown/Dropdown'
+import DropdownDivider from 'src/modules/Dropdown/DropdownDivider'
+import DropdownHeader from 'src/modules/Dropdown/DropdownHeader'
+import DropdownItem from 'src/modules/Dropdown/DropdownItem'
+import DropdownMenu from 'src/modules/Dropdown/DropdownMenu'
 
 let attachTo
 let options
@@ -64,6 +68,7 @@ describe('Dropdown Component', () => {
 
   common.isConformant(Dropdown)
   common.hasUIClassName(Dropdown)
+  common.hasSubComponents(Dropdown, [DropdownDivider, DropdownHeader, DropdownItem, DropdownMenu])
   common.isTabbable(Dropdown)
   common.implementsIconProp(Dropdown)
   common.propKeyOnlyToClassName(Dropdown, 'multiple')

--- a/test/specs/modules/Dropdown/DropdownDivider-test.js
+++ b/test/specs/modules/Dropdown/DropdownDivider-test.js
@@ -1,0 +1,6 @@
+import DropdownDivider from 'src/modules/Dropdown/DropdownDivider'
+import * as common from 'test/specs/commonTests'
+
+describe('DropdownDivider', () => {
+  common.isConformant(DropdownDivider)
+})

--- a/test/specs/modules/Dropdown/DropdownHeader-test.js
+++ b/test/specs/modules/Dropdown/DropdownHeader-test.js
@@ -1,0 +1,7 @@
+import DropdownHeader from 'src/modules/Dropdown/DropdownHeader'
+import * as common from 'test/specs/commonTests'
+
+describe('DropdownHeader', () => {
+  common.isConformant(DropdownHeader)
+  common.rendersChildren(DropdownHeader)
+})

--- a/test/specs/modules/Dropdown/DropdownItem-test.js
+++ b/test/specs/modules/Dropdown/DropdownItem-test.js
@@ -3,6 +3,7 @@ import * as common from 'test/specs/commonTests'
 
 describe('DropdownItem', () => {
   common.isConformant(DropdownItem)
+  common.rendersChildren(DropdownItem)
   common.propKeyOnlyToClassName(DropdownItem, 'selected')
   common.propKeyOnlyToClassName(DropdownItem, 'active')
 })


### PR DESCRIPTION
This PR:
- adds `Header` subcomponent ([**#382**](https://github.com/TechnologyAdvice/stardust/pull/382#discussion_r77453498));
- adds tests to `DropdownDivider`;
- adds `common.rendersChildren` test to `DropdownItem`.
