### PR TITLE
feat(commonTests): add implementsShorthandProp

### DIFF
--- a/src/collections/Message/Message.js
+++ b/src/collections/Message/Message.js
@@ -77,9 +77,9 @@ function Message(props) {
         {createIcon(icon)}
         {(header || content || list) && (
           <MessageContent>
-            {header && <MessageHeader>{header}</MessageHeader>}
+            {createShorthand(MessageHeader, val => ({ children: val }), header)}
             {createShorthand(MessageList, val => ({ items: val }), list)}
-            {content && <p>{content}</p>}
+            {createShorthand('p', val => ({ children: val }), content)}
           </MessageContent>
         )}
       </ElementType>

--- a/src/elements/Step/StepContent.js
+++ b/src/elements/Step/StepContent.js
@@ -61,7 +61,7 @@ StepContent.propTypes = {
       PropTypes.string,
       PropTypes.number,
       PropTypes.object,
-    ])
+    ]),
   ]),
 }
 

--- a/src/elements/Step/StepContent.js
+++ b/src/elements/Step/StepContent.js
@@ -57,7 +57,11 @@ StepContent.propTypes = {
   /** Primary content of the StepTitle. Mutually exclusive with children. */
   title: customPropTypes.every([
     customPropTypes.disallow(['children']),
-    PropTypes.node,
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.object,
+    ])
   ]),
 }
 

--- a/test/specs/collections/Breadcrumb/BreadcrumbDivider-test.js
+++ b/test/specs/collections/Breadcrumb/BreadcrumbDivider-test.js
@@ -4,7 +4,11 @@ import * as common from 'test/specs/commonTests'
 
 describe('BreadcrumbDivider', () => {
   common.isConformant(BreadcrumbDivider)
-  common.implementsIconProp(BreadcrumbDivider)
+  common.implementsIconProp(BreadcrumbDivider, {
+    requiredShorthandProps: {
+      className: 'divider',
+    },
+  })
   common.rendersChildren(BreadcrumbDivider)
 
   it('renders as a div by default', () => {

--- a/test/specs/collections/Message/Message-test.js
+++ b/test/specs/collections/Message/Message-test.js
@@ -11,9 +11,28 @@ import { sandbox } from 'test/utils'
 describe('Message', () => {
   common.isConformant(Message)
   common.hasUIClassName(Message)
-  common.rendersChildren(Message)
   common.hasSubComponents(Message, [MessageContent, MessageHeader, MessageList])
-
+  common.implementsIconProp(Message)
+  common.implementsShorthandProp(Message, {
+    propKey: 'list',
+    ShorthandComponent: MessageList,
+    mapValueToProps: val => ({ items: val }),
+  })
+  common.implementsShorthandProp(Message, {
+    propKey: 'header',
+    ShorthandComponent: MessageHeader,
+    mapValueToProps: val => ({ children: val }),
+  })
+  common.implementsShorthandProp(Message, {
+    propKey: 'list',
+    ShorthandComponent: MessageList,
+    mapValueToProps: val => ({ items: val }),
+  })
+  common.implementsShorthandProp(Message, {
+    propKey: 'content',
+    ShorthandComponent: 'p',
+    mapValueToProps: val => ({ children: val }),
+  })
   common.propValueOnlyToClassName(Message, 'size')
   common.propValueOnlyToClassName(Message, 'color')
 
@@ -31,72 +50,19 @@ describe('Message', () => {
 
   common.propKeyOrValueToClassName(Message, 'attached')
 
-  describe('content', () => {
-    it('does not exist by default', () => {
-      shallow(<Message />)
-        .should.not.have.descendants('MessageContent')
-    })
-    it('adds a MessageContent child when defined', () => {
-      const wrapper = shallow(<Message content='Yo there' />)
-
-      wrapper.should.have.descendants('MessageContent')
-
-      wrapper
-        .find('MessageContent')
-        .shallow()
-        .should.contain.text('Yo there')
-    })
-
-    it('wraps content value in a p tag', () => {
-      const wrapper = shallow(<Message content='This is a paragraph' />)
-
-      wrapper.should.have.descendants('p')
-
-      wrapper
-        .find('p')
-        .shallow()
-        .should.contain.text('This is a paragraph')
-    })
-  })
+  common.rendersChildren(Message)
 
   describe('header', () => {
-    it('does not exist by default', () => {
-      shallow(<Message />)
-        .should.not.have.descendants('MessageHeader')
-    })
-    it('adds a MessageHeader child when defined', () => {
-      const wrapper = shallow(<Message header='Yo there' />)
-
-      wrapper.should.have.descendants('MessageHeader')
-
-      wrapper
-        .find('MessageHeader')
-        .shallow()
-        .should.contain.text('Yo there')
-    })
-    it('adds a "content" wrapper when defined', () => {
+    it('adds MessageContent when defined', () => {
       shallow(<Message header='This is a message' />)
         .should.have.descendants('MessageContent')
     })
   })
 
   describe('icon', () => {
-    it('does not exist by default', () => {
-      shallow(<Message />)
-        .should.not.have.descendants('Icon')
-    })
-    it('does not have a "content" wrapper by default', () => {
+    it('does not have MessageContent by default', () => {
       shallow(<Message />)
         .should.not.have.descendants('.content')
-    })
-    it('adds a Icon child when defined', () => {
-      const wrapper = shallow(<Message icon='user' />)
-
-      wrapper.should.have.descendants('Icon')
-
-      wrapper
-        .find('Icon')
-        .should.have.prop('name', 'user')
     })
     it('renders children when "true"', () => {
       const text = 'child text'
@@ -111,21 +77,7 @@ describe('Message', () => {
   })
 
   describe('list', () => {
-    it('does not exist by default', () => {
-      shallow(<Message />)
-        .should.not.have.descendants('MessageList')
-    })
-    it('adds a MessageList and passes the items prop', () => {
-      const items = ['a', 'b', 'c']
-      const wrapper = shallow(<Message list={items} />)
-
-      wrapper.should.have.descendants('MessageList')
-
-      wrapper
-        .find('MessageList')
-        .should.have.prop('items', items)
-    })
-    it('adds a "content" wrapper when defined', () => {
+    it('adds MessageContent when defined', () => {
       shallow(<Message list={[]} />)
         .should.have.descendants('MessageContent')
     })

--- a/test/specs/elements/Button/Button-test.js
+++ b/test/specs/elements/Button/Button-test.js
@@ -12,7 +12,12 @@ describe('Button', () => {
   common.hasUIClassName(Button)
   common.hasSubComponents(Button, [ButtonContent, ButtonGroup, ButtonOr])
   common.implementsIconProp(Button)
-  common.implementsLabelProp(Button)
+  common.implementsLabelProp(Button, {
+    requiredShorthandProps: {
+      basic: true,
+      pointing: 'left',
+    },
+  })
 
   common.propKeyOnlyToClassName(Button, 'active')
   common.propKeyOrValueToClassName(Button, 'animated')

--- a/test/specs/elements/Header/Header-test.js
+++ b/test/specs/elements/Header/Header-test.js
@@ -26,19 +26,16 @@ describe('Header', () => {
   common.implementsIconProp(Header)
   common.implementsImageProp(Header)
   common.implementsTextAlignProp(Header)
+  common.implementsShorthandProp(Header, {
+    propKey: 'subheader',
+    ShorthandComponent: HeaderSubheader,
+    mapValueToProps: val => ({ content: val }),
+  })
 
   describe('icon', () => {
     it('adds an icon class when true', () => {
       shallow(<Header icon />)
         .should.have.className('icon')
-    })
-    it('does not add an Icon when true', () => {
-      shallow(<Header icon />)
-        .should.not.have.descendants('Icon')
-    })
-    it('adds an Icon when given a name', () => {
-      shallow(<Header icon='user' />)
-        .should.have.descendants('Icon')
     })
     it('does not add an icon class given a name', () => {
       shallow(<Header icon='user' />)
@@ -72,14 +69,7 @@ describe('Header', () => {
   })
 
   describe('subheader', () => {
-    it('adds HeaderSubheader as child', () => {
-      const text = faker.hacker.phrase()
-
-      shallow(<Header subheader={text} />)
-        .find('HeaderSubheader')
-        .should.have.prop('content', text)
-    })
-    it('adds HeaderSubheader as child when given a name to icon prop', () => {
+    it('adds HeaderSubheader as child when there is an icon', () => {
       const text = faker.hacker.phrase()
 
       shallow(<Header icon='user' subheader={text} />)

--- a/test/specs/elements/Step/StepContent-test.js
+++ b/test/specs/elements/Step/StepContent-test.js
@@ -1,6 +1,3 @@
-import faker from 'faker'
-import React from 'react'
-
 import * as common from 'test/specs/commonTests'
 import StepContent from 'src/elements/Step/StepContent'
 import StepDescription from 'src/elements/Step/StepDescription'
@@ -9,22 +6,14 @@ import StepTitle from 'src/elements/Step/StepTitle'
 describe('StepContent', () => {
   common.isConformant(StepContent)
   common.rendersChildren(StepContent)
-
-  describe('description prop', () => {
-    it('renders description component', () => {
-      const text = faker.hacker.phrase()
-
-      shallow(<StepContent description={text} />)
-        .should.contain(<StepDescription description={text} />)
-    })
+  common.implementsShorthandProp(StepContent, {
+    propKey: 'title',
+    ShorthandComponent: StepTitle,
+    mapValueToProps: val => ({ title: val }),
   })
-
-  describe('title prop', () => {
-    it('renders title component', () => {
-      const text = faker.hacker.phrase()
-
-      shallow(<StepContent title={text} />)
-        .should.contain(<StepTitle title={text} />)
-    })
+  common.implementsShorthandProp(StepContent, {
+    propKey: 'description',
+    ShorthandComponent: StepDescription,
+    mapValueToProps: val => ({ description: val }),
   })
 })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -71,6 +71,12 @@ describe('Dropdown Component', () => {
   common.hasSubComponents(Dropdown, [DropdownDivider, DropdownHeader, DropdownItem, DropdownMenu])
   common.isTabbable(Dropdown)
   common.implementsIconProp(Dropdown)
+  common.implementsShorthandProp(Dropdown, {
+    propKey: 'header',
+    ShorthandComponent: DropdownHeader,
+    mapValueToProps: val => ({ content: val }),
+  })
+
   common.propKeyOnlyToClassName(Dropdown, 'multiple')
   common.propKeyOnlyToClassName(Dropdown, 'search')
   common.propKeyOnlyToClassName(Dropdown, 'selection')

--- a/test/specs/modules/Dropdown/DropdownItem-test.js
+++ b/test/specs/modules/Dropdown/DropdownItem-test.js
@@ -4,18 +4,15 @@ import * as common from 'test/specs/commonTests'
 
 describe('DropdownItem', () => {
   common.isConformant(DropdownItem)
+  common.implementsShorthandProp(DropdownItem, {
+    propKey: 'description',
+    ShorthandComponent: 'span',
+    mapValueToProps: val => ({
+      className: 'description',
+      children: val,
+    }),
+  })
   common.rendersChildren(DropdownItem)
   common.propKeyOnlyToClassName(DropdownItem, 'selected')
   common.propKeyOnlyToClassName(DropdownItem, 'active')
-
-  describe('description', () => {
-    it('adds a description span', () => {
-      const wrapper = shallow(<DropdownItem description='foo' />)
-      wrapper.should.have.exactly(1).descendants('.description')
-
-      const description = wrapper.find('span')
-      description.should.have.className('description')
-      description.should.have.text('foo')
-    })
-  })
 })

--- a/test/specs/modules/Dropdown/DropdownItem-test.js
+++ b/test/specs/modules/Dropdown/DropdownItem-test.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import DropdownItem from 'src/modules/Dropdown/DropdownItem'
 import * as common from 'test/specs/commonTests'
 

--- a/test/specs/views/Card/CardContent-test.js
+++ b/test/specs/views/Card/CardContent-test.js
@@ -1,6 +1,3 @@
-import faker from 'faker'
-import React from 'react'
-
 import * as common from 'test/specs/commonTests'
 import CardContent from 'src/views/Card/CardContent'
 import CardDescription from 'src/views/Card/CardDescription'
@@ -9,33 +6,23 @@ import CardMeta from 'src/views/Card/CardMeta'
 
 describe('CardContent', () => {
   common.isConformant(CardContent)
+
+  common.implementsShorthandProp(CardContent, {
+    propKey: 'header',
+    ShorthandComponent: CardHeader,
+    mapValueToProps: val => ({ content: val }),
+  })
+  common.implementsShorthandProp(CardContent, {
+    propKey: 'meta',
+    ShorthandComponent: CardMeta,
+    mapValueToProps: val => ({ content: val }),
+  })
+  common.implementsShorthandProp(CardContent, {
+    propKey: 'description',
+    ShorthandComponent: CardDescription,
+    mapValueToProps: val => ({ content: val }),
+  })
+
   common.propKeyOnlyToClassName(CardContent, 'extra')
   common.rendersChildren(CardContent)
-
-  describe('description prop', () => {
-    it('renders CardDescription component', () => {
-      const text = faker.hacker.phrase()
-
-      shallow(<CardContent description={text} />)
-        .should.contain(<CardDescription content={text} />)
-    })
-  })
-
-  describe('header prop', () => {
-    it('renders CardHeader component', () => {
-      const text = faker.hacker.phrase()
-
-      shallow(<CardContent header={text} />)
-        .should.contain(<CardHeader content={text} />)
-    })
-  })
-
-  describe('meta prop', () => {
-    it('renders CardMeta component', () => {
-      const text = faker.hacker.phrase()
-
-      shallow(<CardContent meta={text} />)
-        .should.contain(<CardMeta content={text} />)
-    })
-  })
 })

--- a/test/specs/views/Feed/FeedContent-test.js
+++ b/test/specs/views/Feed/FeedContent-test.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import faker from 'faker'
 import React from 'react'
 

--- a/test/specs/views/Feed/FeedContent-test.js
+++ b/test/specs/views/Feed/FeedContent-test.js
@@ -4,41 +4,45 @@ import React from 'react'
 
 import * as common from 'test/specs/commonTests'
 import FeedContent from 'src/views/Feed/FeedContent'
+import FeedDate from 'src/views/Feed/FeedDate'
+import FeedSummary from 'src/views/Feed/FeedSummary'
+import FeedExtra from 'src/views/Feed/FeedExtra'
+import FeedMeta from 'src/views/Feed/FeedMeta'
 
 describe('FeedContent', () => {
   common.isConformant(FeedContent)
+
+  common.implementsShorthandProp(FeedContent, {
+    propKey: 'date',
+    ShorthandComponent: FeedDate,
+    mapValueToProps: val => ({ date: val }),
+  })
+  common.implementsShorthandProp(FeedContent, {
+    propKey: 'summary',
+    ShorthandComponent: FeedSummary,
+    mapValueToProps: val => ({ summary: val }),
+  })
+  common.implementsShorthandProp(FeedContent, {
+    propKey: 'extraImages',
+    ShorthandComponent: FeedExtra,
+    mapValueToProps: val => ({ images: val }),
+  })
+  common.implementsShorthandProp(FeedContent, {
+    propKey: 'extraText',
+    ShorthandComponent: FeedExtra,
+    mapValueToProps: val => ({ text: val }),
+  })
+  common.implementsShorthandProp(FeedContent, {
+    propKey: 'meta',
+    ShorthandComponent: FeedMeta,
+    mapValueToProps: val => ({ meta: val }),
+  })
+
   common.rendersChildren(FeedContent)
 
   it('renders text with content prop', () => {
     const text = faker.hacker.phrase()
 
     shallow(<FeedContent content={text} />).should.contain.text(text)
-  })
-
-  it('renders <FeedDate> with date prop', () => {
-    shallow(<FeedContent date={faker.hacker.phrase()} />)
-      .should.have.descendants('FeedDate')
-  })
-
-  it('renders <FeedExtra> with extraImages prop', () => {
-    const images = _.times(3, () => faker.image.imageUrl())
-
-    shallow(<FeedContent extraImages={images} />)
-      .should.have.descendants('FeedExtra')
-  })
-
-  it('renders <FeedExtra> with extraText prop', () => {
-    shallow(<FeedContent extraText={faker.hacker.phrase()} />)
-      .should.have.descendants('FeedExtra')
-  })
-
-  it('renders <FeedMeta> with meta prop', () => {
-    shallow(<FeedContent meta={faker.hacker.phrase()} />)
-      .should.have.descendants('FeedMeta')
-  })
-
-  it('renders <FeedSummary> with summary prop', () => {
-    shallow(<FeedContent summary={faker.hacker.phrase()} />)
-      .should.have.descendants('FeedSummary')
   })
 })

--- a/test/specs/views/Feed/FeedEvent-test.js
+++ b/test/specs/views/Feed/FeedEvent-test.js
@@ -4,19 +4,20 @@ import React from 'react'
 
 import * as common from 'test/specs/commonTests'
 import FeedEvent from 'src/views/Feed/FeedEvent'
+import FeedLabel from 'src/views/Feed/FeedLabel'
 
 describe('FeedEvent', () => {
   common.isConformant(FeedEvent)
   common.rendersChildren(FeedEvent)
-
-  it('renders <FeedLabel> with icon prop', () => {
-    shallow(<FeedEvent icon={faker.hacker.phrase()} />)
-      .should.have.descendants('FeedLabel')
+  common.implementsShorthandProp(FeedEvent, {
+    propKey: 'icon',
+    ShorthandComponent: FeedLabel,
+    mapValueToProps: val => ({ icon: val }),
   })
-
-  it('renders <FeedLabel> with image prop', () => {
-    shallow(<FeedEvent image={faker.image.imageUrl()} />)
-      .should.have.descendants('FeedLabel')
+  common.implementsShorthandProp(FeedEvent, {
+    propKey: 'image',
+    ShorthandComponent: FeedLabel,
+    mapValueToProps: val => ({ image: val }),
   })
 
   describe('content props', () => {

--- a/test/specs/views/Feed/FeedMeta-test.js
+++ b/test/specs/views/Feed/FeedMeta-test.js
@@ -3,14 +3,15 @@ import React from 'react'
 
 import * as common from 'test/specs/commonTests'
 import FeedMeta from 'src/views/Feed/FeedMeta'
+import FeedLike from 'src/views/Feed/FeedLike'
 
 describe('FeedMeta', () => {
   common.isConformant(FeedMeta)
   common.rendersChildren(FeedMeta)
-
-  it('renders <FeedLike> with like prop', () => {
-    shallow(<FeedMeta like={faker.hacker.phrase()} />)
-      .should.have.descendants('FeedLike')
+  common.implementsShorthandProp(FeedMeta, {
+    propKey: 'like',
+    ShorthandComponent: FeedLike,
+    mapValueToProps: val => ({ like: val }),
   })
 
   it('renders text with meta prop', () => {

--- a/test/specs/views/Feed/FeedSummary-test.js
+++ b/test/specs/views/Feed/FeedSummary-test.js
@@ -3,14 +3,15 @@ import React from 'react'
 
 import * as common from 'test/specs/commonTests'
 import FeedSummary from 'src/views/Feed/FeedSummary'
+import FeedDate from 'src/views/Feed/FeedDate'
 
 describe('FeedSummary', () => {
   common.isConformant(FeedSummary)
   common.rendersChildren(FeedSummary)
-
-  it('renders <FeedDate> with date prop', () => {
-    shallow(<FeedSummary date={faker.hacker.phrase()} />)
-      .should.have.descendants('FeedDate')
+  common.implementsShorthandProp(FeedSummary, {
+    propKey: 'date',
+    ShorthandComponent: FeedDate,
+    mapValueToProps: val => ({ date: val }),
   })
 
   it('renders text with summary prop', () => {

--- a/test/specs/views/Item/Item-test.js
+++ b/test/specs/views/Item/Item-test.js
@@ -15,6 +15,11 @@ describe('Item', () => {
   common.isConformant(Item)
   common.hasSubComponents(Item, [ItemContent, ItemDescription, ItemExtra, ItemGroup, ItemHeader, ItemImage, ItemMeta])
   common.rendersChildren(Item)
+  common.implementsShorthandProp(Item, {
+    propKey: 'image',
+    ShorthandComponent: ItemImage,
+    mapValueToProps: val => ({ src: val }),
+  })
 
   describe('content prop', () => {
     it('renders ItemContent component', () => {

--- a/test/specs/views/Item/ItemContent-test.js
+++ b/test/specs/views/Item/ItemContent-test.js
@@ -11,6 +11,26 @@ import ItemMeta from 'src/views/Item/ItemMeta'
 describe('ItemContent', () => {
   common.isConformant(ItemContent)
   common.implementsVerticalAlignProp(ItemContent)
+  common.implementsShorthandProp(ItemContent, {
+    propKey: 'header',
+    ShorthandComponent: ItemHeader,
+    mapValueToProps: val => ({ content: val }),
+  })
+  common.implementsShorthandProp(ItemContent, {
+    propKey: 'meta',
+    ShorthandComponent: ItemMeta,
+    mapValueToProps: val => ({ content: val }),
+  })
+  common.implementsShorthandProp(ItemContent, {
+    propKey: 'description',
+    ShorthandComponent: ItemDescription,
+    mapValueToProps: val => ({ content: val }),
+  })
+  common.implementsShorthandProp(ItemContent, {
+    propKey: 'extra',
+    ShorthandComponent: ItemExtra,
+    mapValueToProps: val => ({ content: val }),
+  })
   common.rendersChildren(ItemContent)
 
   describe('content prop', () => {
@@ -19,42 +39,6 @@ describe('ItemContent', () => {
 
       shallow(<ItemContent content={text} />)
         .should.contain.text(text)
-    })
-  })
-
-  describe('description prop', () => {
-    it('renders ItemDescription component', () => {
-      const text = faker.hacker.phrase()
-
-      shallow(<ItemContent description={text} />)
-        .should.contain(<ItemDescription content={text} />)
-    })
-  })
-
-  describe('extra prop', () => {
-    it('renders ItemExtra component', () => {
-      const text = faker.hacker.phrase()
-
-      shallow(<ItemContent extra={text} />)
-        .should.contain(<ItemExtra content={text} />)
-    })
-  })
-
-  describe('header prop', () => {
-    it('renders ItemHeader component', () => {
-      const text = faker.hacker.phrase()
-
-      shallow(<ItemContent header={text} />)
-        .should.contain(<ItemHeader content={text} />)
-    })
-  })
-
-  describe('meta prop', () => {
-    it('renders ItemMeta component', () => {
-      const text = faker.hacker.phrase()
-
-      shallow(<ItemContent meta={text} />)
-        .should.contain(<ItemMeta content={text} />)
     })
   })
 })


### PR DESCRIPTION
/cc @jcarbo @layershifter 

This PR adds a common test for shorthand props.  As with the factories, there is a base common test.  It takes all the same arguments as the factory.  The specific shorthand common tests simply call the base test with defaults.  Note, instead passing many arguments a config object is used to define the test params.
## Custom Shorthand Tests

When a component implements the `createShorthand` factory for a shorthand prop, you can define a test for that:

``` jsx
common.implementsShorthandProp(Header, {
  propKey: 'subheader',
  ShorthandComponent: HeaderSubheader,
  mapValueToProps: val => ({ content: val }),
})
```
## Pre-Defined Shorthand Tests

Basic Icon/Image/Label tests remain the same:

``` jsx
common.implementsIconProp(Header)
common.implementsImageProp(Header)
```

Since these are just implementations of `implementsShorthandProp` with default values set, you can customize them as well.  When a component passes additional params to the `create(Icon|Image|Label)` factory, you can configure the test to match:

``` jsx
common.implementsIconProp(BreadcrumbDivider, {
  requiredShorthandProps: {
    className: 'divider',
  },
})

common.implementsLabelProp(Button, {
  requiredShorthandProps: {
    basic: true,
    pointing: 'left',
  },
})
```
