### PR TITLE
fix(dropdown): Label props for multi-select

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -821,10 +821,10 @@ export default class Dropdown extends Component {
       return (
         <Label
           key={item.value}
-          text={item.text}
+          as={'a'}
+          content={item.text}
           value={item.value}
           onRemove={this.handleLabelRemove}
-          link
         />
       )
     })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -654,7 +654,7 @@ describe('Dropdown Component', () => {
 
       wrapper
         .find('Label')
-        .should.have.prop('text', activeItem.text)
+        .should.have.prop('content', activeItem.text)
     })
     it('keeps the selection within the range of remaining options', () => {
       // items are removed as they are made active


### PR DESCRIPTION
The labels for the `multiple` dropdown type were broken since they were using the old props. This fixes it.
