### PR TITLE
docs(Menu): open nested dropdown item on hover

### DIFF
--- a/docs/app/Examples/collections/Menu/Types/Attached.js
+++ b/docs/app/Examples/collections/Menu/Types/Attached.js
@@ -7,7 +7,7 @@ const Attached = () => {
   return (
     <div>
       <Menu attached='top'>
-        <Dropdown as={Menu.Item} icon='wrench'>
+        <Dropdown as={Menu.Item} icon='wrench' simple>
           <Dropdown.Menu>
             <Dropdown.Item>
               <Icon name='dropdown icon' />


### PR DESCRIPTION
Fixes #533 

This PR adds the `simple` prop to the Dropdown item so it opens on hover via CSS.  This also handles nested menus 👍 

![simple Dropdown](http://g.recordit.co/LWO7x9hopj.gif)
