### PR TITLE
fix(customPropTypes): fix logic and warning messages

### DIFF
--- a/docs/app/Examples/modules/Modal/Types/ModalBasicExample.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalBasicExample.js
@@ -15,7 +15,7 @@ class ModalBasicExample extends Component {
         <Button onClick={this.show}>Basic Modal</Button>
 
         <Modal basic size='small' active={active} onHide={this.hide}>
-          <Header icon='archive'>Archive Old Messages</Header>
+          <Header icon='archive' content='Archive Old Messages' />
           <Modal.Content>
             <p>Your inbox is getting full, would you like us to enable automatic archiving of old messages?</p>
           </Modal.Content>

--- a/docs/app/Examples/modules/Modal/Variations/ModalCloseConfigExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalCloseConfigExample.js
@@ -29,7 +29,7 @@ class ModalCloseConfigExample extends Component {
           </Modal.Content>
           <Modal.Actions>
             <Button negative>No</Button>
-            <Button positive labled='right' icon>
+            <Button positive labeled='right' icon>
               Yes <Icon name='checkmark' />
             </Button>
           </Modal.Actions>

--- a/docs/app/Examples/views/Item/Variations/Divided.js
+++ b/docs/app/Examples/views/Item/Variations/Divided.js
@@ -17,7 +17,7 @@ const Divided = () => (
         <Description>{paragraph}</Description>
         <Extra>
           <Label>IMAX</Label>
-          <Label icon='globe'>Additional Languages</Label>
+          <Label icon='globe' content='Additional Languages' />
         </Extra>
       </Content>
     </Item>

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -159,10 +159,14 @@ Input.propTypes = {
 
   /** Primary content.  Used when there are multiple Labels or multiple Actions. */
   children: customPropTypes.every([
-    customPropTypes.disallow(['icon', 'input', 'label']),
+    customPropTypes.disallow(['input', 'label']),
     customPropTypes.givenProps(
       { action: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.element]).isRequired },
       customPropTypes.disallow(['action']),
+    ),
+    customPropTypes.givenProps(
+      { icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.element]).isRequired },
+      customPropTypes.disallow(['icon']),
     ),
     PropTypes.node,
   ]),
@@ -192,10 +196,7 @@ Input.propTypes = {
   ]),
 
   /** An Icon can appear inside an Input on the left or right */
-  iconPosition: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOf(Input._meta.props.iconPosition),
-  ]),
+  iconPosition: PropTypes.oneOf(Input._meta.props.iconPosition),
 
   /** Format to appear on dark backgrounds */
   inverted: PropTypes.bool,

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -73,7 +73,6 @@ export default class Dropdown extends Component {
         { children: PropTypes.any.isRequired },
         React.PropTypes.element.isRequired,
       ),
-      customPropTypes.ofComponentTypes(['DropdownMenu']),
     ]),
 
     /** Current value or value array if multiple. Creates a controlled component. */


### PR DESCRIPTION
This is a breakout of #449.

This PR fixes a number of issues with customPropTypes.  Typos, bad messages, issues with logic, etc.  I also reworked them to use `lodash/fp` which cleaned things up a bit.

Later, we'll add the additional propTypes for shorthand, icon, image, children, etc.
