### PR TITLE
chore(style): Make some common patterns more consistent

### DIFF
--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -14,6 +14,7 @@ import {
 function TextArea(props) {
   const rest = getUnhandledProps(TextArea, props)
   const ElementType = getElementType(TextArea, props)
+
   return <ElementType {...rest} />
 }
 

--- a/src/collections/Breadcrumb/Breadcrumb.js
+++ b/src/collections/Breadcrumb/Breadcrumb.js
@@ -17,8 +17,8 @@ import BreadcrumbSection from './BreadcrumbSection'
  */
 function Breadcrumb(props) {
   const { children, className, divider, icon, size, sections } = props
-  const rest = getUnhandledProps(Breadcrumb, props)
   const classes = cx('ui', className, size, 'breadcrumb')
+  const rest = getUnhandledProps(Breadcrumb, props)
   const ElementType = getElementType(Breadcrumb, props)
 
   if (!sections) return <ElementType {...rest} className={classes}>{children}</ElementType>

--- a/src/collections/Breadcrumb/BreadcrumbDivider.js
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.js
@@ -14,8 +14,8 @@ import Icon from '../../elements/Icon'
  */
 function BreadcrumbDivider(props) {
   const { children, icon, className } = props
-  const rest = getUnhandledProps(BreadcrumbDivider, props)
   const classes = cx(className, 'divider')
+  const rest = getUnhandledProps(BreadcrumbDivider, props)
   const ElementType = getElementType(BreadcrumbDivider, props)
 
   if (icon) return Icon.create(icon, { ...rest, className: classes })

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -168,7 +168,7 @@ function formSerializer(formNode) {
  * @see TextArea
  */
 function Form(props) {
-  const { className, children, error, loading, onSubmit, size, success, warning, widths } = props
+  const { children, className, error, loading, onSubmit, size, success, warning, widths } = props
   const classes = cx(
     'ui',
     size,

--- a/src/collections/Form/FormButton.js
+++ b/src/collections/Form/FormButton.js
@@ -19,6 +19,7 @@ function FormButton(props) {
   const { control } = props
   const rest = getUnhandledProps(FormButton, props)
   const ElementType = getElementType(FormButton, props)
+
   return <ElementType {...rest} control={control} />
 }
 

--- a/src/collections/Form/FormCheckbox.js
+++ b/src/collections/Form/FormCheckbox.js
@@ -19,6 +19,7 @@ function FormCheckbox(props) {
   const { control } = props
   const rest = getUnhandledProps(FormCheckbox, props)
   const ElementType = getElementType(FormCheckbox, props)
+
   return <ElementType {...rest} control={control} />
 }
 

--- a/src/collections/Form/FormDropdown.js
+++ b/src/collections/Form/FormDropdown.js
@@ -19,6 +19,7 @@ function FormDropdown(props) {
   const { control } = props
   const rest = getUnhandledProps(FormDropdown, props)
   const ElementType = getElementType(FormDropdown, props)
+
   return <ElementType {...rest} control={control} />
 }
 

--- a/src/collections/Form/FormGroup.js
+++ b/src/collections/Form/FormGroup.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react'
-import classNames from 'classnames'
+import cx from 'classnames'
 
 import {
   getElementType,
@@ -17,8 +17,7 @@ import {
  */
 function FormGroup(props) {
   const { children, className, grouped, inline, widths } = props
-
-  const classes = classNames(
+  const classes = cx(
     useWidthProp(widths, null, true),
     useKeyOnly(inline, 'inline'),
     useKeyOnly(grouped, 'grouped'),
@@ -27,11 +26,8 @@ function FormGroup(props) {
   )
   const rest = getUnhandledProps(FormGroup, props)
   const ElementType = getElementType(FormGroup, props)
-  return (
-    <ElementType {...rest} className={classes}>
-      {children}
-    </ElementType>
-  )
+
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 FormGroup._meta = {

--- a/src/collections/Form/FormInput.js
+++ b/src/collections/Form/FormInput.js
@@ -19,6 +19,7 @@ function FormInput(props) {
   const { control } = props
   const rest = getUnhandledProps(FormInput, props)
   const ElementType = getElementType(FormInput, props)
+
   return <ElementType {...rest} control={control} />
 }
 

--- a/src/collections/Form/FormRadio.js
+++ b/src/collections/Form/FormRadio.js
@@ -19,6 +19,7 @@ function FormRadio(props) {
   const { control } = props
   const rest = getUnhandledProps(FormRadio, props)
   const ElementType = getElementType(FormRadio, props)
+
   return <ElementType {...rest} control={control} />
 }
 

--- a/src/collections/Form/FormTextArea.js
+++ b/src/collections/Form/FormTextArea.js
@@ -19,6 +19,7 @@ function FormTextArea(props) {
   const { control } = props
   const rest = getUnhandledProps(FormTextArea, props)
   const ElementType = getElementType(FormTextArea, props)
+
   return <ElementType {...rest} control={control} />
 }
 

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -36,7 +36,7 @@ const _meta = {
 
 /**
  * A menu displays grouped navigation actions.
- * */
+ **/
 class Menu extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
@@ -172,7 +172,7 @@ class Menu extends Component {
 
   render() {
     const {
-      attached, borderless, className, children, color, compact, fixed, floated, fluid, icon, inverted, pagination,
+      attached, borderless, children, className, color, compact, fixed, floated, fluid, icon, inverted, pagination,
       pointing, secondary, stackable, tabular, text, vertical, size, widths,
     } = this.props
     const classes = cx(
@@ -198,7 +198,6 @@ class Menu extends Component {
       className,
       'menu'
     )
-
     const rest = getUnhandledProps(Menu, this.props)
     const ElementType = getElementType(Menu, this.props)
 

--- a/src/collections/Menu/MenuHeader.js
+++ b/src/collections/Menu/MenuHeader.js
@@ -11,8 +11,8 @@ import {
 function MenuHeader(props) {
   const { children, className, content } = props
   const classes = cx(className, 'header')
-  const ElementType = getElementType(MenuHeader, props)
   const rest = getUnhandledProps(MenuHeader, props)
+  const ElementType = getElementType(MenuHeader, props)
 
   return <ElementType {...rest} className={classes}>{children || content}</ElementType>
 }

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -37,11 +37,7 @@ function MenuItem(props) {
   const rest = getUnhandledProps(MenuItem, props)
 
   if (children) {
-    return (
-      <ElementType {...rest} className={classes} onClick={handleClick}>
-        {children}
-      </ElementType>
-    )
+    return <ElementType {...rest} className={classes} onClick={handleClick}>{children}</ElementType>
   }
 
   return (

--- a/src/collections/Menu/MenuMenu.js
+++ b/src/collections/Menu/MenuMenu.js
@@ -11,8 +11,8 @@ import {
 function MenuMenu(props) {
   const { children, className, position } = props
   const classes = cx(className, position, 'menu')
-  const ElementType = getElementType(MenuMenu, props)
   const rest = getUnhandledProps(MenuMenu, props)
+  const ElementType = getElementType(MenuMenu, props)
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }

--- a/src/collections/Message/MessageContent.js
+++ b/src/collections/Message/MessageContent.js
@@ -9,9 +9,9 @@ import {
 } from '../../lib'
 
 function MessageContent(props) {
-  const { className, children } = props
-  const rest = getUnhandledProps(MessageContent, props)
+  const { children, className } = props
   const classes = cx('content', className)
+  const rest = getUnhandledProps(MessageContent, props)
   const ElementType = getElementType(MessageContent, props)
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>

--- a/src/collections/Message/MessageHeader.js
+++ b/src/collections/Message/MessageHeader.js
@@ -9,9 +9,9 @@ import {
 } from '../../lib'
 
 function MessageHeader(props) {
-  const { className, children } = props
-  const rest = getUnhandledProps(MessageHeader, props)
+  const { children, className } = props
   const classes = cx('header', className)
+  const rest = getUnhandledProps(MessageHeader, props)
   const ElementType = getElementType(MessageHeader, props)
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>

--- a/src/collections/Message/MessageItem.js
+++ b/src/collections/Message/MessageItem.js
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
@@ -8,11 +9,12 @@ import {
 } from '../../lib'
 
 function MessageItem(props) {
-  const { children } = props
+  const { children, className } = props
+  const classes = cx('content', className)
   const rest = getUnhandledProps(MessageItem, props)
   const ElementType = getElementType(MessageItem, props)
 
-  return <ElementType {...rest}>{children}</ElementType>
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 MessageItem._meta = {
@@ -27,6 +29,9 @@ MessageItem.propTypes = {
 
   /** Primary content. */
   children: PropTypes.node,
+
+  /** Additional classes. */
+  className: PropTypes.node,
 }
 
 MessageItem.defaultProps = {

--- a/src/collections/Message/MessageList.js
+++ b/src/collections/Message/MessageList.js
@@ -11,9 +11,9 @@ import {
 import MessageItem from './MessageItem'
 
 function MessageList(props) {
-  const { className, children, items } = props
-  const rest = getUnhandledProps(MessageList, props)
+  const { children, className, items } = props
   const classes = cx('list', className)
+  const rest = getUnhandledProps(MessageList, props)
   const ElementType = getElementType(MessageList, props)
 
   const itemsJSX = items && items.map(item => <MessageItem key={item}>{item}</MessageItem>)

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -49,6 +49,7 @@ function Table(props) {
     tableData,
     unstackable,
   } = props
+
   const classes = cx(
     'ui',
     color,
@@ -72,9 +73,8 @@ function Table(props) {
     className,
     'table'
   )
-
-  const ElementType = getElementType(Table, props)
   const rest = getUnhandledProps(Table, props)
+  const ElementType = getElementType(Table, props)
 
   if (children) {
     return <ElementType {...rest} className={classes}>{children}</ElementType>
@@ -155,7 +155,7 @@ Table.propTypes = {
 
   /**
    * A table can use fixed a special faster form of table rendering that does not resize table cells based on content
-   * */
+   **/
   fixed: PropTypes.bool,
 
   /** Shorthand for a TableRow to be placed within Table.Footer. */

--- a/src/collections/Table/TableBody.js
+++ b/src/collections/Table/TableBody.js
@@ -11,8 +11,8 @@ import {
 function TableBody(props) {
   const { children, className } = props
   const classes = cx(className)
-  const ElementType = getElementType(TableBody, props)
   const rest = getUnhandledProps(TableBody, props)
+  const ElementType = getElementType(TableBody, props)
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }

--- a/src/collections/Table/TableCell.js
+++ b/src/collections/Table/TableCell.js
@@ -33,6 +33,7 @@ function TableCell(props) {
     warning,
     width,
   } = props
+
   const classes = cx(
     useKeyOnly(active, 'active'),
     useKeyOnly(collapsing, 'collapsing'),
@@ -47,9 +48,8 @@ function TableCell(props) {
     useWidthProp(width, 'wide'),
     className,
   )
-
-  const ElementType = getElementType(TableCell, props)
   const rest = getUnhandledProps(TableCell, props)
+  const ElementType = getElementType(TableCell, props)
 
   if (children) {
     return <ElementType {...rest} className={classes}>{children}</ElementType>

--- a/src/collections/Table/TableHeader.js
+++ b/src/collections/Table/TableHeader.js
@@ -15,9 +15,8 @@ function TableHeader(props) {
     useKeyOnly(fullWidth, 'full-width'),
     className
   )
-
-  const ElementType = getElementType(TableHeader, props)
   const rest = getUnhandledProps(TableHeader, props)
+  const ElementType = getElementType(TableHeader, props)
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }

--- a/src/collections/Table/TableRow.js
+++ b/src/collections/Table/TableRow.js
@@ -30,6 +30,7 @@ function TableRow(props) {
     verticalAlign,
     warning,
   } = props
+
   const classes = cx(
     useKeyOnly(active, 'active'),
     useKeyOnly(disabled, 'disabled'),
@@ -41,9 +42,8 @@ function TableRow(props) {
     useVerticalAlignProp(verticalAlign),
     className,
   )
-
-  const ElementType = getElementType(TableRow, props)
   const rest = getUnhandledProps(TableRow, props)
+  const ElementType = getElementType(TableRow, props)
 
   if (children) {
     return <ElementType {...rest} className={classes}>{children}</ElementType>

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -59,7 +59,6 @@ function Button(props) {
     useKeyOnly(secondary, 'secondary'),
     useKeyOnly(toggle, 'toggle'),
   )
-
   const rest = getUnhandledProps(Button, props)
   const ElementType = getElementType(Button, props, () => {
     if (label || attached) return 'div'

--- a/src/elements/Button/ButtonContent.js
+++ b/src/elements/Button/ButtonContent.js
@@ -20,15 +20,10 @@ function ButtonContent(props) {
     'content',
     className,
   )
-
   const rest = getUnhandledProps(ButtonContent, props)
   const ElementType = getElementType(ButtonContent, props)
 
-  return (
-    <ElementType className={classes} {...rest}>
-      {children}
-    </ElementType>
-  )
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 ButtonContent._meta = {

--- a/src/elements/Button/ButtonGroup.js
+++ b/src/elements/Button/ButtonGroup.js
@@ -32,15 +32,10 @@ function ButtonGroup(props) {
     'buttons',
     className,
   )
-
   const rest = getUnhandledProps(ButtonGroup, props)
   const ElementType = getElementType(ButtonGroup, props)
 
-  return (
-    <ElementType className={classes} {...rest}>
-      {children}
-    </ElementType>
-  )
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 ButtonGroup._meta = {

--- a/src/elements/Button/ButtonOr.js
+++ b/src/elements/Button/ButtonOr.js
@@ -17,7 +17,7 @@ function ButtonOr(props) {
   const rest = getUnhandledProps(ButtonOr, props)
   const ElementType = getElementType(ButtonOr, props)
 
-  return <ElementType className={classes} {...rest} />
+  return <ElementType {...rest} className={classes} />
 }
 
 ButtonOr._meta = {

--- a/src/elements/Container/Container.js
+++ b/src/elements/Container/Container.js
@@ -26,7 +26,7 @@ function Container(props) {
   const rest = getUnhandledProps(Container, props)
   const ElementType = getElementType(Container, props)
 
-  return <ElementType className={classes} {...rest}>{children}</ElementType>
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 Container._meta = {

--- a/src/elements/Divider/Divider.js
+++ b/src/elements/Divider/Divider.js
@@ -30,15 +30,10 @@ function Divider(props) {
     'divider',
     className
   )
-
-  const ElementType = getElementType(Divider, props)
   const rest = getUnhandledProps(Divider, props)
+  const ElementType = getElementType(Divider, props)
 
-  return (
-    <ElementType className={classes} {...rest}>
-      {children}
-    </ElementType>
-  )
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 Divider._meta = {

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -54,11 +54,11 @@ const names = [
 
 function Flag(props) {
   const { className, name } = props
-  const rest = getUnhandledProps(Flag, props)
   const classes = cx(name, className, 'flag')
+  const rest = getUnhandledProps(Flag, props)
   const ElementType = getElementType(Flag, props)
 
-  return <ElementType className={classes} {...rest} />
+  return <ElementType {...rest} className={classes} />
 }
 
 Flag._meta = {

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -45,16 +45,11 @@ function Header(props) {
     className,
     'header',
   )
-
-  const ElementType = getElementType(Header, props)
   const rest = getUnhandledProps(Header, props)
+  const ElementType = getElementType(Header, props)
 
   if (children) {
-    return (
-      <ElementType {...rest} className={classes}>
-        {children}
-      </ElementType>
-    )
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
   }
 
   if ((image && typeof image !== 'boolean') || (icon && typeof icon !== 'boolean')) {

--- a/src/elements/Header/HeaderContent.js
+++ b/src/elements/Header/HeaderContent.js
@@ -12,7 +12,7 @@ import {
  * Header content wraps the main content when there is an adjacent Icon or Image.
  */
 function HeaderContent(props) {
-  const { className, children } = props
+  const { children, className } = props
   const classes = cx(className, 'content')
   const rest = getUnhandledProps(HeaderContent, props)
   const ElementType = getElementType(HeaderContent, props)

--- a/src/elements/Header/HeaderSubheader.js
+++ b/src/elements/Header/HeaderSubheader.js
@@ -14,11 +14,7 @@ function HeaderSubheader(props) {
   const rest = getUnhandledProps(HeaderSubheader, props)
   const ElementType = getElementType(HeaderSubheader, props)
 
-  return (
-    <ElementType className={classes} {...rest}>
-      {children || content}
-    </ElementType>
-  )
+  return <ElementType {...rest} className={classes}>{children || content}</ElementType>
 }
 
 HeaderSubheader._meta = {

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -40,12 +40,11 @@ function Icon(props) {
     className,
     'icon'
   )
-
   const rest = getUnhandledProps(Icon, props)
   const ElementType = getElementType(Icon, props)
 
   return (
-    <ElementType className={classes} {...rest} />
+    <ElementType {...rest} className={classes} />
   )
 }
 

--- a/src/elements/Icon/IconGroup.js
+++ b/src/elements/Icon/IconGroup.js
@@ -14,7 +14,7 @@ import {
  */
 function IconGroup(props) {
   const {
-    className, children, size,
+    children, className, size,
   } = props
 
   const classes = cx(
@@ -22,15 +22,10 @@ function IconGroup(props) {
     'icons',
     className
   )
-
   const rest = getUnhandledProps(IconGroup, props)
   const ElementType = getElementType(IconGroup, props)
 
-  return (
-    <ElementType className={classes} {...rest}>
-      {children}
-    </ElementType>
-  )
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 IconGroup._meta = {

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -63,7 +63,6 @@ function Image(props) {
     className,
     'image'
   )
-
   const rest = getUnhandledProps(Image, props)
   const rootProps = { className: classes, ...rest }
   const imgTagProps = { src, alt, width, height }

--- a/src/elements/Image/ImageGroup.js
+++ b/src/elements/Image/ImageGroup.js
@@ -13,12 +13,12 @@ import {
  * A group of images
  */
 function ImageGroup(props) {
-  const { className, children, size } = props
+  const { children, className, size } = props
   const classes = cx('ui', size, className, 'images')
   const rest = getUnhandledProps(ImageGroup, props)
   const ElementType = getElementType(ImageGroup, props)
 
-  return <ElementType className={classes} {...rest}>{children}</ElementType>
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 ImageGroup._meta = {

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -86,7 +86,6 @@ function Input(props) {
     className,
     'input',
   )
-
   const rest = getUnhandledProps(Input, props)
   const ElementType = getElementType(Input, props)
   const inputProps = _.pick(props, htmlInputPropNames)

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -72,9 +72,8 @@ function Label(props) {
     'label',
     className,
   )
-
-  const ElementType = getElementType(Label, props)
   const rest = getUnhandledProps(Label, props)
+  const ElementType = getElementType(Label, props)
 
   if (children) {
     return <ElementType {...rest} className={classes} onClick={handleClick}>{children}</ElementType>

--- a/src/elements/Label/LabelDetail.js
+++ b/src/elements/Label/LabelDetail.js
@@ -11,10 +11,10 @@ import {
 function LabelDetail(props) {
   const { children, className, content } = props
   const classes = cx('detail', className)
-  const ElementType = getElementType(LabelDetail, props)
   const rest = getUnhandledProps(LabelDetail, props)
+  const ElementType = getElementType(LabelDetail, props)
 
-  return <ElementType className={classes} {...rest}>{ children || content }</ElementType>
+  return <ElementType {...rest} className={classes}>{children || content}</ElementType>
 }
 
 LabelDetail._meta = {

--- a/src/elements/Label/LabelGroup.js
+++ b/src/elements/Label/LabelGroup.js
@@ -19,6 +19,7 @@ function LabelGroup(props) {
     size,
     tag,
   } = props
+
   const classes = cx(
     'ui',
     color,
@@ -28,11 +29,10 @@ function LabelGroup(props) {
     'labels',
     className
   )
-
-  const ElementType = getElementType(LabelGroup, props)
   const rest = getUnhandledProps(LabelGroup, props)
+  const ElementType = getElementType(LabelGroup, props)
 
-  return <ElementType className={classes} {...rest}>{ children }</ElementType>
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 LabelGroup._meta = {

--- a/src/elements/List/List.js
+++ b/src/elements/List/List.js
@@ -21,7 +21,7 @@ import ListList from './ListList'
 
 /**
  * A list groups related content
- * */
+ **/
 function List(props) {
   const {
     animated,
@@ -40,6 +40,7 @@ function List(props) {
     selection,
     verticalAlign,
   } = props
+
   const classes = cx(
     'ui',
     size,
@@ -58,9 +59,8 @@ function List(props) {
     'list',
     className,
   )
-
-  const ElementType = getElementType(List, props)
   const rest = getUnhandledProps(List, props)
+  const ElementType = getElementType(List, props)
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }

--- a/src/elements/List/ListContent.js
+++ b/src/elements/List/ListContent.js
@@ -18,15 +18,15 @@ function ListContent(props) {
     floated,
     verticalAlign,
   } = props
+
   const classes = cx(
     useValueAndKey(floated, 'floated'),
     useVerticalAlignProp(verticalAlign),
     'content',
     className,
   )
-
-  const ElementType = getElementType(ListContent, props)
   const rest = getUnhandledProps(ListContent, props)
+  const ElementType = getElementType(ListContent, props)
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }

--- a/src/elements/List/ListDescription.js
+++ b/src/elements/List/ListDescription.js
@@ -11,9 +11,8 @@ import {
 function ListDescription(props) {
   const { children, className } = props
   const classes = cx(className, 'description')
-
-  const ElementType = getElementType(ListDescription, props)
   const rest = getUnhandledProps(ListDescription, props)
+  const ElementType = getElementType(ListDescription, props)
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }

--- a/src/elements/List/ListHeader.js
+++ b/src/elements/List/ListHeader.js
@@ -11,9 +11,8 @@ import {
 function ListHeader(props) {
   const { children, className } = props
   const classes = cx(className, 'header')
-
-  const ElementType = getElementType(ListHeader, props)
   const rest = getUnhandledProps(ListHeader, props)
+  const ElementType = getElementType(ListHeader, props)
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }

--- a/src/elements/List/ListItem.js
+++ b/src/elements/List/ListItem.js
@@ -25,7 +25,6 @@ function ListItem(props) {
     useKeyOnly(ElementType !== 'li', 'item'),
     className,
   )
-
   const rest = getUnhandledProps(ListItem, props)
   const valueProp = ElementType === 'li' ? { value } : { 'data-value': value }
 

--- a/src/elements/List/ListList.js
+++ b/src/elements/List/ListList.js
@@ -12,12 +12,12 @@ import {
 function ListList(props) {
   const { children, className } = props
 
+  const rest = getUnhandledProps(ListList, props)
   const ElementType = getElementType(ListList, props)
   const classes = cx(
     useKeyOnly(ElementType !== 'ul' && ElementType !== 'ol', 'list'),
     className,
   )
-  const rest = getUnhandledProps(ListList, props)
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }

--- a/src/elements/Loader/Loader.js
+++ b/src/elements/Loader/Loader.js
@@ -28,7 +28,7 @@ function Loader(props) {
   const rest = getUnhandledProps(Loader, props)
   const ElementType = getElementType(Loader, props)
 
-  return <ElementType className={classes} {...rest}>{ children || text }</ElementType>
+  return <ElementType {...rest} className={classes}>{children || text}</ElementType>
 }
 
 Loader._meta = {

--- a/src/elements/Rail/Rail.js
+++ b/src/elements/Rail/Rail.js
@@ -31,7 +31,7 @@ function Rail(props) {
   const rest = getUnhandledProps(Rail, props)
   const ElementType = getElementType(Rail, props)
 
-  return <ElementType className={classes} {...rest}>{ children }</ElementType>
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 Rail._meta = {

--- a/src/elements/Segment/Segment.js
+++ b/src/elements/Segment/Segment.js
@@ -67,7 +67,6 @@ function Segment(props) {
     className,
     'segment',
   )
-
   const rest = getUnhandledProps(Segment, props)
   const ElementType = getElementType(Segment, props)
 

--- a/src/elements/Segment/SegmentGroup.js
+++ b/src/elements/Segment/SegmentGroup.js
@@ -27,11 +27,10 @@ function SegmentGroup(props) {
     className,
     'segments',
   )
-
   const rest = getUnhandledProps(SegmentGroup, props)
   const ElementType = getElementType(SegmentGroup, props)
 
-  return <ElementType className={classes} {...rest}>{children}</ElementType>
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 SegmentGroup._meta = {

--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -20,7 +20,7 @@ import StepTitle from './StepTitle'
  */
 function Step(props) {
   const {
-    active, className, children, completed, description, disabled, icon, href, link, onClick, title,
+    active, children, className, completed, description, disabled, icon, href, link, onClick, title,
   } = props
   const classes = cx(
     useKeyOnly(active, 'active'),

--- a/src/elements/Step/StepContent.js
+++ b/src/elements/Step/StepContent.js
@@ -12,13 +12,13 @@ import StepDescription from './StepDescription'
 import StepTitle from './StepTitle'
 
 function StepContent(props) {
-  const { className, children, description, title } = props
+  const { children, className, description, title } = props
   const classes = cx(className, 'content')
   const rest = getUnhandledProps(StepContent, props)
   const ElementType = getElementType(StepContent, props)
 
   if (children) {
-    return <div {...rest} className={classes}>{ children }</div>
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
   }
 
   return (

--- a/src/elements/Step/StepDescription.js
+++ b/src/elements/Step/StepDescription.js
@@ -9,7 +9,7 @@ import {
 } from '../../lib'
 
 function StepDescription(props) {
-  const { className, children, description } = props
+  const { children, className, description } = props
   const classes = cx(className, 'description')
   const rest = getUnhandledProps(StepDescription, props)
   const ElementType = getElementType(StepDescription, props)

--- a/src/elements/Step/StepGroup.js
+++ b/src/elements/Step/StepGroup.js
@@ -14,7 +14,7 @@ import {
 import Step from './Step'
 
 function StepGroup(props) {
-  const { className, children, fluid, items, ordered, size, stackable, vertical } = props
+  const { children, className, fluid, items, ordered, size, stackable, vertical } = props
   const classes = cx(
     'ui',
     useKeyOnly(fluid, 'fluid'),

--- a/src/elements/Step/StepTitle.js
+++ b/src/elements/Step/StepTitle.js
@@ -9,7 +9,7 @@ import {
 } from '../../lib'
 
 function StepTitle(props) {
-  const { className, children, title } = props
+  const { children, className, title } = props
   const classes = cx(className, 'title')
   const rest = getUnhandledProps(StepTitle, props)
   const ElementType = getElementType(StepTitle, props)

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -162,7 +162,6 @@ export default class Accordion extends Component {
       useKeyOnly(styled, 'styled'),
       'accordion'
     )
-
     const rest = _.omit(this.props, _.keys(Accordion.propTypes))
     const ElementType = getElementType(Accordion, this.props)
 

--- a/src/modules/Accordion/AccordionContent.js
+++ b/src/modules/Accordion/AccordionContent.js
@@ -18,11 +18,8 @@ function AccordionContent(props) {
   )
   const rest = getUnhandledProps(AccordionContent, props)
   const ElementType = getElementType(AccordionContent, props)
-  return (
-    <ElementType {...rest} className={classes}>
-      {children}
-    </ElementType>
-  )
+
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 AccordionContent.displayName = 'AccordionContent'

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -21,8 +21,8 @@ function AccordionTitle(props) {
     if (onClick) onClick(e)
   }
 
-  const ElementType = getElementType(AccordionTitle, props)
   const rest = getUnhandledProps(AccordionTitle, props)
+  const ElementType = getElementType(AccordionTitle, props)
 
   return (
     <ElementType {...rest} className={classes} onClick={handleClick}>

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -141,6 +141,7 @@ export default class Checkbox extends Component {
     )
     const rest = getUnhandledProps(Checkbox, this.props)
     const ElementType = getElementType(Checkbox, this.props)
+
     return (
       <ElementType {...rest} className={classes} onClick={this.handleClick} onChange={this.handleClick}>
         <input

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -955,7 +955,6 @@ export default class Dropdown extends Component {
       className,
       'dropdown',
     )
-
     const rest = getUnhandledProps(Dropdown, this.props)
     const ElementType = getElementType(Dropdown, this.props)
 

--- a/src/modules/Dropdown/DropdownDivider.js
+++ b/src/modules/Dropdown/DropdownDivider.js
@@ -14,7 +14,7 @@ function DropdownDivider(props) {
   const rest = getUnhandledProps(DropdownDivider, props)
   const ElementType = getElementType(DropdownDivider, props)
 
-  return <ElementType className={classes} {...rest} />
+  return <ElementType {...rest} className={classes} />
 }
 
 DropdownDivider._meta = {

--- a/src/modules/Dropdown/DropdownHeader.js
+++ b/src/modules/Dropdown/DropdownHeader.js
@@ -10,21 +10,17 @@ import {
 import Icon from '../../elements/Icon'
 
 function DropdownHeader(props) {
-  const { className, children, content, icon } = props
+  const { children, className, content, icon } = props
   const classes = cx('header', className)
   const rest = getUnhandledProps(DropdownHeader, props)
   const ElementType = getElementType(DropdownHeader, props)
 
   if (children) {
-    return (
-      <ElementType className={classes} {...rest}>
-        {children}
-      </ElementType>
-    )
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
   }
 
   return (
-    <ElementType className={classes} {...rest}>
+    <ElementType {...rest} className={classes}>
       {Icon.create(icon)}
       {content}
     </ElementType>

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -39,8 +39,8 @@ function DropdownItem(props) {
   )
   // add default dropdown icon if item contains another menu
   const iconName = icon || childrenUtils.someByType(children, 'DropdownMenu') && 'dropdown'
-  const ElementType = getElementType(DropdownItem, props)
   const rest = getUnhandledProps(DropdownItem, props)
+  const ElementType = getElementType(DropdownItem, props)
 
   return (
     <ElementType {...rest} className={classes} onClick={handleClick}>

--- a/src/modules/Modal/ModalActions.js
+++ b/src/modules/Modal/ModalActions.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react'
-import classNames from 'classnames'
+import cx from 'classnames'
 
 import {
   customPropTypes,
@@ -10,20 +10,11 @@ import {
 
 function ModalActions(props) {
   const { children, className } = props
-
-  const classes = classNames(
-    className,
-    'actions'
-  )
-
+  const classes = cx(className, 'actions')
   const rest = getUnhandledProps(ModalActions, props)
   const ElementType = getElementType(ModalActions, props)
 
-  return (
-    <ElementType className={classes} {...rest}>
-      {children}
-    </ElementType>
-  )
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 ModalActions._meta = {

--- a/src/modules/Modal/ModalContent.js
+++ b/src/modules/Modal/ModalContent.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react'
-import classNames from 'classnames'
+import cx from 'classnames'
 
 import {
   customPropTypes,
@@ -11,21 +11,15 @@ import {
 
 function ModalContent(props) {
   const { children, image, className } = props
-
-  const classes = classNames(
+  const classes = cx(
     className,
     useKeyOnly(image, 'image'),
     'content'
   )
-
   const rest = getUnhandledProps(ModalContent, props)
   const ElementType = getElementType(ModalContent, props)
 
-  return (
-    <ElementType className={classes} {...rest}>
-      {children}
-    </ElementType>
-  )
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 ModalContent._meta = {

--- a/src/modules/Modal/ModalDescription.js
+++ b/src/modules/Modal/ModalDescription.js
@@ -10,19 +10,11 @@ import {
 
 function ModalDescription(props) {
   const { children, className } = props
-
-  const classes = cx(
-    className,
-    'description'
-  )
-
+  const classes = cx(className, 'description')
   const rest = getUnhandledProps(ModalDescription, props)
   const ElementType = getElementType(ModalDescription, props)
-  return (
-    <ElementType className={classes} {...rest}>
-      {children}
-    </ElementType>
-  )
+
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 ModalDescription._meta = {

--- a/src/modules/Modal/ModalHeader.js
+++ b/src/modules/Modal/ModalHeader.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react'
-import classNames from 'classnames'
+import cx from 'classnames'
 
 import {
   customPropTypes,
@@ -10,20 +10,11 @@ import {
 
 function ModalHeader(props) {
   const { children, className } = props
-
-  const classes = classNames(
-    className,
-    'header'
-  )
-
+  const classes = cx(className, 'header')
   const rest = getUnhandledProps(ModalHeader, props)
   const ElementType = getElementType(ModalHeader, props)
 
-  return (
-    <ElementType className={classes} {...rest}>
-      {children}
-    </ElementType>
-  )
+  return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
 
 ModalHeader._meta = {

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -60,7 +60,6 @@ function Progress(props) {
     className,
     'progress'
   )
-
   const rest = getUnhandledProps(Progress, props)
   const ElementType = getElementType(Progress, props)
 

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -149,7 +149,6 @@ class Rating extends Component {
       'rating',
       className,
     )
-
     const rest = getUnhandledProps(Rating, this.props)
     const ElementType = getElementType(Rating, this.props)
 

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -607,9 +607,8 @@ export default class Search extends Component {
       className,
       'search',
     )
-
-    const ElementType = getElementType(Search, this.props)
     const rest = getUnhandledProps(Search, this.props)
+    const ElementType = getElementType(Search, this.props)
 
     return (
       <ElementType

--- a/src/modules/Search/SearchCategory.js
+++ b/src/modules/Search/SearchCategory.js
@@ -12,7 +12,7 @@ import {
 const defaultRenderer = ({ name }) => name
 
 function SearchCategory(props) {
-  const { active, className, children, renderer } = props
+  const { active, children, className, renderer } = props
   const classes = cx(
     useKeyOnly(active, 'active'),
     'category',

--- a/src/modules/Search/SearchResult.js
+++ b/src/modules/Search/SearchResult.js
@@ -44,8 +44,8 @@ function SearchResult(props) {
     'result',
     className,
   )
-  const ElementType = getElementType(SearchResult, props)
   const rest = getUnhandledProps(SearchResult, props)
+  const ElementType = getElementType(SearchResult, props)
 
   // Note: You technically only need the 'content' wrapper when there's an
   // image. However, optionally wrapping it makes this function a lot more

--- a/src/views/Card/Card.js
+++ b/src/views/Card/Card.js
@@ -55,11 +55,7 @@ function Card(props) {
   })
 
   if (children) {
-    return (
-      <ElementType {...rest} className={classes} href={href} onClick={handleClick}>
-        {children}
-      </ElementType>
-    )
+    return <ElementType {...rest} className={classes} href={href} onClick={handleClick}>{children}</ElementType>
   }
 
   return (

--- a/src/views/Card/CardContent.js
+++ b/src/views/Card/CardContent.js
@@ -17,7 +17,7 @@ import CardMeta from './CardMeta'
  * A card can contain blocks of content or extra content meant to be formatted separately from the main content
  */
 function CardContent(props) {
-  const { className, children, description, extra, header, meta } = props
+  const { children, className, description, extra, header, meta } = props
   const classes = cx(
     className,
     useKeyOnly(extra, 'extra'),
@@ -27,7 +27,7 @@ function CardContent(props) {
   const ElementType = getElementType(CardContent, props)
 
   if (children) {
-    return <div {...rest} className={classes}>{children}</div>
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
   }
 
   return (

--- a/src/views/Card/CardDescription.js
+++ b/src/views/Card/CardDescription.js
@@ -12,7 +12,7 @@ import {
  * A card can contain a description with one or more paragraphs
  */
 function CardDescription(props) {
-  const { className, children, content } = props
+  const { children, className, content } = props
   const classes = cx(className, 'description')
   const rest = getUnhandledProps(CardDescription, props)
   const ElementType = getElementType(CardDescription, props)

--- a/src/views/Card/CardGroup.js
+++ b/src/views/Card/CardGroup.js
@@ -16,7 +16,7 @@ import Card from './Card'
  * A group of cards.
  */
 function CardGroup(props) {
-  const { className, children, doubling, items, itemsPerRow, stackable } = props
+  const { children, className, doubling, items, itemsPerRow, stackable } = props
   const classes = cx('ui',
     useWidthProp(itemsPerRow),
     useKeyOnly(doubling, 'doubling'),

--- a/src/views/Card/CardHeader.js
+++ b/src/views/Card/CardHeader.js
@@ -12,7 +12,7 @@ import {
  * A card can contain a header
  */
 function CardHeader(props) {
-  const { className, children, content } = props
+  const { children, className, content } = props
   const classes = cx(className, 'header')
   const rest = getUnhandledProps(CardHeader, props)
   const ElementType = getElementType(CardHeader, props)

--- a/src/views/Card/CardMeta.js
+++ b/src/views/Card/CardMeta.js
@@ -12,7 +12,7 @@ import {
  * A card can contain content metadata
  */
 function CardMeta(props) {
-  const { className, children, content } = props
+  const { children, className, content } = props
   const classes = cx(className, 'meta')
   const rest = getUnhandledProps(CardMeta, props)
   const ElementType = getElementType(CardMeta, props)

--- a/src/views/Item/Item.js
+++ b/src/views/Item/Item.js
@@ -18,7 +18,7 @@ import ItemMeta from './ItemMeta'
 
 /**
  * An item view presents large collections of site content for display
- * */
+ **/
 function Item(props) {
   const { children, className, content, description, extra, header, image, meta } = props
   const classes = cx(className, 'item')

--- a/src/views/Item/ItemContent.js
+++ b/src/views/Item/ItemContent.js
@@ -17,7 +17,7 @@ import ItemMeta from './ItemMeta'
 
 /**
  * An item can contain content
- * */
+ **/
 function ItemContent(props) {
   const { children, className, content, description, extra, header, meta, verticalAlign } = props
   const classes = cx(
@@ -25,7 +25,6 @@ function ItemContent(props) {
     useVerticalAlignProp(verticalAlign),
     'content',
   )
-
   const rest = getUnhandledProps(ItemContent, props)
   const ElementType = getElementType(ItemContent, props)
 

--- a/src/views/Item/ItemDescription.js
+++ b/src/views/Item/ItemDescription.js
@@ -10,7 +10,7 @@ import {
 
 /**
  * An item can contain a description with a single or multiple paragraphs
- * */
+ **/
 function ItemDescription(props) {
   const { children, className, content } = props
   const classes = cx(className, 'description')

--- a/src/views/Item/ItemExtra.js
+++ b/src/views/Item/ItemExtra.js
@@ -10,7 +10,7 @@ import {
 
 /**
  * An item can contain extra content meant to be formatted separately from the main content
- * */
+ **/
 function ItemExtra(props) {
   const { children, className, content } = props
   const classes = cx(className, 'extra')

--- a/src/views/Item/ItemGroup.js
+++ b/src/views/Item/ItemGroup.js
@@ -14,9 +14,9 @@ import Item from './Item'
 
 /**
  * A group of items
- * */
+ **/
 function ItemGroup(props) {
-  const { className, children, divided, items, link, relaxed } = props
+  const { children, className, divided, items, link, relaxed } = props
   const classes = cx(
     'ui',
     className,
@@ -25,7 +25,6 @@ function ItemGroup(props) {
     useKeyOrValueAndKey(relaxed, 'relaxed'),
     'items'
   )
-
   const rest = getUnhandledProps(ItemGroup, props)
   const ElementType = getElementType(ItemGroup, props)
 

--- a/src/views/Item/ItemHeader.js
+++ b/src/views/Item/ItemHeader.js
@@ -10,7 +10,7 @@ import {
 
 /**
  * An item can contain a header
- * */
+ **/
 function ItemHeader(props) {
   const { children, className, content } = props
   const classes = cx(className, 'header')

--- a/src/views/Item/ItemImage.js
+++ b/src/views/Item/ItemImage.js
@@ -1,19 +1,14 @@
 import React from 'react'
 import {
-  getElementType,
-  getUnhandledProps,
   META,
 } from '../../lib'
 import Image from '../../elements/Image'
 
 /**
  * An item can contain an image
- * */
+ **/
 function ItemImage(props) {
-  const ElementType = getElementType(ItemImage, props)
-  const rest = getUnhandledProps(ItemImage, props)
-
-  return <Image {...rest} as={ElementType} ui={false} />
+  return <Image {...props} ui={false} />
 }
 
 ItemImage._meta = {

--- a/src/views/Item/ItemMeta.js
+++ b/src/views/Item/ItemMeta.js
@@ -10,7 +10,7 @@ import {
 
 /**
  * An item can contain content metadata.
- * */
+ **/
 function ItemMeta(props) {
   const { children, className, content } = props
   const classes = cx(className, 'meta')


### PR DESCRIPTION
There were some things that we did in a lot of files but slightly differently. These aren't really lintable so there's no way to enforce them moving forward, but figured I take a pass through so at least it's more likely someone will copy/paste the "right" way 😄 . I tried to grep for some of this stuff when possible and chose the most common variation of the pattern:
- Added className prop to `MessageItem`
- Swapped order of `className={classes} {...rest}` to `{...rest} className={classes}` (the latter was way more common and makes more sense).
- Use `ElementType` in a few places we weren't.
- Always import 'classnames' as 'cx'
- Always order setting variables: props, classes, rest, ElementType
- Newline between setting variables and returning `<ElementType>`
- When returning early because children, render a one-liner
- Order children before className in props
