### PR TITLE
feat(Dropdown): support disabled items

### DIFF
--- a/docs/app/Examples/modules/Dropdown/States/DisabledItem.js
+++ b/docs/app/Examples/modules/Dropdown/States/DisabledItem.js
@@ -1,0 +1,15 @@
+import _ from 'lodash'
+import faker from 'faker'
+import React from 'react'
+import { Dropdown } from 'stardust'
+
+const options = _.times(10, (i) => {
+  const name = faker.name.findName()
+  return { text: name, value: _.snakeCase(name), disabled: i % 3 === 0 }
+})
+
+const DropdownItemDisabledExample = () => (
+  <Dropdown text='Dropdown' options={options} />
+)
+
+export default DropdownItemDisabledExample

--- a/docs/app/Examples/modules/Dropdown/index.js
+++ b/docs/app/Examples/modules/Dropdown/index.js
@@ -43,8 +43,13 @@ const DropdownExamples = () => (
     <ExampleSection title='States'>
       <ComponentExample
         title='Disabled'
-        description='A disabled dropdown menu or item does not allow user interaction'
+        description='A disabled dropdown menu does not allow user interaction'
         examplePath='modules/Dropdown/States/Disabled'
+      />
+      <ComponentExample
+        title='Disabled Item'
+        description='A disabled dropdown item does not allow user interaction'
+        examplePath='modules/Dropdown/States/DisabledItem'
       />
     </ExampleSection>
   </div>

--- a/docs/app/Examples/modules/Dropdown/index.js
+++ b/docs/app/Examples/modules/Dropdown/index.js
@@ -43,12 +43,10 @@ const DropdownExamples = () => (
     <ExampleSection title='States'>
       <ComponentExample
         title='Disabled'
-        description='A disabled dropdown menu does not allow user interaction'
+        description='A disabled dropdown menu or item does not allow user interaction'
         examplePath='modules/Dropdown/States/Disabled'
       />
       <ComponentExample
-        title='Disabled Item'
-        description='A disabled dropdown item does not allow user interaction'
         examplePath='modules/Dropdown/States/DisabledItem'
       />
     </ExampleSection>

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -385,10 +385,10 @@ export default class Dropdown extends Component {
 
   selectHighlightedItem = (e) => {
     const { multiple, onAddItem, options } = this.props
-    const { value, disabled } = this.getSelectedItem() || {}
+    const value = _.get(this.getSelectedItem(), 'value')
 
-    // prevent selecting null (if there was no selected item value) or disabled options
-    if (!value || disabled) return
+    // prevent selecting null if there was no selected item value
+    if (!value) return
 
     // notify the onAddItem prop if this is a new value
     if (onAddItem && !_.some(options, { text: value })) onAddItem(value)
@@ -519,7 +519,7 @@ export default class Dropdown extends Component {
     if (search && newQuery && !open) this.open()
 
     this.setState({
-      selectedIndex: 0,
+      selectedIndex: this.getEnabledIndices()[0],
       searchQuery: newQuery,
     })
   }
@@ -528,9 +528,11 @@ export default class Dropdown extends Component {
   // Getters
   // ----------------------------------------
 
-  getMenuOptions = () => {
+  // There are times when we need to calculate the options based on a value
+  // that hasn't yet been persisted to state.
+  getMenuOptions = (value = this.state.value) => {
     const { multiple, search, allowAdditions, additionPosition, additionLabel, options } = this.props
-    const { searchQuery, value } = this.state
+    const { searchQuery } = this.state
 
     let filteredOptions = options
 
@@ -565,6 +567,15 @@ export default class Dropdown extends Component {
     return _.get(options, `[${selectedIndex}]`)
   }
 
+  getEnabledIndices = (givenOptions) => {
+    const options = givenOptions || this.getMenuOptions()
+
+    return _.reduce(options, (memo, item, index) => {
+      if (!item.disabled) memo.push(index)
+      return memo
+    }, [])
+  }
+
   getItemByValue = (value) => {
     const { options } = this.props
     return _.find(options, { value })
@@ -585,27 +596,34 @@ export default class Dropdown extends Component {
     debug('value', value)
     const { multiple } = this.props
     const { selectedIndex } = this.state
-    const options = this.getMenuOptions()
+    const options = this.getMenuOptions(value)
+    const enabledIndicies = this.getEnabledIndices(options)
     const newState = {
       searchQuery: '',
     }
 
     // update the selected index
     if (!selectedIndex) {
+      const firstIndex = enabledIndicies[0]
+
       // Select the currently active item, if none, use the first item.
       // Multiple selects remove active items from the list,
       // their initial selected index should be 0.
-      newState.selectedIndex = multiple ? 0 : this.getMenuItemIndexByValue(value || _.get(options, '[0].value'))
+      newState.selectedIndex = multiple
+        ? firstIndex
+        : this.getMenuItemIndexByValue(value || _.get(options, `[${firstIndex}].value`))
     } else if (multiple) {
       // multiple selects remove options from the menu as they are made active
       // keep the selected index within range of the remaining items
       if (selectedIndex >= options.length - 1) {
-        newState.selectedIndex = selectedIndex - 1
+        newState.selectedIndex = enabledIndicies[enabledIndicies.length - 1]
       }
     } else {
+      const activeIndex = this.getMenuItemIndexByValue(value)
+
       // regular selects can only have one active item
       // set the selected index to the currently active item
-      newState.selectedIndex = this.getMenuItemIndexByValue(value)
+      newState.selectedIndex = _.includes(enabledIndicies, activeIndex) ? activeIndex : undefined
     }
 
     this.trySetState({ value }, newState)
@@ -626,10 +644,9 @@ export default class Dropdown extends Component {
     this.onChange(e, newValue)
   }
 
-  moveSelectionBy = (offset) => {
+  moveSelectionBy = (offset, startIndex = this.state.selectedIndex) => {
     debug('moveSelectionBy()')
     debug(`offset: ${offset}`)
-    const { selectedIndex } = this.state
 
     const options = this.getMenuOptions()
     const lastIndex = options.length - 1
@@ -639,14 +656,13 @@ export default class Dropdown extends Component {
 
     // next is after last, wrap to beginning
     // next is before first, wrap to end
-    let nextIndex = selectedIndex + offset
+    let nextIndex = startIndex + offset
     if (nextIndex > lastIndex) nextIndex = 0
     else if (nextIndex < 0) nextIndex = lastIndex
 
+    if (options[nextIndex].disabled) return this.moveSelectionBy(offset, nextIndex)
+
     this.setState({ selectedIndex: nextIndex })
-
-    if (options[nextIndex].disabled) return this.moveSelectionBy(offset)
-
     this.scrollSelectedItemIntoView()
   }
 

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -16,6 +16,7 @@ function DropdownItem(props) {
     active,
     children,
     className,
+    disabled,
     description,
     icon,
     onClick,
@@ -30,6 +31,7 @@ function DropdownItem(props) {
 
   const classes = cx(
     useKeyOnly(active, 'active'),
+    useKeyOnly(disabled, 'disabled'),
     useKeyOnly(selected, 'selected'),
     'item',
     className,
@@ -77,6 +79,9 @@ DropdownItem.propTypes = {
 
   /** Additional text with less emphasis. */
   description: PropTypes.string,
+
+  /** A dropdown item can be disabled. */
+  disabled: PropTypes.bool,
 
   /** Add an icon to the item. */
   icon: PropTypes.string,

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -115,6 +115,27 @@ describe('Dropdown Component', () => {
         .first()
         .should.have.prop('selected', true)
     })
+    it('defaults to the first non-disabled item', () => {
+      options[0].disabled = true
+      wrapperShallow(<Dropdown options={options} selection />)
+
+      // selection moved to second item
+      wrapper
+        .find('DropdownItem')
+        .first()
+        .should.have.prop('selected', false)
+
+      wrapper
+        .find('DropdownItem')
+        .at(1)
+        .should.have.prop('selected', true)
+    })
+    it('is null when all options disabled', () => {
+      const disabledOptions = options.map((o) => ({ ...o, disabled: true }))
+
+      wrapperRender(<Dropdown options={disabledOptions} selection />)
+        .should.not.have.descendants('.selected')
+    })
     it('is set when clicking an item', () => {
       // random item, skip the first as its selected by default
       const randomIndex = 1 + _.random(options.length - 2)
@@ -137,7 +158,7 @@ describe('Dropdown Component', () => {
         .find('DropdownItem')
         .at(randomIndex)
         .simulate('click', nativeEvent)
-        .should.have.not.prop('selected', true)
+        .should.not.have.prop('selected', true)
 
       dropdownMenuIsOpen()
     })
@@ -298,23 +319,6 @@ describe('Dropdown Component', () => {
       domEvent.keyDown(document, { key: 'Enter' })
 
       item.should.have.prop('active', true)
-    })
-    it('does not become active on enter when disabled', () => {
-      const disabledOptions = _.map(options, (o) => ({ ...o, disabled: true }))
-      const item = wrapperMount(<Dropdown options={disabledOptions} selection />)
-        .simulate('click')
-        .find('DropdownItem')
-        .at(0)
-
-      // initial item props
-      item.should.have.prop('selected', true)
-      item.should.have.prop('active', false)
-
-      // attempt to make active
-      domEvent.keyDown(document, { key: 'Enter' })
-
-      item.should.have.prop('active', false)
-      dropdownMenuIsOpen()
     })
     it('closes the menu', () => {
       wrapperMount(<Dropdown options={options} selection />)


### PR DESCRIPTION
Addresses #478

I added code that should handle ignoring a click on the dropdown item and keeping the menu open. However, the onClick is never getting called so the event is bubbling to the `Dropdown` element itself which is toggling it's visibility.

Is there some magic happening somewhere that disables clicks on an element with `disabled` passed as props? As you can see, it's not being applied onto the element. It's just being used to add the `disabled` class.

_EDIT_ AHH it's `pointer-events: none;` 😞 . Thoughts on how to handle this? Two ideas:
- manually enable pointer-events via inline style
- in the dropdown `handleClick` function, check if the click was within the menu (can you even do that with synthetic events?) and ignore it.

I don't love either of those idea, tbh.
