### PR TITLE
fix(src/index): use module exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,8 +5,7 @@
     "stage-1"
   ],
   "plugins": [
-    "lodash",
-    "add-module-exports"
+    "lodash"
   ],
   "env": {
     "development": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.0",
     "babel-plugin-__coverage__": "^11.0.0",
-    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-lodash": "^3.1.4",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-preset-es2015": "^6.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import * as elements from './elements'
 import * as modules from './modules'
 import * as views from './views'
 
-export default {
+module.exports = {
   ...addons,
   ...collections,
   ...elements,


### PR DESCRIPTION
The browser build release broke the doc site, however, adding module exports breaks tests.  Opting to drop the plugin and use module exports explicitly.  This works since all other es modules remain in tact while the exported window variable for browser builds does not need to use `.default` after importing the main module.
