### PR TITLE
docs(.github): create ISSUE_TEMPLATE

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -531,7 +531,7 @@ Adding documentation for new components is a bit tedious.  The best way to do th
 [5]: http://semantic-ui.com/elements/header
 [6]: http://semantic-ui.com/views/item
 [7]: https://github.com/TechnologyAdvice/stardust/pull/281#issuecomment-228663527
-[8]: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit
+[8]: https://github.com/angular/angular.js/blob/master/.github/CONTRIBUTING.md#commit
 [9]: http://semantic-ui.com/introduction/glossary.html
 [10]: http://semantic-ui.com/elements/label.html
 [11]: https://nodejs.org/

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--=======================================================
+Thanks for submitting!
+
+Use the appropriate template below, remove the other.
+========================================================-->
+
+<!--------------------------------------
+              BUG TEMPLATE
+--------------------------------------->
+## Steps to Reproduce
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Version
+
+Stardust: `x.y.z`
+Browser:
+OS:
+
+## Test Case
+
+Fork: http://codepen.io/levithomason/pen/ZpBaJX
+
+<!--------------------------------------
+        FEATURE REQUEST TEMPLATE
+--------------------------------------->
+## Description
+
+I'd like...
+
+This is needed because...
+
+## Example Code
+
+## Example Result
+
+## Prototype (optional)
+
+Fork: http://codepen.io/levithomason/pen/ZpBaJX

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ npm run release:patch
 
 Made with :heart: [@TechnologyAdvice][9], a ridiculous [place to work][16].
 
-[1]: https://github.com/TechnologyAdvice/stardust/blob/master/CONTRIBUTING.md
+[1]: https://github.com/TechnologyAdvice/stardust/blob/master/.github/CONTRIBUTING.md
 [2]: https://technologyadvice.github.io/stardust/
 [3]: https://facebook.github.io/react/
 [4]: https://github.com/TechnologyAdvice/stardust/labels/help%20wanted

--- a/docs/app/Components/ComponentDoc/ComponentDoc.js
+++ b/docs/app/Components/ComponentDoc/ComponentDoc.js
@@ -207,7 +207,7 @@ export default class ComponentDoc extends Component {
           {docgen.docBlock.description || (
             <span>
               <a href={getGithubEditUrl(_meta.name)}>Add a description</a>. Instructions are{' '}
-              <a href={'https://github.com/TechnologyAdvice/stardust/blob/master/CONTRIBUTING.md#components'}>
+              <a href={'https://github.com/TechnologyAdvice/stardust/blob/master/.github/CONTRIBUTING.md#components'}>
                 here.
               </a>
               {' '}Description is in the SUI Docs, right there <Icon name='pointing right' />

--- a/docs/app/Components/ComponentDoc/ComponentExamples.js
+++ b/docs/app/Components/ComponentDoc/ComponentExamples.js
@@ -29,8 +29,10 @@ export default class ComponentExamples extends Component {
             <Message.Content>
               If there's no
               <a href='https://github.com/TechnologyAdvice/stardust/pulls'> pull request </a>
-              open for <code>{`<${name} />`}</code> examples, you should
-              <a href='https://github.com/TechnologyAdvice/stardust/blob/master/CONTRIBUTING.md'> contribute</a>!
+              open for <code>{`<${name} />`}</code> examples, you should{' '}
+              <a href='https://github.com/TechnologyAdvice/stardust/blob/master/.github/CONTRIBUTING.md'>
+                contribute
+              </a>!
             </Message.Content>
           </Message>
         </Grid.Column>


### PR DESCRIPTION
Adds an issue template with links to the new Codepen.  It includes the new browser build so users can submit bug examples against the latest Stardust: http://codepen.io/levithomason/pen/ZpBaJX
