### PR TITLE
fix(dll): fix dll build order

### DIFF
--- a/gulp/tasks/dll.js
+++ b/gulp/tasks/dll.js
@@ -1,5 +1,5 @@
 import del from 'del'
-import { task, parallel, series } from 'gulp'
+import { task, series } from 'gulp'
 import loadPlugins from 'gulp-load-plugins'
 import webpack from 'webpack'
 
@@ -12,8 +12,8 @@ const { log, PluginError } = g.util
 // Clean
 // ----------------------------------------
 
-task('clean:umd', (cb) => {
-  del.sync(config.paths.umdDist())
+task('clean:dll', (cb) => {
+  del.sync(config.paths.base('dll'))
   cb()
 })
 
@@ -21,9 +21,9 @@ task('clean:umd', (cb) => {
 // Build
 // ----------------------------------------
 
-task('build:umd:webpack', (cb) => {
-  const webpackUMDConfig = require('../../webpack.umd.config')
-  const compiler = webpack(webpackUMDConfig)
+task('build:dll', (cb) => {
+  const webpackDLLConfig = require('../../webpack.dll')
+  const compiler = webpack(webpackDLLConfig)
 
   compiler.run((err, stats) => {
     const { errors, warnings } = stats.toJson()
@@ -46,18 +46,11 @@ task('build:umd:webpack', (cb) => {
   })
 })
 
-task('build:umd', series(
-  parallel(
-    'dll',
-    'clean:umd'
-  ),
-  'build:umd:webpack'
-))
-
 // ----------------------------------------
 // Default
 // ----------------------------------------
 
-task('umd', series(
-  'build:umd'
+task('dll', series(
+  'clean:dll',
+  'build:dll',
 ))

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "scripts": {
     "docs": "gulp docs",
     "build": "npm run build:commonjs && npm run build:umd && npm run build:docs",
-    "prebuild:commonjs": "rimraf dist/commonjs",
+    "prebuild:commonjs": "rimraf dist/commonjs && npm run build:dll",
     "build:commonjs": "babel src -d dist/commonjs",
     "prebuild:docs": "npm run build:docs-toc",
+    "build:dll": "gulp dll",
     "build:docs": "gulp build:docs",
     "build:umd": "cross-env NODE_ENV=browser gulp umd",
     "build:docs-toc": "doctoc README.md ./.github/CONTRIBUTING.md --github --maxlevel 4",
@@ -30,7 +31,7 @@
     "release:patch": "ta-script npm/release.sh patch",
     "start": "npm run docs",
     "start:local-modules": "npm run docs -- --local-modules",
-    "pretest": "gulp build:docs:dll",
+    "pretest": "npm run build:dll",
     "test": "cross-env NODE_ENV=test karma start",
     "test:watch": "npm run test --silent -- --watch"
   },


### PR DESCRIPTION
The `dll` build is required for all other builds. This is because they utilize config from the base config, which tries to instantiate the dll plugin.  It is currently associated with the doc build only.  This PR makes it a separate gulp task and npm script and ensures it runs before every build task.

Should fix what is breaking master on CI right now.
