### PR TITLE
fix(package): remove bad engines versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,6 @@
     "url": "https://github.com/TechnologyAdvice/stardust/issues"
   },
   "homepage": "https://github.com/TechnologyAdvice/stardust#readme",
-  "engines": {
-    "node": "0.12 - 5",
-    "npm": "2 - 4"
-  },
   "dependencies": {
     "classnames": "^2.1.5",
     "debug": "^2.2.0",


### PR DESCRIPTION
Resolves https://github.com/TechnologyAdvice/stardust/issues/491.

I could be totally wrong about the original issue, but I believe it's a syntax issue. The suggested syntax for specifying version ranges is:

``` js
{
  "node": ">=0.12.0",
  "npm": ">=2.0.0"
}
```

My initial PR was just to fix the syntax and let us carry on, but after considering it a bit further I think we could just get rid of these altogether. Local Stardust development is done through webpack with Babel transforms, as is its deployment, and users are not interacting directly with this package with Node, so specifying these versions is not meaningful in any real way.
