### PR TITLE
fix(MenuItem): do not add `icon` class given `name` or `content`

### DIFF
--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -20,7 +20,7 @@ function MenuItem(props) {
   const classes = cx(
     useKeyOnly(active, 'active'),
     useKeyOrValueAndKey(fitted, 'fitted'),
-    useKeyOnly(icon, 'icon'),
+    useKeyOnly(icon === true || icon && !(name || content), 'icon'),
     useKeyOnly(header, 'header'),
     useKeyOnly(link, 'link'),
     color,

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -38,6 +38,21 @@ describe('MenuItem', () => {
     })
   })
 
+  describe('icon', () => {
+    it('does not add `icon` className if there is also `name`', () => {
+      shallow(<MenuItem icon='user' name='users' />)
+        .should.not.have.className('icon')
+    })
+    it('does not add `icon` className if there is also `content`', () => {
+      shallow(<MenuItem icon='user' content='Users' />)
+        .should.not.have.className('icon')
+    })
+    it('adds `icon` className if there is an `icon` without `name` or `content`', () => {
+      shallow(<MenuItem icon='user' />)
+        .should.have.className('icon')
+    })
+  })
+
   describe('onClick', () => {
     it('can be omitted', () => {
       const click = () => mount(<MenuItem />).simulate('click')


### PR DESCRIPTION
The `icon` class collapses the whitespace.  It should only be added if there is an `icon` only, without any adjacent text.
### Before

![image](https://cloud.githubusercontent.com/assets/5067638/19024209/6a48daa8-88b3-11e6-9f9a-e3526e4e0ced.png)
### After

![image](https://cloud.githubusercontent.com/assets/5067638/19024237/fe1d4dcc-88b3-11e6-9563-3a1a7a87aa2a.png)
