### PR TITLE
Dropdown: Dropdown.Header via shorthand prop

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Content/Header.js
+++ b/docs/app/Examples/modules/Dropdown/Content/Header.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Dropdown } from 'stardust'
+
+const options = [
+  { text: 'English', value: 'English' },
+  { text: 'French', value: 'French' },
+  { text: 'Spanish', value: 'Spanish' },
+  { text: 'German', value: 'German' },
+  { text: 'Chinese', value: 'Chinese' },
+]
+
+const DropdownHeaderExample = () => (
+  <Dropdown placeholder='Language' options={options} header='Select a language' />
+)
+
+export default DropdownHeaderExample

--- a/docs/app/Examples/modules/Dropdown/index.js
+++ b/docs/app/Examples/modules/Dropdown/index.js
@@ -40,6 +40,13 @@ const DropdownExamples = () => (
         </Message>
       </ComponentExample>
     </ExampleSection>
+    <ExampleSection title='Content'>
+      <ComponentExample
+        title='Header'
+        description='A dropdown menu can contain a header'
+        examplePath='modules/Dropdown/Content/Header'
+      />
+    </ExampleSection>
     <ExampleSection title='States'>
       <ComponentExample
         title='Disabled'

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -181,6 +181,9 @@ export default class Dropdown extends Component {
     /** Display the menu as detached from the Dropdown. */
     floating: PropTypes.bool,
 
+    /** A dropdown menu can contain a header. */
+    header: PropTypes.node,
+
     inline: PropTypes.bool,
     labeled: PropTypes.bool,
     linkItem: PropTypes.bool,
@@ -865,7 +868,7 @@ export default class Dropdown extends Component {
   }
 
   renderMenu = () => {
-    const { children } = this.props
+    const { children, header } = this.props
     const { open } = this.state
     const menuClasses = open ? 'visible' : ''
 
@@ -879,6 +882,7 @@ export default class Dropdown extends Component {
 
     return (
       <DropdownMenu className={menuClasses}>
+        {header && <DropdownHeader content={header} />}
         {this.renderOptions()}
       </DropdownMenu>
     )

--- a/src/modules/Dropdown/DropdownHeader.js
+++ b/src/modules/Dropdown/DropdownHeader.js
@@ -1,15 +1,34 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
+import { createIcon } from '../../factories'
 
 function DropdownHeader(props) {
-  const { className, children } = props
+  const { className, children, content, icon } = props
   const classes = cx('header', className)
   const rest = getUnhandledProps(DropdownHeader, props)
   const ElementType = getElementType(DropdownHeader, props)
 
-  return <ElementType className={classes} {...rest}>{children}</ElementType>
+  if (children) {
+    return (
+      <ElementType className={classes} {...rest}>
+        {children}
+      </ElementType>
+    )
+  }
+
+  return (
+    <ElementType className={classes} {...rest}>
+      {createIcon(icon)}
+      {content}
+    </ElementType>
+  )
 }
 
 DropdownHeader._meta = {
@@ -25,11 +44,24 @@ DropdownHeader.propTypes = {
     PropTypes.func,
   ]),
 
-  /** Primary content */
-  children: PropTypes.node,
+  /** Primary content of the header, same as content. */
+  children: customPropTypes.every([
+    customPropTypes.disallow(['content', 'icon']),
+    PropTypes.node,
+  ]),
 
   /** Additional classes */
   className: PropTypes.node,
+
+  /** Primary content of the header, same as children. */
+  content: PropTypes.node,
+
+  /** Add an icon by icon name or pass an <Icon /> */
+  icon: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+    PropTypes.object,
+  ]),
 }
 
 export default DropdownHeader

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1537,4 +1537,17 @@ describe('Dropdown Component', () => {
       spy.firstCall.args[0].should.equal('boo')
     })
   })
+  describe('header', () => {
+    it('renders a header when present', () => {
+      const text = faker.hacker.phrase()
+
+      wrapperRender(<Dropdown options={options} header={text} />)
+        .find('.menu .header')
+        .should.contain.text(text)
+    })
+    it('does not render a header when not present', () => {
+      wrapperRender(<Dropdown options={options} />)
+        .should.not.have.descendants('.menu .header')
+    })
+  })
 })

--- a/test/specs/modules/Dropdown/DropdownHeader-test.js
+++ b/test/specs/modules/Dropdown/DropdownHeader-test.js
@@ -4,4 +4,5 @@ import * as common from 'test/specs/commonTests'
 describe('DropdownHeader', () => {
   common.isConformant(DropdownHeader)
   common.rendersChildren(DropdownHeader)
+  common.implementsIconProp(DropdownHeader)
 })


### PR DESCRIPTION
Adds support for a `header` shorthand prop for dropdown.

I was thinking of using a factory for `header` since it can have some other properties other than text (e.g. an icon). It would basically be:

``` js
const createDropdownHeader = createFactory(DropdownHeader, value => ({ content: value }))
```

However, there's no precedent in the codebase for using a factory on a subcomponent so I was unsure where to put that. Some options would be:
1. `src/factories/index.js` (seems weird since the factory is not really usable globally.)
2. `src/modules/Dropdown/factories.js`
3. `src/modules/Dropdown/Dropdown.js` (just define it at the top of the file)

Kinda leaning option 3, but would love some other opinions.

**Edit**: It seems the PR on standardizing childKey and shorthand props has some discussion related to this question about the factories. Perhaps we can hold off on the factory thing until and review this as-is until that's settled?
