### PR TITLE
feat(ComponentExample): add copy JSX button

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentExample.js
+++ b/docs/app/Components/ComponentDoc/ComponentExample.js
@@ -3,6 +3,7 @@ import _ from 'lodash'
 import React, { Component, createElement, isValidElement, PropTypes } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { html } from 'js-beautify'
+import copyToClipboard from 'copy-to-clipboard'
 
 import { exampleContext } from 'docs/app/utils'
 import { Label, Divider, Grid, Icon, Header } from 'src'
@@ -78,6 +79,12 @@ export default class ComponentExample extends Component {
       sourceCode,
       staticMarkup,
     })
+  }
+
+  copyToClipboard = () => {
+    const { sourceCode } = this.state
+    copyToClipboard(sourceCode)
+    alert('Copied to clipboard!')
   }
 
   resetEditor = () => {
@@ -193,6 +200,15 @@ export default class ComponentExample extends Component {
     return (
       <Grid.Column style={style}>
         <Divider horizontal>
+          <Label
+            as='a'
+            basic
+            horizontal
+            color={error ? 'red' : 'green'}
+            icon='copy'
+            content={error ? 'See Error' : 'JSX'}
+            onClick={this.copyToClipboard}
+          />
           <Label
             as='a'
             basic

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "chai": "^3.3.0",
     "chai-enzyme": "^0.5.0",
     "connect-history-api-fallback": "^1.2.0",
+    "copy-to-clipboard": "^3.0.5",
     "cross-env": "^2.0.0",
     "css-loader": "^0.23.1",
     "del": "^2.2.2",


### PR DESCRIPTION
<img width="198" alt="screen shot 2016-10-02 at 1 42 22 am" src="https://cloud.githubusercontent.com/assets/847027/19018934/8b35a1dc-8841-11e6-8fca-4cc713a20fd0.png">

Adds "copy" functionality to the examples.

Fixes #574 
