### PR TITLE
feat(Dropdown): Pass object with name to onChange

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Types/AllowAdditions.js
+++ b/docs/app/Examples/modules/Dropdown/Types/AllowAdditions.js
@@ -12,23 +12,23 @@ const options = [
 export default class AllowAdditionsExample extends Component {
   state = { optionsSingle: options, optionsMultiple: options }
 
-  handleAdditionSingle = value => {
+  handleAdditionSingle = (e, { value }) => {
     // validate, save to server, show a message to the user ...
     this.setState({
       optionsSingle: [{ text: value, value }, ...this.state.optionsSingle],
     })
   }
 
-  handleAdditionMultiple = value => {
+  handleAdditionMultiple = (e, { value }) => {
     // validate, save to server, show a message to the user ...
     this.setState({
       optionsMultiple: [{ text: value, value }, ...this.state.optionsMultiple],
     })
   }
 
-  handleChangeSingle = (e, value) => this.setState({ currentValue: value })
+  handleChangeSingle = (e, { value }) => this.setState({ currentValue: value })
 
-  handleChangeMultiple = (e, values) => this.setState({ currentValues: values })
+  handleChangeMultiple = (e, { value }) => this.setState({ currentValues: value })
 
   render() {
     const { currentValue, currentValues } = this.state

--- a/docs/app/Examples/modules/Dropdown/Types/Selection.js
+++ b/docs/app/Examples/modules/Dropdown/Types/Selection.js
@@ -20,7 +20,7 @@ export default class DropdownSelectionExample extends Component {
     })
   }
 
-  handleChange = (e, value) => this.setState({ value })
+  handleChange = (e, { value }) => this.setState({ value })
   handleSearchChange = (e, value) => this.setState({ searchQuery: value })
 
   fetchOptions = () => {

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -144,7 +144,7 @@ export default class Dropdown extends Component {
     /** Called with the React Synthetic Event on Dropdown blur. */
     onBlur: PropTypes.func,
 
-    /** Called with the React Synthetic Event and current value on change. */
+    /** Called with the React Synthetic Event and { name, value } on change. */
     onChange: PropTypes.func,
 
     /** Called with the React Synthetic Event and current value on search input change. */
@@ -356,11 +356,11 @@ export default class Dropdown extends Component {
 
   // onChange needs to receive a value
   // can't rely on props.value if we are controlled
-  onChange = (e, value) => {
-    debug('onChange()')
+  handleChange = (e, value) => {
+    debug('handleChange()')
     debug(value)
-    const { onChange } = this.props
-    if (onChange) onChange(e, value)
+    const { name, onChange } = this.props
+    if (onChange) onChange(e, { name, value })
   }
 
   closeOnEscape = (e) => {
@@ -420,10 +420,10 @@ export default class Dropdown extends Component {
       // state value may be undefined
       const newValue = _.union(this.state.value, [value])
       this.setValue(newValue)
-      this.onChange(e, newValue)
+      this.handleChange(e, newValue)
     } else {
       this.setValue(value)
-      this.onChange(e, value)
+      this.handleChange(e, value)
       this.close()
     }
   }
@@ -453,7 +453,7 @@ export default class Dropdown extends Component {
     const newValue = _.dropRight(value)
 
     this.setValue(newValue)
-    this.onChange(e, newValue)
+    this.handleChange(e, newValue)
   }
 
   closeOnDocumentClick = (e) => {
@@ -511,10 +511,10 @@ export default class Dropdown extends Component {
     if (multiple) {
       const newValue = _.union(this.state.value, [value])
       this.setValue(newValue)
-      this.onChange(e, newValue)
+      this.handleChange(e, newValue)
     } else {
       this.setValue(value)
-      this.onChange(e, value)
+      this.handleChange(e, value)
       this.close()
     }
   }
@@ -677,7 +677,7 @@ export default class Dropdown extends Component {
     debug('new value:', newValue)
 
     this.setValue(newValue)
-    this.onChange(e, newValue)
+    this.handleChange(e, newValue)
   }
 
   moveSelectionBy = (offset, startIndex = this.state.selectedIndex) => {
@@ -962,7 +962,7 @@ export default class Dropdown extends Component {
         onClick={this.handleClick}
         onMouseDown={this.handleMouseDown}
         onFocus={this.handleFocus}
-        onChange={this.onChange}
+        onChange={this.handleChange}
         tabIndex={search ? undefined : 0}
         ref={c => (this._dropdown = c)}
       >

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -116,9 +116,6 @@ export default class Dropdown extends Component {
       PropTypes.bool,
     ]),
 
-    /** Called with the new value added by the user. Use this to update the options list. */
-    onAddItem: PropTypes.func,
-
     /** Position of the `Add: ...` option in the dropdown list ('top' or 'bottom'). */
     additionPosition: PropTypes.oneOf(_meta.props.additionPosition),
 
@@ -140,6 +137,9 @@ export default class Dropdown extends Component {
     // ------------------------------------
     // Callbacks
     // ------------------------------------
+
+    /** Called with the name and new value added by the user. Use this to update the options list. */
+    onAddItem: PropTypes.func,
 
     /** Called with the React Synthetic Event on Dropdown blur. */
     onBlur: PropTypes.func,
@@ -405,7 +405,7 @@ export default class Dropdown extends Component {
 
   selectHighlightedItem = (e) => {
     const { open } = this.state
-    const { multiple, onAddItem, options } = this.props
+    const { multiple, name, onAddItem, options } = this.props
     const value = _.get(this.getSelectedItem(), 'value')
 
     // prevent selecting null if there was no selected item value
@@ -413,7 +413,9 @@ export default class Dropdown extends Component {
     if (!value || !open) return
 
     // notify the onAddItem prop if this is a new value
-    if (onAddItem && !_.some(options, { text: value })) onAddItem(value)
+    if (onAddItem && !_.some(options, { text: value })) {
+      onAddItem(e, { name, value })
+    }
 
     // notify the onChange prop that the user is trying to change value
     if (multiple) {
@@ -492,7 +494,7 @@ export default class Dropdown extends Component {
   handleItemClick = (e, value) => {
     debug('handleItemClick()')
     debug(value)
-    const { multiple, onAddItem, options } = this.props
+    const { multiple, name, onAddItem, options } = this.props
     const item = this.getItemByValue(value) || {}
 
     // prevent toggle() in handleClick()
@@ -505,7 +507,9 @@ export default class Dropdown extends Component {
     if (item.disabled) return
 
     // notify the onAddItem prop if this is a new value
-    if (onAddItem && !_.some(options, { value })) onAddItem(value)
+    if (onAddItem && !_.some(options, { text: value })) {
+      onAddItem(e, { name, value })
+    }
 
     // notify the onChange prop that the user is trying to change value
     if (multiple) {

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -243,8 +243,8 @@ export default class Search extends Component {
 
   // onChange needs to receive a value
   // can't rely on props.value if we are controlled
-  onChange = (e, result) => {
-    debug('onChange()')
+  handleChange = (e, result) => {
+    debug('handleChange()')
     debug(result)
     const { onChange } = this.props
     if (onChange) onChange(e, result)
@@ -286,7 +286,7 @@ export default class Search extends Component {
 
     // notify the onChange prop that the user is trying to change value
     this.setValue(result.title)
-    this.onChange(e, result)
+    this.handleChange(e, result)
     this.close()
   }
 
@@ -333,7 +333,7 @@ export default class Search extends Component {
 
     // notify the onChange prop that the user is trying to change value
     this.setValue(result.title)
-    this.onChange(e, result)
+    this.handleChange(e, result)
     this.close()
   }
 
@@ -616,7 +616,7 @@ export default class Search extends Component {
         className={classes}
         onBlur={this.handleBlur}
         onFocus={this.handleFocus}
-        onChange={this.onChange}
+        onChange={this.handleChange}
         onMouseDown={this.handleMouseDown}
       >
         {this.renderSearchInput()}

--- a/test/specs/commonTests.js
+++ b/test/specs/commonTests.js
@@ -298,16 +298,13 @@ export const isConformant = (Component, options = {}) => {
           'You may need to hoist your event handlers up to the root element.\n'
         )
 
-        // TODO: https://github.com/TechnologyAdvice/stardust/issues/218
-        // some components currently return useful data in the first position
-        // update those to return the event first, then any data, finally uncomment this test
-        //
-        // handlerSpy.calledWithMatch(eventShape).should.equal(true,
-        //   `<${constructorName} ${listenerName}={${handlerName}} />\n` +
-        //   `${leftPad} ^ was not called with an "${listenerName}" event\n` +
-        //   'It was called with args:\n' +
-        //   JSON.stringify(handlerSpy.args, null, 2)
-        // )
+        // Components should return the event first, then any data
+        handlerSpy.calledWithMatch(eventShape).should.equal(true,
+          `<${constructorName} ${listenerName}={${handlerName}} />\n` +
+          `${leftPad} ^ was not called with an "${listenerName}" event\n` +
+          'It was called with args:\n' +
+          JSON.stringify(handlerSpy.args, null, 2)
+        )
       })
     })
   })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1596,8 +1596,9 @@ describe('Dropdown Component', () => {
 
     it('calls onAddItem prop when clicking new value', () => {
       const spy = sandbox.spy()
+      const name = 'my-dropdown'
       const search = wrapperMount(
-        <Dropdown options={customOptions} selection search allowAdditions onAddItem={spy} />
+        <Dropdown options={customOptions} selection search allowAdditions onAddItem={spy} name={name} />
       )
         .find('input.search')
 
@@ -1609,13 +1610,14 @@ describe('Dropdown Component', () => {
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[0].should.equal('boo')
+      spy.should.have.been.calledWith(sandbox.match.any, { name, value: 'boo' })
     })
 
     it('calls onAddItem prop when pressing enter on new value', () => {
       const spy = sandbox.spy()
+      const name = 'my-dropdown'
       const search = wrapperMount(
-        <Dropdown options={customOptions} selection search allowAdditions onAddItem={spy} />
+        <Dropdown options={customOptions} selection search allowAdditions onAddItem={spy} name={name} />
       )
         .find('input.search')
 
@@ -1623,7 +1625,7 @@ describe('Dropdown Component', () => {
       domEvent.keyDown(document, { key: 'Enter' })
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[0].should.equal('boo')
+      spy.should.have.been.calledWith(sandbox.match.any, { name, value: 'boo' })
     })
   })
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -798,12 +798,13 @@ describe('Dropdown Component', () => {
 
     describe('removing items', () => {
       it('calls onChange without the clicked value', () => {
+        const name = 'my-dropdown'
         const value = _.map(options, 'value')
         const randomIndex = _.random(options.length - 1)
         const randomValue = value[randomIndex]
         const expected = _.without(value, randomValue)
         const spy = sandbox.spy()
-        wrapperMount(<Dropdown options={options} selection value={value} multiple onChange={spy} />)
+        wrapperMount(<Dropdown options={options} selection name={name} value={value} multiple onChange={spy} />)
 
         wrapper
           .find('.delete.icon')
@@ -811,7 +812,7 @@ describe('Dropdown Component', () => {
           .simulate('click')
 
         spy.should.have.been.calledOnce()
-        spy.firstCall.args[1].should.deep.equal(expected)
+        spy.should.have.been.calledWith(sandbox.match.any, { name, value: expected })
       })
     })
   })
@@ -833,9 +834,10 @@ describe('Dropdown Component', () => {
       spy.should.not.have.been.called()
     })
     it('removes the last item when there is no search query', () => {
+      const name = 'my-dropdown'
       const value = _.map(options, 'value')
       const expected = _.dropRight(value)
-      wrapperMount(<Dropdown options={options} selection value={value} multiple search onChange={spy} />)
+      wrapperMount(<Dropdown options={options} selection name={name} value={value} multiple search onChange={spy} />)
 
       // open
       wrapper.simulate('click')
@@ -843,12 +845,15 @@ describe('Dropdown Component', () => {
       domEvent.keyDown(document, { key: 'Backspace' })
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[1].should.deep.equal(expected)
+      spy.should.have.been.calledWith(sandbox.match.any, { name, value: expected })
     })
     it('removes the last item when there is no search query when uncontrolled', () => {
+      const name = 'my-dropdown'
       const value = _.map(options, 'value')
       const expected = _.dropRight(value)
-      wrapperMount(<Dropdown options={options} selection defaultValue={value} multiple search onChange={spy} />)
+      wrapperMount(
+        <Dropdown options={options} selection name={name} defaultValue={value} multiple search onChange={spy} />
+      )
 
       // open
       wrapper.simulate('click')
@@ -856,7 +861,7 @@ describe('Dropdown Component', () => {
       domEvent.keyDown(document, { key: 'Backspace' })
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[1].should.deep.equal(expected)
+      spy.should.have.been.calledWith(sandbox.match.any, { name, value: expected })
 
       wrapper
         .state('value')
@@ -897,35 +902,38 @@ describe('Dropdown Component', () => {
     })
 
     it('is called with event and value on item click', () => {
+      const name = 'my-dropdown'
       const randomIndex = _.random(options.length - 1)
       const randomValue = options[randomIndex].value
-      wrapperMount(<Dropdown options={options} selection onChange={spy} />)
+      wrapperMount(<Dropdown options={options} selection onChange={spy} name={name} />)
         .simulate('click')
         .find('DropdownItem')
         .at(randomIndex)
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[1].should.deep.equal(randomValue)
+      spy.should.have.been.calledWith(sandbox.match.any, { name, value: randomValue })
     })
     it('is called with event and value when pressing enter on a selected item', () => {
+      const name = 'my-dropdown'
       const firstValue = options[0].value
-      wrapperMount(<Dropdown options={options} selection onChange={spy} />)
+      wrapperMount(<Dropdown options={options} selection onChange={spy} name={name} />)
         .simulate('click')
 
       domEvent.keyDown(document, { key: 'Enter' })
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[1].should.deep.equal(firstValue)
+      spy.should.have.been.calledWith(sandbox.match.any, { name, value: firstValue })
     })
     it('is called with event and value when blurring', () => {
+      const name = 'my-dropdown'
       const firstValue = options[0].value
-      wrapperMount(<Dropdown options={options} selection onChange={spy} />)
+      wrapperMount(<Dropdown options={options} selection onChange={spy} name={name} />)
         .simulate('focus')  // open, highlights first item
         .simulate('blur')   // blur should activate selected item
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[1].should.deep.equal(firstValue)
+      spy.should.have.been.calledWith(sandbox.match.any, { name, value: firstValue })
     })
     it('is not called on blur when closed', () => {
       wrapperMount(<Dropdown options={options} selection open={false} onChange={spy} />)

--- a/test/specs/modules/Search/Search-test.js
+++ b/test/specs/modules/Search/Search-test.js
@@ -540,7 +540,7 @@ describe('Search Component', () => {
         .simulate('click', nativeEvent)
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[1].should.deep.equal(randomResult)
+      spy.should.have.been.calledWith(sandbox.match.any, randomResult)
     })
     it('is called with event and value when pressing enter on a selected item', () => {
       const firstResult = options[0]
@@ -553,7 +553,7 @@ describe('Search Component', () => {
       domEvent.keyDown(document, { key: 'Enter' })
 
       spy.should.have.been.calledOnce()
-      spy.firstCall.args[1].should.deep.equal(firstResult)
+      spy.should.have.been.calledWith(sandbox.match.any, firstResult)
     })
     it('is not called when updating the value prop', () => {
       const value = _.sample(options).title


### PR DESCRIPTION
Fixes #218 

This is a breaking change but I think it's worth it. There's currently no easy way to get the `name` of the `Dropdown` in the `onChange` event. Normally in an `onChange` the `event.target` will be the input that received the change. So in a form, for example, you can attach the same change handler to multiple elements and use the event to determine the appropriate field/value to update.

For `Dropdown` that's not the case - it will likely be a `DropdownItem`.

The `Checkbox` is an example of a component that faces a similar issue regarding the target. In that component, the `onClick` and `onChange` are both called with `{ name, value, checked }`. This PR updates `Dropdown` to be called with `{ name, value }`.

I also cleaned up the naming of our internal event handler to be `handleChange`. The pattern of this project seems to be:
- `handle<event>` for our internal handlers
- `on<event>` is a prop that the user passes in and is called by our internal handlers if set.
