### PR TITLE
feat(customPropTypes): add "as" prop type

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -485,10 +485,7 @@ A doc block should appear above each prop in `propTypes` to describe them:
 ```js
 Label.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A label can reduce its complexity. */
   basic: PropTypes.bool,

--- a/docs/app/Examples/elements/Icon/IconSet/IconCategoryExample.js
+++ b/docs/app/Examples/elements/Icon/IconSet/IconCategoryExample.js
@@ -16,12 +16,6 @@ const IconCategoryExample = ({ category }) => (
 )
 
 IconCategoryExample.propTypes = {
-  /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
-
   category: PropTypes.shape({
     icons: PropTypes.array.isRequired,
   }),

--- a/docs/app/Examples/elements/Rail/Variations/RailSizeExample.js
+++ b/docs/app/Examples/elements/Rail/Variations/RailSizeExample.js
@@ -13,12 +13,6 @@ const Wrapper = ({ children }) => (
 )
 
 Wrapper.propTypes = {
-  /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
-
   children: PropTypes.node,
 }
 

--- a/docs/app/Views/Introduction.js
+++ b/docs/app/Views/Introduction.js
@@ -132,12 +132,6 @@ const Comparison = ({ jsx, html }) => (
 )
 
 Comparison.propTypes = {
-  /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
-
   jsx: PropTypes.string,
   html: PropTypes.string,
 }

--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -1,5 +1,10 @@
-import React, { PropTypes } from 'react'
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import React from 'react'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 /**
  * A simple <textarea> wrapper for use in Form.TextArea.
@@ -19,10 +24,7 @@ TextArea._meta = {
 
 TextArea.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 }
 
 TextArea.defaultProps = {

--- a/src/collections/Breadcrumb/Breadcrumb.js
+++ b/src/collections/Breadcrumb/Breadcrumb.js
@@ -53,10 +53,7 @@ Breadcrumb._meta = {
 
 Breadcrumb.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the Breadcrumb */
   children: customPropTypes.every([

--- a/src/collections/Breadcrumb/BreadcrumbDivider.js
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.js
@@ -31,10 +31,7 @@ BreadcrumbDivider._meta = {
 
 BreadcrumbDivider.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the Breadcrumb.Divider. */
   children: customPropTypes.every([

--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -43,10 +43,7 @@ BreadcrumbSection._meta = {
 
 BreadcrumbSection.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Style as the currently active section. */
   active: PropTypes.bool,

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -3,6 +3,7 @@ import _ from 'lodash'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   makeDebugger,
@@ -220,10 +221,7 @@ Form._meta = {
 
 Form.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content */
   children: PropTypes.node,

--- a/src/collections/Form/FormButton.js
+++ b/src/collections/Form/FormButton.js
@@ -1,6 +1,11 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 import FormField from './FormField'
 import { Button } from '../../elements'
 
@@ -24,10 +29,7 @@ FormButton._meta = {
 
 FormButton.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A FormField control prop */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormCheckbox.js
+++ b/src/collections/Form/FormCheckbox.js
@@ -1,6 +1,11 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 import FormField from './FormField'
 import { Checkbox } from '../../modules'
 
@@ -24,10 +29,7 @@ FormCheckbox._meta = {
 
 FormCheckbox.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A FormField control prop */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormDropdown.js
+++ b/src/collections/Form/FormDropdown.js
@@ -1,6 +1,11 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 import FormField from './FormField'
 import { Dropdown } from '../../modules'
 
@@ -24,10 +29,7 @@ FormDropdown._meta = {
 
 FormDropdown.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A FormField control prop */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -120,10 +120,7 @@ FormField._meta = {
 
 FormField.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /**
    * A form control component (i.e. Dropdown) or HTML tagName (i.e. 'input').

--- a/src/collections/Form/FormGroup.js
+++ b/src/collections/Form/FormGroup.js
@@ -45,10 +45,7 @@ FormGroup._meta = {
 
 FormGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content.  Intended to be Form Fields. */
   children: PropTypes.node,

--- a/src/collections/Form/FormInput.js
+++ b/src/collections/Form/FormInput.js
@@ -1,6 +1,11 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 import FormField from './FormField'
 import { Input } from '../../elements'
 
@@ -24,10 +29,7 @@ FormInput._meta = {
 
 FormInput.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A FormField control prop */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormRadio.js
+++ b/src/collections/Form/FormRadio.js
@@ -1,6 +1,11 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 import FormField from './FormField'
 import { Radio } from '../../addons'
 
@@ -24,10 +29,7 @@ FormRadio._meta = {
 
 FormRadio.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A FormField control prop */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormSelect.js
+++ b/src/collections/Form/FormSelect.js
@@ -1,6 +1,11 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 import FormField from './FormField'
 import { Select } from '../../addons'
 
@@ -25,10 +30,7 @@ FormSelect._meta = {
 
 FormSelect.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A FormField control prop */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormTextArea.js
+++ b/src/collections/Form/FormTextArea.js
@@ -1,6 +1,11 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 import FormField from './FormField'
 import { TextArea } from '../../addons'
 
@@ -24,10 +29,7 @@ FormTextArea._meta = {
 
 FormTextArea.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A FormField control prop */
   control: FormField.propTypes.control,

--- a/src/collections/Grid/Grid.js
+++ b/src/collections/Grid/Grid.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -65,10 +66,7 @@ Grid._meta = {
 
 Grid.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A grid can have rows divided into cells. */
   celled: PropTypes.oneOfType([

--- a/src/collections/Grid/GridColumn.js
+++ b/src/collections/Grid/GridColumn.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -61,10 +62,7 @@ GridColumn._meta = {
 
 GridColumn.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the GridColumn. */
   children: PropTypes.node,

--- a/src/collections/Grid/GridRow.js
+++ b/src/collections/Grid/GridRow.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -49,10 +50,7 @@ GridRow._meta = {
 
 GridRow.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A row can have its columns centered. */
   centered: PropTypes.bool,

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -39,10 +39,7 @@ const _meta = {
 class Menu extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     /** Index of the currently active item. */
     activeIndex: PropTypes.number,

--- a/src/collections/Menu/MenuHeader.js
+++ b/src/collections/Menu/MenuHeader.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -24,10 +25,7 @@ MenuHeader._meta = {
 
 MenuHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content */
   children: PropTypes.node,

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -55,10 +55,7 @@ MenuItem._meta = {
 
 MenuItem.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A menu item can be active. */
   active: PropTypes.bool,

--- a/src/collections/Menu/MenuMenu.js
+++ b/src/collections/Menu/MenuMenu.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -27,10 +28,7 @@ MenuMenu._meta = {
 
 MenuMenu.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the MenuMenu. */
   children: PropTypes.node,

--- a/src/collections/Message/Message.js
+++ b/src/collections/Message/Message.js
@@ -106,10 +106,7 @@ Message._meta = {
 
 Message.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the message. */
   children: customPropTypes.every([

--- a/src/collections/Message/MessageContent.js
+++ b/src/collections/Message/MessageContent.js
@@ -1,7 +1,12 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 function MessageContent(props) {
   const { className, children } = props
@@ -20,10 +25,7 @@ MessageContent._meta = {
 
 MessageContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Message/MessageHeader.js
+++ b/src/collections/Message/MessageHeader.js
@@ -1,7 +1,12 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 function MessageHeader(props) {
   const { className, children } = props
@@ -20,10 +25,7 @@ MessageHeader._meta = {
 
 MessageHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Message/MessageItem.js
+++ b/src/collections/Message/MessageItem.js
@@ -1,5 +1,11 @@
 import React, { PropTypes } from 'react'
-import { getElementType, getUnhandledProps, META } from '../../lib'
+
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 function MessageItem(props) {
   const { children } = props
@@ -17,10 +23,7 @@ MessageItem._meta = {
 
 MessageItem.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Message/MessageList.js
+++ b/src/collections/Message/MessageList.js
@@ -1,7 +1,12 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 import MessageItem from './MessageItem'
 
@@ -24,10 +29,7 @@ MessageList._meta = {
 
 MessageList.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -12,10 +12,7 @@ import TableColumn from './TableColumn'
 export default class Table extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     children: customPropTypes.ofComponentTypes(['TableColumn']),
     className: PropTypes.string,

--- a/src/collections/Table/TableColumn.js
+++ b/src/collections/Table/TableColumn.js
@@ -6,12 +6,6 @@ import { META } from '../../lib'
 const TableColumn = () => <noscript />
 
 TableColumn.propTypes = {
-  /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
-
   /**
    * A function that returns the cell contents.
    * Receives the row data as its only argument.

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -140,10 +140,7 @@ Button._meta = {
 
 Button.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A button can show it is currently the active user selection */
   active: PropTypes.bool,

--- a/src/elements/Button/ButtonContent.js
+++ b/src/elements/Button/ButtonContent.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -38,10 +39,7 @@ ButtonContent._meta = {
 
 ButtonContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Initially visible, hidden on hover */
   visible: PropTypes.bool,

--- a/src/elements/Button/ButtonGroup.js
+++ b/src/elements/Button/ButtonGroup.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -56,10 +57,7 @@ ButtonGroup._meta = {
 
 ButtonGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A button can be attached to the top or bottom of other content */
   attached: PropTypes.oneOf(ButtonGroup._meta.props.attached),

--- a/src/elements/Button/ButtonOr.js
+++ b/src/elements/Button/ButtonOr.js
@@ -1,7 +1,12 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 /**
  * Used in some Button types, such as `animated`
@@ -23,10 +28,7 @@ ButtonOr._meta = {
 
 ButtonOr.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Additional classes */
   className: PropTypes.string,

--- a/src/elements/Container/Container.js
+++ b/src/elements/Container/Container.js
@@ -1,10 +1,11 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 import {
-  META,
-  SUI,
+  customPropTypes,
   getElementType,
   getUnhandledProps,
+  META,
+  SUI,
   useKeyOnly,
   useTextAlignProp,
 } from '../../lib'
@@ -38,10 +39,7 @@ Container._meta = {
 
 Container.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the Container */
   children: PropTypes.node,

--- a/src/elements/Divider/Divider.js
+++ b/src/elements/Divider/Divider.js
@@ -1,7 +1,13 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
-import { getElementType, getUnhandledProps, META, useKeyOnly } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+  useKeyOnly,
+} from '../../lib'
 
 /**
  * A divider visually segments content into groups
@@ -42,10 +48,7 @@ Divider._meta = {
 
 Divider.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the Divider */
   children: PropTypes.node,

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -1,7 +1,12 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 const names = [
   'ad', 'andorra', 'ae', 'united arab emirates', 'uae', 'af', 'afghanistan', 'ag', 'antigua', 'ai', 'anguilla', 'al',
@@ -66,10 +71,7 @@ Flag._meta = {
 
 Flag.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Classes that will be added to the Flag className. */
   className: PropTypes.string,

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -89,10 +89,7 @@ Header._meta = {
 
 Header.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Additional classes */
   className: PropTypes.string,

--- a/src/elements/Header/HeaderContent.js
+++ b/src/elements/Header/HeaderContent.js
@@ -1,7 +1,12 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 /**
  * Header content wraps the main content when there is an adjacent Icon or Image.
@@ -23,10 +28,7 @@ HeaderContent._meta = {
 
 HeaderContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content */
   children: PropTypes.node,

--- a/src/elements/Header/HeaderSubheader.js
+++ b/src/elements/Header/HeaderSubheader.js
@@ -29,10 +29,7 @@ HeaderSubheader._meta = {
 
 HeaderSubheader.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the HeaderSubheader. Mutually exclusive with content */
   children: customPropTypes.every([

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -63,10 +64,7 @@ Icon._meta = {
 
 Icon.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Formatted to appear bordered */
   bordered: PropTypes.bool,

--- a/src/elements/Icon/IconGroup.js
+++ b/src/elements/Icon/IconGroup.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -43,10 +44,7 @@ IconGroup._meta = {
 
 IconGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Class names for custom styling. */
   className: PropTypes.string,

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -76,10 +76,7 @@ Image._meta = {
 
 Image.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** An image can specify its vertical alignment */
   verticalAlign: PropTypes.oneOf(Image._meta.props.verticalAlign),

--- a/src/elements/Image/ImageGroup.js
+++ b/src/elements/Image/ImageGroup.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -31,10 +32,7 @@ ImageGroup._meta = {
 
 ImageGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Class names for custom styling. */
   children: PropTypes.any,

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -2,7 +2,12 @@ import _ from 'lodash'
 import classNames from 'classnames'
 import React, { Component, PropTypes, Children } from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 import { Icon } from '../../elements'
 
 const inputPropNames = [
@@ -46,10 +51,7 @@ const inputPropNames = [
 export default class Input extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     children: PropTypes.node,
     className: PropTypes.string,

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -82,10 +82,7 @@ Label._meta = {
 
 Label.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Attach to a <Segment />. */
   attached: PropTypes.oneOf(Label._meta.props.attached),

--- a/src/elements/List/List.js
+++ b/src/elements/List/List.js
@@ -1,16 +1,17 @@
 import React, { Component, PropTypes } from 'react'
 import classNames from 'classnames'
 
-import { getElementType, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  META,
+} from '../../lib'
 import ListItem from './ListItem'
 
 export default class List extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     children: PropTypes.node,
     className: PropTypes.string,

--- a/src/elements/List/ListItem.js
+++ b/src/elements/List/ListItem.js
@@ -1,16 +1,17 @@
 import React, { Component, PropTypes } from 'react'
 import cx from 'classnames'
 
-import { getElementType, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  META,
+} from '../../lib'
 import { createIcon, createImage } from '../../factories'
 
 export default class ListItem extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     children: PropTypes.node,
     className: PropTypes.string,

--- a/src/elements/Loader/Loader.js
+++ b/src/elements/Loader/Loader.js
@@ -42,10 +42,7 @@ Loader._meta = {
 
 Loader.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A loader can be active or visible. */
   active: PropTypes.bool,

--- a/src/elements/Rail/Rail.js
+++ b/src/elements/Rail/Rail.js
@@ -3,6 +3,7 @@ import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -45,10 +46,7 @@ Rail._meta = {
 
 Rail.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A rail can appear attached to the main viewport. */
   attached: PropTypes.bool,

--- a/src/elements/Segment/Segment.js
+++ b/src/elements/Segment/Segment.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -86,10 +87,7 @@ Segment._meta = {
 
 Segment.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Attach segment to other content, like a header */
   attached: PropTypes.oneOfType([

--- a/src/elements/Segment/SegmentGroup.js
+++ b/src/elements/Segment/SegmentGroup.js
@@ -1,6 +1,7 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -37,10 +38,7 @@ SegmentGroup._meta = {
 
 SegmentGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Class names for custom styling. */
   className: PropTypes.string,

--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -58,10 +58,7 @@ Step._meta = {
 
 Step.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A step can be highlighted as active. */
   active: PropTypes.bool,

--- a/src/elements/Step/StepContent.js
+++ b/src/elements/Step/StepContent.js
@@ -36,10 +36,7 @@ StepContent._meta = {
 
 StepContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Classes that will be added to the StepContent className. */
   className: PropTypes.string,

--- a/src/elements/Step/StepDescription.js
+++ b/src/elements/Step/StepDescription.js
@@ -25,10 +25,7 @@ StepDescription._meta = {
 
 StepDescription.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Classes that will be added to the StepDescription className. */
   className: PropTypes.string,

--- a/src/elements/Step/StepGroup.js
+++ b/src/elements/Step/StepGroup.js
@@ -48,10 +48,7 @@ StepGroup._meta = {
 
 StepGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Classes that will be added to the StepGroup className. */
   className: PropTypes.string,

--- a/src/elements/Step/StepTitle.js
+++ b/src/elements/Step/StepTitle.js
@@ -25,10 +25,7 @@ StepTitle._meta = {
 
 StepTitle.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Classes that will be added to the StepTitle className. */
   className: PropTypes.string,

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -1,7 +1,15 @@
-import { Children } from 'react'
+import { Children, PropTypes } from 'react'
 import _ from 'lodash'
 
 const type = (...args) => Object.prototype.toString.call(...args)
+
+/**
+ * Ensure a component can render as a give prop value.
+ */
+export const as = (...args) => PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.func,
+])(...args)
 
 /**
  * Ensures children are of a set of types. Matches are made against the component _meta.name property.

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -23,10 +23,7 @@ export default class Accordion extends Component {
 
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     /** Index of the currently active panel. */
     activeIndex: PropTypes.number,

--- a/src/modules/Accordion/AccordionContent.js
+++ b/src/modules/Accordion/AccordionContent.js
@@ -1,7 +1,13 @@
 import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
-import { getElementType, getUnhandledProps, META, useKeyOnly } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+  useKeyOnly,
+} from '../../lib'
 
 function AccordionContent(props) {
   const { active, children, className } = props
@@ -23,10 +29,7 @@ AccordionContent.displayName = 'AccordionContent'
 
 AccordionContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Whether or not the content is visible. */
   active: PropTypes.bool,

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -1,7 +1,13 @@
 import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
-import { getElementType, getUnhandledProps, META, useKeyOnly } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+  useKeyOnly,
+} from '../../lib'
 
 function AccordionTitle(props) {
   const { active, children, className, onClick } = props
@@ -29,10 +35,7 @@ AccordionTitle.displayName = 'AccordionTitle'
 
 AccordionTitle.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Whether or not the title is in the open state. */
   active: PropTypes.bool,

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -32,10 +32,7 @@ const _meta = {
 export default class Checkbox extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     /** Additional classes. */
     className: PropTypes.string,

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -40,10 +40,7 @@ const _meta = {
 export default class Dropdown extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     // ------------------------------------
     // Behavior

--- a/src/modules/Dropdown/DropdownDivider.js
+++ b/src/modules/Dropdown/DropdownDivider.js
@@ -1,7 +1,12 @@
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 function DropdownDivider(props) {
   const { className } = props
@@ -20,10 +25,7 @@ DropdownDivider._meta = {
 
 DropdownDivider.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Additional classes */
   className: PropTypes.node,

--- a/src/modules/Dropdown/DropdownHeader.js
+++ b/src/modules/Dropdown/DropdownHeader.js
@@ -39,10 +39,7 @@ DropdownHeader._meta = {
 
 DropdownHeader.propTypes = {
   /** An element type to render as (string or function) */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the header, same as content. */
   children: customPropTypes.every([

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -60,10 +60,7 @@ DropdownItem._meta = {
 
 DropdownItem.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Style as the currently chosen item. */
   active: PropTypes.bool,

--- a/src/modules/Dropdown/DropdownMenu.js
+++ b/src/modules/Dropdown/DropdownMenu.js
@@ -1,7 +1,12 @@
 import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 function DropdownMenu(props) {
   const { children, className } = props
@@ -20,10 +25,7 @@ DropdownMenu._meta = {
 
 DropdownMenu.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Should be <Dropdown.Item /> components. */
   children: PropTypes.node,

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -9,6 +9,7 @@ import ModalDescription from './ModalDescription'
 import Portal from 'react-portal'
 
 import {
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   keyboardKey,
@@ -35,10 +36,7 @@ const _meta = {
 class Modal extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     /** Primary content of the modal. Consider using ModalHeader, ModalContent or ModalActions here */
     children: PropTypes.node,

--- a/src/modules/Modal/ModalActions.js
+++ b/src/modules/Modal/ModalActions.js
@@ -1,7 +1,12 @@
 import React, { PropTypes } from 'react'
 import classNames from 'classnames'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 function ModalActions(props) {
   const { children, className } = props
@@ -29,10 +34,7 @@ ModalActions._meta = {
 
 ModalActions.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the modal actions */
   children: PropTypes.any,

--- a/src/modules/Modal/ModalContent.js
+++ b/src/modules/Modal/ModalContent.js
@@ -1,7 +1,13 @@
 import React, { PropTypes } from 'react'
 import classNames from 'classnames'
 
-import { getElementType, getUnhandledProps, META, useKeyOnly } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+  useKeyOnly,
+} from '../../lib'
 
 function ModalContent(props) {
   const { children, image, className } = props
@@ -30,10 +36,7 @@ ModalContent._meta = {
 
 ModalContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the modal content */
   children: PropTypes.any,

--- a/src/modules/Modal/ModalDescription.js
+++ b/src/modules/Modal/ModalDescription.js
@@ -1,7 +1,12 @@
 import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 function ModalDescription(props) {
   const { children, className } = props
@@ -28,10 +33,7 @@ ModalDescription._meta = {
 
 ModalDescription.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content */
   children: PropTypes.any,

--- a/src/modules/Modal/ModalHeader.js
+++ b/src/modules/Modal/ModalHeader.js
@@ -1,7 +1,12 @@
 import React, { PropTypes } from 'react'
 import classNames from 'classnames'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 function ModalHeader(props) {
   const { children, className } = props
@@ -29,10 +34,7 @@ ModalHeader._meta = {
 
 ModalHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the modal header */
   children: PropTypes.any,

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -87,10 +87,7 @@ Progress._meta = {
 
 Progress.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A progress bar can show activity. */
   active: PropTypes.bool,

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -4,6 +4,7 @@ import React, { PropTypes } from 'react'
 
 import {
   AutoControlledComponent as Component,
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
@@ -23,10 +24,7 @@ const _meta = {
 class Rating extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     /** Additional className. */
     className: PropTypes.string,

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -4,13 +4,14 @@ import React, { PropTypes } from 'react'
 
 import {
   AutoControlledComponent as Component,
+  customPropTypes,
   getElementType,
   getUnhandledProps,
   keyboardKey,
   makeDebugger,
   META,
-  SUI,
   objectDiff,
+  SUI,
   useKeyOnly,
   useValueAndKey,
 } from '../../lib'
@@ -35,10 +36,7 @@ const _meta = {
 export default class Search extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
+    as: customPropTypes.as,
 
     // ------------------------------------
     // Behavior

--- a/src/modules/Search/SearchCategory.js
+++ b/src/modules/Search/SearchCategory.js
@@ -2,9 +2,10 @@ import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
 import {
-  META,
+  customPropTypes,
   getElementType,
   getUnhandledProps,
+  META,
   useKeyOnly,
 } from '../../lib'
 
@@ -38,10 +39,7 @@ SearchCategory._meta = {
 
 SearchCategory.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** The item currently selected by keyboard shortcut. */
   active: PropTypes.bool,

--- a/src/modules/Search/SearchResult.js
+++ b/src/modules/Search/SearchResult.js
@@ -2,9 +2,10 @@ import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
 import {
-  META,
+  customPropTypes,
   getElementType,
   getUnhandledProps,
+  META,
   useKeyOnly,
 } from '../../lib'
 import { createImg } from '../../factories'
@@ -65,10 +66,7 @@ SearchResult._meta = {
 
 SearchResult.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** The item currently selected by keyboard shortcut. */
   active: PropTypes.bool,

--- a/src/modules/Search/SearchResults.js
+++ b/src/modules/Search/SearchResults.js
@@ -1,7 +1,12 @@
 import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
-import { getElementType, getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 
 function SearchResults(props) {
   const { children, className } = props
@@ -20,10 +25,7 @@ SearchResults._meta = {
 
 SearchResults.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Should be <Search.Result /> components. */
   children: PropTypes.node,

--- a/src/views/Card/Card.js
+++ b/src/views/Card/Card.js
@@ -82,10 +82,7 @@ Card._meta = {
 
 Card.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A Card can center itself inside its container. */
   centered: PropTypes.bool,

--- a/src/views/Card/CardContent.js
+++ b/src/views/Card/CardContent.js
@@ -46,10 +46,7 @@ CardContent._meta = {
 
 CardContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the CardContent. Mutually exclusive with all shorthand props. */
   children: customPropTypes.every([

--- a/src/views/Card/CardDescription.js
+++ b/src/views/Card/CardDescription.js
@@ -28,10 +28,7 @@ CardDescription._meta = {
 
 CardDescription.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the CardDescription. Mutually exclusive with content. */
   children: customPropTypes.every([

--- a/src/views/Card/CardGroup.js
+++ b/src/views/Card/CardGroup.js
@@ -46,10 +46,7 @@ CardGroup._meta = {
 
 CardGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** A group of Card components. Mutually exclusive with items. */
   children: customPropTypes.every([

--- a/src/views/Card/CardHeader.js
+++ b/src/views/Card/CardHeader.js
@@ -28,10 +28,7 @@ CardHeader._meta = {
 
 CardHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the CardHeader. Mutually exclusive with content. */
   children: customPropTypes.every([

--- a/src/views/Card/CardMeta.js
+++ b/src/views/Card/CardMeta.js
@@ -28,10 +28,7 @@ CardMeta._meta = {
 
 CardMeta.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the CardMeta. Mutually exclusive with content. */
   children: customPropTypes.every([

--- a/src/views/Feed/Feed.js
+++ b/src/views/Feed/Feed.js
@@ -57,10 +57,7 @@ Feed._meta = {
 
 Feed.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the Feed. */
   children: customPropTypes.every([

--- a/src/views/Feed/FeedContent.js
+++ b/src/views/Feed/FeedContent.js
@@ -38,10 +38,7 @@ FeedContent._meta = {
 
 FeedContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the FeedContent. */
   children: customPropTypes.every([

--- a/src/views/Feed/FeedDate.js
+++ b/src/views/Feed/FeedDate.js
@@ -27,10 +27,7 @@ FeedDate._meta = {
 
 FeedDate.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the FeedDate. Mutually exclusive with the date prop. */
   children: customPropTypes.every([

--- a/src/views/Feed/FeedEvent.js
+++ b/src/views/Feed/FeedEvent.js
@@ -37,10 +37,7 @@ FeedEvent._meta = {
 
 FeedEvent.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the FeedEvent. */
   children: customPropTypes.every([

--- a/src/views/Feed/FeedExtra.js
+++ b/src/views/Feed/FeedExtra.js
@@ -42,10 +42,7 @@ FeedExtra._meta = {
 
 FeedExtra.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the FeedExtra. */
   children: PropTypes.node,

--- a/src/views/Feed/FeedLabel.js
+++ b/src/views/Feed/FeedLabel.js
@@ -32,10 +32,7 @@ FeedLabel._meta = {
 
 FeedLabel.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the FeedLabel. */
   children: customPropTypes.every([

--- a/src/views/Feed/FeedLike.js
+++ b/src/views/Feed/FeedLike.js
@@ -36,10 +36,7 @@ FeedLike.defaultProps = {
 
 FeedLike.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the FeedLike. */
   children: customPropTypes.every([

--- a/src/views/Feed/FeedMeta.js
+++ b/src/views/Feed/FeedMeta.js
@@ -31,10 +31,7 @@ FeedMeta._meta = {
 
 FeedMeta.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the FeedMeta. */
   children: customPropTypes.every([

--- a/src/views/Feed/FeedSummary.js
+++ b/src/views/Feed/FeedSummary.js
@@ -31,10 +31,7 @@ FeedSummary._meta = {
 
 FeedSummary.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the FeedSummary. */
   children: customPropTypes.every([

--- a/src/views/Feed/FeedUser.js
+++ b/src/views/Feed/FeedUser.js
@@ -25,10 +25,7 @@ FeedUser._meta = {
 
 FeedUser.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the FeedUser. */
   children: customPropTypes.every([

--- a/src/views/Item/Item.js
+++ b/src/views/Item/Item.js
@@ -59,10 +59,7 @@ Item.Meta = ItemMeta
 
 Item.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the Item. */
   children: PropTypes.node,

--- a/src/views/Item/ItemContent.js
+++ b/src/views/Item/ItemContent.js
@@ -50,10 +50,7 @@ ItemContent._meta = {
 
 ItemContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the ItemContent. */
   children: customPropTypes.every([

--- a/src/views/Item/ItemDescription.js
+++ b/src/views/Item/ItemDescription.js
@@ -28,10 +28,7 @@ ItemDescription._meta = {
 
 ItemDescription.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the ItemDescription. */
   children: customPropTypes.every([

--- a/src/views/Item/ItemExtra.js
+++ b/src/views/Item/ItemExtra.js
@@ -28,10 +28,7 @@ ItemExtra._meta = {
 
 ItemExtra.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the ItemExtra. */
   children: customPropTypes.every([

--- a/src/views/Item/ItemGroup.js
+++ b/src/views/Item/ItemGroup.js
@@ -54,10 +54,7 @@ ItemGroup._meta = {
 
 ItemGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the ItemGroup. */
   children: PropTypes.node,

--- a/src/views/Item/ItemHeader.js
+++ b/src/views/Item/ItemHeader.js
@@ -28,10 +28,7 @@ ItemHeader._meta = {
 
 ItemHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the ItemHeader. */
   children: customPropTypes.every([

--- a/src/views/Item/ItemMeta.js
+++ b/src/views/Item/ItemMeta.js
@@ -28,10 +28,7 @@ ItemMeta._meta = {
 
 ItemMeta.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the ItemMeta. */
   children: customPropTypes.every([

--- a/src/views/Statistic/Statistic.js
+++ b/src/views/Statistic/Statistic.js
@@ -54,10 +54,7 @@ Statistic._meta = {
 
 Statistic.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the Statistic. */
   children: customPropTypes.every([

--- a/src/views/Statistic/StatisticGroup.js
+++ b/src/views/Statistic/StatisticGroup.js
@@ -47,10 +47,7 @@ StatisticGroup._meta = {
 
 StatisticGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the StatisticGroup. */
   children: customPropTypes.every([

--- a/src/views/Statistic/StatisticLabel.js
+++ b/src/views/Statistic/StatisticLabel.js
@@ -25,10 +25,7 @@ StatisticLabel._meta = {
 
 StatisticLabel.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the StatisticLabel. */
   children: customPropTypes.every([

--- a/src/views/Statistic/StatisticValue.js
+++ b/src/views/Statistic/StatisticValue.js
@@ -26,10 +26,7 @@ StatisticValue._meta = {
 
 StatisticValue.propTypes = {
   /** An element type to render as (string or function). */
-  as: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]),
+  as: customPropTypes.as,
 
   /** Primary content of the StatisticValue. */
   children: customPropTypes.every([


### PR DESCRIPTION
This is a break out of #452.  It adds the `as` customPropType and updates all components to use it.
