### PR TITLE
fix(Label): Fix `ribbon` propType

### DIFF
--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -166,7 +166,10 @@ Label.propTypes = {
   ]),
 
   /** Format the label as a ribbon on another component. */
-  ribbon: PropTypes.oneOf(Label._meta.props.ribbon),
+  ribbon: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.oneOf(Label._meta.props.ribbon),
+  ]),
 
   /** Size of the label. */
   size: PropTypes.oneOf(Label._meta.props.size),


### PR DESCRIPTION
### Small fix for `ribbon` type.

> Warning: Failed prop type: Invalid prop `ribbon` of value `true` supplied to `Label`, expected one of ["right"].

But, according to [SUI docs](http://semantic-ui.com/elements/label.html#ribbon) `ribbon` can be left, if position no defined. Component and tests accepts `bool` value, so bug is only in `propTypes`.
