### PR TITLE
feat(Modal): Enable usage without wrapper, add custom Portal

### DIFF
--- a/docs/app/Examples/modules/Modal/Types/ModalBasicExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalBasicExample.js
@@ -1,36 +1,21 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Button, Header, Icon, Modal } from 'stardust'
 
-class ModalBasicExample extends Component {
-  state = { active: false }
-
-  show = () => this.setState({ active: true })
-  hide = () => this.setState({ active: false })
-
-  render() {
-    const { active } = this.state
-
-    return (
-      <div>
-        <Button onClick={this.show}>Basic Modal</Button>
-
-        <Modal basic size='small' active={active} onHide={this.hide}>
-          <Header icon='archive' content='Archive Old Messages' />
-          <Modal.Content>
-            <p>Your inbox is getting full, would you like us to enable automatic archiving of old messages?</p>
-          </Modal.Content>
-          <Modal.Actions>
-            <Button basic color='red' inverted onClick={this.hide}>
-              <Icon name='remove' /> No
-            </Button>
-            <Button color='green' inverted onClick={this.hide}>
-              <Icon name='checkmark' /> Yes
-            </Button>
-          </Modal.Actions>
-        </Modal>
-      </div>
-    )
-  }
-}
+const ModalBasicExample = () => (
+  <Modal portal={{ trigger: <Button>Basic Modal</Button> }} basic size='small'>
+    <Header icon='archive' content='Archive Old Messages' />
+    <Modal.Content>
+      <p>Your inbox is getting full, would you like us to enable automatic archiving of old messages?</p>
+    </Modal.Content>
+    <Modal.Actions>
+      <Button basic color='red' inverted>
+        <Icon name='remove' /> No
+      </Button>
+      <Button color='green' inverted>
+        <Icon name='checkmark' /> Yes
+      </Button>
+    </Modal.Actions>
+  </Modal>
+)
 
 export default ModalBasicExample

--- a/docs/app/Examples/modules/Modal/Types/ModalBasicExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalBasicExample.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button, Header, Icon, Modal } from 'stardust'
 
 const ModalBasicExample = () => (
-  <Modal portal={{ trigger: <Button>Basic Modal</Button> }} basic size='small'>
+  <Modal trigger={<Button>Basic Modal</Button>} basic size='small'>
     <Header icon='archive' content='Archive Old Messages' />
     <Modal.Content>
       <p>Your inbox is getting full, would you like us to enable automatic archiving of old messages?</p>

--- a/docs/app/Examples/modules/Modal/Types/ModalModalExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalModalExample.js
@@ -1,33 +1,18 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Button, Header, Image, Modal } from 'stardust'
 
-class ModalModalExample extends Component {
-  state = { active: false }
-
-  show = () => this.setState({ active: true })
-  hide = () => this.setState({ active: false })
-
-  render() {
-    const { active } = this.state
-
-    return (
-      <div>
-        <Button onClick={this.show}>Show Modal</Button>
-
-        <Modal active={active} onHide={this.hide}>
-          <Modal.Header>Select a Photo</Modal.Header>
-          <Modal.Content image>
-            <Image wrapped className='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
-            <Modal.Description>
-              <Header>Default Profile Image</Header>
-              <p>We've found the following gravatar image associated with your e-mail address.</p>
-              <p>Is it okay to use this photo?</p>
-            </Modal.Description>
-          </Modal.Content>
-        </Modal>
-      </div>
-    )
-  }
-}
+const ModalModalExample = () => (
+  <Modal portal={{ trigger: <Button>Show Modal</Button> }}>
+    <Modal.Header>Select a Photo</Modal.Header>
+    <Modal.Content image>
+      <Image wrapped className='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
+      <Modal.Description>
+        <Header>Default Profile Image</Header>
+        <p>We've found the following gravatar image associated with your e-mail address.</p>
+        <p>Is it okay to use this photo?</p>
+      </Modal.Description>
+    </Modal.Content>
+  </Modal>
+)
 
 export default ModalModalExample

--- a/docs/app/Examples/modules/Modal/Types/ModalModalExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalModalExample.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button, Header, Image, Modal } from 'stardust'
 
 const ModalModalExample = () => (
-  <Modal portal={{ trigger: <Button>Show Modal</Button> }}>
+  <Modal trigger={<Button>Show Modal</Button>}>
     <Modal.Header>Select a Photo</Modal.Header>
     <Modal.Content image>
       <Image wrapped size='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />

--- a/docs/app/Examples/modules/Modal/Types/ModalModalExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalModalExample.js
@@ -5,7 +5,7 @@ const ModalModalExample = () => (
   <Modal portal={{ trigger: <Button>Show Modal</Button> }}>
     <Modal.Header>Select a Photo</Modal.Header>
     <Modal.Content image>
-      <Image wrapped className='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
+      <Image wrapped size='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
       <Modal.Description>
         <Header>Default Profile Image</Header>
         <p>We've found the following gravatar image associated with your e-mail address.</p>

--- a/docs/app/Examples/modules/Modal/Types/ModalScrollingExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalScrollingExample.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button, Header, Icon, Image, Modal } from 'stardust'
 
 const ModalScrollingExample = () => (
-  <Modal portal={{ trigger: <Button>Long Modal</Button> }}>
+  <Modal trigger={<Button>Long Modal</Button>}>
     <Modal.Header>Profile Picture</Modal.Header>
     <Modal.Content image>
       <Image wrapped size='medium' src='http://semantic-ui.com/images/wireframe/image.png' />

--- a/docs/app/Examples/modules/Modal/Types/ModalScrollingExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalScrollingExample.js
@@ -5,7 +5,7 @@ const ModalScrollingExample = () => (
   <Modal portal={{ trigger: <Button>Long Modal</Button> }}>
     <Modal.Header>Profile Picture</Modal.Header>
     <Modal.Content image>
-      <Image wrapped className='medium' src='http://semantic-ui.com/images/wireframe/image.png' />
+      <Image wrapped size='medium' src='http://semantic-ui.com/images/wireframe/image.png' />
       <Modal.Description>
         <Header>Modal Header</Header>
         <p>This is an example of expanded content that will cause the modal's dimmer to scroll</p>

--- a/docs/app/Examples/modules/Modal/Types/ModalScrollingExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalScrollingExample.js
@@ -1,46 +1,31 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Button, Header, Icon, Image, Modal } from 'stardust'
 
-class ModalScrollingExample extends Component {
-  state = { active: false }
-
-  show = () => this.setState({ active: true })
-  hide = () => this.setState({ active: false })
-
-  render() {
-    const { active, dimmer } = this.state
-
-    return (
-      <div>
-        <Button onClick={this.show}>Long Modal</Button>
-
-        <Modal dimmer={dimmer} active={active} onHide={this.hide}>
-          <Modal.Header>Profile Picture</Modal.Header>
-          <Modal.Content image>
-            <Image wrapped className='medium' src='http://semantic-ui.com/images/wireframe/image.png' />
-            <Modal.Description>
-              <Header>Modal Header</Header>
-              <p>This is an example of expanded content that will cause the modal's dimmer to scroll</p>
-              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
-              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
-              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
-              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
-              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
-              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
-              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
-              <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
-            </Modal.Description>
-          </Modal.Content>
-          <Modal.Actions>
-            <Button primary icon onClick={this.hide}>
-              Proceed <Icon name='right chevron' />
-            </Button>
-          </Modal.Actions>
-        </Modal>
-      </div>
-    )
-  }
-}
+const ModalScrollingExample = () => (
+  <Modal portal={{ trigger: <Button>Long Modal</Button> }}>
+    <Modal.Header>Profile Picture</Modal.Header>
+    <Modal.Content image>
+      <Image wrapped className='medium' src='http://semantic-ui.com/images/wireframe/image.png' />
+      <Modal.Description>
+        <Header>Modal Header</Header>
+        <p>This is an example of expanded content that will cause the modal's dimmer to scroll</p>
+        <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+        <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+        <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+        <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+        <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+        <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+        <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+        <Image src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+      </Modal.Description>
+    </Modal.Content>
+    <Modal.Actions>
+      <Button primary icon>
+        Proceed <Icon name='right chevron' />
+      </Button>
+    </Modal.Actions>
+  </Modal>
+)
 
 export default ModalScrollingExample
 

--- a/docs/app/Examples/modules/Modal/Variations/ModalCloseConfigExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalCloseConfigExample.js
@@ -8,7 +8,7 @@ class ModalCloseConfigExample extends Component {
     this.setState({ closeOnEscape, closeOnDocumentClick, open: true })
   }
 
-  hide = () => this.setState({ open: false })
+  close = () => this.setState({ open: false })
 
   render() {
     const { open, closeOnEscape, closeOnDocumentClick } = this.state
@@ -18,7 +18,12 @@ class ModalCloseConfigExample extends Component {
         <Button onClick={this.closeConfigShow(false, true)}>No Close on Escape</Button>
         <Button onClick={this.closeConfigShow(true, false)}>No Close on Click Outside</Button>
 
-        <Modal portal={{ open, closeOnEscape, closeOnDocumentClick }} onHide={this.hide}>
+        <Modal
+          open={open}
+          closeOnEscape={closeOnEscape}
+          closeOnDocumentClick={closeOnDocumentClick}
+          onClose={this.close}
+        >
           <Modal.Header>
             Delete Your Account
           </Modal.Header>

--- a/docs/app/Examples/modules/Modal/Variations/ModalCloseConfigExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalCloseConfigExample.js
@@ -2,25 +2,23 @@ import React, { Component } from 'react'
 import { Button, Icon, Modal } from 'stardust'
 
 class ModalCloseConfigExample extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  closeConfigShow = (closeOnEscape, closeOnClickOutside) => () => {
-    this.setState({ closeOnEscape, closeOnClickOutside, active: true })
+  closeConfigShow = (closeOnEscape, closeOnDocumentClick) => () => {
+    this.setState({ closeOnEscape, closeOnDocumentClick, open: true })
   }
 
-  hide = () => this.setState({ active: false })
+  hide = () => this.setState({ open: false })
 
   render() {
-    const { active, closeOnEscape, closeOnClickOutside } = this.state
+    const { open, closeOnEscape, closeOnDocumentClick } = this.state
 
     return (
       <div>
         <Button onClick={this.closeConfigShow(false, true)}>No Close on Escape</Button>
         <Button onClick={this.closeConfigShow(true, false)}>No Close on Click Outside</Button>
 
-        <Modal active={active} onHide={this.hide}
-          closeOnEscape={closeOnEscape} closeOnClickOutside={closeOnClickOutside}
-        >
+        <Modal portal={{ open, closeOnEscape, closeOnDocumentClick }} onHide={this.hide}>
           <Modal.Header>
             Delete Your Account
           </Modal.Header>

--- a/docs/app/Examples/modules/Modal/Variations/ModalDimmerExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalDimmerExample.js
@@ -5,7 +5,7 @@ class ModalDimmerExample extends Component {
   state = { open: false }
 
   show = (dimmer) => () => this.setState({ dimmer, open: true })
-  hide = () => this.setState({ open: false })
+  close = () => this.setState({ open: false })
 
   render() {
     const { open, dimmer } = this.state
@@ -17,7 +17,7 @@ class ModalDimmerExample extends Component {
         <Button onClick={this.show('blurring')}>Blurring</Button>
         <Button onClick={this.show(false)}>None</Button>
 
-        <Modal dimmer={dimmer} portal={{ open }} onHide={this.hide}>
+        <Modal dimmer={dimmer} open={open} onClose={this.close}>
           <Modal.Header>Select a Photo</Modal.Header>
           <Modal.Content image>
             <Image wrapped size='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
@@ -28,10 +28,10 @@ class ModalDimmerExample extends Component {
             </Modal.Description>
           </Modal.Content>
           <Modal.Actions>
-            <Button color='black' onClick={this.hide}>
+            <Button color='black' onClick={this.close}>
               Nope
             </Button>
-            <Button positive icon labeled='right' onClick={this.hide}>
+            <Button positive icon labeled='right' onClick={this.close}>
               Yep, that's me <Icon name='checkmark' />
             </Button>
           </Modal.Actions>

--- a/docs/app/Examples/modules/Modal/Variations/ModalDimmerExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalDimmerExample.js
@@ -20,7 +20,7 @@ class ModalDimmerExample extends Component {
         <Modal dimmer={dimmer} portal={{ open }} onHide={this.hide}>
           <Modal.Header>Select a Photo</Modal.Header>
           <Modal.Content image>
-            <Image wrapped className='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
+            <Image wrapped size='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />
             <Modal.Description>
               <Header>Default Profile Image</Header>
               <p>We've found the following gravatar image associated with your e-mail address.</p>

--- a/docs/app/Examples/modules/Modal/Variations/ModalDimmerExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalDimmerExample.js
@@ -2,13 +2,13 @@ import React, { Component } from 'react'
 import { Button, Header, Icon, Image, Modal } from 'stardust'
 
 class ModalDimmerExample extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  show = (dimmer) => () => this.setState({ dimmer, active: true })
-  hide = () => this.setState({ active: false })
+  show = (dimmer) => () => this.setState({ dimmer, open: true })
+  hide = () => this.setState({ open: false })
 
   render() {
-    const { active, dimmer } = this.state
+    const { open, dimmer } = this.state
 
     return (
       <div>
@@ -17,7 +17,7 @@ class ModalDimmerExample extends Component {
         <Button onClick={this.show('blurring')}>Blurring</Button>
         <Button onClick={this.show(false)}>None</Button>
 
-        <Modal dimmer={dimmer} active={active} onHide={this.hide}>
+        <Modal dimmer={dimmer} portal={{ open }} onHide={this.hide}>
           <Modal.Header>Select a Photo</Modal.Header>
           <Modal.Content image>
             <Image wrapped className='medium' src='http://semantic-ui.com/images/avatar2/large/rachel.png' />

--- a/docs/app/Examples/modules/Modal/Variations/ModalSizeExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalSizeExample.js
@@ -5,7 +5,7 @@ class ModalSizeExample extends Component {
   state = { open: false }
 
   show = (size) => () => this.setState({ size, open: true })
-  hide = () => this.setState({ open: false })
+  close = () => this.setState({ open: false })
 
   render() {
     const { open, size } = this.state
@@ -16,7 +16,7 @@ class ModalSizeExample extends Component {
         <Button onClick={this.show('large')}>Large</Button>
         <Button onClick={this.show('fullscreen')}>Fullscreen</Button>
 
-        <Modal size={size} portal={{ open }} onHide={this.hide}>
+        <Modal size={size} open={open} onClose={this.close}>
           <Modal.Header>
             Delete Your Account
           </Modal.Header>

--- a/docs/app/Examples/modules/Modal/Variations/ModalSizeExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalSizeExample.js
@@ -2,13 +2,13 @@ import React, { Component } from 'react'
 import { Button, Icon, Modal } from 'stardust'
 
 class ModalSizeExample extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  show = (size) => () => this.setState({ size, active: true })
-  hide = () => this.setState({ active: false })
+  show = (size) => () => this.setState({ size, open: true })
+  hide = () => this.setState({ open: false })
 
   render() {
-    const { active, size } = this.state
+    const { open, size } = this.state
 
     return (
       <div>
@@ -16,7 +16,7 @@ class ModalSizeExample extends Component {
         <Button onClick={this.show('large')}>Large</Button>
         <Button onClick={this.show('fullscreen')}>Fullscreen</Button>
 
-        <Modal size={size} active={active} onHide={this.hide}>
+        <Modal size={size} portal={{ open }} onHide={this.hide}>
           <Modal.Header>
             Delete Your Account
           </Modal.Header>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "classnames": "^2.1.5",
     "debug": "^2.2.0",
     "lodash": "^4.6.1",
-    "react-dom": "^15.3.1",
     "semantic-ui-css": "^2.2.2"
   },
   "devDependencies": {
@@ -109,6 +108,7 @@
     "react-addons-test-utils": "^15.3.1",
     "react-docgen": "^2.10.0",
     "react-document-title": "^2.0.2",
+    "react-dom": "^15.3.1",
     "react-hot-loader": "^1.3.0",
     "react-router": "^2.7.0",
     "react-transform-catch-errors": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "classnames": "^2.1.5",
     "debug": "^2.2.0",
     "lodash": "^4.6.1",
-    "react-portal": "^2.2.1",
+    "react-dom": "^15.3.1",
     "semantic-ui-css": "^2.2.2"
   },
   "devDependencies": {
@@ -109,7 +109,6 @@
     "react-addons-test-utils": "^15.3.1",
     "react-docgen": "^2.10.0",
     "react-document-title": "^2.0.2",
-    "react-dom": "^15.3.1",
     "react-hot-loader": "^1.3.0",
     "react-router": "^2.7.0",
     "react-transform-catch-errors": "^1.0.2",

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -4,9 +4,6 @@ import ReactDOM from 'react-dom'
 
 import {
   AutoControlledComponent as Component,
-  // customPropTypes,
-  // getElementType,
-  // getUnhandledProps,
   keyboardKey,
   makeDebugger,
   META,

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -36,6 +36,9 @@ class Portal extends Component {
     /** Controls whether or not the portal should close when escape is pressed is displayed. */
     closeOnEscape: PropTypes.bool,
 
+    /** Controls whether or not the portal should close when when mousing out of the trigger. */
+    closeOnTriggerMouseLeave: PropTypes.bool,
+
     /** Initial value of open. */
     defaultOpen: PropTypes.bool,
 
@@ -51,7 +54,7 @@ class Portal extends Component {
     /** Controls whether or not the portal should open when the trigger is clicked. */
     openOnTriggerClick: PropTypes.bool,
 
-    /** Controls whether or not the portal should open when the trigger is clicked. */
+    /** Controls whether or not the portal should open when mousing over the trigger. */
     openOnTriggerMouseOver: PropTypes.bool,
 
     /** Element to be rendered in-place where the portal is defined. */
@@ -139,6 +142,13 @@ class Portal extends Component {
     this.open()
   }
 
+  handleTriggerMouseLeave = (e) => {
+    if (!this.props.closeOnTriggerMouseLeave) return
+
+    debug('handleTriggerMouseLeave()')
+    this.close()
+  }
+
   handleTriggerMouseOver = (e) => {
     if (!this.props.openOnTriggerMouseOver) return
 
@@ -215,6 +225,7 @@ class Portal extends Component {
     return React.cloneElement(trigger, {
       onClick: this.handleTriggerClick,
       onMouseOver: this.handleTriggerMouseOver,
+      onMouseLeave: this.handleTriggerMouseLeave
     })
   }
 }

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -46,11 +46,17 @@ class Portal extends Component {
     /** Initial value of open. */
     defaultOpen: PropTypes.bool,
 
-    /** Called when open changes from true to false */
+    /** Called when a close event happens */
     onClose: PropTypes.func,
 
-    /** Called when open changes from false to true */
+    /** Called when the portal is mounted on the DOM */
+    onMount: PropTypes.func,
+
+    /** Called when an open event happens */
     onOpen: PropTypes.func,
+
+    /** Called when the portal is unmounted from the DOM */
+    onUnmount: PropTypes.func,
 
     /** Controls whether or not the portal is displayed. */
     open: PropTypes.bool,
@@ -240,7 +246,8 @@ class Portal extends Component {
   mountPortal = () => {
     if (this.node) return
 
-    this.open()
+    const { onMount } = this.props
+    if (onMount) onMount()
 
     this.node = document.createElement('div')
     document.body.appendChild(this.node)
@@ -252,7 +259,8 @@ class Portal extends Component {
   unmountPortal = () => {
     if (!this.node) return
 
-    this.close()
+    const { onUnmount } = this.props
+    if (onUnmount) onUnmount()
 
     ReactDOM.unmountComponentAtNode(this.node)
     document.body.removeChild(this.node)

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -157,6 +157,11 @@ class Portal extends Component {
     debug('handleTriggerClick()')
 
     e.stopPropagation()
+
+    // Prevents closeOnDocumentClick from closing the portal when
+    // openOnTriggerFocus is set. Focus shifts on mousedown so the portal opens
+    // before the click finishes so it may actually wind up on the document.
+    e.nativeEvent.stopImmediatePropagation()
     this.open()
   }
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -126,7 +126,7 @@ class Portal extends Component {
     debug('closeOnDocumentClick()')
 
     e.stopPropagation()
-    this.close()
+    this.close(e)
   }
 
   closeOnEscape = (e) => {
@@ -136,7 +136,7 @@ class Portal extends Component {
     debug('closeOnEscape()')
 
     e.preventDefault()
-    this.close()
+    this.close(e)
   }
 
   // ----------------------------------------
@@ -152,7 +152,7 @@ class Portal extends Component {
     if (!closeOnTriggerBlur) return
 
     debug('handleTriggerBlur()')
-    this.close()
+    this.close(e)
   }
 
   handleTriggerClick = (e) => {
@@ -171,7 +171,7 @@ class Portal extends Component {
     // openOnTriggerFocus is set. Focus shifts on mousedown so the portal opens
     // before the click finishes so it may actually wind up on the document.
     e.nativeEvent.stopImmediatePropagation()
-    this.open()
+    this.open(e)
   }
 
   handleTriggerFocus = (e) => {
@@ -183,7 +183,7 @@ class Portal extends Component {
     if (!openOnTriggerFocus) return
 
     debug('handleTriggerFocus()')
-    this.open()
+    this.open(e)
   }
 
   handleTriggerMouseLeave = (e) => {
@@ -195,7 +195,7 @@ class Portal extends Component {
     if (!closeOnTriggerMouseLeave) return
 
     debug('handleTriggerMouseLeave()')
-    this.close()
+    this.close(e)
   }
 
   handleTriggerMouseOver = (e) => {
@@ -207,27 +207,27 @@ class Portal extends Component {
     if (!openOnTriggerMouseOver) return
 
     debug('handleTriggerMouseOver()')
-    this.open()
+    this.open(e)
   }
 
   // ----------------------------------------
   // Behavior
   // ----------------------------------------
 
-  open = () => {
+  open = (e) => {
     debug('open()')
 
     const { onOpen } = this.props
-    if (onOpen) onOpen()
+    if (onOpen) onOpen(e)
 
     this.trySetState({ open: true })
   }
 
-  close = () => {
+  close = (e) => {
     debug('close()')
 
     const { onClose } = this.props
-    if (onClose) onClose()
+    if (onClose) onClose(e)
 
     this.trySetState({ open: false })
   }
@@ -249,9 +249,6 @@ class Portal extends Component {
   mountPortal = () => {
     if (this.node) return
 
-    const { onMount } = this.props
-    if (onMount) onMount()
-
     const { mountNode = document.body } = this.props
 
     this.node = document.createElement('div')
@@ -259,13 +256,13 @@ class Portal extends Component {
 
     document.addEventListener('keydown', this.closeOnEscape)
     document.addEventListener('click', this.closeOnDocumentClick)
+
+    const { onMount } = this.props
+    if (onMount) onMount()
   }
 
   unmountPortal = () => {
     if (!this.node) return
-
-    const { onUnmount } = this.props
-    if (onUnmount) onUnmount()
 
     ReactDOM.unmountComponentAtNode(this.node)
     this.node.parentNode.removeChild(this.node)
@@ -275,6 +272,9 @@ class Portal extends Component {
 
     document.removeEventListener('keydown', this.closeOnEscape)
     document.removeEventListener('click', this.closeOnDocumentClick)
+
+    const { onUnmount } = this.props
+    if (onUnmount) onUnmount()
   }
 
   render() {

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -1,0 +1,222 @@
+import React, { Children, cloneElement, PropTypes } from 'react'
+import ReactDOM, { findDOMNode } from 'react-dom'
+
+import {
+  AutoControlledComponent as Component,
+  // customPropTypes,
+  // getElementType,
+  // getUnhandledProps,
+  keyboardKey,
+  makeDebugger,
+  META,
+} from '../../lib'
+
+const debug = makeDebugger('portal')
+
+const _meta = {
+  name: 'Portal',
+  type: META.TYPES.ADDON,
+}
+
+/**
+ * A component that allows you to render children outside their parent.
+ * @see Modal
+ */
+class Portal extends Component {
+  static propTypes = {
+    /** Primary content */
+    children: PropTypes.node.isRequired,
+
+    /** Classes to be added to the portal node element. */
+    className: PropTypes.string,
+
+    /** Controls whether or not the portal should close on a click outside. */
+    closeOnDocumentClick: PropTypes.bool,
+
+    /** Controls whether or not the portal should close when escape is pressed is displayed. */
+    closeOnEscape: PropTypes.bool,
+
+    /** Initial value of open. */
+    defaultOpen: PropTypes.bool,
+
+    /** Called when open changes from true to false */
+    onClose: PropTypes.func,
+
+    /** Called when open changes from false to true */
+    onOpen: PropTypes.func,
+
+    /** Controls whether or not the portal is displayed. */
+    open: PropTypes.bool,
+
+    /** Controls whether or not the portal should open when the trigger is clicked. */
+    openOnTriggerClick: PropTypes.bool,
+
+    /** Controls whether or not the portal should open when the trigger is clicked. */
+    openOnTriggerMouseOver: PropTypes.bool,
+
+    /** Element to be rendered in-place where the portal is defined. */
+    trigger: PropTypes.node,
+  }
+
+  static defaultProps = {
+    closeOnEscape: true,
+    closeOnDocumentClick: true,
+    openOnTriggerClick: true,
+  }
+
+  static autoControlledProps = [
+    'open',
+  ]
+
+  static _meta = _meta
+
+  componentDidMount() {
+    if (this.state.open) {
+      this.renderPortal()
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) { // eslint-disable-line complexity
+    // NOTE: Ideally the portal rendering would happen in the render() function
+    // but React gives a warning about not being pure and suggests doing it
+    // within this method.
+
+    // If the portal is open, render (or re-render) the portal and child.
+    if (this.state.open) {
+      this.renderPortal()
+    }
+
+    if (prevState.open && !this.state.open) {
+      debug('portal closed')
+      this.unmountPortal()
+    }
+  }
+
+  componentWillUnmount() {
+    this.unmountPortal()
+  }
+
+  // ----------------------------------------
+  // Document Event Handlers
+  // ----------------------------------------
+
+  closeOnDocumentClick = (e) => {
+    if (!this.props.closeOnDocumentClick) return
+
+    debug('closeOnDocumentClick()')
+
+    e.stopPropagation()
+    this.close()
+  }
+
+  closeOnEscape = (e) => {
+    if (!this.props.closeOnEscape) return
+    if (keyboardKey.getCode(e) !== keyboardKey.Escape) return
+
+    debug('closeOnEscape()')
+
+    e.preventDefault()
+    this.close()
+  }
+
+  // ----------------------------------------
+  // Component Event Handlers
+  // ----------------------------------------
+
+  handleChildClick = (e) => {
+    debug('handleChildClick()')
+
+    // Prevent closeOnDocumentClick
+    e.nativeEvent.stopImmediatePropagation()
+  }
+
+  handleTriggerClick = (e) => {
+    if (!this.props.openOnTriggerClick) return
+
+    debug('handleTriggerClick()')
+
+    e.stopPropagation()
+    this.open()
+  }
+
+  handleTriggerMouseOver = (e) => {
+    if (!this.props.openOnTriggerMouseOver) return
+
+    debug('handleTriggerMouseOver()')
+    this.open()
+  }
+
+  // ----------------------------------------
+  // Behavior
+  // ----------------------------------------
+
+  open = () => {
+    debug('open()')
+    this.trySetState({ open: true })
+  }
+
+  close = () => {
+    debug('close()')
+    this.trySetState({ open: false })
+  }
+
+  renderPortal() {
+    const { children, className } = this.props
+
+    this.mountPortal()
+
+    this.node.className = className
+
+    const child = cloneElement(Children.only(children), {
+      onClick: this.handleChildClick,
+    })
+
+    this.portal = ReactDOM.unstable_renderSubtreeIntoContainer(
+      this,
+      child,
+      this.node
+    )
+  }
+
+  mountPortal = () => {
+    if (this.node) return
+
+    this.node = document.createElement('div')
+    document.body.appendChild(this.node)
+
+    const { onOpen } = this.props
+    if (onOpen) onOpen()
+
+    document.addEventListener('keydown', this.closeOnEscape)
+    document.addEventListener('click', this.closeOnDocumentClick)
+  }
+
+  unmountPortal = () => {
+    if (!this.node) return
+
+    ReactDOM.unmountComponentAtNode(this.node)
+    document.body.removeChild(this.node)
+
+    this.node = null
+    this.portal = null
+
+    const { onClose } = this.props
+    if (onClose) onClose()
+
+    document.removeEventListener('keydown', this.closeOnEscape)
+    document.removeEventListener('click', this.closeOnDocumentClick)
+  }
+
+  render() {
+    const { trigger } = this.props
+
+    if (!trigger) return null
+
+    return React.cloneElement(trigger, {
+      onClick: this.handleTriggerClick,
+      onMouseOver: this.handleTriggerMouseOver,
+    })
+  }
+}
+
+export default Portal

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -1,5 +1,5 @@
 import React, { Children, cloneElement, PropTypes } from 'react'
-import ReactDOM, { findDOMNode } from 'react-dom'
+import ReactDOM from 'react-dom'
 
 import {
   AutoControlledComponent as Component,

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -36,7 +36,10 @@ class Portal extends Component {
     /** Controls whether or not the portal should close when escape is pressed is displayed. */
     closeOnEscape: PropTypes.bool,
 
-    /** Controls whether or not the portal should close when when mousing out of the trigger. */
+    /** Controls whether or not the portal should close on blur of the trigger. */
+    closeOnTriggerBlur: PropTypes.bool,
+
+    /** Controls whether or not the portal should close when mousing out of the trigger. */
     closeOnTriggerMouseLeave: PropTypes.bool,
 
     /** Initial value of open. */
@@ -53,6 +56,9 @@ class Portal extends Component {
 
     /** Controls whether or not the portal should open when the trigger is clicked. */
     openOnTriggerClick: PropTypes.bool,
+
+    /** Controls whether or not the portal should open on focus of the trigger. */
+    openOnTriggerFocus: PropTypes.bool,
 
     /** Controls whether or not the portal should open when mousing over the trigger. */
     openOnTriggerMouseOver: PropTypes.bool,
@@ -133,12 +139,26 @@ class Portal extends Component {
     e.nativeEvent.stopImmediatePropagation()
   }
 
+  handleTriggerBlur = (e) => {
+    if (!this.props.closeOnTriggerBlur) return
+
+    debug('handleTriggerBlur()')
+    this.close()
+  }
+
   handleTriggerClick = (e) => {
     if (!this.props.openOnTriggerClick) return
 
     debug('handleTriggerClick()')
 
     e.stopPropagation()
+    this.open()
+  }
+
+  handleTriggerFocus = (e) => {
+    if (!this.props.openOnTriggerFocus) return
+
+    debug('handleTriggerFocus()')
     this.open()
   }
 
@@ -223,9 +243,11 @@ class Portal extends Component {
     if (!trigger) return null
 
     return React.cloneElement(trigger, {
+      onBlur: this.handleTriggerBlur,
       onClick: this.handleTriggerClick,
+      onFocus: this.handleTriggerFocus,
+      onMouseLeave: this.handleTriggerMouseLeave,
       onMouseOver: this.handleTriggerMouseOver,
-      onMouseLeave: this.handleTriggerMouseLeave
     })
   }
 }

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -46,6 +46,9 @@ class Portal extends Component {
     /** Initial value of open. */
     defaultOpen: PropTypes.bool,
 
+    /** The node where the portal should mount.. */
+    mountNode: PropTypes.any,
+
     /** Called when a close event happens */
     onClose: PropTypes.func,
 
@@ -249,8 +252,10 @@ class Portal extends Component {
     const { onMount } = this.props
     if (onMount) onMount()
 
+    const { mountNode = document.body } = this.props
+
     this.node = document.createElement('div')
-    document.body.appendChild(this.node)
+    mountNode.appendChild(this.node)
 
     document.addEventListener('keydown', this.closeOnEscape)
     document.addEventListener('click', this.closeOnDocumentClick)
@@ -263,7 +268,7 @@ class Portal extends Component {
     if (onUnmount) onUnmount()
 
     ReactDOM.unmountComponentAtNode(this.node)
-    document.body.removeChild(this.node)
+    this.node.parentNode.removeChild(this.node)
 
     this.node = null
     this.portal = null

--- a/src/addons/index.js
+++ b/src/addons/index.js
@@ -1,4 +1,5 @@
 export { default as Confirm } from './Confirm/Confirm'
+export { default as Portal } from './Portal/Portal'
 export { default as Radio } from './Radio/Radio'
 export { default as Select } from './Select/Select'
 export { default as TextArea } from './TextArea/TextArea'

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -148,7 +148,7 @@ class Modal extends Component {
   }
 
   render() {
-    const { basic, children, className, dimmer, onClose, onOpen, portal, size  } = this.props
+    const { basic, children, className, dimmer, onClose, onOpen, portal, size } = this.props
     const { marginTop, scrolling } = this.state
     const classes = cx(
       'ui',

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -52,6 +52,9 @@ class Modal extends Component {
       PropTypes.oneOf(_meta.props.dimmer),
     ]),
 
+    /** The node where the modal should mount.. */
+    mountNode: PropTypes.any,
+
     /** Props to be passed to the Portal */
     portal: PropTypes.object,
 
@@ -90,14 +93,15 @@ class Modal extends Component {
   handleMount = () => {
     debug('handleOpen()')
     const { dimmer } = this.props
+    const mountNode = this.getMountNode()
 
     if (dimmer) {
       debug('adding dimmer')
-      document.body.classList.add('dimmable', 'dimmed')
+      mountNode.classList.add('dimmable', 'dimmed')
 
       if (dimmer === 'blurring') {
         debug('adding blurred dimmer')
-        document.body.classList.add('blurring')
+        mountNode.classList.add('blurring')
       }
     }
   }
@@ -105,14 +109,21 @@ class Modal extends Component {
   handleUnmount = () => {
     debug('handleUnmount()')
 
+    const mountNode = this.getMountNode()
+
     // Always remove all dimmer classes.
     // If the dimmer value changes while the modal is open,
     //   then removing its current value could leave cruft classes previously added.
-    document.body.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
+    mountNode.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
+  }
+
+  getMountNode = () => {
+    return this.props.mountNode || document.body
   }
 
   setPosition = () => {
     if (this._modalNode) {
+      const mountNode = this.getMountNode()
       const { height } = this._modalNode.getBoundingClientRect()
       const scrolling = height >= window.innerHeight
 
@@ -123,9 +134,9 @@ class Modal extends Component {
 
       // add/remove scrolling class on body
       if (!this.state.scrolling && scrolling) {
-        document.body.classList.add('scrolling')
+        mountNode.classList.add('scrolling')
       } else if (this.state.scrolling && !scrolling) {
-        document.body.classList.remove('scrolling')
+        mountNode.classList.remove('scrolling')
       }
 
       if (!_.isEqual(newState, this.state)) {
@@ -137,7 +148,7 @@ class Modal extends Component {
   }
 
   render() {
-    const { basic, children, className, dimmer, onClose, onOpen, size, portal } = this.props
+    const { basic, children, className, dimmer, onClose, onOpen, portal, size  } = this.props
     const { marginTop, scrolling } = this.state
     const classes = cx(
       'ui',
@@ -178,6 +189,7 @@ class Modal extends Component {
       <Portal
         {...portal}
         className={dimmerClasses}
+        mountNode={this.getMountNode()}
         onClose={onClose}
         onMount={this.handleMount}
         onOpen={onOpen}

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -31,6 +31,7 @@ const _meta = {
 /**
  * A modal displays content that temporarily blocks interactions with the main view of a site
  * @see Confirm
+ * @see Portal
  */
 class Modal extends Component {
   static propTypes = {

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -84,22 +84,10 @@ class Modal extends Component {
 
   componentWillUnmount() {
     debug('componentWillUnmount()')
-    this.handleClose()
+    this.handleUnmount()
   }
 
-  handleClose = () => {
-    debug('handleClose()')
-
-    // Always remove all dimmer classes.
-    // If the dimmer value changes while the modal is open,
-    //   then removing its current value could leave cruft classes previously added.
-    document.body.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
-
-    const { onClose } = this.props
-    if (onClose) onClose()
-  }
-
-  handleOpen = () => {
+  handleMount = () => {
     debug('handleOpen()')
     const { dimmer } = this.props
 
@@ -112,9 +100,15 @@ class Modal extends Component {
         document.body.classList.add('blurring')
       }
     }
+  }
 
-    const { onOpen } = this.props
-    if (onOpen) onOpen()
+  handleUnmount = () => {
+    debug('handleUnmount()')
+
+    // Always remove all dimmer classes.
+    // If the dimmer value changes while the modal is open,
+    //   then removing its current value could leave cruft classes previously added.
+    document.body.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
   }
 
   setPosition = () => {
@@ -143,7 +137,7 @@ class Modal extends Component {
   }
 
   render() {
-    const { basic, children, className, dimmer, size, portal } = this.props
+    const { basic, children, className, dimmer, onClose, onOpen, size, portal } = this.props
     const { marginTop, scrolling } = this.state
     const classes = cx(
       'ui',
@@ -184,8 +178,10 @@ class Modal extends Component {
       <Portal
         {...portal}
         className={dimmerClasses}
-        onClose={this.handleClose}
-        onOpen={this.handleOpen}
+        onClose={onClose}
+        onMount={this.handleMount}
+        onOpen={onOpen}
+        onUnmount={this.handleUnmount}
       >
         {modalJSX}
       </Portal>

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -55,17 +55,13 @@ class Modal extends Component {
     /** The node where the modal should mount.. */
     mountNode: PropTypes.any,
 
-    /** Props to be passed to the Portal */
-    portal: PropTypes.object,
-
     /** A modal can vary in size */
     size: PropTypes.oneOf(_meta.props.size),
 
-    /** Called when the modal is hidden */
-    onClose: PropTypes.func,
-
-    /** Called when the modal is opened */
-    onOpen: PropTypes.func,
+    /**
+     * NOTE: Any unhandled props that are defined in Portal are passed-through
+     * to the wrapping Portal.
+     */
   }
 
   static defaultProps = {
@@ -148,7 +144,7 @@ class Modal extends Component {
   }
 
   render() {
-    const { basic, children, className, dimmer, onClose, onOpen, portal, size } = this.props
+    const { basic, children, className, dimmer, size } = this.props
     const { marginTop, scrolling } = this.state
     const classes = cx(
       'ui',
@@ -160,6 +156,7 @@ class Modal extends Component {
     )
     const rest = getUnhandledProps(Modal, this.props)
     const ElementType = getElementType(Modal, this.props)
+    const portalProps = _.pick(rest, _.keys(Portal.propTypes))
 
     const modalJSX = (
       <ElementType {...rest} className={classes} style={{ marginTop }} ref={c => (this._modalNode = c)}>
@@ -187,12 +184,10 @@ class Modal extends Component {
 
     return (
       <Portal
-        {...portal}
+        {...portalProps}
         className={dimmerClasses}
         mountNode={this.getMountNode()}
-        onClose={onClose}
         onMount={this.handleMount}
-        onOpen={onOpen}
         onUnmount={this.handleUnmount}
       >
         {modalJSX}

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -6,7 +6,7 @@ import ModalHeader from './ModalHeader'
 import ModalContent from './ModalContent'
 import ModalActions from './ModalActions'
 import ModalDescription from './ModalDescription'
-import { Portal } from './../../addons'
+import Portal from './../../addons/Portal/Portal'
 
 import {
   customPropTypes,

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -165,6 +165,19 @@ describe('Portal', () => {
     })
   })
 
+  describe('mountNode', () => {
+    it('render portal within mountNode', () => {
+      const mountNode = document.createElement('div')
+      document.body.appendChild(mountNode)
+
+      wrapperMount(<Portal mountNode={mountNode} open><p>Hi</p></Portal>)
+      const instance = wrapper.instance()
+
+      mountNode.lastElementChild.should.equal(instance.node)
+      mountNode.childElementCount.should.equal(1)
+    })
+  })
+
   describe('openOnTriggerClick', () => {
     it('should open portal on click by default', () => {
       const spy = sandbox.spy()

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import React from 'react'
 import { unmountComponentAtNode } from 'react-dom'
 
@@ -11,6 +12,8 @@ const wrapperMount = (node, opts) => {
   wrapper = mount(node, opts)
   return wrapper
 }
+
+const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }
 
 describe('Portal', () => {
   beforeEach(() => {
@@ -81,61 +84,61 @@ describe('Portal', () => {
   })
 
   describe('callbacks', () => {
-    it('should call props.onOpen() when portal opens', () => {
-      const props = { open: false, onOpen: sandbox.spy() }
+    it('should call props.onMount() when portal opens', () => {
+      const props = { open: false, onMount: sandbox.spy() }
       wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
 
       wrapper.setProps({ open: true, children: <p>Hi</p> })
-      props.onOpen.should.have.been.calledOnce()
+      props.onMount.should.have.been.calledOnce()
     })
 
-    it('should not call props.onOpen() when portal receives props', () => {
-      const props = { open: false, onOpen: sandbox.spy() }
+    it('should not call props.onMount() when portal receives props', () => {
+      const props = { open: false, onMount: sandbox.spy() }
       wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
 
       wrapper.setProps({ open: true, children: <p>Hi</p>, className: 'old' })
-      props.onOpen.should.have.been.calledOnce()
+      props.onMount.should.have.been.calledOnce()
 
       wrapper.setProps({ open: true, children: <p>Hi</p>, className: 'new' })
-      props.onOpen.should.have.been.calledOnce()
+      props.onMount.should.have.been.calledOnce()
     })
 
-    it('should call props.onClose() when portal closes', () => {
-      const props = { open: true, onClose: sandbox.spy() }
+    it('should call props.onUnmount() when portal closes', () => {
+      const props = { open: true, onUnmount: sandbox.spy() }
       wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
 
       wrapper.setProps({ open: false, children: <p>Hi</p> })
-      props.onClose.should.have.been.calledOnce()
+      props.onUnmount.should.have.been.calledOnce()
     })
 
-    it('should not call props.onClose() when portal receives props', () => {
-      const props = { open: true, onClose: sandbox.spy() }
+    it('should not call props.onUnmount() when portal receives props', () => {
+      const props = { open: true, onUnmount: sandbox.spy() }
       wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
 
       wrapper.setProps({ open: false, children: <p>Hi</p>, className: 'old' })
-      props.onClose.should.have.been.calledOnce()
+      props.onUnmount.should.have.been.calledOnce()
 
       wrapper.setProps({ open: false, children: <p>Hi</p>, className: 'new' })
-      props.onClose.should.have.been.calledOnce()
+      props.onUnmount.should.have.been.calledOnce()
     })
 
-    it('should call props.onClose() only once when portal closes and then is unmounted', () => {
+    it('should call props.onUnmount() only once when portal closes and then is unmounted', () => {
       const div = document.createElement('div')
-      const props = { open: true, onClose: sandbox.spy() }
+      const props = { open: true, onUnmount: sandbox.spy() }
       wrapperMount(<Portal {...props}><p>Hi</p></Portal>, { attachTo: div })
 
       wrapper.setProps({ open: false, children: <p>Hi</p> })
       unmountComponentAtNode(div)
-      props.onClose.should.have.been.calledOnce()
+      props.onUnmount.should.have.been.calledOnce()
     })
 
-    it('should call props.onClose() only once when directly unmounting', () => {
+    it('should call props.onUnmount() only once when directly unmounting', () => {
       const div = document.createElement('div')
-      const props = { open: true, onClose: sandbox.spy() }
+      const props = { open: true, onUnmount: sandbox.spy() }
 
       wrapperMount(<Portal {...props}><p>Hi</p></Portal>, { attachTo: div })
       unmountComponentAtNode(div)
-      props.onClose.should.have.been.calledOnce()
+      props.onUnmount.should.have.been.calledOnce()
     })
 
     it('should not call this.setState() if portal is unmounted', () => {
@@ -184,7 +187,7 @@ describe('Portal', () => {
       const trigger = <button onClick={spy}>button</button>
       wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
 
-      wrapper.find('button').simulate('click')
+      wrapper.find('button').simulate('click', nativeEvent)
       document.body.lastElementChild.should.equal(wrapper.instance().node)
       spy.should.have.been.calledOnce()
     })
@@ -194,7 +197,7 @@ describe('Portal', () => {
       const trigger = <button onClick={spy}>button</button>
       wrapperMount(<Portal trigger={trigger} openOnTriggerClick={false}><p>Hi</p></Portal>)
 
-      wrapper.find('button').simulate('click')
+      wrapper.find('button').simulate('click', nativeEvent)
       document.body.childElementCount.should.equal(0)
       spy.should.have.been.calledOnce()
     })
@@ -204,7 +207,7 @@ describe('Portal', () => {
       const trigger = <button onClick={spy}>button</button>
       wrapperMount(<Portal trigger={trigger} openOnTriggerClick><p>Hi</p></Portal>)
 
-      wrapper.find('button').simulate('click')
+      wrapper.find('button').simulate('click', nativeEvent)
       document.body.lastElementChild.should.equal(wrapper.instance().node)
       spy.should.have.been.calledOnce()
     })

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -209,6 +209,42 @@ describe('Portal', () => {
     })
   })
 
+  describe('openOnTriggerFocus', () => {
+    it('should not open portal on focus when not set', () => {
+      const trigger = <button>button</button>
+      wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('focus')
+      document.body.childElementCount.should.equal(0)
+    })
+
+    it('should open portal on focus when set', () => {
+      const trigger = <button>button</button>
+      wrapperMount(<Portal trigger={trigger} openOnTriggerFocus><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('focus')
+      document.body.lastElementChild.should.equal(wrapper.instance().node)
+    })
+  })
+
+  describe('closeOnTriggerBlur', () => {
+    it('should not close portal on blur when not set', () => {
+      const trigger = <button>button</button>
+      wrapperMount(<Portal trigger={trigger} defaultOpen><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('blur')
+      document.body.lastElementChild.should.equal(wrapper.instance().node)
+    })
+
+    it('should close portal on blur when set', () => {
+      const trigger = <button>button</button>
+      wrapperMount(<Portal trigger={trigger} defaultOpen closeOnTriggerBlur><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('blur')
+      document.body.childElementCount.should.equal(0)
+    })
+  })
+
   describe('close actions', () => {
     it('closeOnEscape', () => {
       wrapperMount(<Portal closeOnEscape defaultOpen><p>Hi</p></Portal>)

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -143,9 +143,9 @@ describe('Portal', () => {
       const props = { open: true }
       wrapperMount(<Portal {...props}><p>Hi</p></Portal>, { attachTo: div })
 
-      sandbox.spy(wrapper, 'setState')
+      const spy = sandbox.spy(wrapper, 'setState')
       unmountComponentAtNode(div)
-      wrapper.setState.callCount.should.equal(0)
+      spy.should.not.have.been.called()
     })
   })
 
@@ -163,85 +163,125 @@ describe('Portal', () => {
 
       wrapper.text().should.equal(text)
     })
+  })
 
-    it('should open portal when clicking trigger element', () => {
-      const trigger = <button>button</button>
+  describe('openOnTriggerClick', () => {
+    it('should open portal on click by default', () => {
+      const spy = sandbox.spy()
+      const trigger = <button onClick={spy}>button</button>
       wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
 
       wrapper.find('button').simulate('click')
       document.body.lastElementChild.should.equal(wrapper.instance().node)
+      spy.should.have.been.calledOnce()
+    })
+
+    it('should not open portal on click when false', () => {
+      const spy = sandbox.spy()
+      const trigger = <button onClick={spy}>button</button>
+      wrapperMount(<Portal trigger={trigger} openOnTriggerClick={false}><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('click')
+      document.body.childElementCount.should.equal(0)
+      spy.should.have.been.calledOnce()
+    })
+
+    it('should open portal on click when set', () => {
+      const spy = sandbox.spy()
+      const trigger = <button onClick={spy}>button</button>
+      wrapperMount(<Portal trigger={trigger} openOnTriggerClick><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('click')
+      document.body.lastElementChild.should.equal(wrapper.instance().node)
+      spy.should.have.been.calledOnce()
     })
   })
 
   describe('openOnTriggerMouseOver', () => {
     it('should not open portal on mouseover when not set', () => {
-      const trigger = <button>button</button>
+      const spy = sandbox.spy()
+      const trigger = <button onMouseOver={spy}>button</button>
       wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
 
       wrapper.find('button').simulate('mouseover')
       document.body.childElementCount.should.equal(0)
+      spy.should.have.been.calledOnce()
     })
 
     it('should open portal on mouseover when set', () => {
-      const trigger = <button>button</button>
+      const spy = sandbox.spy()
+      const trigger = <button onMouseOver={spy}>button</button>
       wrapperMount(<Portal trigger={trigger} openOnTriggerMouseOver><p>Hi</p></Portal>)
 
       wrapper.find('button').simulate('mouseover')
       document.body.lastElementChild.should.equal(wrapper.instance().node)
+      spy.should.have.been.calledOnce()
     })
   })
 
   describe('closeOnTriggerMouseLeave', () => {
     it('should not close portal on mouseleave when not set', () => {
-      const trigger = <button>button</button>
+      const spy = sandbox.spy()
+      const trigger = <button onMouseLeave={spy}>button</button>
       wrapperMount(<Portal trigger={trigger} defaultOpen><p>Hi</p></Portal>)
 
       wrapper.find('button').simulate('mouseleave')
       document.body.lastElementChild.should.equal(wrapper.instance().node)
+      spy.should.have.been.calledOnce()
     })
 
     it('should close portal on mouseleave when set', () => {
-      const trigger = <button>button</button>
+      const spy = sandbox.spy()
+      const trigger = <button onMouseLeave={spy}>button</button>
       wrapperMount(<Portal trigger={trigger} defaultOpen closeOnTriggerMouseLeave><p>Hi</p></Portal>)
 
       wrapper.find('button').simulate('mouseleave')
       document.body.childElementCount.should.equal(0)
+      spy.should.have.been.calledOnce()
     })
   })
 
   describe('openOnTriggerFocus', () => {
     it('should not open portal on focus when not set', () => {
-      const trigger = <button>button</button>
+      const spy = sandbox.spy()
+      const trigger = <button onFocus={spy}>button</button>
       wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
 
       wrapper.find('button').simulate('focus')
       document.body.childElementCount.should.equal(0)
+      spy.should.have.been.calledOnce()
     })
 
     it('should open portal on focus when set', () => {
-      const trigger = <button>button</button>
+      const spy = sandbox.spy()
+      const trigger = <button onFocus={spy}>button</button>
       wrapperMount(<Portal trigger={trigger} openOnTriggerFocus><p>Hi</p></Portal>)
 
       wrapper.find('button').simulate('focus')
       document.body.lastElementChild.should.equal(wrapper.instance().node)
+      spy.should.have.been.calledOnce()
     })
   })
 
   describe('closeOnTriggerBlur', () => {
     it('should not close portal on blur when not set', () => {
-      const trigger = <button>button</button>
+      const spy = sandbox.spy()
+      const trigger = <button onBlur={spy}>button</button>
       wrapperMount(<Portal trigger={trigger} defaultOpen><p>Hi</p></Portal>)
 
       wrapper.find('button').simulate('blur')
       document.body.lastElementChild.should.equal(wrapper.instance().node)
+      spy.should.have.been.calledOnce()
     })
 
     it('should close portal on blur when set', () => {
-      const trigger = <button>button</button>
+      const spy = sandbox.spy()
+      const trigger = <button onBlur={spy}>button</button>
       wrapperMount(<Portal trigger={trigger} defaultOpen closeOnTriggerBlur><p>Hi</p></Portal>)
 
       wrapper.find('button').simulate('blur')
       document.body.childElementCount.should.equal(0)
+      spy.should.have.been.calledOnce()
     })
   })
 

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -1,0 +1,197 @@
+import React from 'react'
+import { unmountComponentAtNode } from 'react-dom'
+
+import { domEvent, sandbox } from 'test/utils'
+import { Portal } from 'src/addons'
+
+let attachTo
+let wrapper
+
+const wrapperMount = (node, opts) => {
+  wrapper = mount(node, opts)
+  return wrapper
+}
+
+describe('Portal', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    attachTo = undefined
+    wrapper = undefined
+  })
+
+  afterEach(() => {
+    if (wrapper && wrapper.unmount) wrapper.unmount()
+    if (attachTo) document.body.removeChild(attachTo)
+  })
+
+  it('propTypes.children should be required', () => {
+    Portal.propTypes.children.should.equal(React.PropTypes.node.isRequired)
+  })
+
+  it('Portal.node should be undefined if portal is not open', () => {
+    wrapperMount(<Portal><p>Hi</p></Portal>)
+    const instance = wrapper.instance()
+
+    expect(instance.node).to.equal(undefined)
+  })
+
+  it('should append portal with children to the document.body', () => {
+    wrapperMount(<Portal open><p>Hi</p></Portal>)
+    const instance = wrapper.instance()
+
+    instance.node.firstElementChild.tagName.should.equal('P')
+    document.body.lastElementChild.should.equal(instance.node)
+    document.body.childElementCount.should.equal(1)
+  })
+
+  it('when props.open is false and then set to true should open portal', () => {
+    wrapperMount(<Portal open={false}><p>Hi</p></Portal>)
+    const instance = wrapper.instance()
+
+    document.body.childElementCount.should.equal(0)
+
+    // Enzyme docs say it merges previous props but without children, react complains
+    wrapper.setProps({ open: true, children: <p>Hi</p> })
+    document.body.lastElementChild.should.equal(instance.node)
+    document.body.childElementCount.should.equal(1)
+  })
+
+  it('when props.open is true and then set to false should close portal', () => {
+    wrapperMount(<Portal open><p>Hi</p></Portal>)
+    const instance = wrapper.instance()
+
+    document.body.lastElementChild.should.equal(instance.node)
+    document.body.childElementCount.should.equal(1)
+
+    wrapper.setProps({ open: false, children: <p>Hi</p> })
+    document.body.childElementCount.should.equal(0)
+  })
+
+  it('should add className to the portal\'s wrapping node', () => {
+    wrapperMount(<Portal className='some-class' open><p>Hi</p></Portal>)
+
+    document.body.lastElementChild.className.should.equal('some-class')
+  })
+
+  it('should update className on the portal\'s wrapping node when props.className changes', () => {
+    wrapperMount(<Portal className='some-class' open><p>Hi</p></Portal>)
+
+    wrapper.setProps({ className: 'some-other-class', children: <p>Hi</p> })
+    document.body.lastElementChild.className.should.equal('some-other-class')
+  })
+
+  describe('callbacks', () => {
+    it('should call props.onOpen() when portal opens', () => {
+      const props = { open: false, onOpen: sandbox.spy() }
+      wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
+
+      wrapper.setProps({ open: true, children: <p>Hi</p> })
+      props.onOpen.should.have.been.calledOnce()
+    })
+
+    it('should not call props.onOpen() when portal receives props', () => {
+      const props = { open: false, onOpen: sandbox.spy() }
+      wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
+
+      wrapper.setProps({ open: true, children: <p>Hi</p>, className: 'old' })
+      props.onOpen.should.have.been.calledOnce()
+
+      wrapper.setProps({ open: true, children: <p>Hi</p>, className: 'new' })
+      props.onOpen.should.have.been.calledOnce()
+    })
+
+    it('should call props.onClose() when portal closes', () => {
+      const props = { open: true, onClose: sandbox.spy() }
+      wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
+
+      wrapper.setProps({ open: false, children: <p>Hi</p> })
+      props.onClose.should.have.been.calledOnce()
+    })
+
+    it('should not call props.onClose() when portal receives props', () => {
+      const props = { open: true, onClose: sandbox.spy() }
+      wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
+
+      wrapper.setProps({ open: false, children: <p>Hi</p>, className: 'old' })
+      props.onClose.should.have.been.calledOnce()
+
+      wrapper.setProps({ open: false, children: <p>Hi</p>, className: 'new' })
+      props.onClose.should.have.been.calledOnce()
+    })
+
+    it('should call props.onClose() only once when portal closes and then is unmounted', () => {
+      const div = document.createElement('div')
+      const props = { open: true, onClose: sandbox.spy() }
+      wrapperMount(<Portal {...props}><p>Hi</p></Portal>, { attachTo: div })
+
+      wrapper.setProps({ open: false, children: <p>Hi</p> })
+      unmountComponentAtNode(div)
+      props.onClose.should.have.been.calledOnce()
+    })
+
+    it('should call props.onClose() only once when directly unmounting', () => {
+      const div = document.createElement('div')
+      const props = { open: true, onClose: sandbox.spy() }
+
+      wrapperMount(<Portal {...props}><p>Hi</p></Portal>, { attachTo: div })
+      unmountComponentAtNode(div)
+      props.onClose.should.have.been.calledOnce()
+    })
+
+    it('should not call this.setState() if portal is unmounted', () => {
+      const div = document.createElement('div')
+      const props = { open: true }
+      wrapperMount(<Portal {...props}><p>Hi</p></Portal>, { attachTo: div })
+
+      sandbox.spy(wrapper, 'setState')
+      unmountComponentAtNode(div)
+      wrapper.setState.callCount.should.equal(0)
+    })
+  })
+
+  describe('trigger', () => {
+    it('render should return null if no props.trigger', () => {
+      wrapperMount(<Portal><p>Hi</p></Portal>)
+
+      expect(wrapper.html()).to.equal(null)
+    })
+
+    it('should render the props.trigger element', () => {
+      const text = 'open by click on me'
+      const trigger = <button>{text}</button>
+      wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
+
+      wrapper.text().should.equal(text)
+    })
+
+    it('should open portal when clicking trigger element', () => {
+      const trigger = <button>button</button>
+      wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('click')
+      document.body.lastElementChild.should.equal(wrapper.instance().node)
+    })
+  })
+
+  describe('close actions', () => {
+    it('closeOnEscape', () => {
+      wrapperMount(<Portal closeOnEscape defaultOpen><p>Hi</p></Portal>)
+      document.body.childElementCount.should.equal(1)
+
+      domEvent.keyDown(document, { key: 'Escape' })
+      document.body.childElementCount.should.equal(0)
+    })
+
+    it('closeOnDocumentClick', () => {
+      wrapperMount(<Portal closeOnDocumentClick defaultOpen><p>Hi</p></Portal>)
+      document.body.childElementCount.should.equal(1)
+
+      // Should not close when inside
+      domEvent.click(wrapper.instance().node.firstElementChild)
+      document.body.childElementCount.should.equal(1)
+
+      domEvent.click(document)
+      document.body.childElementCount.should.equal(0)
+    })
+  })
+})

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -191,6 +191,24 @@ describe('Portal', () => {
     })
   })
 
+  describe('closeOnTriggerMouseLeave', () => {
+    it('should not close portal on mouseleave when not set', () => {
+      const trigger = <button>button</button>
+      wrapperMount(<Portal trigger={trigger} defaultOpen><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('mouseleave')
+      document.body.lastElementChild.should.equal(wrapper.instance().node)
+    })
+
+    it('should close portal on mouseleave when set', () => {
+      const trigger = <button>button</button>
+      wrapperMount(<Portal trigger={trigger} defaultOpen closeOnTriggerMouseLeave><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('mouseleave')
+      document.body.childElementCount.should.equal(0)
+    })
+  })
+
   describe('close actions', () => {
     it('closeOnEscape', () => {
       wrapperMount(<Portal closeOnEscape defaultOpen><p>Hi</p></Portal>)

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -173,6 +173,24 @@ describe('Portal', () => {
     })
   })
 
+  describe('openOnTriggerMouseOver', () => {
+    it('should not open portal on mouseover when not set', () => {
+      const trigger = <button>button</button>
+      wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('mouseover')
+      document.body.childElementCount.should.equal(0)
+    })
+
+    it('should open portal on mouseover when set', () => {
+      const trigger = <button>button</button>
+      wrapperMount(<Portal trigger={trigger} openOnTriggerMouseOver><p>Hi</p></Portal>)
+
+      wrapper.find('button').simulate('mouseover')
+      document.body.lastElementChild.should.equal(wrapper.instance().node)
+    })
+  })
+
   describe('close actions', () => {
     it('closeOnEscape', () => {
       wrapperMount(<Portal closeOnEscape defaultOpen><p>Hi</p></Portal>)

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -1,12 +1,12 @@
 import _ from 'lodash'
 import React from 'react'
-import Portal from 'react-portal'
 
 import Modal from 'src/modules/Modal/Modal'
 import ModalHeader from 'src/modules/Modal/ModalHeader'
 import ModalContent from 'src/modules/Modal/ModalContent'
 import ModalActions from 'src/modules/Modal/ModalActions'
 import ModalDescription from 'src/modules/Modal/ModalDescription'
+import { Portal } from 'src/addons'
 
 import { keyboardKey } from 'src/lib'
 import { domEvent, sandbox } from 'test/utils'
@@ -59,18 +59,18 @@ describe('Modal', () => {
   // The Modal is wrapped in a Portal, so we manually test a few things here.
 
   it('renders a Portal', () => {
-    wrapperShallow(<Modal active />)
+    wrapperShallow(<Modal portal={{ open: true }} />)
       .type()
       .should.equal(Portal)
   })
 
   it('renders to the document body', () => {
-    wrapperMount(<Modal active />)
+    wrapperMount(<Modal portal={{ open: true }} />)
     assertInBody('.ui.modal')
   })
 
   it('renders child text', () => {
-    wrapperMount(<Modal active>child text</Modal>)
+    wrapperMount(<Modal portal={{ open: true }}>child text</Modal>)
 
     document.querySelector('.ui.modal')
       .innerText
@@ -79,7 +79,7 @@ describe('Modal', () => {
 
   it('renders child components', () => {
     const child = <div data-child />
-    wrapperMount(<Modal active>{child}</Modal>)
+    wrapperMount(<Modal portal={{ open: true }}>{child}</Modal>)
 
     document
       .querySelector('.ui.modal')
@@ -87,59 +87,59 @@ describe('Modal', () => {
       .should.not.equal(null, 'Modal did not render the child component.')
   })
 
-  describe('active', () => {
-    it('is not active by default', () => {
+  describe('open', () => {
+    it('is not open by default', () => {
       wrapperMount(<Modal />)
-      assertInBody('.ui.modal.active', false)
+      assertInBody('.ui.modal.open', false)
     })
 
-    it('is passed to Portal isOpened', () => {
-      shallow(<Modal active />)
+    it('is passed to Portal open', () => {
+      shallow(<Modal portal={{ open: true }} />)
         .find('Portal')
-        .should.have.prop('isOpened', true)
+        .should.have.prop('open', true)
 
-      shallow(<Modal active={false} />)
+      shallow(<Modal portal={{ open: false }} />)
         .find('Portal')
-        .should.have.prop('isOpened', false)
+        .should.have.prop('open', false)
     })
 
     it('does not show the modal when false', () => {
-      wrapperMount(<Modal active={false} />)
+      wrapperMount(<Modal portal={{ open: false }} />)
       assertInBody('.ui.modal', false)
     })
 
     it('does not show the dimmer when false', () => {
-      wrapperMount(<Modal active={false} />)
+      wrapperMount(<Modal portal={{ open: false }} />)
       assertInBody('.ui.dimmer', false)
     })
 
     it('shows the dimmer when true', () => {
-      wrapperMount(<Modal active dimmer />)
+      wrapperMount(<Modal portal={{ open: true }} dimmer />)
       assertInBody('.ui.dimmer')
     })
 
     it('shows the modal when true', () => {
-      wrapperMount(<Modal active />)
+      wrapperMount(<Modal portal={{ open: true }} />)
       assertInBody('.ui.modal')
     })
 
     it('shows the modal and dimmer on changing from false to true', () => {
-      wrapperMount(<Modal active={false} />)
+      wrapperMount(<Modal portal={{ open: false }} />)
       assertInBody('.ui.modal', false)
       assertInBody('.ui.dimmer', false)
 
-      wrapper.setProps({ active: true })
+      wrapper.setProps({ portal: { open: true } })
 
       assertInBody('.ui.modal')
       assertInBody('.ui.dimmer')
     })
 
     it('hides the modal and dimmer on changing from true to false', () => {
-      wrapperMount(<Modal active />)
+      wrapperMount(<Modal portal={{ open: true }} />)
       assertInBody('.ui.modal')
       assertInBody('.ui.dimmer')
 
-      wrapper.setProps({ active: false })
+      wrapper.setProps({ portal: { open: false } })
 
       assertInBody('.ui.modal', false)
       assertInBody('.ui.dimmer', false)
@@ -148,7 +148,7 @@ describe('Modal', () => {
 
   describe('basic', () => {
     it('adds basic to the modal className', () => {
-      wrapperMount(<Modal basic active />)
+      wrapperMount(<Modal basic portal={{ open: true }} />)
       assertInBody('.ui.basic.modal')
     })
   })
@@ -161,7 +161,7 @@ describe('Modal', () => {
 
     it('adds the size to the modal className', () => {
       Modal._meta.props.size.forEach(size => {
-        wrapperMount(<Modal size={size} active />)
+        wrapperMount(<Modal size={size} portal={{ open: true }} />)
         assertInBody(`.ui.${size}.modal`)
       })
     })
@@ -175,67 +175,67 @@ describe('Modal', () => {
       })
 
       it('is present by default', () => {
-        wrapperMount(<Modal active />)
+        wrapperMount(<Modal portal={{ open: true }} />)
         assertInBody('.ui.dimmer')
       })
     })
 
     describe('true', () => {
       it('adds classes "dimmable dimmed" to the body', () => {
-        wrapperMount(<Modal active dimmer />)
+        wrapperMount(<Modal portal={{ open: true }} dimmer />)
         assertBodyClasses('dimmable', 'dimmed')
       })
 
       it('adds a dimmer to the body', () => {
-        wrapperMount(<Modal active dimmer />)
+        wrapperMount(<Modal portal={{ open: true }} dimmer />)
         assertInBody('.ui.page.modals.dimmer.transition.visible.active')
       })
     })
 
     describe('false', () => {
       it('does not render a dimmer', () => {
-        wrapperMount(<Modal active dimmer={false} />)
+        wrapperMount(<Modal portal={{ open: true }} dimmer={false} />)
         assertBodyClasses('dimmable', 'dimmed', 'blurring', false)
       })
 
       it('does not add any dimmer classes to the body', () => {
-        wrapperMount(<Modal active dimmer={false} />)
+        wrapperMount(<Modal portal={{ open: true }} dimmer={false} />)
         assertBodyClasses('dimmable', 'dimmed', 'blurring', false)
       })
     })
 
     describe('blurring', () => {
       it('adds class "dimmable dimmed blurring" to the body', () => {
-        wrapperMount(<Modal active dimmer='blurring' />)
+        wrapperMount(<Modal portal={{ open: true }} dimmer='blurring' />)
         assertBodyClasses('dimmable', 'dimmed', 'blurring')
       })
 
       it('adds a dimmer to the body', () => {
-        wrapperMount(<Modal active dimmer='blurring' />)
+        wrapperMount(<Modal portal={{ open: true }} dimmer='blurring' />)
         assertInBody('.ui.page.modals.dimmer.transition.visible.active')
       })
     })
 
     describe('inverted', () => {
       it('adds class "dimmable dimmed" to the body', () => {
-        wrapperMount(<Modal active dimmer='inverted' />)
+        wrapperMount(<Modal portal={{ open: true }} dimmer='inverted' />)
         assertBodyClasses('dimmable', 'dimmed')
         assertBodyClasses('inverted', false)
       })
 
       it('adds an inverted dimmer to the body', () => {
-        wrapperMount(<Modal active dimmer='inverted' />)
+        wrapperMount(<Modal portal={{ open: true }} dimmer='inverted' />)
         assertInBody('.ui.inverted.page.modals.dimmer.transition.visible.active')
       })
     })
   })
 
-  describe('onHide', () => {
+  describe('onClose', () => {
     let spy
 
     beforeEach(() => {
       spy = sandbox.spy()
-      wrapperMount(<Modal onHide={spy} active />)
+      wrapperMount(<Modal onClose={spy} portal={{ defaultOpen: true }} />)
     })
 
     it('is called on dimmer click', () => {
@@ -250,7 +250,7 @@ describe('Modal', () => {
 
     it('is not called on click inside of the modal', () => {
       domEvent.click(document.querySelector('.ui.modal'))
-      spy.should.have.been.calledOnce()
+      spy.should.not.have.been.calledOnce()
     })
 
     it('is called on body click', () => {
@@ -269,22 +269,22 @@ describe('Modal', () => {
         if (val === keyboardKey.Escape) return
 
         domEvent.keyDown(document, { key })
-        spy.should.not.have.been.called(`onHide was called when pressing "${key}"`)
+        spy.should.not.have.been.called(`onClose was called when pressing "${key}"`)
       })
     })
 
-    it('is not called when the active prop changes to false', () => {
-      wrapper.setProps({ active: false })
+    it('is not called when the open prop changes to false', () => {
+      wrapper.setProps({ open: false })
       spy.should.not.have.been.called()
     })
   })
 
-  describe('with configurable close behaviours, onHide', () => {
+  describe('with configurable close behaviours, onClose', () => {
     let spy
 
     beforeEach(() => {
       spy = sandbox.spy()
-      wrapperMount(<Modal onHide={spy} active closeOnEscape={false} closeOnClickOutside={false} />)
+      wrapperMount(<Modal onClose={spy} open closeOnEscape={false} closeOnClickOutside={false} />)
     })
 
     it('is not called on dimmer click', () => {
@@ -318,12 +318,12 @@ describe('Modal', () => {
         if (val === keyboardKey.Escape) return
 
         domEvent.keyDown(document, { key })
-        spy.should.not.have.been.called(`onHide was called when pressing "${key}"`)
+        spy.should.not.have.been.called(`onClose was called when pressing "${key}"`)
       })
     })
 
-    it('is not called when the active prop changes to false', () => {
-      wrapper.setProps({ active: false })
+    it('is not called when the open prop changes to false', () => {
+      wrapper.setProps({ open: false })
       spy.should.not.have.been.called()
     })
   })
@@ -334,12 +334,12 @@ describe('Modal', () => {
     })
 
     it('does not add the scrolling class to the body by default', () => {
-      wrapperMount(<Modal active />)
+      wrapperMount(<Modal portal={{ open: true }} />)
       assertBodyClasses('scrolling', false)
     })
 
     it('adds the scrolling class to the body when taller than the window', (done) => {
-      wrapperMount(<Modal active>foo</Modal>)
+      wrapperMount(<Modal portal={{ open: true }}>foo</Modal>)
 
       window.innerHeight = 10
 
@@ -352,7 +352,7 @@ describe('Modal', () => {
     it('removes the scrolling class from the body when the window grows taller', (done) => {
       assertBodyClasses('scrolling', false)
 
-      wrapperMount(<Modal active>foo</Modal>)
+      wrapperMount(<Modal portal={{ open: true }}>foo</Modal>)
       window.innerHeight = 10
 
       requestAnimationFrame(() => {

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -44,6 +44,7 @@ const assertBodyClasses = (...rest) => {
 describe('Modal', () => {
   beforeEach(() => {
     wrapper = undefined
+    document.body.innerHTML = ''
   })
 
   afterEach(() => {
@@ -284,7 +285,7 @@ describe('Modal', () => {
 
     beforeEach(() => {
       spy = sandbox.spy()
-      wrapperMount(<Modal onClose={spy} open closeOnEscape={false} closeOnClickOutside={false} />)
+      wrapperMount(<Modal onClose={spy} portal={{ open: true, closeOnEscape: false, closeOnDocumentClick: false }} />)
     })
 
     it('is not called on dimmer click', () => {

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -62,18 +62,18 @@ describe('Modal', () => {
   // The Modal is wrapped in a Portal, so we manually test a few things here.
 
   it('renders a Portal', () => {
-    wrapperShallow(<Modal portal={{ open: true }} />)
+    wrapperShallow(<Modal open />)
       .type()
       .should.equal(Portal)
   })
 
   it('renders to the document body', () => {
-    wrapperMount(<Modal portal={{ open: true }} />)
+    wrapperMount(<Modal open />)
     assertInBody('.ui.modal')
   })
 
   it('renders child text', () => {
-    wrapperMount(<Modal portal={{ open: true }}>child text</Modal>)
+    wrapperMount(<Modal open>child text</Modal>)
 
     document.querySelector('.ui.modal')
       .innerText
@@ -82,7 +82,7 @@ describe('Modal', () => {
 
   it('renders child components', () => {
     const child = <div data-child />
-    wrapperMount(<Modal portal={{ open: true }}>{child}</Modal>)
+    wrapperMount(<Modal open>{child}</Modal>)
 
     document
       .querySelector('.ui.modal')
@@ -97,52 +97,52 @@ describe('Modal', () => {
     })
 
     it('is passed to Portal open', () => {
-      shallow(<Modal portal={{ open: true }} />)
+      shallow(<Modal open />)
         .find('Portal')
         .should.have.prop('open', true)
 
-      shallow(<Modal portal={{ open: false }} />)
+      shallow(<Modal open={false} />)
         .find('Portal')
         .should.have.prop('open', false)
     })
 
     it('does not show the modal when false', () => {
-      wrapperMount(<Modal portal={{ open: false }} />)
+      wrapperMount(<Modal open={false} />)
       assertInBody('.ui.modal', false)
     })
 
     it('does not show the dimmer when false', () => {
-      wrapperMount(<Modal portal={{ open: false }} />)
+      wrapperMount(<Modal open={false} />)
       assertInBody('.ui.dimmer', false)
     })
 
     it('shows the dimmer when true', () => {
-      wrapperMount(<Modal portal={{ open: true }} dimmer />)
+      wrapperMount(<Modal open dimmer />)
       assertInBody('.ui.dimmer')
     })
 
     it('shows the modal when true', () => {
-      wrapperMount(<Modal portal={{ open: true }} />)
+      wrapperMount(<Modal open />)
       assertInBody('.ui.modal')
     })
 
     it('shows the modal and dimmer on changing from false to true', () => {
-      wrapperMount(<Modal portal={{ open: false }} />)
+      wrapperMount(<Modal open={false} />)
       assertInBody('.ui.modal', false)
       assertInBody('.ui.dimmer', false)
 
-      wrapper.setProps({ portal: { open: true } })
+      wrapper.setProps({ open: true })
 
       assertInBody('.ui.modal')
       assertInBody('.ui.dimmer')
     })
 
     it('hides the modal and dimmer on changing from true to false', () => {
-      wrapperMount(<Modal portal={{ open: true }} />)
+      wrapperMount(<Modal open />)
       assertInBody('.ui.modal')
       assertInBody('.ui.dimmer')
 
-      wrapper.setProps({ portal: { open: false } })
+      wrapper.setProps({ open: false })
 
       assertInBody('.ui.modal', false)
       assertInBody('.ui.dimmer', false)
@@ -151,7 +151,7 @@ describe('Modal', () => {
 
   describe('basic', () => {
     it('adds basic to the modal className', () => {
-      wrapperMount(<Modal basic portal={{ open: true }} />)
+      wrapperMount(<Modal basic open />)
       assertInBody('.ui.basic.modal')
     })
   })
@@ -164,7 +164,7 @@ describe('Modal', () => {
 
     it('adds the size to the modal className', () => {
       Modal._meta.props.size.forEach(size => {
-        wrapperMount(<Modal size={size} portal={{ open: true }} />)
+        wrapperMount(<Modal size={size} open />)
         assertInBody(`.ui.${size}.modal`)
       })
     })
@@ -178,56 +178,56 @@ describe('Modal', () => {
       })
 
       it('is present by default', () => {
-        wrapperMount(<Modal portal={{ open: true }} />)
+        wrapperMount(<Modal open />)
         assertInBody('.ui.dimmer')
       })
     })
 
     describe('true', () => {
       it('adds classes "dimmable dimmed" to the body', () => {
-        wrapperMount(<Modal portal={{ open: true }} dimmer />)
+        wrapperMount(<Modal open dimmer />)
         assertBodyClasses('dimmable', 'dimmed')
       })
 
       it('adds a dimmer to the body', () => {
-        wrapperMount(<Modal portal={{ open: true }} dimmer />)
+        wrapperMount(<Modal open dimmer />)
         assertInBody('.ui.page.modals.dimmer.transition.visible.active')
       })
     })
 
     describe('false', () => {
       it('does not render a dimmer', () => {
-        wrapperMount(<Modal portal={{ open: true }} dimmer={false} />)
+        wrapperMount(<Modal open dimmer={false} />)
         assertBodyClasses('dimmable', 'dimmed', 'blurring', false)
       })
 
       it('does not add any dimmer classes to the body', () => {
-        wrapperMount(<Modal portal={{ open: true }} dimmer={false} />)
+        wrapperMount(<Modal open dimmer={false} />)
         assertBodyClasses('dimmable', 'dimmed', 'blurring', false)
       })
     })
 
     describe('blurring', () => {
       it('adds class "dimmable dimmed blurring" to the body', () => {
-        wrapperMount(<Modal portal={{ open: true }} dimmer='blurring' />)
+        wrapperMount(<Modal open dimmer='blurring' />)
         assertBodyClasses('dimmable', 'dimmed', 'blurring')
       })
 
       it('adds a dimmer to the body', () => {
-        wrapperMount(<Modal portal={{ open: true }} dimmer='blurring' />)
+        wrapperMount(<Modal open dimmer='blurring' />)
         assertInBody('.ui.page.modals.dimmer.transition.visible.active')
       })
     })
 
     describe('inverted', () => {
       it('adds class "dimmable dimmed" to the body', () => {
-        wrapperMount(<Modal portal={{ open: true }} dimmer='inverted' />)
+        wrapperMount(<Modal open dimmer='inverted' />)
         assertBodyClasses('dimmable', 'dimmed')
         assertBodyClasses('inverted', false)
       })
 
       it('adds an inverted dimmer to the body', () => {
-        wrapperMount(<Modal portal={{ open: true }} dimmer='inverted' />)
+        wrapperMount(<Modal open dimmer='inverted' />)
         assertInBody('.ui.inverted.page.modals.dimmer.transition.visible.active')
       })
     })
@@ -238,7 +238,7 @@ describe('Modal', () => {
 
     beforeEach(() => {
       spy = sandbox.spy()
-      wrapperMount(<Modal onClose={spy} portal={{ defaultOpen: true }} />)
+      wrapperMount(<Modal onClose={spy} defaultOpen />)
     })
 
     it('is called on dimmer click', () => {
@@ -287,7 +287,7 @@ describe('Modal', () => {
 
     beforeEach(() => {
       spy = sandbox.spy()
-      wrapperMount(<Modal onClose={spy} portal={{ open: true, closeOnEscape: false, closeOnDocumentClick: false }} />)
+      wrapperMount(<Modal onClose={spy} open closeOnEscape={false} closeOnDocumentClick={false} />)
     })
 
     it('is not called on dimmer click', () => {
@@ -336,7 +336,7 @@ describe('Modal', () => {
       const mountNode = document.createElement('div')
       document.body.appendChild(mountNode)
 
-      wrapperMount(<Modal mountNode={mountNode} portal={{ open: true }}>foo</Modal>)
+      wrapperMount(<Modal mountNode={mountNode} open>foo</Modal>)
       assertIn(mountNode, '.ui.modal')
     })
   })
@@ -347,12 +347,12 @@ describe('Modal', () => {
     })
 
     it('does not add the scrolling class to the body by default', () => {
-      wrapperMount(<Modal portal={{ open: true }} />)
+      wrapperMount(<Modal open />)
       assertBodyClasses('scrolling', false)
     })
 
     it('adds the scrolling class to the body when taller than the window', (done) => {
-      wrapperMount(<Modal portal={{ open: true }}>foo</Modal>)
+      wrapperMount(<Modal open>foo</Modal>)
 
       window.innerHeight = 10
 
@@ -365,7 +365,7 @@ describe('Modal', () => {
     it('removes the scrolling class from the body when the window grows taller', (done) => {
       assertBodyClasses('scrolling', false)
 
-      wrapperMount(<Modal portal={{ open: true }}>foo</Modal>)
+      wrapperMount(<Modal open>foo</Modal>)
       window.innerHeight = 10
 
       requestAnimationFrame(() => {

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -22,10 +22,12 @@ let wrapper
 const wrapperMount = (...args) => (wrapper = mount(...args))
 const wrapperShallow = (...args) => (wrapper = shallow(...args))
 
-const assertInBody = (selector, isPresent = true) => {
-  const didFind = document.body.querySelector(selector) !== null
-  didFind.should.equal(isPresent, `${didFind ? 'Found' : 'Did not find'} "${selector}" in the document.body.`)
+const assertIn = (node, selector, isPresent = true) => {
+  const didFind = node.querySelector(selector) !== null
+  didFind.should.equal(isPresent, `${didFind ? 'Found' : 'Did not find'} "${selector}" in the ${node}.`)
 }
+
+const assertInBody = (...args) => assertIn(document.body, ...args)
 
 const assertBodyClasses = (...rest) => {
   const hasClasses = typeof rest[rest.length - 1] === 'boolean' ? rest.pop() : true
@@ -326,6 +328,16 @@ describe('Modal', () => {
     it('is not called when the open prop changes to false', () => {
       wrapper.setProps({ open: false })
       spy.should.not.have.been.called()
+    })
+  })
+
+  describe('mountNode', () => {
+    it('render modal within mountNode', () => {
+      const mountNode = document.createElement('div')
+      document.body.appendChild(mountNode)
+
+      wrapperMount(<Modal mountNode={mountNode} portal={{ open: true }}>foo</Modal>)
+      assertIn(mountNode, '.ui.modal')
     })
   })
 


### PR DESCRIPTION
In an issue (#553) I had suggested we rely more heavily on `react-portal`. After digging into it a bit more, I realized a few things:
- It's not very actively maintained. The maintainers haven't commented on a PR in weeks if not months.
- Didn't seem like they had an interest in adding much more. In order to make use of this component for other components (e.g. `Popup`) we may need more flexibility.
- There's not a ton of code to get "Portal" functionality.

Therefore, I decided to build our own `Portal` loosely based on `react-portal`. I used their test file as a starting point to ensure we didn't lose much parity. I put it in the "addons" for now but let me know if there's a better spot for it. It has some cool features:
- configurable `closeOnDocumentClick` and `closeOnEscape` props
- `trigger` props that lets you render a node (e.g. a button) where you define the Portal so you don't need a wrapping div.
- configurable `openOnTriggerClick` and `openOnTriggerMouseOver` props. There's no `closeOnTriggerMouseLeave` but I figured something like that would be useful for `Popup`/`tooltips`.
- It's more declarative than `react-portal`. The `open`/`close` methods just set state and then the portal renders based on that.

---

I updated `Modal` to work with the new `Portal` component. There are still a few things that I need to solidify and/or figure out:
- `Modal` now takes a `portal` prop, which are props to be passed to the `Portal`. It's not a shorthand because the `Portal` is not rendered like a regular element. The other option here would be to pass the props directly to the `Modal` and use something like `_.pick(rest, _.keys(Portal.propTypes))` to figure out what to pass to `Portal`. Here's why I prefer the one prop:
  - We can theoretically allow passing null to not render the portal (e.g. if the use wants a modal but wants to handle hiding/showing it some other way).
  - It goes farther in decoupling the modal from the portal.
  - The negative is that it's slightly more verbose: `<Modal portal={{ trigger: <Button>Long Modal</Button> }}>` vs `<Modal trigger={<Button>Long Modal</Button>}>`
- `Portal` is an autocontrolled component which changes the existing usage of `Modal` slightly.
  - Uncontrolled - you can specify a trigger and have it open on click/hover and then configure the modal to close via clickaway or escape. You can pass `onOpen` and `onClose` to the modal which will be called when the modal is opened or closed. Issue:
    - Ideally you'd be able to close the modal by interacting with some content (e.g. a button) within the modal in the uncontrolled case. Can that be possible somehow? 
  - Controlled - you can specify open/close state but since `onOpen` and `onClose` are only called when the modal is actually opened/closed, there are no hooks to actually control them from the outside.
    - I'm thinking that if the modal would have closed in the uncontrolled state (e.g. press escape and have `closeOnEscape` set) we fire a `onCloseAttempt` (better name?) callback. If it would've opened, we fire the `onOpenAttempt`.
