### PR TITLE
fix(Dropdown): skip select item on blur when closed

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -401,11 +401,13 @@ export default class Dropdown extends Component {
   }
 
   selectHighlightedItem = (e) => {
+    const { open } = this.state
     const { multiple, onAddItem, options } = this.props
     const value = _.get(this.getSelectedItem(), 'value')
 
     // prevent selecting null if there was no selected item value
-    if (!value) return
+    // prevent selecting duplicate items when the dropdown is closed
+    if (!value || !open) return
 
     // notify the onAddItem prop if this is a new value
     if (onAddItem && !_.some(options, { text: value })) onAddItem(value)

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -848,6 +848,13 @@ describe('Dropdown Component', () => {
       spy.should.have.been.calledOnce()
       spy.firstCall.args[1].should.deep.equal(firstValue)
     })
+    it('is not called on blur when closed', () => {
+      wrapperMount(<Dropdown options={options} selection open={false} onChange={spy} />)
+        .simulate('focus')
+        .simulate('blur')
+
+      spy.should.not.have.been.called()
+    })
     it('is not called on blur when selectOnBlur is false', () => {
       wrapperMount(<Dropdown options={options} selection onChange={spy} selectOnBlur={false} />)
         .simulate('focus')

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -840,10 +840,8 @@ describe('Dropdown Component', () => {
     it('is called with event and value when blurring', () => {
       const firstValue = options[0].value
       wrapperMount(<Dropdown options={options} selection onChange={spy} />)
-        .simulate('focus')
-        .simulate('click')
-
-      wrapper.simulate('blur')
+        .simulate('focus')  // open, highlights first item
+        .simulate('blur')   // blur should activate selected item
 
       spy.should.have.been.calledOnce()
       spy.firstCall.args[1].should.deep.equal(firstValue)


### PR DESCRIPTION
Fixes #504 

The Dropdown method `selectHighlightedItem()` is called on blur.  This method should only continue if the Dropdown is open.

This PR adds the open logic to prevent duplicate calls to onChange.  Without this, onChange is called on item click and again when the Dropdown is blurred.
