### PR TITLE
feat(Dropdown): editable search

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Types/Selection.js
+++ b/docs/app/Examples/modules/Dropdown/Types/Selection.js
@@ -14,6 +14,7 @@ export default class DropdownSelectionExample extends Component {
       isFetching: false,
       multiple: true,
       search: true,
+      editableSearch: false,
       searchQuery: null,
       value: [],
       options: getOptions(),
@@ -38,7 +39,12 @@ export default class DropdownSelectionExample extends Component {
     this.setState({ value: multiple ? [value] : value })
   }
 
-  toggleSearch = (e) => this.setState({ search: e.target.checked })
+  toggleSearch = (e) => this.setState({
+    search: e.target.checked,
+    editableSearch: e.target.checked ? this.state.editableSearch : false,
+  })
+
+  toggleEditableSearch = (e) => this.setState({ editableSearch: e.target.checked })
 
   toggleMultiple = (e) => {
     const { value } = this.state
@@ -49,7 +55,7 @@ export default class DropdownSelectionExample extends Component {
   }
 
   render() {
-    const { multiple, options, isFetching, search, value } = this.state
+    const { multiple, options, isFetching, search, value, editableSearch } = this.state
 
     return (
       <Grid>
@@ -62,6 +68,12 @@ export default class DropdownSelectionExample extends Component {
             </label>
             {' '}
             <label>
+              <input type='checkbox' checked={editableSearch && search}
+                disabled={!search} onChange={this.toggleEditableSearch}
+              /> Editable Search
+            </label>
+            {' '}
+            <label>
               <input type='checkbox' checked={multiple} onChange={this.toggleMultiple} /> Multiple
             </label>
           </p>
@@ -70,6 +82,7 @@ export default class DropdownSelectionExample extends Component {
             selection
             multiple={multiple}
             search={search}
+            editableSearch={editableSearch}
             options={options}
             value={value}
             placeholder='Add Users'

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1071,6 +1071,84 @@ describe('Dropdown Component', () => {
         .at(1)
         .should.not.have.prop('selected', true)
     })
+
+    describe('editableSearch', () => {
+      it('sets the current value text as value prop to the search input', () => {
+        wrapperShallow(
+          <Dropdown name='foo' value={options[1].value} options={options} selection search editableSearch />
+        )
+          .should.have.descendants('input.search')
+
+        wrapper.find('input.search').should.have.prop('value', options[1].text)
+      })
+
+      it('does not set the current value text as value prop to the search input when multiple is true', () => {
+        wrapperShallow(
+          <Dropdown name='foo' value={[options[1].value]} options={options} selection search editableSearch multiple />
+        )
+          .should.have.descendants('input.search')
+
+        wrapper.find('input.search').should.have.prop('value', '')
+      })
+
+      it('sets the current value text as value prop to the search input when editableSearch is changed to true', () => {
+        wrapperShallow(<Dropdown name='foo' value={options[1].value} options={options} selection search />)
+          .should.have.descendants('input.search')
+
+        wrapper.find('input.search').should.have.prop('value', '')
+
+        wrapper.setProps({ editableSearch: true })
+
+        wrapper.find('input.search').should.have.prop('value', options[1].text)
+      })
+
+      it('does not set the current value text as value prop to the search input when'
+        + ' editableSearch is changed to false', () => {
+        wrapperShallow(
+          <Dropdown name='foo' value={options[1].value} options={options} selection search editableSearch />
+        )
+          .should.have.descendants('input.search')
+
+        wrapper.find('input.search').should.have.prop('value', options[1].text)
+
+        wrapper.setProps({ editableSearch: false })
+
+        wrapper.find('input.search').should.have.prop('value', '')
+      })
+
+      it('does not set the current value text as value prop to the search input when'
+        + ' editableSearch is changed to true and multiple is true', () => {
+        wrapperShallow(<Dropdown name='foo' value={[options[1].value]} options={options} selection search multiple />)
+          .should.have.descendants('input.search')
+
+        wrapper.find('input.search').should.have.prop('value', '')
+
+        wrapper.setProps({ editableSearch: true })
+
+        wrapper.find('input.search').should.have.prop('value', '')
+      })
+
+      it('does not clear the search query when an item is selected', () => {
+        // search for random item
+        const searchQuery = _.sample(options).text
+
+        wrapperMount(<Dropdown options={options} selection search editableSearch />)
+
+        // open and simulate search
+        wrapper
+          .simulate('click')
+          .setState({ searchQuery })
+
+        // click first item (we searched for exact text)
+        wrapper
+          .find('DropdownItem')
+          .first()
+          .simulate('click')
+
+        // search query still here
+        wrapper.should.have.state('searchQuery', searchQuery)
+      })
+    })
   })
 
   describe('no results message', () => {


### PR DESCRIPTION
I added an extra property `editableSearch` that allows you to edit the search query of a Dropdown also after it previously lost focus.

**How to use**: 
1. Select an option in the dropdown. The dropdown will close.
2. Click in the dropdown search input.
3. Your search query is set to the current value and you can adapt the search query from here.

**Use case**: You have `allowAdditions` set to true. With `editableSearch` you can easily edit your custom value by clicking in the search input again and changing part of your value.

![sep-08-2016 17-49-12](https://cloud.githubusercontent.com/assets/5985577/18356363/b03c1018-75ec-11e6-9882-901fc2e23609.gif)
