### PR TITLE
feat(Popup): add component

### DIFF
--- a/docs/app/Examples/modules/Popup/Triggers/PopupClickExample.js
+++ b/docs/app/Examples/modules/Popup/Triggers/PopupClickExample.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const PopupClickExample = () => (
+  <Popup
+    trigger={<Button color='red' icon='flask' content='Activate doomsday device' />}
+    content={<Button color='green' content='Confirm the launch' />}
+    on='click'
+    positioning='top right'
+  />
+)
+
+export default PopupClickExample

--- a/docs/app/Examples/modules/Popup/Triggers/PopupFocusExample.js
+++ b/docs/app/Examples/modules/Popup/Triggers/PopupFocusExample.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Input, Popup } from 'semantic-ui-react'
+
+const PopupFocusExample = () => (
+  <Popup
+    trigger={<Input icon='search' placeholder='Search...' />}
+    header='Movie Search'
+    content='You may search by genre, header, year and actors'
+    on='focus'
+  />
+)
+
+export default PopupFocusExample

--- a/docs/app/Examples/modules/Popup/Triggers/PopupHoverExample.js
+++ b/docs/app/Examples/modules/Popup/Triggers/PopupHoverExample.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const PopupHoverExample = () => (
+  <Popup
+    trigger={<Button icon='add' content='Add a friend' />}
+    content='Sends an email invite to a friend.'
+    on='hover'
+  />
+)
+
+export default PopupHoverExample

--- a/docs/app/Examples/modules/Popup/Triggers/index.js
+++ b/docs/app/Examples/modules/Popup/Triggers/index.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const PopupTriggersExamples = () => (
+  <ExampleSection title='Triggers'>
+    <ComponentExample
+      title='Hover'
+      description='A popup can be triggered on hover'
+      examplePath='modules/Popup/Triggers/PopupHoverExample'
+    />
+    <ComponentExample
+      title='Click'
+      description='A popup can be triggered on click'
+      examplePath='modules/Popup/Triggers/PopupClickExample'
+    />
+    <ComponentExample
+      title='Focus'
+      description='A popup can be triggered on focus'
+      examplePath='modules/Popup/Triggers/PopupFocusExample'
+    />
+  </ExampleSection>
+)
+
+export default PopupTriggersExamples

--- a/docs/app/Examples/modules/Popup/Types/PopupExample.js
+++ b/docs/app/Examples/modules/Popup/Types/PopupExample.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const PopupExample = () => (
+  <Popup
+    trigger={<Button icon='add' />}
+    content='Add users to your feed'
+  />
+)
+
+export default PopupExample

--- a/docs/app/Examples/modules/Popup/Types/PopupHtmlExample.js
+++ b/docs/app/Examples/modules/Popup/Types/PopupHtmlExample.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Popup, Card, Rating, Image } from 'semantic-ui-react'
+
+const IndividualCard = (
+  <Card>
+    <Image src='http://semantic-ui.com/images/movies/totoro-horizontal.jpg' />
+    <Card.Content>
+      <Card.Header>
+        My Neighbor Totoro
+      </Card.Header>
+      <Card.Description>
+        Two sisters move to the country with their father in order to be
+        closer to their hospitalized mother, and discover the surrounding
+        trees are inhabited by magical spirits.
+      </Card.Description>
+    </Card.Content>
+  </Card>
+)
+
+const PopupHtmlExample = () => (
+  <Popup trigger={IndividualCard}>
+    <Popup.Header>User Rating</Popup.Header>
+    <Popup.Content>
+      <Rating icon='star' defaultRating={3} maxRating={4} />
+    </Popup.Content>
+  </Popup>
+)
+
+export default PopupHtmlExample

--- a/docs/app/Examples/modules/Popup/Types/PopupTitledExample.js
+++ b/docs/app/Examples/modules/Popup/Types/PopupTitledExample.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Image, Popup } from 'semantic-ui-react'
+
+const users = [
+  {
+    name: 'Elliot Fu',
+    bio: 'Elliot has been a member since July 2012',
+    avatar: 'http://semantic-ui.com/images/avatar/small/elliot.jpg',
+  },
+  {
+    name: 'Stevie Feliciano',
+    bio: 'Stevie has been a member since August 2013',
+    avatar: 'http://semantic-ui.com/images/avatar/small/stevie.jpg',
+  },
+  {
+    name: 'Matt',
+    bio: 'Matt has been a member since July 2014',
+    avatar: 'http://semantic-ui.com/images/avatar/small/matt.jpg',
+  },
+]
+
+export default function PopupTitledExample() {
+  const avatars = users.map((user, index) =>
+    <Popup
+      key={user.name}
+      trigger={<Image src={user.avatar} avatar />}
+      header={user.name}
+      content={user.bio}
+    />
+  )
+
+  return <div>{avatars}</div>
+}

--- a/docs/app/Examples/modules/Popup/Types/index.js
+++ b/docs/app/Examples/modules/Popup/Types/index.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const PopupTypesExamples = () => (
+  <ExampleSection title='Types'>
+    <ComponentExample
+      title='Popup'
+      description='An element can specify popup content to appear'
+      examplePath='modules/Popup/Types/PopupExample'
+    />
+    <ComponentExample
+      title='Titled'
+      description='An element can specify popup content with a title'
+      examplePath='modules/Popup/Types/PopupTitledExample'
+    />
+    <ComponentExample
+      title='HTML'
+      description='An element can specify HTML for a popup'
+      examplePath='modules/Popup/Types/PopupHtmlExample'
+    />
+  </ExampleSection>
+)
+
+export default PopupTypesExamples

--- a/docs/app/Examples/modules/Popup/Variations/PopupBasicExample.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupBasicExample.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const PopupBasicExample = () => (
+  <Popup
+    trigger={<Button icon='add' />}
+    content="The default theme's basic popup removes the pointing arrow."
+    basic
+  />
+)
+
+export default PopupBasicExample

--- a/docs/app/Examples/modules/Popup/Variations/PopupFlowingExample.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupFlowingExample.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Header, Button, Popup, Grid } from 'semantic-ui-react'
+
+const PopupFlowingExample = () => (
+  <Popup
+    trigger={<Button>Show flowing popup</Button>}
+    flowing
+    hoverable
+  >
+    <Grid centered divided columns={3}>
+      <Grid.Column textAlign='center'>
+        <Header as='h4'>Basic Plan</Header>
+        <p><b>2</b> projects, $10 a month</p>
+        <Button>Choose</Button>
+      </Grid.Column>
+      <Grid.Column textAlign='center'>
+        <Header as='h4'>Business Plan</Header>
+        <p><b>5</b> projects, $20 a month</p>
+        <Button>Choose</Button>
+      </Grid.Column>
+      <Grid.Column textAlign='center'>
+        <Header as='h4'>Premium Plan</Header>
+        <p><b>8</b> projects, $25 a month</p>
+        <Button>Choose</Button>
+      </Grid.Column>
+    </Grid>
+  </Popup>
+)
+
+export default PopupFlowingExample

--- a/docs/app/Examples/modules/Popup/Variations/PopupHideOnScrollExample.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupHideOnScrollExample.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const PopupHideOnScrollExample = () => (
+  <div>
+    <Popup
+      trigger={<Button icon>Click me</Button>}
+      content='Hide the popup on any scroll event'
+      on='click'
+      hideOnScroll
+    />
+    <Popup
+      trigger={<Button icon>Hover me</Button>}
+      content='Hide the popup on any scroll event'
+      hideOnScroll
+    />
+  </div>
+)
+
+export default PopupHideOnScrollExample

--- a/docs/app/Examples/modules/Popup/Variations/PopupInvertedExample.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupInvertedExample.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Button, Icon, Popup } from 'semantic-ui-react'
+
+const PopupInvertedExample = () => (
+  <div>
+    <Popup
+      trigger={<Button icon='add' />}
+      content='Hello. This is an inverted popup'
+      inverted
+    />
+    <Popup
+      trigger={<Icon circular name='heart' />}
+      content='Hello. This is an inverted popup'
+      inverted
+    />
+  </div>
+)
+
+export default PopupInvertedExample

--- a/docs/app/Examples/modules/Popup/Variations/PopupOffsetExample.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupOffsetExample.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Icon, Popup } from 'semantic-ui-react'
+
+const PopupOffsetExample = () => (
+  <div>
+    <Popup
+      trigger={<Icon size='large' name='heart' circular />}
+      content='Way off to the left'
+      offset={50}
+      positioning='left center'
+    />
+    <Popup
+      trigger={<Icon size='large' name='heart' circular />}
+      content='As expected this popup is way off to the right'
+      offset={50}
+      positioning='right center'
+    />
+  </div>
+)
+
+export default PopupOffsetExample

--- a/docs/app/Examples/modules/Popup/Variations/PopupPositionExample.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupPositionExample.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import { Icon, Popup, Grid } from 'semantic-ui-react'
+
+const PopupPositionExample = () => (
+  <Grid columns={3} style={{ width: '600px' }}>
+    <Grid.Row>
+      <Grid.Column>
+        <Popup
+          trigger={<Icon name='heart' color='red' size='large' circular />}
+          content='I am positioned to the top left'
+          positioning='top left'
+        />
+      </Grid.Column>
+      <Grid.Column textAlign='center'>
+        <Popup
+          trigger={<Icon name='heart' color='red' size='large' circular />}
+          content='I am positioned to the top center'
+          positioning='top center'
+        />
+      </Grid.Column>
+      <Grid.Column textAlign='right'>
+        <Popup
+          trigger={<Icon name='heart' color='red' size='large' circular />}
+          content='I am positioned to the top right'
+          positioning='top right'
+        />
+      </Grid.Column>
+    </Grid.Row>
+    <Grid.Row>
+      <Grid.Column floated='left'>
+        <Popup
+          trigger={<Icon name='heart' color='red' size='large' circular />}
+          content='I am positioned to the left center'
+          positioning='left center'
+        />
+      </Grid.Column>
+      <Grid.Column floated='right' textAlign='right'>
+        <Popup
+          trigger={<Icon name='heart' color='red' size='large' circular />}
+          content='I am positioned to the right center'
+          positioning='right center'
+        />
+      </Grid.Column>
+    </Grid.Row>
+    <Grid.Row>
+      <Grid.Column>
+        <Popup
+          trigger={<Icon name='heart' color='red' size='large' circular />}
+          content='I am positioned to the bottom left'
+          positioning='bottom left'
+        />
+      </Grid.Column>
+      <Grid.Column textAlign='center'>
+        <Popup
+          trigger={<Icon name='heart' color='red' size='large' circular />}
+          content='I am positioned to the bottom center'
+          positioning='bottom center'
+        />
+      </Grid.Column>
+      <Grid.Column textAlign='right'>
+        <Popup
+          trigger={<Icon name='heart' color='red' size='large' circular />}
+          content='I am positioned to the bottom right'
+          positioning='bottom right'
+        />
+      </Grid.Column>
+    </Grid.Row>
+  </Grid>
+)
+
+export default PopupPositionExample

--- a/docs/app/Examples/modules/Popup/Variations/PopupSizeExample.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupSizeExample.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Icon, Popup } from 'semantic-ui-react'
+
+const PopupSizeExample = () => (
+  <div>
+    <Popup
+      trigger={<Icon circular name='heart' />}
+      content='Hello. This is a mini popup'
+      size='mini'
+    />
+    <Popup
+      trigger={<Icon circular name='heart' />}
+      content='Hello. This is a tiny popup'
+      size='tiny'
+    />
+    <Popup
+      trigger={<Icon circular name='heart' />}
+      content='Hello. This is a small popup'
+      size='small'
+    />
+    <Popup
+      trigger={<Icon circular name='heart' />}
+      content='Hello. This is a large popup'
+      size='large'
+    />
+    <Popup
+      trigger={<Icon circular name='heart' />}
+      content='Hello. This is a huge popup'
+      size='huge'
+    />
+  </div>
+)
+
+export default PopupSizeExample

--- a/docs/app/Examples/modules/Popup/Variations/PopupStyleExample.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupStyleExample.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const style = {
+  borderRadius: 0,
+  opacity: 0.7,
+  padding: '2em',
+}
+
+const PopupStyleExample = () => (
+  <Popup
+    trigger={<Button icon='eye' />}
+    content='Popup with a custom style prop'
+    style={style}
+    inverted
+  />
+)
+
+export default PopupStyleExample

--- a/docs/app/Examples/modules/Popup/Variations/PopupWideExample.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupWideExample.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Icon, Popup } from 'semantic-ui-react'
+
+const PopupWideExample = () => (
+  <div>
+    <Popup trigger={<Icon circular name='heart' />} >
+      Hello. This is a regular pop-up which does not allow for lots
+      of content. You cannot fit a lot of words here as the
+      paragraphs will be pretty narrow.
+    </Popup>
+    <Popup
+      trigger={<Icon circular name='heart' />}
+      wide
+    >
+      Hello. This is a wide pop-up which allows for lots of content
+      with additional space. You can fit a lot of words here and the
+      paragraphs will be pretty wide.
+    </Popup>
+    <Popup
+      trigger={<Icon circular name='heart' />}
+      wide='very'
+    >
+      Hello. This is a very wide pop-up which allows for lots of
+      content with additional space. You can fit a lot of words
+      here and the paragraphs will be pretty wide.
+    </Popup>
+  </div>
+)
+
+export default PopupWideExample

--- a/docs/app/Examples/modules/Popup/Variations/index.js
+++ b/docs/app/Examples/modules/Popup/Variations/index.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const PopupVariationsExamples = () => (
+  <ExampleSection title='Variations'>
+    <ComponentExample
+      title='Basic'
+      description='A popup can provide more basic formatting'
+      examplePath='modules/Popup/Variations/PopupBasicExample'
+    />
+    <ComponentExample
+      title='Wide'
+      description='A popup can be extra wide to allow for longer content'
+      examplePath='modules/Popup/Variations/PopupWideExample'
+    />
+    <ComponentExample
+      title='Size'
+      description='A popup can vary in size'
+      examplePath='modules/Popup/Variations/PopupSizeExample'
+    />
+    <ComponentExample
+      title='Flowing'
+      description='A popup can have no maximum width and continue to flow to fit its content'
+      examplePath='modules/Popup/Variations/PopupFlowingExample'
+    />
+    <ComponentExample
+      title='Inverted'
+      description='A popup can have its colors inverted'
+      examplePath='modules/Popup/Variations/PopupInvertedExample'
+    />
+    <ComponentExample
+      title='Position'
+      description='A popup can be position around its trigger'
+      examplePath='modules/Popup/Variations/PopupPositionExample'
+    />
+    <ComponentExample
+      title='Offset'
+      description='A popup position can be adjusted manually by specifying an offset property'
+      examplePath='modules/Popup/Variations/PopupOffsetExample'
+    />
+    <ComponentExample
+      title='Style'
+      description='A popup accepts custom styles'
+      examplePath='modules/Popup/Variations/PopupStyleExample'
+    />
+    <ComponentExample
+      title='Hide on scroll'
+      description='A popup can be hidden on a scroll event'
+      examplePath='modules/Popup/Variations/PopupHideOnScrollExample'
+    />
+  </ExampleSection>
+)
+
+export default PopupVariationsExamples

--- a/docs/app/Examples/modules/Popup/index.js
+++ b/docs/app/Examples/modules/Popup/index.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import Types from './Types'
+import Variations from './Variations'
+import Triggers from './Triggers'
+
+const PopupExamples = () => (
+  <div>
+    <Types />
+    <Variations />
+    <Triggers />
+  </div>
+)
+
+export default PopupExamples

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -205,14 +205,14 @@ class Portal extends Component {
       e.stopPropagation()
       this.close(e)
     } else if (!open && openOnTriggerClick) {
-      // Prevents closeOnDocumentClick from closing the portal when
-      // openOnTriggerFocus is set. Focus shifts on mousedown so the portal opens
-      // before the click finishes so it may actually wind up on the document.
-      e.nativeEvent.stopImmediatePropagation()
-
       e.stopPropagation()
       this.open(e)
     }
+
+    // Prevents closeOnDocumentClick from closing the portal when
+    // openOnTriggerFocus is set. Focus shifts on mousedown so the portal opens
+    // before the click finishes so it may actually wind up on the document.
+    e.nativeEvent.stopImmediatePropagation()
   }
 
   handleTriggerFocus = (e) => {

--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,10 @@ export { default as ModalContent } from './modules/Modal/ModalContent'
 export { default as ModalDescription } from './modules/Modal/ModalDescription'
 export { default as ModalHeader } from './modules/Modal/ModalHeader'
 
+export { default as Popup } from './modules/Popup'
+export { default as PopupContent } from './modules/Popup/PopupContent'
+export { default as PopupHeader } from './modules/Popup/PopupHeader'
+
 export { default as Progress } from './modules/Progress'
 
 export { default as Rating } from './modules/Rating'

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -1,0 +1,306 @@
+import React, { Component, PropTypes } from 'react'
+import cx from 'classnames'
+import _ from 'lodash'
+import {
+  getElementType,
+  getUnhandledProps,
+  META,
+  SUI,
+  useKeyOnly,
+  useKeyOrValueAndKey,
+} from '../../lib'
+import Portal from '../../addons/Portal'
+import PopupContent from './PopupContent'
+import PopupHeader from './PopupHeader'
+
+const _meta = {
+  name: 'Popup',
+  type: META.TYPES.MODULE,
+  props: {
+    content: [PropTypes.string, PropTypes.node],
+    on: ['hover', 'click', 'focus'],
+    positioning: [
+      'top left',
+      'top right',
+      'bottom right',
+      'bottom left',
+      'right center',
+      'left center',
+      'top center',
+      'bottom center',
+    ],
+    size: _.without(SUI.SIZES, 'medium', 'big', 'massive'),
+    wide: [true, false, 'very'],
+  },
+}
+
+/**
+ * A Popup displays additional information on top of a page.
+ */
+export default class Popup extends Component {
+  static propTypes = {
+    /** Display the popup without the pointing arrow */
+    basic: PropTypes.bool,
+
+    /** You may pass a content as children of the Popup */
+    children: PropTypes.node,
+
+    /** Classes to add to the Popup className. */
+    className: PropTypes.string,
+
+    /** Simple text content for the popover */
+    content: PropTypes.oneOfType(_meta.props.content),
+
+    /** A Flowing popup have no maximum width and continue to flow to fit its content */
+    flowing: PropTypes.bool,
+
+    /** Takes up the entire width of its offset container */
+    // TODO: implement the Popup fluid layout
+    // fluid: PropTypes.bool,
+
+    /** Header displayed above the content in bold */
+    header: PropTypes.string,
+
+    /** Whether the popup should not close on hover */
+    hoverable: PropTypes.bool,
+
+    /** Invert the colors of the popup */
+    inverted: PropTypes.bool,
+
+    /** The node where the popup should mount.. */
+    hideOnScroll: PropTypes.bool,
+
+    /** Horizontal offset in pixels to be applied to the popup */
+    offset: PropTypes.number,
+
+    /** Event triggering the popup */
+    on: PropTypes.oneOf(_meta.props.on),
+
+    /** Positioning for the popover */
+    positioning: PropTypes.oneOf(_meta.props.positioning),
+
+    /** Popup size */
+    size: PropTypes.oneOf(_meta.props.size),
+
+    /** custom popup style */
+    style: PropTypes.object,
+
+    /** Element to be rendered in-place where the popup is defined. */
+    trigger: PropTypes.node,
+
+    /** Popup width */
+    wide: PropTypes.oneOf(_meta.props.wide),
+  }
+
+  static defaultProps = {
+    positioning: 'top left',
+    on: 'hover',
+  }
+
+  static _meta = _meta
+  static Content = PopupContent
+  static Header = PopupHeader
+
+  state = {}
+
+  computePopupStyle(positions) {
+    const style = { position: 'absolute' }
+    const { offset } = this.props
+    const { pageYOffset, pageXOffset } = window
+    const { clientWidth, clientHeight } = document.documentElement
+
+    if (_.includes(positions, 'right')) {
+      style.right = Math.round(clientWidth - (this.coords.right + pageXOffset))
+      style.left = 'auto'
+    } else if (_.includes(positions, 'left')) {
+      style.left = Math.round(this.coords.left + pageXOffset)
+      style.right = 'auto'
+    } else {  // if not left nor right, we are horizontally centering the element
+      const xOffset = (this.coords.width - this.popupCoords.width) / 2
+      style.left = Math.round(this.coords.left + xOffset + pageXOffset)
+      style.right = 'auto'
+    }
+
+    if (_.includes(positions, 'top')) {
+      style.bottom = Math.round(clientHeight - (this.coords.top + pageYOffset))
+      style.top = 'auto'
+    } else if (_.includes(positions, 'bottom')) {
+      style.top = Math.round(this.coords.bottom + pageYOffset)
+      style.bottom = 'auto'
+    } else {  // if not top nor bottom, we are vertically centering the element
+      const yOffset = (this.coords.height + this.popupCoords.height) / 2
+      style.top = Math.round(this.coords.bottom + pageYOffset - yOffset)
+      style.bottom = 'auto'
+
+      const xOffset = this.popupCoords.width + 8
+      if (_.includes(positions, 'right')) {
+        style.right -= xOffset
+      } else {
+        style.left -= xOffset
+      }
+    }
+
+    if (offset) {
+      if (_.isNumber(style.right)) {
+        style.right -= offset
+      } else {
+        style.left -= offset
+      }
+    }
+
+    return style
+  }
+
+  // check if the style would display
+  // the popup outside of the view port
+  isStyleInViewport(style) {
+    const { pageYOffset, pageXOffset } = window
+    const { clientWidth, clientHeight } = document.documentElement
+
+    const element = {
+      top: style.top,
+      left: style.left,
+      width: this.popupCoords.width,
+      height: this.popupCoords.height,
+    }
+    if (_.isNumber(style.right)) {
+      element.left = clientWidth - style.right - element.width
+    }
+    if (_.isNumber(style.bottom)) {
+      element.top = clientHeight - style.bottom - element.height
+    }
+
+    // hidden on top
+    if (element.top < pageYOffset) return false
+    // hidden on the bottom
+    if (element.top + element.height > pageYOffset + clientHeight) return false
+    // hidden the left
+    if (element.left < pageXOffset) return false
+    // hidden on the right
+    if (element.left + element.width > pageXOffset + clientWidth) return false
+
+    return true
+  }
+
+  setPopupStyle() {
+    if (!this.coords || !this.popupCoords) return
+    let positioning = this.props.positioning
+    let style = this.computePopupStyle(positioning)
+
+    // Lets detect if the popup is out of the viewport and adjust
+    // the position accordingly
+    const positions = _.without(_meta.props.positioning, positioning)
+    for (let i = 0; !this.isStyleInViewport(style) && i < positions.length; i++) {
+      style = this.computePopupStyle(positions[i])
+      positioning = positions[i]
+    }
+
+    // Append 'px' to every numerical values in the style
+    style = _.mapValues(style, value => _.isNumber(value) ? value + 'px' : value)
+    this.setState({ style, positioning })
+  }
+
+  getPortalProps() {
+    const portalProps = { onOpen: this.onOpen }
+    const { on, hoverable } = this.props
+
+    switch (on) {
+      case 'click':
+        portalProps.openOnTriggerClick = true
+        portalProps.closeOnTriggerClick = true
+        portalProps.closeOnDocumentClick = true
+        break
+
+      case 'focus':
+        portalProps.openOnTriggerFocus = true
+        portalProps.closeOnTriggerBlur = true
+        break
+
+      default:  // default to hover
+        portalProps.openOnTriggerMouseOver = true
+        portalProps.closeOnTriggerMouseLeave = true
+        // Taken from SUI: https://git.io/vPmCm
+        portalProps.mouseLeaveDelay = 70
+        portalProps.mouseOverDelay = 50
+        break
+    }
+
+    if (hoverable) {
+      portalProps.closeOnPortalMouseLeave = true
+      portalProps.mouseLeaveDelay = 300
+    }
+
+    return portalProps
+  }
+
+  hideOnScroll = (event) => {
+    this.setState({ closed: true })
+    window.removeEventListener('scroll', this.hideOnScroll)
+    setTimeout(() => this.setState({ closed: false }), 50)
+  }
+
+  onOpen = (event) => {
+    this.coords = event.currentTarget.getBoundingClientRect()
+    if (this.props.hideOnScroll) {
+      window.addEventListener('scroll', this.hideOnScroll)
+    }
+  }
+
+  popupMounted = (ref) => {
+    this.popupCoords = ref ? ref.getBoundingClientRect() : null
+    this.setPopupStyle()
+  }
+
+  render() {
+    const {
+      basic,
+      children,
+      className,
+      content,
+      flowing,
+      header,
+      inverted,
+      size,
+      trigger,
+      wide,
+    } = this.props
+
+    const { positioning, closed } = this.state
+    const style = _.assign({}, this.state.style, this.props.style)
+    const classes = cx(
+      'ui',
+      positioning,
+      size,
+      useKeyOrValueAndKey(wide, 'wide'),
+      useKeyOnly(basic, 'basic'),
+      useKeyOnly(flowing, 'flowing'),
+      useKeyOnly(inverted, 'inverted'),
+      'popup transition visible',
+      className,
+    )
+
+    if (closed) return trigger
+
+    const rest = getUnhandledProps(Popup, this.props)
+    const ElementType = getElementType(Popup, this.props)
+    const portalProps = _.pick(rest, _.keys(Portal.propTypes))
+
+    const popupJSX = (
+      <ElementType {...rest} className={classes} style={style} ref={this.popupMounted}>
+        {children}
+        {!children && PopupHeader.create(header)}
+        {!children && PopupContent.create(content)}
+      </ElementType>
+    )
+
+    return (
+      <Portal
+        {...portalProps}
+        trigger={trigger}
+        {...this.getPortalProps()}
+      >
+        {popupJSX}
+      </Portal>
+    )
+  }
+}

--- a/src/modules/Popup/PopupContent.js
+++ b/src/modules/Popup/PopupContent.js
@@ -1,0 +1,36 @@
+import React, { PropTypes } from 'react'
+import cx from 'classnames'
+import {
+  createShorthandFactory,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
+
+/**
+ * A PopupContent displays the content body of a Popover.
+ */
+export default function PopupContent(props) {
+  const { children, className } = props
+  const classes = cx('content', className)
+  const rest = getUnhandledProps(PopupContent, props)
+  const ElementType = getElementType(PopupContent, props)
+
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
+}
+
+PopupContent.create = createShorthandFactory(PopupContent, value => ({ children: value }))
+
+PopupContent.propTypes = {
+  /** The content of the Popup */
+  children: PropTypes.node,
+
+  /** Classes to add to the Popup content className. */
+  className: PropTypes.string,
+}
+
+PopupContent._meta = {
+  name: 'PopupContent',
+  type: META.TYPES.MODULE,
+  parent: 'Popup',
+}

--- a/src/modules/Popup/PopupHeader.js
+++ b/src/modules/Popup/PopupHeader.js
@@ -1,0 +1,36 @@
+import React, { PropTypes } from 'react'
+import cx from 'classnames'
+import {
+  createShorthandFactory,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
+
+/**
+ * A PopupHeader displays a header in a Popover.
+ */
+export default function PopupHeader(props) {
+  const { children, className } = props
+  const classes = cx('header', className)
+  const rest = getUnhandledProps(PopupHeader, props)
+  const ElementType = getElementType(PopupHeader, props)
+
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
+}
+
+PopupHeader.create = createShorthandFactory(PopupHeader, value => ({ children: value }))
+
+PopupHeader.propTypes = {
+  /** The header of the Popup */
+  children: PropTypes.node,
+
+  /** Classes to add to the Popup header className. */
+  className: PropTypes.string,
+}
+
+PopupHeader._meta = {
+  name: 'PopupHeader',
+  type: META.TYPES.MODULE,
+  parent: 'Popup',
+}

--- a/src/modules/Popup/index.js
+++ b/src/modules/Popup/index.js
@@ -1,0 +1,1 @@
+export default from './Popup'

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -1,0 +1,327 @@
+import _ from 'lodash'
+import React from 'react'
+
+import Popup from 'src/modules/Popup/Popup'
+import PopupHeader from 'src/modules/Popup/PopupHeader'
+import PopupContent from 'src/modules/Popup/PopupContent'
+import Portal from 'src/addons/Portal/Portal'
+
+import { keyboardKey } from 'src/lib'
+import { domEvent, sandbox } from 'test/utils'
+import * as common from 'test/specs/commonTests'
+
+// ----------------------------------------
+// Wrapper
+// ----------------------------------------
+let wrapper
+
+// we need to unmount the Popup after every test to remove it from the document
+// wrap the render methods to update a global wrapper that is unmounted after each test
+const wrapperMount = (...args) => (wrapper = mount(...args))
+const wrapperShallow = (...args) => (wrapper = shallow(...args))
+
+const assertIn = (node, selector, isPresent = true) => {
+  const didFind = node.querySelector(selector) !== null
+  didFind.should.equal(isPresent, `${didFind ? 'Found' : 'Did not find'} "${selector}" in the ${node}.`)
+}
+const assertInBody = (...args) => assertIn(document.body, ...args)
+
+const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }
+
+describe('Popup', () => {
+  beforeEach(() => {
+    wrapper = undefined
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    if (wrapper && wrapper.unmount) wrapper.unmount()
+  })
+
+  common.hasSubComponents(Popup, [PopupHeader, PopupContent])
+
+  // Heads up!
+  //
+  // Our commonTests do not currently handle wrapped components.
+  // Nor do they handle components rendered to the body with Portal.
+  // The Popup is wrapped in a Portal, so we manually test a few things here.
+
+  it('renders a Portal', () => {
+    wrapperShallow(<Popup />)
+      .type()
+      .should.equal(Portal)
+  })
+
+  it('renders to the document body', () => {
+    wrapperMount(<Popup open />)
+    assertInBody('.ui.popup.visible')
+  })
+
+  it('renders child text', () => {
+    wrapperMount(<Popup open>child text</Popup>)
+
+    document.querySelector('.ui.popup.visible')
+      .innerText
+      .should.equal('child text')
+  })
+
+  it('renders child components', () => {
+    const child = <div data-child />
+    wrapperMount(<Popup open>{child}</Popup>)
+
+    document
+      .querySelector('.ui.popup.visible')
+      .querySelector('[data-child]')
+      .should.not.equal(null, 'Popup did not render the child component.')
+  })
+
+  it('should add className to the Popup wrapping node', () => {
+    wrapperMount(<Popup className='some-class' open />)
+    assertInBody('.ui.popup.visible.some-class')
+  })
+
+  describe('offest', () => {
+    it('accepts an offest to the left', () => {
+      wrapperMount(
+        <Popup
+          offset={50}
+          positioning='bottom right'
+          content='foo'
+          trigger={<button>foo</button>}
+        />
+      )
+
+      wrapper.find('button').simulate('click', nativeEvent)
+      assertInBody('.ui.popup.visible')
+    })
+    it('accepts an offest to the right', () => {
+      wrapperMount(
+        <Popup
+          offset={50}
+          positioning='bottom left'
+          content='foo'
+          trigger={<button>foo</button>}
+        />
+      )
+
+      wrapper.find('button').simulate('click', nativeEvent)
+      assertInBody('.ui.popup.visible')
+    })
+  })
+
+  describe('positioning', () => {
+    it('is always within the viewport', () => {
+      _.each(Popup._meta.props.positions, position => {
+        wrapperMount(
+          <Popup
+            positioning={position}
+            content='_'
+            trigger={<button>foo</button>}
+            on='click'
+          />
+        )
+        wrapper.find('button').simulate('click', nativeEvent)
+        const {
+          top,
+          right,
+          bottom,
+          left,
+        } = document.querySelector('.popup.ui').getBoundingClientRect()
+
+        expect(top).to.be.at.least(0)
+        expect(left).to.be.at.least(0)
+        expect(bottom).to.be.at.most(document.documentElement.clientHeight)
+        expect(right).to.be.at.most(document.documentElement.clientWidth)
+      })
+    })
+  })
+
+  describe('hoverable', () => {
+    it('can be set to stay visible while hovering the popup', () => {
+      shallow(<Popup hoverable open />)
+        .find('Portal')
+        .should.have.prop('closeOnPortalMouseLeave', true)
+    })
+  })
+
+  describe('hide on scroll', () => {
+    it('hides on window scroll', () => {
+      const trigger = <button>foo</button>
+      wrapperMount(<Popup hideOnScroll content='foo' trigger={trigger} />)
+
+      wrapper.find('button').simulate('click', nativeEvent)
+      assertInBody('.ui.popup.visible')
+
+      document.body.scrollTop = 100
+
+      const evt = document.createEvent('CustomEvent')
+      evt.initCustomEvent('scroll', false, false, null)
+
+      window.dispatchEvent(evt)
+
+      assertInBody('.ui.popup.visible', false)
+    })
+  })
+
+  describe('trigger', () => {
+    it('it appears on click', () => {
+      const trigger = <button>foo</button>
+      wrapperMount(<Popup on='click' content='foo' header='bar' trigger={trigger} />)
+
+      wrapper.find('button').simulate('click', nativeEvent)
+      assertInBody('.ui.popup.visible')
+    })
+
+    it('it appears on hover', (done) => {
+      const trigger = <button>foo</button>
+      wrapperMount(<Popup content='foo' trigger={trigger} />)
+
+      wrapper.find('button').simulate('mouseover', nativeEvent)
+      setTimeout(() => {
+        assertInBody('.ui.popup.visible')
+        done()
+      }, 51)
+    })
+
+    it('it appears on focus', () => {
+      const trigger = <input type='text' />
+      wrapperMount(<Popup on='focus' content='foo' trigger={trigger} />)
+
+      wrapper.find('input').simulate('focus', nativeEvent)
+      assertInBody('.ui.popup.visible')
+    })
+  })
+
+  describe('open', () => {
+    it('is not open by default', () => {
+      wrapperMount(<Popup />)
+      assertInBody('.ui.popup.visible', false)
+    })
+
+    it('is passed to Portal open', () => {
+      shallow(<Popup open />)
+        .find('Portal')
+        .should.have.prop('open', true)
+
+      shallow(<Popup open={false} />)
+        .find('Portal')
+        .should.have.prop('open', false)
+    })
+
+    it('does not show the popup when false', () => {
+      wrapperMount(<Popup open={false} />)
+      assertInBody('.ui.popup.visible', false)
+    })
+
+    it('shows the popup on changing from false to true', () => {
+      wrapperMount(<Popup open={false} />)
+      assertInBody('.ui.popup.visible', false)
+
+      wrapper.setProps({ open: true })
+
+      assertInBody('.ui.popup.visible')
+    })
+
+    it('hides the popup on changing from true to false', () => {
+      wrapperMount(<Popup open />)
+      assertInBody('.ui.popup.visible')
+
+      wrapper.setProps({ open: false })
+
+      assertInBody('.ui.popup.visible', false)
+    })
+  })
+
+  describe('basic', () => {
+    it('adds basic to the popup className', () => {
+      wrapperMount(<Popup basic open />)
+      assertInBody('.ui.basic.popup.visible')
+    })
+  })
+
+  describe('flowing', () => {
+    it('adds flowing to the popup className', () => {
+      wrapperMount(<Popup flowing open />)
+      assertInBody('.ui.flowing.popup.visible')
+    })
+  })
+
+  describe('inverted', () => {
+    it('adds inverted to the popup className', () => {
+      wrapperMount(<Popup inverted open />)
+      assertInBody('.ui.inverted.popup.visible')
+    })
+  })
+
+  describe('wide', () => {
+    it('adds wide to the popup className', () => {
+      wrapperMount(<Popup wide open />)
+      assertInBody('.ui.wide.popup.visible')
+    })
+  })
+
+  describe('very wide', () => {
+    it('adds very wide to the popup className', () => {
+      wrapperMount(<Popup wide='very' open />)
+      assertInBody('.ui.very.wide.popup.visible')
+    })
+  })
+
+  describe('size', () => {
+    it('defines prop options in _meta', () => {
+      Popup._meta.props.should.have.any.keys('size')
+      Popup._meta.props.size.should.be.an('array')
+    })
+
+    it('adds the size to the popup className', () => {
+      Popup._meta.props.size.forEach(size => {
+        wrapperMount(<Popup size={size} open />)
+        assertInBody(`.ui.${size}.popup`)
+      })
+    })
+  })
+
+  describe('onClose', () => {
+    let spy
+
+    beforeEach(() => {
+      spy = sandbox.spy()
+      wrapperMount(<Popup onClose={spy} defaultOpen />)
+    })
+
+    it('is called on body click', () => {
+      domEvent.click(document.querySelector('.ui.popup').parentNode)
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is not called on click inside of the popup', () => {
+      domEvent.click(document.querySelector('.ui.popup'))
+      spy.should.not.have.been.calledOnce()
+    })
+
+    it('is called on body click', () => {
+      domEvent.click('body')
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is called when pressing escape', () => {
+      domEvent.keyDown(document, { key: 'Escape' })
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is not called when pressing a key other than "Escape"', () => {
+      _.each(keyboardKey, (val, key) => {
+        // skip Escape key
+        if (val === keyboardKey.Escape) return
+
+        domEvent.keyDown(document, { key })
+        spy.should.not.have.been.called(`onClose was called when pressing "${key}"`)
+      })
+    })
+
+    it('is not called when the open prop changes to false', () => {
+      wrapper.setProps({ open: false })
+      spy.should.not.have.been.called()
+    })
+  })
+})

--- a/test/specs/modules/Popup/PopupContent-test.js
+++ b/test/specs/modules/Popup/PopupContent-test.js
@@ -1,0 +1,7 @@
+import PopupContent from 'src/modules/Popup/PopupContent'
+import * as common from 'test/specs/commonTests'
+
+describe('PopupContent', () => {
+  common.isConformant(PopupContent)
+  common.rendersChildren(PopupContent)
+})

--- a/test/specs/modules/Popup/PopupHeader-test.js
+++ b/test/specs/modules/Popup/PopupHeader-test.js
@@ -1,0 +1,7 @@
+import PopupHeader from 'src/modules/Popup/PopupHeader'
+import * as common from 'test/specs/commonTests'
+
+describe('PopupHeader', () => {
+  common.isConformant(PopupHeader)
+  common.rendersChildren(PopupHeader)
+})


### PR DESCRIPTION
Port of SUI Popup module

Fixes #193 
- [x] sizing
- [x] content / header
- [x] positioning
- [x] events
  - [x] hover
  - [x] click
  - [x] focus
- [x] hoverable (will be fixed by #590)
- [x] widths
  - [x] use SUI enums
- [x] sizes
  - [x] use SUI enums
- [x] inverted
- [x] basic
- [x] offset
- [x] hideOnScroll (quick solution to scrollable sub-content like a sidebar) 
- [x] exclusive
- [x] custom class names
- [x] custom styles

To be done later:
- inline (popup as a sibling of trigger, will be implemented later)
- transition (animation will probably be for later)
