### PR TITLE
fix(createFactory): do not create elements from `null` values

### DIFF
--- a/src/factories/createFactory.js
+++ b/src/factories/createFactory.js
@@ -19,7 +19,7 @@ const mergePropsAndClassName = (props, extraProps) => {
 /**
  * Return a function that produces ReactElements.  Similar to React.createFactory with some extras.
  * If the returned factory is passed a ReactElement it will be cloned.
- * If it passed undefined it will do nothing.
+ * If it passed null or undefined it will do nothing.
  * @param {function|string} Component A ReactClass or string
  * @param {function} mapValueToProps A function that maps a primitive value to the Component props
  * @param {function} [mergeExtraProps=mergePropsAndClassName]
@@ -38,7 +38,7 @@ const createFactory = (Component, mapValueToProps, mergeExtraProps = mergePropsA
     }
 
     // Map values to props and create an ReactElement
-    if (val !== undefined) {
+    if (!_.isNil(val)) {
       return <Component {...mergeExtraProps(mapValueToProps(val), extraProps)} />
     }
   }

--- a/test/specs/commonTests.js
+++ b/test/specs/commonTests.js
@@ -514,13 +514,13 @@ export const implementsWidthProp = (Component, options, requiredProps = {}) => {
 
 export const implementsIconProp = (Component, requiredProps = {}) => {
   const iconName = faker.hacker.noun()
-  const assertValid = (element) => {
+  const assertValid = (element, expectedName = iconName) => {
     const wrapper = shallow(element)
     wrapper
       .should.have.descendants('Icon')
     wrapper
       .find('Icon')
-      .should.have.prop('name', iconName)
+      .should.have.prop('name', expectedName)
   }
 
   describe('icon (common)', () => {
@@ -528,9 +528,20 @@ export const implementsIconProp = (Component, requiredProps = {}) => {
 
     _noDefaultClassNameFromProp(Component, 'icon')
 
-    it('has no i when not defined', () => {
-      shallow(<Component />)
-        .should.not.have.descendants('i')
+    if (Component.defaultProps && Component.defaultProps.icon) {
+      it('has default Icon when not defined', () => {
+        assertValid(<Component />, Component.defaultProps.icon)
+      })
+    } else {
+      it('has no Icon when not defined', () => {
+        shallow(<Component />)
+          .should.not.have.descendants('Icon')
+      })
+    }
+
+    it('has no Icon when null', () => {
+      shallow(<Component icon={null} />)
+        .should.not.have.descendants('Icon')
     })
 
     it('accepts an Icon instance', () => {
@@ -556,9 +567,14 @@ export const implementsImageProp = (Component, requiredProps = {}) => {
 
     _noDefaultClassNameFromProp(Component, 'image')
 
-    it('has no img when prop is not defined', () => {
+    it('has no Image when prop is not defined', () => {
       shallow(<Component />)
-        .should.not.have.descendants('img')
+        .should.not.have.descendants('Image')
+    })
+
+    it('has no Image when prop is null', () => {
+      shallow(<Component image={null} />)
+        .should.not.have.descendants('Image')
     })
 
     it('adds a img as first child', () => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -106,6 +106,11 @@ describe('Dropdown Component', () => {
       wrapperRender(<Dropdown />)
         .should.contain.descendants('.dropdown.icon')
     })
+    it('allows disabling icon via null', () => {
+      Dropdown.defaultProps.icon.should.equal('dropdown')
+      wrapperRender(<Dropdown icon={null} />)
+        .should.not.contain.descendants('.icon')
+    })
   })
 
   describe('selected item', () => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -106,11 +106,6 @@ describe('Dropdown Component', () => {
       wrapperRender(<Dropdown />)
         .should.contain.descendants('.dropdown.icon')
     })
-    it('allows disabling icon via null', () => {
-      Dropdown.defaultProps.icon.should.equal('dropdown')
-      wrapperRender(<Dropdown icon={null} />)
-        .should.not.contain.descendants('.icon')
-    })
   })
 
   describe('selected item', () => {


### PR DESCRIPTION
Before this PR, all three of these specs failed:

```
    it('allows disabling icon via null', () => {
      Dropdown.defaultProps.icon.should.equal('dropdown')
      wrapperRender(<Dropdown icon={null} />)
        .should.not.contain.descendants('.icon')
    })
    it('allows disabling icon via undefined', () => {
      Dropdown.defaultProps.icon.should.equal('dropdown')
      wrapperRender(<Dropdown icon={undefined} />)
        .should.not.contain.descendants('.icon')
    })
    it("allows disabling icon via ''", () => {
      Dropdown.defaultProps.icon.should.equal('dropdown')
      wrapperRender(<Dropdown icon={''} />)
        .should.not.contain.descendants('.icon')
    })
```

...meaning there's no way to disable the icon on the `Dropdown` component. I'd say the third probably shouldn't disable it (it would have an icon element with an empty name), but one of the first two should.

This updates `createFactory` to do nothing for both `undefined` and `null`. Previously it only ignored `undefined`, which meant for components that had a default value (e.g. Dropdown icon defaults to `dropdown`) there was no way to disable it. The default prop will override `undefined` but it won't override `null`.

There may be wider implications to consider, but I figured it'd be easier/faster to discuss this over a PR with a potential fix vs an issue.
