### PR TITLE
fix(Checkbox): no onChange/onClick when disabled

### DIFF
--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -110,22 +110,22 @@ export default class Checkbox extends Component {
 
   handleClick = (e) => {
     debug('handleClick()')
-    const { onChange, onClick, disabled, name, value } = this.props
+    const { onChange, onClick, name, value } = this.props
     const { checked } = this.state
     debug(`  name:       ${name}`)
     debug(`  value:      ${value}`)
     debug(`  checked:    ${checked}`)
 
-    if (onClick) onClick(e, { name, value, checked: !!checked })
-    if (onChange && !disabled) onChange(e, { name, value, checked: !checked })
-
     if (this.canToggle()) {
+      if (onClick) onClick(e, { name, value, checked: !!checked })
+      if (onChange) onChange(e, { name, value, checked: !checked })
+
       this.trySetState({ checked: !checked })
     }
   }
 
   render() {
-    const { className, label, name, radio, slider, toggle, type, value } = this.props
+    const { className, label, name, radio, slider, toggle, type, value, disabled, readOnly } = this.props
     const { checked } = this.state
     const classes = cx(
       'ui',
@@ -136,6 +136,8 @@ export default class Checkbox extends Component {
       useKeyOnly(radio, 'radio'),
       useKeyOnly(slider, 'slider'),
       useKeyOnly(toggle, 'toggle'),
+      useKeyOnly(disabled, 'disabled'),
+      useKeyOnly(readOnly, 'read-only'),
       'checkbox',
       className
     )

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -110,7 +110,7 @@ export default class Checkbox extends Component {
 
   handleClick = (e) => {
     debug('handleClick()')
-    const { onChange, onClick, name, value } = this.props
+    const { onChange, onClick, disabled, name, value } = this.props
     const { checked } = this.state
     debug(`  name:       ${name}`)
     debug(`  value:      ${value}`)

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -117,7 +117,7 @@ export default class Checkbox extends Component {
     debug(`  checked:    ${checked}`)
 
     if (onClick) onClick(e, { name, value, checked: !!checked })
-    if (onChange) onChange(e, { name, value, checked: !checked })
+    if (onChange && !disabled) onChange(e, { name, value, checked: !checked })
 
     if (this.canToggle()) {
       this.trySetState({ checked: !checked })

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -10,6 +10,10 @@ describe('Checkbox', () => {
   common.propKeyOnlyToClassName(Checkbox, 'checked')
   common.propKeyOnlyToClassName(Checkbox, 'slider')
   common.propKeyOnlyToClassName(Checkbox, 'toggle')
+  common.propKeyOnlyToClassName(Checkbox, 'disabled')
+  common.propKeyOnlyToClassName(Checkbox, 'readOnly', {
+    className: 'read-only',
+  })
 
   describe('defaultChecked', () => {
     it('sets the initial checked state', () => {

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -85,6 +85,11 @@ describe('Checkbox', () => {
       spy.firstCall.args[1]
         .should.deep.equal(expectProps)
     })
+    it('is not called when the checkbox has the disabled prop set', () => {
+      const spy = sandbox.spy()
+      mount(<Checkbox disabled onClick={spy} />).simulate('click')
+      spy.should.not.have.been.called()
+    })
   })
 
   describe('onChange', () => {

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -95,6 +95,11 @@ describe('Checkbox', () => {
       spy.firstCall.args[1]
         .should.deep.equal({ ...expectProps, checked: true })
     })
+    it('is not called when the checkbox has the disabled prop set', () => {
+      const spy = sandbox.spy()
+      mount(<Checkbox disabled onChange={spy} />).simulate('click')
+      spy.should.not.have.been.called()
+    })
   })
 
   describe('readOnly', () => {


### PR DESCRIPTION
Check if `disabled` before calling `onChange` function. 

Fixes #600 
