### PR TITLE
fix(factories): explicitly handle each value type

### DIFF
--- a/src/factories.js
+++ b/src/factories.js
@@ -45,11 +45,11 @@ export function createShorthand(Component, mapValueToProps, val, extraProps = {}
   }
 
   // Map values to props and create a ReactElement
-  if (!_.isNil(val)) {
+  if (_.isString(val) || _.isNumber(val)) {
     return <Component {...mergePropsAndClassName(mapValueToProps(val), extraProps)} />
   }
 
-  // React requires ReactElements or null be returned
+  // Otherwise null
   return null
 }
 


### PR DESCRIPTION
Factories were returning empty components give boolean values.  This PR makes each return type explicitly list what it _includes_ rather than _excludes_.  The final else condition is null.
