### PR TITLE
fix(package): remove semantic-ui-css dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   "dependencies": {
     "classnames": "^2.1.5",
     "debug": "^2.2.0",
-    "lodash": "^4.6.1",
-    "semantic-ui-css": "^2.2.2"
+    "lodash": "^4.6.1"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",


### PR DESCRIPTION
I believe this was left over from when we used to bundle jquery plugins. We don't bundle any Semantic packages with ours. 
