### PR TITLE
chore(icon): cleanup icon doc data

### DIFF
--- a/docs/app/utils.js
+++ b/docs/app/utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import * as semanticUIReact from 'src'
-import { META, SUI } from 'src/lib'
+import { META } from 'src/lib'
 
 export const typeOrder = [
   META.TYPES.ELEMENT,
@@ -19,101 +19,3 @@ export const parentComponents = _.flow(
  * Get the Webpack Context for all doc site examples.
  */
 export const exampleContext = require.context('docs/app/Examples/', true, /\.js$/)
-
-export const iconsByCategory = [{
-  name: 'Web Content',
-  description: 'Icons can represent types of content found on websites',
-  icons: SUI.WEB_CONTENT_ICONS,
-}, {
-  name: 'User Actions',
-  description: 'Icons can represent common actions a user can take',
-  icons: SUI.USER_ACTIONS_ICONS,
-}, {
-  name: 'Message',
-  description: 'Icons can alert users to the type of message being displayed',
-  icons: SUI.MESSAGE_ICONS,
-}, {
-  name: 'User Types',
-  description: 'Icons can represent types of people',
-  icons: SUI.USER_TYPES_ICONS,
-}, {
-  name: 'Gender & Sexuality',
-  description: 'Icons can represent genders or types of sexuality',
-  icons: SUI.GENDER_AND_SEXUALITY_ICONS,
-}, {
-  name: 'Layout Adjustment',
-  description: 'Icons can alert users to common ways to adjust page layouts',
-  icons: SUI.LAYOUT_ADJUSTMENT_ICONS,
-}, {
-  name: 'Objects',
-  description: 'Icons can be used to represent common objects',
-  icons: SUI.OBJECTS_ICONS,
-}, {
-  name: 'Shapes',
-  description: 'Icons can be used to create shapes',
-  icons: SUI.SHAPES_ICONS,
-}, {
-  name: 'Item Selection',
-  description: 'Icons can show whether an item is included in a set',
-  icons: SUI.ITEM_SELECTION_ICONS,
-}, {
-  name: 'Media',
-  description: 'Icons can represent common media types',
-  icons: SUI.MEDIA_ICONS,
-}, {
-  name: 'Pointers',
-  description: 'Icons can be used to indicate a direction',
-  icons: SUI.POINTERS_ICONS,
-}, {
-  name: 'Mobile',
-  description: 'Icons can represent mobile devices, types of content found on mobile devices.',
-  icons: SUI.MOBILE_ICONS,
-}, {
-  name: 'Computer',
-  description: 'Icons can represent computing devices, or types of content found on a computer.',
-  icons: SUI.COMPUTER_ICONS,
-}, {
-  name: 'Computer and File System',
-  description: 'Icons can represent elements of a computer and its file system',
-  icons: SUI.COMPUTER_AND_FILE_SYSTEM_ICONS,
-}, {
-  name: 'Technologies',
-  description: 'Icons can represent common technologies',
-  icons: SUI.TECHNOLOGIES_ICONS,
-}, {
-  name: 'Rating',
-  description: 'Icons can be used to represent users attitude towards content',
-  icons: SUI.RATING_ICONS,
-}, {
-  name: 'Audio',
-  description: 'Icons can be used to represent common ways to interact with audio',
-  icons: SUI.AUDIO_ICONS,
-}, {
-  name: 'Map',
-  description: 'Icons can be used to represent elements on a map',
-  icons: SUI.MAP_ICONS,
-}, {
-  name: 'Tables',
-  description: 'Icons can be used to represent common actions inside a table',
-  icons: SUI.TABLES_ICONS,
-}, {
-  name: 'Text Editor',
-  description: 'Icons can represent common actions when editing text',
-  icons: SUI.TEXT_EDITOR_ICONS,
-}, {
-  name: 'Currency',
-  description: 'Icons can represent units of currency',
-  icons: SUI.CURRENCY_ICONS,
-}, {
-  name: 'Payment Options',
-  description: 'Icons can represent common forms of payment',
-  icons: SUI.PAYMENT_OPTIONS_ICONS,
-}, {
-  name: 'Accessibility',
-  description: 'Icons can represent accessibility standards',
-  icons: SUI.ACCESSIBILITY_ICONS,
-}, {
-  name: 'Brands',
-  description: '',
-  icons: SUI.BRANDS_ICONS,
-}]

--- a/src/lib/SUI.js
+++ b/src/lib/SUI.js
@@ -27,7 +27,8 @@ export const WIDTHS = [
   ..._.values(numberToWordMap),
 ]
 
-export const WEB_CONTENT_ICONS = [
+export const ICONS = [
+  // Web Content Icons
   'add to calendar', 'alarm outline', 'alarm mute outline', 'alarm mute', 'alarm', 'at', 'browser', 'bug',
   'calendar outline', 'calendar', 'checked calendar', 'cloud', 'code', 'comment outline', 'comment', 'comments outline',
   'comments', 'copyright', 'creative commons', 'dashboard', 'delete calendar', 'external square', 'external',
@@ -37,9 +38,8 @@ export const WEB_CONTENT_ICONS = [
   'protect', 'registered', 'remove from calendar', 'search', 'setting', 'settings', 'shop', 'shopping bag',
   'shopping basket', 'signal', 'sitemap', 'tag', 'tags', 'tasks', 'terminal', 'text telephone', 'ticket', 'trademark',
   'trophy', 'wifi',
-]
 
-export const USER_ACTIONS_ICONS = [
+  // User Actions Icons
   'add to cart', 'add user', 'adjust', 'archive', 'ban', 'bookmark', 'call', 'call square', 'clone', 'cloud download',
   'cloud upload', 'talk', 'talk outline', 'compress', 'configure', 'download', 'edit', 'erase', 'exchange', 'expand',
   'external share', 'filter', 'hide', 'in cart', 'lock', 'mail forward', 'object group', 'object ungroup', 'pin',
@@ -47,50 +47,41 @@ export const USER_ACTIONS_ICONS = [
   'send', 'send outline', 'share alternate', 'share alternate square', 'share', 'share square', 'sign in', 'sign out',
   'theme', 'translate', 'undo', 'unhide', 'unlock alternate', 'unlock', 'upload', 'wait', 'wizard', 'write',
   'write square',
-]
 
-export const MESSAGE_ICONS = [
+  // Message Icons
   'announcement', 'birthday', 'help circle', 'help', 'info circle', 'info', 'warning circle', 'warning', 'warning sign',
-]
 
-export const USER_TYPES_ICONS = [
+  // User Types Icons
   'child', 'doctor', 'handicap', 'spy', 'student', 'user', 'users',
-]
 
-export const GENDER_AND_SEXUALITY_ICONS = [
+  // Gender And Sexuality Icons
   'female', 'gay', 'genderless', 'heterosexual', 'intergender', 'lesbian', 'male', 'man', 'neuter',
   'non binary transgender', 'other gender horizontal', 'other gender', 'other gender vertical', 'transgender', 'woman',
-]
 
-export const LAYOUT_ADJUSTMENT_ICONS = [
+  // Layout Adjustment Icons
   'block layout', 'crop', 'grid layout', 'list layout', 'maximize', 'resize horizontal', 'resize vertical', 'zoom',
   'zoom out',
-]
 
-export const OBJECTS_ICONS = [
+  // Objects Icons
   'anchor', 'bar', 'bomb', 'book', 'bullseye', 'calculator', 'cocktail', 'diamond', 'fax', 'fire extinguisher', 'fire',
   'flag checkered', 'flag', 'flag outline', 'gift', 'hand lizard', 'hand peace', 'hand paper', 'hand rock',
   'hand scissors', 'hand spock', 'law', 'leaf', 'legal', 'lemon', 'life ring', 'lightning', 'magnet', 'money', 'moon',
   'plane', 'puzzle', 'road', 'rocket', 'shipping', 'soccer', 'sticky note', 'sticky note outline', 'suitcase', 'sun',
   'travel', 'treatment', 'umbrella', 'world',
-]
 
-export const SHAPES_ICONS = [
+  // Shapes Icons
   'asterisk', 'certificate', 'circle', 'circle notched', 'circle thin', 'crosshairs', 'cube', 'cubes',
   'ellipsis horizontal', 'ellipsis vertical', 'quote left', 'quote right', 'spinner', 'square', 'square outline',
-]
 
-export const ITEM_SELECTION_ICONS = [
+  // Item Selection Icons
   'add circle', 'add square', 'check circle', 'check circle outline', 'check square', 'checkmark box', 'checkmark',
   'minus circle', 'minus', 'minus square', 'minus square outline', 'move', 'plus', 'plus square outline', 'radio',
   'remove circle', 'remove circle outline', 'remove', 'selected radio', 'toggle off', 'toggle on',
-]
 
-export const MEDIA_ICONS = [
+  // Media Icons
   'area chart', 'bar chart', 'camera retro', 'film', 'line chart', 'newspaper', 'photo', 'pie chart', 'sound',
-]
 
-export const POINTERS_ICONS = [
+  // Pointers Icons
   'angle double down', 'angle double left', 'angle double right', 'angle double up', 'angle down', 'angle left',
   'angle right', 'angle up', 'arrow circle down', 'arrow circle left', 'arrow circle outline down',
   'arrow circle outline left', 'arrow circle outline right', 'arrow circle outline up', 'arrow circle right',
@@ -99,73 +90,60 @@ export const POINTERS_ICONS = [
   'chevron left', 'chevron right', 'chevron up', 'long arrow down', 'long arrow left', 'long arrow right',
   'long arrow up', 'pointing down', 'pointing left', 'pointing right', 'pointing up', 'toggle down', 'toggle left',
   'toggle right', 'toggle up',
-]
 
-export const MOBILE_ICONS = [
+  // Mobile Icons
   'mobile', 'tablet', 'battery empty', 'battery full', 'battery low', 'battery medium',
-]
 
-export const COMPUTER_ICONS = [
+  // Computer Icons
   'desktop', 'disk outline', 'game', 'high battery', 'keyboard', 'laptop', 'plug', 'power',
-]
 
-export const COMPUTER_AND_FILE_SYSTEM_ICONS = [
+  // Computer And File System Icons
   'file archive outline', 'file audio outline', 'file code outline', 'file excel outline', 'file', 'file image outline',
   'file outline', 'file pdf outline', 'file powerpoint outline', 'file text', 'file text outline', 'file video outline',
   'file word outline', 'folder', 'folder open', 'folder open outline', 'folder outline', 'level down', 'level up',
   'trash', 'trash outline',
-]
 
-export const TECHNOLOGIES_ICONS = [
+  // Technologies Icons
   'barcode', 'bluetooth alternative', 'bluetooth', 'css3', 'database', 'fork', 'html5', 'openid', 'qrcode', 'rss',
   'rss square', 'server', 'usb',
-]
 
-export const RATING_ICONS = [
+  // Rating Icons
   'empty heart', 'empty star', 'frown', 'heart', 'meh', 'smile', 'star half empty', 'star half', 'star', 'thumbs down',
   'thumbs outline down', 'thumbs outline up', 'thumbs up',
-]
 
-export const AUDIO_ICONS = [
+  // Audio Icons
   'backward', 'closed captioning', 'eject', 'fast backward', 'fast forward', 'forward', 'music', 'mute', 'pause circle',
   'pause circle outline', 'pause', 'play', 'record', 'step backward', 'step forward', 'stop circle',
   'stop circle outline', 'stop', 'unmute', 'video play', 'video play outline', 'volume down', 'volume off', 'volume up',
-]
 
-export const MAP_ICONS = [
+  // Map Icons
   'bicycle', 'building', 'building outline', 'bus', 'car', 'coffee', 'compass', 'emergency', 'first aid', 'food', 'h',
   'hospital', 'hotel', 'location arrow', 'map', 'map outline', 'map pin', 'map signs', 'marker', 'military',
   'motorcycle', 'paw', 'ship', 'space shuttle', 'spoon', 'street view', 'subway', 'taxi', 'train', 'television', 'tree',
   'university',
-]
 
-export const TABLES_ICONS = [
+  // Tables Icons
   'columns', 'sort alphabet ascending', 'sort alphabet descending', 'sort ascending', 'sort content ascending',
   'sort content descending', 'sort descending', 'sort', 'sort numeric ascending', 'sort numeric descending', 'table',
-]
 
-export const TEXT_EDITOR_ICONS = [
+  // Text Editor Icons
   'align center', 'align justify', 'align left', 'align right', 'attach', 'bold', 'content', 'copy', 'cut', 'font',
   'header', 'indent', 'italic', 'linkify', 'list', 'ordered list', 'outdent', 'paragraph', 'paste', 'save',
   'strikethrough', 'subscript', 'superscript', 'text cursor', 'text height', 'text width', 'underline', 'unlinkify',
   'unordered list',
-]
 
-export const CURRENCY_ICONS = [
+  // Currency Icons
   'bitcoin', 'dollar', 'euro', 'lira', 'pound', 'ruble', 'rupee', 'shekel', 'won', 'yen',
-]
 
-export const PAYMENT_OPTIONS_ICONS = [
+  // Payment Options Icons
   'american express', 'credit card alternative', 'diners club', 'discover', 'google wallet', 'japan credit bureau',
   'mastercard', 'paypal card', 'paypal', 'stripe', 'visa',
-]
 
-export const ACCESSIBILITY_ICONS = [
+  // Accessibility Icons
   'wheelchair', 'asl interpreting', 'assistive listening systems', 'audio description', 'blind', 'braille', 'deafness',
   'low vision', 'sign language', 'universal access', 'volume control phone',
-]
 
-export const BRANDS_ICONS = [
+  // Brands Icons
   '500px', 'adn', 'amazon', 'android', 'angellist', 'apple', 'behance', 'behance square', 'bitbucket',
   'bitbucket square', 'black tie', 'buysellads', 'chrome', 'codepen', 'codiepie', 'connectdevelop', 'contao',
   'dashcube', 'delicious', 'deviantart', 'digg', 'dribbble', 'dropbox', 'drupal', 'empire', 'envira gallery',
@@ -183,31 +161,4 @@ export const BRANDS_ICONS = [
   'tumblr square', 'twitch', 'twitter', 'twitter square', 'viacoin', 'viadeo', 'viadeo square', 'vimeo', 'vimeo square',
   'vine', 'vk', 'wechat', 'weibo', 'whatsapp', 'wikipedia', 'windows', 'wordpress', 'wpbeginner', 'wpforms', 'xing',
   'xing square', 'y combinator', 'yahoo', 'yelp', 'yoast', 'youtube', 'youtube play', 'youtube square',
-]
-
-export const ICONS = [
-  ...WEB_CONTENT_ICONS,
-  ...USER_ACTIONS_ICONS,
-  ...MESSAGE_ICONS,
-  ...USER_TYPES_ICONS,
-  ...GENDER_AND_SEXUALITY_ICONS,
-  ...LAYOUT_ADJUSTMENT_ICONS,
-  ...OBJECTS_ICONS,
-  ...SHAPES_ICONS,
-  ...ITEM_SELECTION_ICONS,
-  ...MEDIA_ICONS,
-  ...POINTERS_ICONS,
-  ...MOBILE_ICONS,
-  ...COMPUTER_ICONS,
-  ...COMPUTER_AND_FILE_SYSTEM_ICONS,
-  ...TECHNOLOGIES_ICONS,
-  ...RATING_ICONS,
-  ...AUDIO_ICONS,
-  ...MAP_ICONS,
-  ...TABLES_ICONS,
-  ...TEXT_EDITOR_ICONS,
-  ...CURRENCY_ICONS,
-  ...PAYMENT_OPTIONS_ICONS,
-  ...ACCESSIBILITY_ICONS,
-  ...BRANDS_ICONS,
 ]


### PR DESCRIPTION
We no longer generate Icon example source code, there are actual example files.  We no longer need much of the icon data we had for generating the source code.  This PR removes it.
