### PR TITLE
feat(ComponentExample): show code on direct link

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentExample.js
+++ b/docs/app/Components/ComponentDoc/ComponentExample.js
@@ -14,21 +14,27 @@ const showCodeStyle = {
   right: '1rem',
 }
 
-const descriptionStyle = {
-  marginRight: '5em',
-}
-
 const codeIconStyle = {
   fontWeight: 'bold',
 }
 
 const titleStyle = {
-  marginBottom: 0,
+  margin: 0,
 }
 
 const headerColumnStyle = {
   // provide room for absolutely positions toggle code icons
   minHeight: '4em',
+  paddingRight: '7em',
+}
+
+const childrenStyle = {
+  paddingTop: 0,
+}
+
+const renderedExampleStyle = {
+  paddingTop: 0,
+  paddingBottom: 0,
 }
 
 /**
@@ -46,7 +52,11 @@ export default class ComponentExample extends Component {
 
   constructor(props, context) {
     super(props, context)
-    this.state = { showCode: false, showHTML: false }
+    this.state = {
+      // show code for direct links to examples
+      showCode: props.title && _.kebabCase(props.title) === location.hash.replace('#', ''),
+      showHTML: false,
+    }
     this.fileContents = props.exampleSrc || require(`!raw!docs/app/Examples/${props.examplePath}`)
     this.component = exampleContext(`./${props.examplePath}.js`).default
   }
@@ -109,6 +119,8 @@ export default class ComponentExample extends Component {
     return (
       <Grid style={style} divided={active} columns='1'>
         <Grid.Column style={headerColumnStyle}>
+          {title && <Header as='h3' style={titleStyle}>{title}</Header>}
+          {description && <p>{description}</p>}
           <div style={showCodeStyle}>
             <Icon
               link
@@ -126,11 +138,16 @@ export default class ComponentExample extends Component {
               onClick={this.toggleShowHTML}
             />
           </div>
-          {title && <Header as='h3' style={titleStyle}>{title}</Header>}
-          {description && <p style={descriptionStyle}>{description}</p>}
-          {children}
         </Grid.Column>
-        <Grid.Column className={`rendered-example ${this.getKebabExamplePath()}`}>
+        {children && (
+          <Grid.Column style={childrenStyle}>
+            {children}
+          </Grid.Column>
+        )}
+        <Grid.Column
+          className={`rendered-example ${this.getKebabExamplePath()}`}
+          style={renderedExampleStyle}
+        >
           {createElement(this.component, rest)}
         </Grid.Column>
         {showCode && this.renderCode()}


### PR DESCRIPTION
Anchor links allow linking directly to examples.  This PR updates examples to expand their code when they are linked to directly.  For example, http://technologyadvice.github.io/stardust/elements/button#emphasis renders with the code showing:

![image](https://cloud.githubusercontent.com/assets/5067638/18897535/fd269e1e-84df-11e6-8f73-204d3a243ffc.png)

It also fixes some more minor layout issues.
