### PR TITLE
feat(ComponentExample): add show html button to docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "history": "^2.1.2",
     "html-webpack-plugin": "^2.17.0",
     "imports-loader": "^0.6.4",
+    "js-beautify": "^1.6.4",
     "json-loader": "^0.5.3",
     "karma": "^1.3.0",
     "karma-cli": "^1.0.0",


### PR DESCRIPTION
It is very helpful to see the rendered HTML output for examples.  I find I am constantly drilling through the dev tools to very the output of example markup.

This PR adds an HTML5 logo icon button next to the code button for all examples.  You can now toggle the JSX and/or the HTML into view:

![image](https://cloud.githubusercontent.com/assets/5067638/18816159/43640586-82f8-11e6-938a-e7d681a546b7.png)
