### PR TITLE
pass dataKey params to headerRenderer in Table.js

### DIFF
--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -98,7 +98,7 @@ export default class Table extends Component {
   }
 
   _getHeaders() {
-    const { children, data, sort } = this.props
+    const { children, sort } = this.props
 
     return Children.map(children, (column) => {
       const { dataKey, headerRenderer } = column.props

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -102,7 +102,7 @@ export default class Table extends Component {
 
     return Children.map(children, (column) => {
       const { dataKey, headerRenderer } = column.props
-      const content = headerRenderer ? headerRenderer(data[0]) : _.startCase(dataKey)
+      const content = headerRenderer ? headerRenderer(dataKey) : _.startCase(dataKey)
       const isSorted = sort.key === dataKey
       const onClick = () => this._handleSortHeaderChange(
         dataKey, sort.direction === 'ascending' ? 'descending' : 'ascending'


### PR DESCRIPTION
if data is initialized with [] we will get error because data[0] is undefined.
we should pass dataKey to get correct header content.
