### PR TITLE
fix(Dropdown): open/close on focus/blur

### DIFF
--- a/config.js
+++ b/config.js
@@ -52,7 +52,7 @@ config = Object.assign({}, config, {
   // ----------------------------------
   // Compiler Configuration
   // ----------------------------------
-  compiler_devtool: __DEV__ && 'eval-cheap-module-source-map'
+  compiler_devtool: __DEV__ && 'source-map'
   || __TEST__ && 'source-map'
   || __STAGING__ && 'source-map',
   compiler_hash_type: __PROD__ ? 'chunkhash' : 'hash',

--- a/docs/app/Examples/modules/Dropdown/Types/Selection.js
+++ b/docs/app/Examples/modules/Dropdown/Types/Selection.js
@@ -48,13 +48,16 @@ export default class DropdownSelectionExample extends Component {
     this.setState({ multiple, value: newValue })
   }
 
+  toggle = () => this.setState({ open: !this.state.open })
+
   render() {
-    const { multiple, options, isFetching, search, value } = this.state
+    const { multiple, options, isFetching, open, search, value } = this.state
 
     return (
       <Grid>
         <Grid.Column width={8}>
           <p>
+            <Button onClick={this.toggle}>Toggle</Button>
             <Button onClick={this.fetchOptions}>Fetch</Button>
             <Button onClick={this.selectRandom} disabled={_.isEmpty(options)}>Random</Button>
             <label>
@@ -70,6 +73,7 @@ export default class DropdownSelectionExample extends Component {
             selection
             multiple={multiple}
             search={search}
+            open={open}
             options={options}
             value={value}
             placeholder='Add Users'

--- a/docs/app/Examples/modules/Dropdown/Types/Selection.js
+++ b/docs/app/Examples/modules/Dropdown/Types/Selection.js
@@ -48,16 +48,13 @@ export default class DropdownSelectionExample extends Component {
     this.setState({ multiple, value: newValue })
   }
 
-  toggle = () => this.setState({ open: !this.state.open })
-
   render() {
-    const { multiple, options, isFetching, open, search, value } = this.state
+    const { multiple, options, isFetching, search, value } = this.state
 
     return (
       <Grid>
         <Grid.Column width={8}>
           <p>
-            <Button onClick={this.toggle}>Toggle</Button>
             <Button onClick={this.fetchOptions}>Fetch</Button>
             <Button onClick={this.selectRandom} disabled={_.isEmpty(options)}>Random</Button>
             <label>
@@ -73,7 +70,6 @@ export default class DropdownSelectionExample extends Component {
             selection
             multiple={multiple}
             search={search}
-            open={open}
             options={options}
             value={value}
             placeholder='Add Users'

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -385,6 +385,7 @@ export default class Dropdown extends Component {
     debug('openOnSpace()')
     if (keyboardKey.getCode(e) !== keyboardKey.Spacebar) return
     if (this.state.open) return
+    e.preventDefault()
     this.trySetState({ open: true })
   }
 
@@ -393,6 +394,7 @@ export default class Dropdown extends Component {
     debug('openOnArrow()')
     if (!_.includes([keyboardKey.ArrowDown, keyboardKey.ArrowUp], code)) return
     if (this.state.open) return
+    e.preventDefault()
     this.trySetState({ open: true })
   }
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -27,7 +27,7 @@ const _meta = {
   name: 'Dropdown',
   type: META.TYPES.MODULE,
   props: {
-    pointing: ['bottom left', 'bottom right'],
+    pointing: ['left', 'right', 'top', 'top left', 'top right', 'bottom', 'bottom left', 'bottom right'],
     additionPosition: ['top', 'bottom'],
   },
 }
@@ -158,6 +158,9 @@ export default class Dropdown extends Component {
 
     /** Called with the React Synthetic Event on Dropdown focus. */
     onFocus: PropTypes.func,
+
+    /** Called with the React Synthetic Event on Dropdown mouse down. */
+    onMouseDown: PropTypes.func,
 
     // ------------------------------------
     // Style
@@ -379,19 +382,17 @@ export default class Dropdown extends Component {
   }
 
   openOnSpace = (e) => {
+    debug('openOnSpace()')
     if (keyboardKey.getCode(e) !== keyboardKey.Spacebar) return
     if (this.state.open) return
-    e.preventDefault()
-    // TODO open/close should only change state, open/closeMenu should be called on did update
     this.trySetState({ open: true })
   }
 
   openOnArrow = (e) => {
     const code = keyboardKey.getCode(e)
+    debug('openOnArrow()')
     if (!_.includes([keyboardKey.ArrowDown, keyboardKey.ArrowUp], code)) return
     if (this.state.open) return
-    e.preventDefault()
-    // TODO open/close should only change state, open/closeMenu should be called on did update
     this.trySetState({ open: true })
   }
 
@@ -456,8 +457,10 @@ export default class Dropdown extends Component {
   // Component Event Handlers
   // ----------------------------------------
 
-  handleMouseDown = () => {
+  handleMouseDown = (e) => {
     debug('handleMouseDown()')
+    const { onMouseDown } = this.props
+    if (onMouseDown) onMouseDown(e)
     this.isMouseDown = true
     document.addEventListener('mouseup', this.handleDocumentMouseUp)
   }
@@ -708,30 +711,15 @@ export default class Dropdown extends Component {
 
   open = () => {
     debug('open()')
-    debug(`dropdown is ${this.state.open ? 'already' : 'not yet'} open`)
-    if (this.state.open) return
     const { search } = this.props
     if (search) this._search.focus()
 
-    this.trySetState({
-      open: true,
-    }, {
-      dropdownClasses: 'active visible',
-      menuClasses: 'visible',
-    })
+    this.trySetState({ open: true })
   }
 
   close = () => {
     debug('close()')
-    debug(`dropdown is ${!this.state.open ? 'already' : 'not yet'} closed`)
-    if (!this.state.open) return
-
-    this.trySetState({
-      open: false,
-    }, {
-      dropdownClasses: '',
-      menuClasses: '',
-    })
+    this.trySetState({ open: false })
   }
 
   toggle = () => this.state.open ? this.close() : this.open()
@@ -874,7 +862,8 @@ export default class Dropdown extends Component {
 
   renderMenu = () => {
     const { children } = this.props
-    const { menuClasses } = this.state
+    const { open } = this.state
+    const menuClasses = open ? 'visible' : ''
 
     // single menu child
     if (children) {
@@ -895,7 +884,7 @@ export default class Dropdown extends Component {
     debug('render()')
     debug('props', this.props)
     debug('state', this.state)
-    const { dropdownClasses } = this.state
+    const { open } = this.state
 
     const {
       button,
@@ -922,7 +911,7 @@ export default class Dropdown extends Component {
     // Classes
     const classes = cx(
       'ui',
-      dropdownClasses,
+      open && 'active visible',
       useKeyOnly(disabled, 'disabled'),
       useKeyOnly(error, 'error'),
       useKeyOnly(loading, 'loading'),

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -251,23 +251,25 @@ export default class Dropdown extends Component {
     // TODO objectDiff still runs in prod, stop it
     debug('to props:', objectDiff(this.props, nextProps))
 
+    /* eslint-disable no-console */
     if (process.env.NODE_ENV !== 'production') {
       // in development, validate value type matches dropdown type
       const isNextValueArray = Array.isArray(nextProps.value)
       const hasValue = _.has(nextProps, 'value')
 
       if (hasValue && nextProps.multiple && !isNextValueArray) {
-        console.error( // eslint-disable-line no-console
+        console.error(
           'Dropdown `value` must be an array when `multiple` is set.' +
           ` Received type: \`${Object.prototype.toString.call(nextProps.value)}\`.`,
         )
       } else if (hasValue && !nextProps.multiple && isNextValueArray) {
-        console.error( // eslint-disable-line no-console
+        console.error(
           'Dropdown `value` must not be an array when `multiple` is not set.' +
           ' Either set `multiple={true}` or use a string or number value.'
         )
       }
     }
+    /* eslint-enable no-console */
 
     if (!_.isEqual(nextProps.value, this.props.value)) {
       debug('value changed, setting', nextProps.value)

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -851,8 +851,6 @@ export default class Dropdown extends Component {
         active={isActive(opt.value)}
         onClick={this.handleItemClick}
         selected={selectedIndex === i}
-        // prevent default to allow item select without closing on blur
-        onMouseDown={e => e.preventDefault()}
         {...opt}
         // Needed for handling click events on disabled items
         style={{ ...opt.style, pointerEvents: 'all' }}

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -99,6 +99,23 @@ describe('Dropdown Component', () => {
   //   dropdownMenuIsOpen()
   // })
 
+  describe('isMouseDown', () => {
+    it('tracks whhen the mouse is down', () => {
+      wrapperShallow(<Dropdown />)
+        .simulate('mousedown')
+
+      wrapper.instance()
+        .isMouseDown
+        .should.equal(true)
+
+      domEvent.mouseUp(document)
+
+      wrapper.instance()
+        .isMouseDown
+        .should.equal(false)
+    })
+  })
+
   describe('icon', () => {
     it('defaults to a dropdown icon', () => {
       Dropdown.defaultProps.icon.should.equal('dropdown')
@@ -235,11 +252,9 @@ describe('Dropdown Component', () => {
         { text: 'skip this one', value: 'skip this one', disabled: true },
         { text: 'a2', value: 'a2' },
       ]
-      // search for 'a'
+
       wrapperMount(<Dropdown options={opts} search selection />)
         .simulate('click')
-        .find('input.search')
-        .simulate('change', { target: { value: 'a' } })
 
       wrapper
         .find('.selected')
@@ -251,6 +266,24 @@ describe('Dropdown Component', () => {
       wrapper
         .find('.selected')
         .should.contain.text('a2')
+    })
+    it('does not enter an infinite loop when all items are disabled', () => {
+      const opts = [
+        { text: '1', value: '1', disabled: true },
+        { text: '2', value: '2', disabled: true },
+      ]
+      wrapperMount(<Dropdown options={opts} search selection />)
+        .simulate('click')
+
+      const instance = wrapper.instance()
+      sandbox.spy(instance, 'moveSelectionBy')
+
+      // move selection down
+      domEvent.keyDown(document, { key: 'ArrowDown' })
+
+      instance
+        .moveSelectionBy
+        .should.have.been.calledOnce()
     })
     it('scrolls the selected item into view', () => {
       // get enough options to make the menu scrollable

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -609,12 +609,12 @@ describe('Dropdown Component', () => {
     it('closes the menu when toggled from true to false', () => {
       wrapperShallow(<Dropdown options={options} selection open />)
         .setProps({ open: false })
-      dropdownMenuIsOpen()
+      dropdownMenuIsClosed()
     })
-    it('opens the menu when toggled from false to true', () => {
+    it.only('opens the menu when toggled from false to true', () => {
       wrapperShallow(<Dropdown options={options} selection open={false} />)
         .setProps({ open: true })
-      dropdownMenuIsClosed()
+      dropdownMenuIsOpen()
     })
   })
 
@@ -1121,10 +1121,8 @@ describe('Dropdown Component', () => {
     it('still allows moving selection after blur/focus', () => {
       // open, first item is selected
       const search = wrapperMount(<Dropdown options={options} selection search />)
-        .find('input.search')
-        .simulate('focus')
+        .simulate('click')
 
-      domEvent.keyDown(document, { key: 'ArrowDown' })
       dropdownMenuIsOpen()
 
       const items = wrapper
@@ -1140,7 +1138,6 @@ describe('Dropdown Component', () => {
         .simulate('focus')
 
       domEvent.keyDown(document, { key: 'ArrowDown' })
-      domEvent.keyDown(document, { key: 'ArrowDown' })
 
       items
         .first()
@@ -1155,7 +1152,6 @@ describe('Dropdown Component', () => {
         .simulate('blur')
         .simulate('focus')
 
-      domEvent.keyDown(document, { key: 'ArrowDown' })
       domEvent.keyDown(document, { key: 'ArrowUp' })
 
       items

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -77,7 +77,6 @@ describe('Dropdown Component', () => {
 
   it('closes on blur', () => {
     wrapperMount(<Dropdown options={options} />)
-      .simulate('focus')
       .simulate('click')
 
     dropdownMenuIsOpen()
@@ -490,30 +489,6 @@ describe('Dropdown Component', () => {
       dropdownMenuIsOpen()
     })
 
-    it('does not call open on space if already open', () => {
-      wrapperMount(<Dropdown options={options} selection />)
-
-      const instance = wrapper.instance()
-      sandbox.spy(instance, 'open')
-
-      dropdownMenuIsClosed()
-      instance.open.should.not.have.been.called()
-
-      // first time
-      wrapper.simulate('focus')
-      domEvent.keyDown(document, { key: ' ' })
-
-      dropdownMenuIsOpen()
-      instance.open.should.have.been.calledOnce()
-
-      // second time
-      wrapper.simulate('focus')
-      domEvent.keyDown(document, { key: ' ' })
-
-      dropdownMenuIsOpen()
-      instance.open.should.have.been.calledOnce()
-    })
-
     it('does not open on arrow down when not focused', () => {
       wrapperMount(<Dropdown options={options} selection />)
 
@@ -607,12 +582,12 @@ describe('Dropdown Component', () => {
       dropdownMenuIsClosed()
     })
     it('closes the menu when toggled from true to false', () => {
-      wrapperShallow(<Dropdown options={options} selection open />)
+      wrapperMount(<Dropdown options={options} selection open />)
         .setProps({ open: false })
       dropdownMenuIsClosed()
     })
-    it.only('opens the menu when toggled from false to true', () => {
-      wrapperShallow(<Dropdown options={options} selection open={false} />)
+    it('opens the menu when toggled from false to true', () => {
+      wrapperMount(<Dropdown options={options} selection open={false} />)
         .setProps({ open: true })
       dropdownMenuIsOpen()
     })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -448,12 +448,6 @@ describe('Dropdown Component', () => {
   })
 
   describe('menu', () => {
-    // DO NOT simulate events on 'document', use the 'domEvent` util
-    // simulate() only uses React's internal event system
-    // it does not touch the actual DOM at all so it can't use any of the DOM event handlers.
-    // We listen for keydown on the raw DOM, not in a React component.
-    // https://github.com/facebook/react/issues/5043
-
     it('opens on dropdown click', () => {
       wrapperMount(<Dropdown options={options} selection />)
 
@@ -462,20 +456,24 @@ describe('Dropdown Component', () => {
       dropdownMenuIsOpen()
     })
 
-    it('opens on arrow down when focused', () => {
+    it('opens on arrow down when focused and closed', () => {
       wrapperMount(<Dropdown options={options} selection />)
 
-      dropdownMenuIsClosed()
       wrapper.simulate('focus')
+      domEvent.keyDown(document, { key: 'Escape' })
+      dropdownMenuIsClosed()
+
       domEvent.keyDown(document, { key: 'ArrowDown' })
       dropdownMenuIsOpen()
     })
 
-    it('opens on arrow up when focused', () => {
+    it('opens on arrow up when focused and closed', () => {
       wrapperMount(<Dropdown options={options} selection />)
 
-      dropdownMenuIsClosed()
       wrapper.simulate('focus')
+      domEvent.keyDown(document, { key: 'Escape' })
+      dropdownMenuIsClosed()
+
       domEvent.keyDown(document, { key: 'ArrowUp' })
       dropdownMenuIsOpen()
     })
@@ -485,6 +483,7 @@ describe('Dropdown Component', () => {
 
       dropdownMenuIsClosed()
       wrapper.simulate('focus')
+      domEvent.keyDown(document, { key: 'Escape' })
       domEvent.keyDown(document, { key: ' ' })
       dropdownMenuIsOpen()
     })
@@ -502,6 +501,14 @@ describe('Dropdown Component', () => {
 
       dropdownMenuIsClosed()
       domEvent.keyDown(document, { key: ' ' })
+      dropdownMenuIsClosed()
+    })
+
+    it('closes on dropdown click', () => {
+      wrapperMount(<Dropdown options={options} selection defaultOpen />)
+
+      dropdownMenuIsOpen()
+      wrapper.simulate('click')
       dropdownMenuIsClosed()
     })
 

--- a/test/utils/domEvent.js
+++ b/test/utils/domEvent.js
@@ -27,6 +27,14 @@ export const fire = (node, eventType, data = {}) => {
 export const keyDown = (node, data) => fire(node, 'keydown', data)
 
 /**
+ * Dispatch a 'mouseup' event on a DOM node.
+ * @param {String|Object} node A querySelector string or DOM node.
+ * @param {Object} [data] Additional event data.
+ * @returns {Object} The event
+ */
+export const mouseUp = (node, data) => fire(node, 'mouseup', data)
+
+/**
  * Dispatch a 'click' event on a DOM node.
  * @param {String|Object} node A querySelector string or DOM node.
  * @param {Object} [data] Additional event data.
@@ -36,6 +44,7 @@ export const click = (node, data) => fire(node, 'click', data)
 
 export default {
   fire,
+  mouseUp,
   keyDown,
   click,
 }


### PR DESCRIPTION
Fixes #493 

The Dropdown opens/closes on focus/blur.  Focus and blur are triggered by either keyboard (tab) or mouse events (click).  Focus and blur fire before on mouse down while click fires on mouse up.

This meant focus and blur would cause the menu to open/close before the click handler would also toggle the menu close.  Further, the blur event would close the menu before the click event could fire on a menu item.

This PR adds a `isMouseDown` flag.  Focus/blur functionality for open/close is only called if the mouse is not down.  This allows the user to tab to open/close, but the focus/blur fired from a click is ignored.  Allowing the user to select items without the Dropdown closing and click on the Dropdown to toggle its open state without double toggling the open state.
