### PR TITLE
fix(tests): Add coverage to missing lines

### DIFF
--- a/test/specs/collections/Form/Form-test.js
+++ b/test/specs/collections/Form/Form-test.js
@@ -51,6 +51,30 @@ describe('Form', () => {
       serializer.should.have.been.calledWithMatch(formNode)
     })
 
+    it('logs an error if an input is missing a name', () => {
+      consoleUtil.disableOnce()
+      const spy = sandbox.spy(console, 'error')
+
+      const wrapper = mount(
+        <Form onSubmit={() => null}>
+          <input type='checkbox' data-has-no-name />
+        </Form>
+      )
+        .simulate('submit')
+
+      const errorMessage = [
+        'Encountered a form control node without a name attribute.',
+        'Each node in a group should have a name.',
+        'Otherwise, the node will serialize as { "undefined": <value> }.',
+      ].join(' ')
+
+      const formNode = findDOMNode(wrapper.instance())
+      const badInput = findDOMNode(formNode.querySelector('[data-has-no-name]'))
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(errorMessage, badInput)
+    })
+
     it('logs an error if a checkbox in a group is missing a value', () => {
       consoleUtil.disableOnce()
       const spy = sandbox.spy(console, 'error')

--- a/test/specs/collections/Form/FormField-test.js
+++ b/test/specs/collections/Form/FormField-test.js
@@ -41,6 +41,12 @@ describe('FormField', () => {
         .find('label')
         .should.contain.text('First Name')
     })
+    it('is sibling to text inputs', () => {
+      const wrapper = shallow(<FormField control='input' type='text' label='Text field' />)
+
+      wrapper.childAt(0).should.have.tagName('label')
+      wrapper.childAt(1).should.have.tagName('input')
+    })
     it('wraps checkbox inputs', () => {
       const label = shallow(<FormField control='input' type='checkbox' label='Check this box' />)
         .find('label')

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -3,7 +3,7 @@ import faker from 'faker'
 import React from 'react'
 
 import * as common from 'test/specs/commonTests'
-import { domEvent, sandbox } from 'test/utils'
+import { consoleUtil, domEvent, sandbox } from 'test/utils'
 import Dropdown from 'src/modules/Dropdown/Dropdown'
 import DropdownDivider from 'src/modules/Dropdown/DropdownDivider'
 import DropdownHeader from 'src/modules/Dropdown/DropdownHeader'
@@ -1630,6 +1630,44 @@ describe('Dropdown Component', () => {
     it('does not render a header when not present', () => {
       wrapperRender(<Dropdown options={options} />)
         .should.not.have.descendants('.menu .header')
+    })
+  })
+
+  describe('value validations', () => {
+    it('logs an error if dropdown is not multiple and value is array', () => {
+      consoleUtil.disableOnce()
+      const spy = sandbox.spy(console, 'error')
+
+      const originalValue = _.pick(options, 'value')[0]
+      const nextValue = _.castArray(_.pick(options, 'value')[1])
+
+      wrapperMount(<Dropdown options={options} value={originalValue} selection />)
+      wrapper.setProps({ value: nextValue })
+
+      const errorMessage =
+        'Dropdown `value` must not be an array when `multiple` is not set.' +
+        ' Either set `multiple={true}` or use a string or number value.'
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(errorMessage)
+    })
+
+    it('logs an error if dropdown is multiple and value not array', () => {
+      consoleUtil.disableOnce()
+      const spy = sandbox.spy(console, 'error')
+
+      const originalValue = _.castArray(_.pick(options, 'value')[0])
+      const nextValue = _.pick(options, 'value')[1]
+
+      wrapperMount(<Dropdown options={options} value={originalValue} selection multiple />)
+      wrapper.setProps({ value: nextValue })
+
+      const errorMessage =
+        'Dropdown `value` must be an array when `multiple` is set.' +
+        ` Received type: \`${Object.prototype.toString.call(nextValue)}\`.`
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(errorMessage)
     })
   })
 })

--- a/test/specs/modules/Search/Search-test.js
+++ b/test/specs/modules/Search/Search-test.js
@@ -88,24 +88,17 @@ describe('Search Component', () => {
     openSearchResults()
 
     searchResultsIsOpen()
-
-    wrapper
-      .simulate('blur')
-
+    wrapper.simulate('blur')
     searchResultsIsClosed()
   })
 
-  // TODO: see Search.handleFocus() todo
-  // it('opens on focus', () => {
-  //   wrapperMount(<Search {...requiredProps} />)
-  //
-  //   searchResultsIsClosed()
-  //
-  //   wrapper
-  //     .simulate('focus')
-  //
-  //   searchResultsIsOpen()
-  // })
+  it('opens on focus', () => {
+    wrapperMount(<Search results={options} minCharacters={0} />)
+
+    searchResultsIsClosed()
+    wrapper.simulate('focus')
+    searchResultsIsOpen()
+  })
 
   describe('isMouseDown', () => {
     it('tracks when the mouse is down', () => {
@@ -493,6 +486,11 @@ describe('Search Component', () => {
   describe('open', () => {
     it('defaultOpen opens the menu when true', () => {
       wrapperShallow(<Search results={options} minCharacters={0} defaultOpen />)
+      searchResultsIsOpen()
+    })
+    it('defaultOpen stays open on focus', () => {
+      wrapperShallow(<Search results={options} minCharacters={0} defaultOpen />)
+      wrapper.simulate('focus')
       searchResultsIsOpen()
     })
     it('defaultOpen closes the menu when false', () => {


### PR DESCRIPTION
It was really bothering me that our coverage was at ~99.6% and not just 100%. I went through codecov.io and found the lines that were missing coverage and added specs. Let's not let it dip back below 100!

On a related note, I realized recently that the one-liner style for conditionals actually masks missing coverage. For example:

``` js
open = (e) => {
  debug('open()')

  const { onOpen } = this.props
  if (onOpen) onOpen(e)

  this.trySetState({ open: true })
}
```

Codecov won't catch if we're missing a test to ensure `onOpen` gets called.

You can enable an eslint rule to force multi-line blocks (http://eslint.org/docs/rules/curly), although that would increase the verbosity of the codebase. Not necessarily advocating for doing anything, just wanted to bring this up.
