### PR TITLE
fix(customPropTypes): show all errors if some() fails

### DIFF
--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -99,18 +99,20 @@ export const some = (validators) => {
       ].join(' '))
     }
 
-    const errors = _.map(validators, validator => {
+    const errors = _.compact(_.map(validators, validator => {
       if (!_.isFunction(validator)) {
         throw new Error(
           `any() argument "validators" should contain functions, found: ${type(validator)}.`
         )
       }
       return validator(props, propName, componentName, ...rest)
-    })
+    }))
 
-    // if no validator passed return the first error found
-    if (!_.some(errors, _.overSome(_.isNull, _.isUndefined))) {
-      return _.find(errors, error => !_.isUndefined(error))
+    // fail only if all validators failed
+    if (errors.length === validators.length) {
+      const error = new Error('One of these validators must pass:')
+      error.message += '\n' + _.map(errors, (err, i) => (`[${i + 1}]: ${err.message}`)).join('\n')
+      return error
     }
   }
 }


### PR DESCRIPTION
The `some()` validator requires at least one prop type validator to pass.  Currently, if they all fail we show only the first validator error message.

This is not helpful as the first error may not be applicable to the usage, perhaps it is the 3rd error that should be resolved for a particular usage.  This PR updates the error message to include all errors messages so the user can correct at least one.  Resulting in `some()` validator passing:

```
Warning: Failed prop type: One of these validators must pass:
[1]: Invalid prop `labeled` of type `string` supplied to `Button`, expected `boolean`.
[2]: Invalid prop `labeled` of value `icon` supplied to `Button`, expected one of ["left icon","right icon"].
    in Button (created by ButtonLabeledIconExample)
    ...
```
