### PR TITLE
feat(Menu): add `floated` and MenuItem `icon` props

### DIFF
--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -24,6 +24,7 @@ const _meta = {
   props: {
     attached: ['top', 'bottom'],
     color: SUI.COLORS,
+    floated: ['right'],
     icon: ['labeled'],
     fixed: ['bottom', 'top'],
     size: _.without(SUI.SIZES, 'medium', 'big'),
@@ -72,6 +73,12 @@ class Menu extends Component {
 
     /** A menu can be fixed to a side of its context. */
     fixed: PropTypes.oneOf(_meta.props.fixed),
+
+    /** A menu can be floated. */
+    floated: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(_meta.props.floated),
+    ]),
 
     /** A vertical menu may take the size of its container. */
     fluid: PropTypes.bool,
@@ -184,8 +191,8 @@ class Menu extends Component {
 
   render() {
     const {
-      attached, borderless, className, children, color, compact, fixed, fluid, icon, inverted, pagination, pointing,
-      secondary, stackable, tabular, text, vertical, size, widths,
+      attached, borderless, className, children, color, compact, fixed, floated, fluid, icon, inverted, pagination,
+      pointing, secondary, stackable, tabular, text, vertical, size, widths,
     } = this.props
     const classes = cx(
       'ui',
@@ -196,6 +203,7 @@ class Menu extends Component {
       useKeyOnly(borderless, 'borderless'),
       useKeyOnly(compact, 'compact'),
       useValueAndKey(fixed, 'fixed'),
+      useKeyOrValueAndKey(floated, 'floated'),
       useKeyOnly(fluid, 'fluid'),
       useKeyOrValueAndKey(icon, 'icon'),
       useKeyOnly(inverted, 'inverted'),

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -14,11 +14,12 @@ import {
 
 function MenuItem(props) {
   const {
-    active, children, className, color, content, fitted, header, index, link, name, onClick, position,
+    active, children, className, color, content, fitted, header, icon, index, link, name, onClick, position,
   } = props
   const classes = cx(
     useKeyOnly(active, 'active'),
     useKeyOrValueAndKey(fitted, 'fitted'),
+    useKeyOnly(icon, 'icon'),
     useKeyOnly(header, 'header'),
     useKeyOnly(link, 'link'),
     color,
@@ -88,6 +89,9 @@ MenuItem.propTypes = {
 
   /** A menu item may include a header or may itself be a header. */
   header: PropTypes.bool,
+
+  /** MenuItem can be only icon. */
+  icon: PropTypes.bool,
 
   /** MenuItem index inside Menu. */
   index: PropTypes.number,

--- a/test/specs/collections/Menu/Menu-test.js
+++ b/test/specs/collections/Menu/Menu-test.js
@@ -18,6 +18,7 @@ describe('Menu', () => {
   common.propValueOnlyToClassName(Menu, 'color')
   common.propKeyOnlyToClassName(Menu, 'compact')
   common.propKeyAndValueToClassName(Menu, 'fixed')
+  common.propKeyOrValueToClassName(Menu, 'floated')
   common.propKeyOnlyToClassName(Menu, 'fluid')
   common.propKeyOrValueToClassName(Menu, 'icon')
   common.propKeyOnlyToClassName(Menu, 'inverted')

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -10,6 +10,7 @@ describe('MenuItem', () => {
   common.propKeyOnlyToClassName(MenuItem, 'active')
   common.propValueOnlyToClassName(MenuItem, 'color')
   common.propKeyOrValueToClassName(MenuItem, 'fitted')
+  common.propKeyOnlyToClassName(MenuItem, 'icon')
   common.propKeyOnlyToClassName(MenuItem, 'header')
   common.propKeyOnlyToClassName(MenuItem, 'link')
   common.propValueOnlyToClassName(MenuItem, 'position')


### PR DESCRIPTION
This PR addes missed props:
- `Menu` - [`floated`](https://github.com/Semantic-Org/UI-Menu/blob/master/menu.css#L1194);
- `MenuItem` - [`icon`](https://github.com/Semantic-Org/UI-Menu/blob/master/menu.css#L1194).
