### PR TITLE
chore(karma): clean and format stacktraces

### DIFF
--- a/config.js
+++ b/config.js
@@ -53,7 +53,7 @@ config = Object.assign({}, config, {
   // Compiler Configuration
   // ----------------------------------
   compiler_devtool: __DEV__ && 'eval-cheap-module-source-map'
-  || __TEST__ && 'cheap-module-source-map'
+  || __TEST__ && 'source-map'
   || __STAGING__ && 'source-map',
   compiler_hash_type: __PROD__ ? 'chunkhash' : 'hash',
   compiler_inline_manifest: false,

--- a/docs/app/Examples/elements/Button/Types/ButtonLabeledBasicExample.js
+++ b/docs/app/Examples/elements/Button/Types/ButtonLabeledBasicExample.js
@@ -14,7 +14,7 @@ const ButtonLabeledExample = () => (
       <Button basic color='blue'>
         <Icon name='fork' /> Fork
       </Button>
-      <Label basic color='blue' pointing='left' link>1,048</Label>
+      <Label as='a' basic color='blue' pointing='left'>1,048</Label>
     </Button>
   </div>
 )

--- a/docs/app/Examples/elements/Button/Types/ButtonLabeledExample.js
+++ b/docs/app/Examples/elements/Button/Types/ButtonLabeledExample.js
@@ -7,18 +7,18 @@ const ButtonLabeledExample = () => (
       <Button>
         <Icon name='heart' /> Like
       </Button>
-      <Label basic link>2,048</Label>
+      <Label as='a' basic>2,048</Label>
     </Button>
 
     <Button labeled='left'>
-      <Label basic pointing='right' link>2,048</Label>
+      <Label as='a' basic pointing='right'>2,048</Label>
       <Button>
         <Icon name='heart' /> Like
       </Button>
     </Button>
 
     <Button labeled='left'>
-      <Label basic link>2,048</Label>
+      <Label as='a' basic>2,048</Label>
       <Button icon>
         <Icon name='fork' />
       </Button>

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "html-webpack-plugin": "^2.17.0",
     "imports-loader": "^0.6.4",
     "json-loader": "^0.5.3",
-    "karma": "^1.2.0",
+    "karma": "^1.3.0",
     "karma-cli": "^1.0.0",
     "karma-coverage": "^1.0.0",
     "karma-mocha": "^1.1.1",

--- a/src/factories/index.js
+++ b/src/factories/index.js
@@ -38,4 +38,4 @@ export const createImg = createFactory('img', value => ({ src: value }))
  * @param {object} [props = {}] Optional additional props.
  * @returns {ReactElement|undefined}
  */
-export const createLabel = createFactory(Label, value => ({ text: value }))
+export const createLabel = createFactory(Label, value => ({ content: value }))

--- a/test/specs/commonTests.js
+++ b/test/specs/commonTests.js
@@ -561,14 +561,14 @@ export const implementsIconProp = (Component, requiredProps = {}) => {
 
 export const implementsLabelProp = (Component, requiredProps = {}) => {
   const labelText = faker.hacker.phrase()
-  const assertValid = (element) => {
+  const assertValid = (element, expectedText = labelText) => {
     const wrapper = shallow(element)
     wrapper
       .should.have.descendants('Label')
     wrapper
       .find('Label')
       .shallow()
-      .should.have.text(labelText)
+      .should.have.text(expectedText)
   }
 
   describe('label (common)', () => {
@@ -595,8 +595,9 @@ export const implementsLabelProp = (Component, requiredProps = {}) => {
     it('accepts Label text string', () => {
       assertValid(<Component {...requiredProps} label={labelText} />)
     })
+
     it('accepts a Label props object', () => {
-      assertValid(<Component {...requiredProps} label={{ text: labelText }} />)
+      assertValid(<Component {...requiredProps} label={{ children: labelText }} />)
     })
   })
 }


### PR DESCRIPTION
🎉 I submitted a [PR to Karma](https://github.com/karma-runner/karma/pull/2313) to allow formatting errors.  Now, when tests fail, we get this:
# After

```
FAILED TESTS:
  Input
    ✖ renders child text
      PhantomJS 2.1.1 (Mac OS X 0.0.0)
      undefined is not an object (evaluating 'child.type._meta')
        src/elements/Input/Input.js                                        85:79
        src/elements/Input/Input.js @ render()                             84:21
        test/specs/commonTests.js                                         407:12
```
# Before

```
FAILED TESTS:
  Input
    ✖ renders child text
      PhantomJS 2.1.1 (Mac OS X 0.0.0)
    undefined is not an object (evaluating 'child.type._meta')
    webpack:///src/elements/Input/Input.js:85:79 <- test/tests.bundle.js:86957
:116
    forEachSingleChild@webpack:///~/react/lib/ReactChildren.js:52:0 <- test/te
sts.bundle.js:9702:13
    traverseAllChildrenImpl@webpack:///~/react/lib/traverseAllChildren.js:69:0
 <- test/tests.bundle.js:10687:14
    traverseAllChildren@webpack:///~/react/lib/traverseAllChildren.js:164:0 <-
 test/tests.bundle.js:10782:34
    forEachChildren@webpack:///~/react/lib/ReactChildren.js:72:0 <- test/tests
.bundle.js:9722:23
    render@webpack:///src/elements/Input/Input.js:84:21 <- test/tests.bundle.j
s:86954:31
    _renderValidatedComponentWithoutOwnerOrContext@webpack:///~/react/lib/Reac
tCompositeComponent.js:808:0 <- test/tests.bundle.js:25444:41
    performInitialMount@webpack:///~/react/lib/ReactCompositeComponent.js:372:
0 <- test/tests.bundle.js:25008:56
    mountComponent@webpack:///~/react/lib/ReactCompositeComponent.js:260:0 <-
test/tests.bundle.js:24896:41
    mountComponent@webpack:///~/react/lib/ReactReconciler.js:47:0 <- test/test
s.bundle.js:17386:50
    _render@webpack:///~/react/lib/ReactTestUtils.js:402:0 <- test/tests.bundl
e.js:13886:36
    _batchedRender@webpack:///~/react/lib/ReactTestUtils.js:383:0 <- test/test
s.bundle.js:13867:20
    batchedUpdates@webpack:///~/react/lib/ReactDefaultBatchingStrategy.js:61:0
 <- test/tests.bundle.js:27203:16
    batchedUpdates@webpack:///~/react/lib/ReactUpdates.js:98:0 <- test/tests.b
undle.js:17043:35
    render@webpack:///~/react/lib/ReactTestUtils.js:376:0 <- test/tests.bundle
.js:13860:31
    render@webpack:///~/enzyme/build/react-compat.js:153:0 <- test/tests.bundl
e.js:70280:44
    webpack:///~/enzyme/build/ShallowWrapper.js:90:0 <- test/tests.bundle.js:7
2116:33
    perform@webpack:///~/react/lib/Transaction.js:138:0 <- test/tests.bundle.j
s:18379:25
    batchedUpdates@webpack:///~/react/lib/ReactDefaultBatchingStrategy.js:63:0
 <- test/tests.bundle.js:27205:27
    batchedUpdates@webpack:///~/react/lib/ReactUpdates.js:98:0 <- test/tests.b
undle.js:17043:35
    webpack:///~/enzyme/build/ShallowWrapper.js:89:0 <- test/tests.bundle.js:7
2115:42
    withSetStateAllowed@webpack:///~/enzyme/build/Utils.js:196:0 <- test/tests
.bundle.js:69021:6
    ShallowWrapper@webpack:///~/enzyme/build/ShallowWrapper.js:88:0 <- test/te
sts.bundle.js:72114:39
    shallow@webpack:///~/enzyme/build/shallow.js:19:0 <- test/tests.bundle.js:
73538:42
    webpack:///test/specs/commonTests.js:407:12 <- test/tests.bundle.js:101646
:13
```
