### PR TITLE
fix(Header): properly wrap contents in HeaderContent

### DIFF
--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -45,29 +45,24 @@ function Header(props) {
   const ElementType = getElementType(Header, props)
   const rest = getUnhandledProps(Header, props)
 
-  if (icon && typeof icon !== 'boolean') {
-    return (
-      <ElementType {...rest} className={classes}>
-        {createIcon(icon)}
-        {content && <HeaderContent>{content}</HeaderContent>}
-        {subheader && <HeaderSubheader content={subheader} />}
-      </ElementType>
-    )
-  }
-
-  if (image) {
-    return (
-      <ElementType {...rest} className={classes}>
-        {createImage(image)} {content}
-        {subheader && <HeaderSubheader content={subheader} />}
-      </ElementType>
-    )
-  }
-
   if (children) {
     return (
       <ElementType {...rest} className={classes}>
         {children}
+      </ElementType>
+    )
+  }
+
+  if (image || icon && typeof icon !== 'boolean') {
+    return (
+      <ElementType {...rest} className={classes}>
+        {createIcon(icon) || createImage(image)}
+        {(content || subheader) && (
+          <HeaderContent>
+            {content}
+            {subheader && <HeaderSubheader content={subheader} />}
+          </HeaderContent>
+        )}
       </ElementType>
     )
   }

--- a/test/specs/elements/Header/Header-test.js
+++ b/test/specs/elements/Header/Header-test.js
@@ -51,14 +51,17 @@ describe('Header', () => {
       shallow(<Header content='foo' />)
         .should.contain.text('foo')
     })
-    it('adds child text when there is an image', () => {
-      shallow(<Header content='foo' image='foo.png' />)
-        .should.contain.text('foo')
+    it('is wrapped in HeaderContent when there is an image src', () => {
+      shallow(<Header image='foo.png' content='Bar' />)
+        .find('HeaderContent')
+        .shallow()
+        .should.contain.text('Bar')
     })
     it('is wrapped in HeaderContent when there is an icon name', () => {
       shallow(<Header icon='users' content='Friends' />)
         .find('HeaderContent')
-        .should.have.prop('children', 'Friends')
+        .shallow()
+        .should.contain.text('Friends')
     })
     it('is not wrapped in HeaderContent when icon is true', () => {
       const wrapper = shallow(<Header icon content='Friends' />)


### PR DESCRIPTION
Fixes #511.

This PR wraps `subheader` shorthand in HeaderContent when there is an icon present.  It also wraps content in HeaderContent when there is an `image` provided.
