### PR TITLE
docs(Menu): MenuItem icon and dropdown item example

### DIFF
--- a/docs/app/Examples/collections/Menu/Types/Attached.js
+++ b/docs/app/Examples/collections/Menu/Types/Attached.js
@@ -7,7 +7,7 @@ const Attached = () => {
   return (
     <div>
       <Menu attached='top'>
-        <Menu.Item as={Dropdown} icon='wrench'>
+        <Dropdown as={Menu.Item} icon='wrench'>
           <Dropdown.Menu>
             <Dropdown.Item>
               <Icon name='dropdown icon' />
@@ -25,7 +25,7 @@ const Attached = () => {
             <Dropdown.Header>Export</Dropdown.Header>
             <Dropdown.Item>Share</Dropdown.Item>
           </Dropdown.Menu>
-        </Menu.Item>
+        </Dropdown>
 
         <Menu.Menu position='right'>
           <div className='ui right aligned category search item'>

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -11,6 +11,7 @@ import {
   useKeyOnly,
   useKeyOrValueAndKey,
 } from '../../lib'
+import { createIcon } from '../../factories'
 
 function MenuItem(props) {
   const {
@@ -35,9 +36,18 @@ function MenuItem(props) {
   }
   const rest = getUnhandledProps(MenuItem, props)
 
+  if (children) {
+    return (
+      <ElementType {...rest} className={classes} onClick={handleClick}>
+        {children}
+      </ElementType>
+    )
+  }
+
   return (
     <ElementType {...rest} className={classes} onClick={handleClick}>
-      {children || content || _.startCase(name)}
+      {createIcon(icon)}
+      {content || _.startCase(name)}
     </ElementType>
   )
 }

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -7,6 +7,7 @@ import { sandbox } from 'test/utils'
 
 describe('MenuItem', () => {
   common.isConformant(MenuItem)
+  common.implementsIconProp(MenuItem)
   common.propKeyOnlyToClassName(MenuItem, 'active')
   common.propValueOnlyToClassName(MenuItem, 'color')
   common.propKeyOrValueToClassName(MenuItem, 'fitted')


### PR DESCRIPTION
This PR changes augmentation order so the Dropdown is augmented with a Menu.Item.  I also added the missing MenuItem icon shorthand.  The prop was there but not actually rendered.
# Before

![image](https://cloud.githubusercontent.com/assets/5067638/18801117/c3a8af80-8195-11e6-84c1-0c709d518db1.png)
# After

![image](https://cloud.githubusercontent.com/assets/5067638/18801125/cd966456-8195-11e6-9688-83af7ceffd20.png)
