### PR TITLE
feat(shorthand): Custom shorthand proptypes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -490,10 +490,10 @@ Label.propTypes = {
   /** A label can reduce its complexity. */
   basic: PropTypes.bool,
 
-  /** Primary content of the label, same as text. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the label className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Color of the label. */

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -42,7 +42,7 @@ Confirm.propTypes = {
   /** The ModalHeader text */
   header: PropTypes.string,
 
-  /** The ModalContent text. Mutually exclusive with children. */
+  /** The ModalContent text. */
   content: PropTypes.string,
 
   /** Called when the OK button is clicked */

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -22,10 +22,10 @@ const _meta = {
  */
 class Portal extends Component {
   static propTypes = {
-    /** Primary content */
+    /** Primary content. */
     children: PropTypes.node.isRequired,
 
-    /** Classes to be added to the portal node element. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Controls whether or not the portal should close on a click outside. */

--- a/src/addons/Select/Select.js
+++ b/src/addons/Select/Select.js
@@ -1,6 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 
-import { getUnhandledProps, META } from '../../lib'
+import { META } from '../../lib'
 import Dropdown from '../../modules/Dropdown'
 
 /**
@@ -9,23 +9,12 @@ import Dropdown from '../../modules/Dropdown'
  * @see Form
  */
 function Select(props) {
-  const { selection } = props
-  const rest = getUnhandledProps(Select, props)
-  return <Dropdown {...rest} selection={selection} />
+  return <Dropdown {...props} selection />
 }
 
 Select._meta = {
   name: 'Select',
   type: META.TYPES.ADDON,
-}
-
-Select.propTypes = {
-  /** selection value */
-  selection: PropTypes.bool,
-}
-
-Select.defaultProps = {
-  selection: true,
 }
 
 export default Select

--- a/src/collections/Breadcrumb/Breadcrumb.js
+++ b/src/collections/Breadcrumb/Breadcrumb.js
@@ -21,12 +21,14 @@ function Breadcrumb(props) {
   const rest = getUnhandledProps(Breadcrumb, props)
   const ElementType = getElementType(Breadcrumb, props)
 
-  if (!sections) return <ElementType {...rest} className={classes}>{children}</ElementType>
+  if (children) {
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
+  }
 
   const dividerJSX = <BreadcrumbDivider icon={icon}>{divider}</BreadcrumbDivider>
   const sectionsJSX = []
 
-  sections.forEach(({ text, key, ...restSection }, index) => {
+  _.each(sections, ({ text, key, ...restSection }, index) => {
     const finalKey = key || text
     const dividerKey = `${finalKey}-divider`
 
@@ -55,33 +57,27 @@ Breadcrumb.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the Breadcrumb */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['sections', 'icon', 'divider']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the Breadcrumb className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** For use with the sections prop. Primary content of the Breadcrumb.Divider. */
+  /** Shorthand for primary content of the Breadcrumb.Divider. */
   divider: customPropTypes.every([
     customPropTypes.disallow(['icon']),
-    PropTypes.string,
+    customPropTypes.content,
   ]),
 
   /** For use with the sections prop. Render as an `Icon` component with `divider` class instead of a `div` in
    *  Breadcrumb.Divider. */
   icon: customPropTypes.every([
     customPropTypes.disallow(['divider']),
-    PropTypes.node,
+    customPropTypes.item,
   ]),
 
-  /** Array of props for Breadcrumb.Section. */
-  sections: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    React.PropTypes.array,
-  ]),
+  /** Shorthand array of props for Breadcrumb.Section. */
+  sections: customPropTypes.items,
 
   /** Size of Breadcrumb */
   size: PropTypes.oneOf(Breadcrumb._meta.props.size),

--- a/src/collections/Breadcrumb/Breadcrumb.js
+++ b/src/collections/Breadcrumb/Breadcrumb.js
@@ -66,18 +66,18 @@ Breadcrumb.propTypes = {
   /** Shorthand for primary content of the Breadcrumb.Divider. */
   divider: customPropTypes.every([
     customPropTypes.disallow(['icon']),
-    customPropTypes.content,
+    customPropTypes.contentShorthand,
   ]),
 
   /** For use with the sections prop. Render as an `Icon` component with `divider` class instead of a `div` in
    *  Breadcrumb.Divider. */
   icon: customPropTypes.every([
     customPropTypes.disallow(['divider']),
-    customPropTypes.item,
+    customPropTypes.itemShorthand,
   ]),
 
   /** Shorthand array of props for Breadcrumb.Section. */
-  sections: customPropTypes.items,
+  sections: customPropTypes.collectionShorthand,
 
   /** Size of Breadcrumb */
   size: PropTypes.oneOf(Breadcrumb._meta.props.size),

--- a/src/collections/Breadcrumb/BreadcrumbDivider.js
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.js
@@ -40,7 +40,7 @@ BreadcrumbDivider.propTypes = {
   className: PropTypes.string,
 
   /** Render as an `Icon` component with `divider` class instead of a `div`. */
-  icon: customPropTypes.item,
+  icon: customPropTypes.itemShorthand,
 }
 
 export default BreadcrumbDivider

--- a/src/collections/Breadcrumb/BreadcrumbDivider.js
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.js
@@ -33,20 +33,14 @@ BreadcrumbDivider.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the Breadcrumb.Divider. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['icon']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the BreadcrumbDivider className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Render as an `Icon` component with `divider` class instead of a `div`. */
-  icon: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+  icon: customPropTypes.item,
 }
 
 export default BreadcrumbDivider

--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -20,10 +20,10 @@ export default class BreadcrumbSection extends Component {
     /** Style as the currently active section. */
     active: PropTypes.bool,
 
-    /** Primary content of the Breadcrumb.Section. */
+    /** Primary content. */
     children: PropTypes.node,
 
-    /** Classes that will be added to the BreadcrumbSection className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Render as an `a` tag instead of a `div`. */

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -186,10 +186,10 @@ export default class Form extends Component {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
 
-    /** Primary content */
+    /** Primary content. */
     children: PropTypes.node,
 
-    /** Additional classes */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Automatically show any error Message children */

--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -131,10 +131,10 @@ FormField.propTypes = {
     PropTypes.oneOf(FormField._meta.props.control),
   ]),
 
-  /** Primary content */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Additional classes to add */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Individual fields may be disabled */

--- a/src/collections/Form/FormGroup.js
+++ b/src/collections/Form/FormGroup.js
@@ -43,10 +43,10 @@ FormGroup.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content.  Intended to be Form Fields. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Additional classes */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Fields can show related choices */

--- a/src/collections/Grid/Grid.js
+++ b/src/collections/Grid/Grid.js
@@ -77,10 +77,10 @@ Grid.propTypes = {
   /** A grid can have its columns centered. */
   centered: PropTypes.bool,
 
-  /** Primary content of the Grid. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes that will be added to the Grid className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Represents column count per row in Grid. */

--- a/src/collections/Grid/GridColumn.js
+++ b/src/collections/Grid/GridColumn.js
@@ -64,10 +64,10 @@ GridColumn.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the GridColumn. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes that will be added to the GridColumn className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A column can specify a width for a computer. */

--- a/src/collections/Grid/GridRow.js
+++ b/src/collections/Grid/GridRow.js
@@ -68,10 +68,10 @@ GridRow.propTypes = {
   /** A row can have its columns centered. */
   centered: PropTypes.bool,
 
-  /** Primary content of the GridRow. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes that will be added to the GridRow className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A grid row can be colored. */

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -54,10 +54,10 @@ class Menu extends Component {
     /** A menu item or menu can have no borders. */
     borderless: PropTypes.bool,
 
-    /** Primary content of the Menu. Mutually exclusive with items. */
+    /** Primary content. */
     children: PropTypes.node,
 
-    /** Classes that will be added to the Menu className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Additional colors can be specified. */
@@ -90,16 +90,8 @@ class Menu extends Component {
     /** A menu may have its colors inverted to show greater contrast. */
     inverted: PropTypes.bool,
 
-    /** Shorthand array of props for Menu. Mutually exclusive with children. */
-    items: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      // Array of shorthands for MenuItem
-      PropTypes.arrayOf(PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.element,
-        PropTypes.object,
-      ])),
-    ]),
+    /** Shorthand array of props for Menu. */
+    items: customPropTypes.items,
 
     /** onClick handler for MenuItem. Mutually exclusive with children. */
     onItemClick: customPropTypes.every([

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -91,7 +91,7 @@ class Menu extends Component {
     inverted: PropTypes.bool,
 
     /** Shorthand array of props for Menu. */
-    items: customPropTypes.items,
+    items: customPropTypes.collectionShorthand,
 
     /** onClick handler for MenuItem. Mutually exclusive with children. */
     onItemClick: customPropTypes.every([

--- a/src/collections/Menu/MenuHeader.js
+++ b/src/collections/Menu/MenuHeader.js
@@ -27,17 +27,14 @@ MenuHeader.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Additional classes */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for primary content */
-  content: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default MenuHeader

--- a/src/collections/Menu/MenuHeader.js
+++ b/src/collections/Menu/MenuHeader.js
@@ -34,7 +34,7 @@ MenuHeader.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default MenuHeader

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -32,23 +32,17 @@ export default class MenuItem extends Component {
     /** A menu item can be active. */
     active: PropTypes.bool,
 
-    /** Primary content of the MenuItem. */
-    children: customPropTypes.every([
-      customPropTypes.disallow(['content']),
-      PropTypes.node,
-    ]),
+    /** Primary content. */
+    children: PropTypes.node,
 
-    /** Classes that will be added to the MenuItem className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Additional colors can be specified. */
     color: PropTypes.oneOf(_meta.props.color),
 
-    /** Shorthand for primary content of the MenuItem. Mutually exclusive with the children. */
-    content: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.string,
-    ]),
+    /** Shorthand for primary content. */
+    content: customPropTypes.content,
 
     /** A menu item or menu can remove element padding, vertically or horizontally. */
     fitted: PropTypes.oneOfType([

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -42,7 +42,7 @@ export default class MenuItem extends Component {
     color: PropTypes.oneOf(_meta.props.color),
 
     /** Shorthand for primary content. */
-    content: customPropTypes.content,
+    content: customPropTypes.contentShorthand,
 
     /** A menu item or menu can remove element padding, vertically or horizontally. */
     fitted: PropTypes.oneOfType([

--- a/src/collections/Menu/MenuMenu.js
+++ b/src/collections/Menu/MenuMenu.js
@@ -30,10 +30,10 @@ MenuMenu.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the MenuMenu. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes that will be added to the MenuMenu className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A sub menu can take right position. */

--- a/src/collections/Message/Message.js
+++ b/src/collections/Message/Message.js
@@ -71,18 +71,11 @@ function Message(props) {
   const rest = getUnhandledProps(Message, props)
   const ElementType = getElementType(Message, props)
 
-  if (content || header || (icon && icon !== true) || list) {
+  if (children) {
     return (
       <ElementType {...rest} className={classes}>
         {dismissIcon}
-        {Icon.create(icon)}
-        {(header || content || list) && (
-          <MessageContent>
-            {createShorthand(MessageHeader, val => ({ children: val }), header)}
-            {createShorthand(MessageList, val => ({ items: val }), list)}
-            {createShorthand('p', val => ({ children: val }), content)}
-          </MessageContent>
-        )}
+        {children}
       </ElementType>
     )
   }
@@ -90,7 +83,14 @@ function Message(props) {
   return (
     <ElementType {...rest} className={classes}>
       {dismissIcon}
-      {children}
+      {Icon.create(icon)}
+      {(header || content || list) && (
+        <MessageContent>
+          {createShorthand(MessageHeader, val => ({ children: val }), header)}
+          {createShorthand(MessageList, val => ({ items: val }), list)}
+          {createShorthand('p', val => ({ children: val }), content)}
+        </MessageContent>
+      )}
     </ElementType>
   )
 }
@@ -109,48 +109,26 @@ Message.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the message. */
-  children: customPropTypes.every([
-    PropTypes.node,
-    customPropTypes.disallow(['header', 'content']),
-    customPropTypes.givenProps(
-      { icon: PropTypes.node.isRequired },
-      customPropTypes.disallow(['icon'])
-    ),
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
   /** Additional classes. */
   className: PropTypes.string,
 
-  /** The body of the message.  Mutually exclusive with children. */
-  content: PropTypes.string,
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
-  /** The content of the MessageHeader. Mutually exclusive with children. */
-  header: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.node,
-    ]),
-  ]),
+  /** Shorthand for MessageHeader. */
+  header: customPropTypes.item,
 
   /** A message can contain an icon. */
-  icon: customPropTypes.every([
-    customPropTypes.givenProps(
-      { children: PropTypes.node.isRequired },
-      PropTypes.bool
-    ),
-    customPropTypes.givenProps(
-      { icon: PropTypes.string.isRequired },
-      customPropTypes.disallow(['children'])
-    ),
+  icon: PropTypes.oneOfType([
+    PropTypes.bool,
+    customPropTypes.item,
   ]),
 
   /** Array of string items for the MessageList. Mutually exclusive with children. */
-  list: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.arrayOf(PropTypes.string),
-  ]),
+  list: customPropTypes.items,
 
   /**
    * A message that the user can choose to hide.

--- a/src/collections/Message/Message.js
+++ b/src/collections/Message/Message.js
@@ -116,19 +116,19 @@ Message.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** Shorthand for MessageHeader. */
-  header: customPropTypes.item,
+  header: customPropTypes.itemShorthand,
 
   /** A message can contain an icon. */
   icon: PropTypes.oneOfType([
     PropTypes.bool,
-    customPropTypes.item,
+    customPropTypes.itemShorthand,
   ]),
 
   /** Array of string items for the MessageList. Mutually exclusive with children. */
-  list: customPropTypes.items,
+  list: customPropTypes.collectionShorthand,
 
   /**
    * A message that the user can choose to hide.

--- a/src/collections/Message/MessageContent.js
+++ b/src/collections/Message/MessageContent.js
@@ -31,7 +31,7 @@ MessageContent.propTypes = {
   children: PropTypes.node,
 
   /** Additional classes. */
-  className: PropTypes.node,
+  className: PropTypes.string,
 }
 
 export default MessageContent

--- a/src/collections/Message/MessageHeader.js
+++ b/src/collections/Message/MessageHeader.js
@@ -31,7 +31,7 @@ MessageHeader.propTypes = {
   children: PropTypes.node,
 
   /** Additional classes. */
-  className: PropTypes.node,
+  className: PropTypes.string,
 }
 
 export default MessageHeader

--- a/src/collections/Message/MessageItem.js
+++ b/src/collections/Message/MessageItem.js
@@ -31,7 +31,7 @@ MessageItem.propTypes = {
   children: PropTypes.node,
 
   /** Additional classes. */
-  className: PropTypes.node,
+  className: PropTypes.string,
 }
 
 MessageItem.defaultProps = {

--- a/src/collections/Message/MessageList.js
+++ b/src/collections/Message/MessageList.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
@@ -16,9 +17,13 @@ function MessageList(props) {
   const rest = getUnhandledProps(MessageList, props)
   const ElementType = getElementType(MessageList, props)
 
-  const itemsJSX = items && items.map(item => <MessageItem key={item}>{item}</MessageItem>)
+  if (children) {
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
+  }
 
-  return <ElementType {...rest} className={classes}>{itemsJSX || children}</ElementType>
+  const content = _.map(items, item => <MessageItem key={item}>{item}</MessageItem>)
+
+  return <ElementType {...rest} className={classes}>{content}</ElementType>
 }
 
 MessageList._meta = {
@@ -35,7 +40,7 @@ MessageList.propTypes = {
   children: PropTypes.node,
 
   /** Additional classes. */
-  className: PropTypes.node,
+  className: PropTypes.string,
 
   /** Strings to use as list items. Mutually exclusive with children. */
   items: PropTypes.arrayOf(PropTypes.string),

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -83,7 +83,9 @@ function Table(props) {
   return (
     <ElementType {...rest} className={classes}>
       {headerRow && <TableHeader>{TableRow.create(headerRow, { cellAs: 'th' })}</TableHeader>}
-      {<TableBody>{_.map(tableData, (data, index) => TableRow.create(renderBodyRow(data, index)))}</TableBody>}
+      <TableBody>
+        {renderBodyRow && _.map(tableData, (data, index) => TableRow.create(renderBodyRow(data, index)))}
+      </TableBody>
       {footerRow && <TableFooter>{TableRow.create(footerRow)}</TableFooter>}
     </ElementType>
   )
@@ -126,13 +128,10 @@ Table.propTypes = {
   /** A table may be divided each row into separate cells. */
   celled: PropTypes.bool,
 
-  /** Primary content of the Table. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['headerRow', 'renderBodyRow', 'footerRow', 'tableData']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the Table className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A table can be collapsing, taking up only as much space as its rows. */
@@ -159,16 +158,10 @@ Table.propTypes = {
   fixed: PropTypes.bool,
 
   /** Shorthand for a TableRow to be placed within Table.Footer. */
-  footerRow: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.element,
-  ]),
+  footerRow: customPropTypes.collection,
 
   /** Shorthand for a TableRow to be placed within Table.Header. */
-  headerRow: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.element,
-  ]),
+  headerRow: customPropTypes.collection,
 
   /** A table's colors can be inverted. */
   inverted: PropTypes.bool,
@@ -184,6 +177,7 @@ Table.propTypes = {
    * to be placed within Table.Body.
    */
   renderBodyRow: customPropTypes.every([
+    customPropTypes.disallow(['children']),
     customPropTypes.demand(['tableData']),
     PropTypes.func,
   ]),
@@ -208,6 +202,7 @@ Table.propTypes = {
 
   /** Data to be passed to the renderBodyRow function. */
   tableData: customPropTypes.every([
+    customPropTypes.disallow(['children']),
     customPropTypes.demand(['renderBodyRow']),
     PropTypes.array,
   ]),

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -158,10 +158,10 @@ Table.propTypes = {
   fixed: PropTypes.bool,
 
   /** Shorthand for a TableRow to be placed within Table.Footer. */
-  footerRow: customPropTypes.collection,
+  footerRow: customPropTypes.itemShorthand,
 
   /** Shorthand for a TableRow to be placed within Table.Header. */
-  headerRow: customPropTypes.collection,
+  headerRow: customPropTypes.itemShorthand,
 
   /** A table's colors can be inverted. */
   inverted: PropTypes.bool,

--- a/src/collections/Table/TableBody.js
+++ b/src/collections/Table/TableBody.js
@@ -31,10 +31,10 @@ TableBody.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the TableBody. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes that will be added to the TableBody className. */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/collections/Table/TableCell.js
+++ b/src/collections/Table/TableCell.js
@@ -95,7 +95,7 @@ TableCell.propTypes = {
   collapsing: PropTypes.bool,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** A cell can be disabled. */
   disabled: PropTypes.bool,
@@ -104,7 +104,7 @@ TableCell.propTypes = {
   error: PropTypes.bool,
 
   /** Add an Icon by name, props object, or pass an <Icon /> */
-  icon: customPropTypes.item,
+  icon: customPropTypes.itemShorthand,
 
   /** A cell may let a user know whether a value is bad. */
   negative: PropTypes.bool,

--- a/src/collections/Table/TableCell.js
+++ b/src/collections/Table/TableCell.js
@@ -85,23 +85,17 @@ TableCell.propTypes = {
   /** A cell can be active or selected by a user. */
   active: PropTypes.bool,
 
-  /** Primary content of the TableCell. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content', 'icon']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the TableCell className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A cell can be collapsing so that it only uses as much space as required. */
   collapsing: PropTypes.bool,
 
-  /** Shorthand for primary content of the TableCell. Mutually exclusive with the children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
   /** A cell can be disabled. */
   disabled: PropTypes.bool,
@@ -110,14 +104,7 @@ TableCell.propTypes = {
   error: PropTypes.bool,
 
   /** Add an Icon by name, props object, or pass an <Icon /> */
-  icon: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.string,
-      PropTypes.element,
-    ]),
-  ]),
+  icon: customPropTypes.item,
 
   /** A cell may let a user know whether a value is bad. */
   negative: PropTypes.bool,

--- a/src/collections/Table/TableHeader.js
+++ b/src/collections/Table/TableHeader.js
@@ -35,10 +35,10 @@ TableHeader.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the TableHeader. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes that will be added to the TableHeader className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A definition table can have a full width header or footer, filling in the gap left by the first column. */

--- a/src/collections/Table/TableRow.js
+++ b/src/collections/Table/TableRow.js
@@ -81,24 +81,13 @@ TableRow.propTypes = {
   /** An element type to render as (string or function). */
   cellAs: customPropTypes.as,
 
-  /** Shorthand array of props for TableCell. Mutually exclusive with children. */
-  cells: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    // Array of shorthands for TableCell
-    PropTypes.arrayOf(PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.element,
-      PropTypes.object,
-    ])),
-  ]),
+  /** Shorthand array of props for TableCell. */
+  cells: customPropTypes.items,
 
-  /** Primary content of the TableRow. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content', 'icon']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the TableRow className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A row can be disabled. */

--- a/src/collections/Table/TableRow.js
+++ b/src/collections/Table/TableRow.js
@@ -82,7 +82,7 @@ TableRow.propTypes = {
   cellAs: customPropTypes.as,
 
   /** Shorthand array of props for TableCell. */
-  cells: customPropTypes.items,
+  cells: customPropTypes.collectionShorthand,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -182,7 +182,7 @@ Button.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** A button can have different colors */
   color: PropTypes.oneOf(Button._meta.props.color),

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -159,7 +159,7 @@ Button.propTypes = {
   /** A basic button is less pronounced */
   basic: PropTypes.bool,
 
-  /** Primary content of the button */
+  /** Primary content. */
   children: customPropTypes.every([
     PropTypes.node,
     customPropTypes.disallow(['label']),
@@ -178,14 +178,11 @@ Button.propTypes = {
   /** A button can be circular */
   circular: PropTypes.bool,
 
-  /** Classes to add to the button className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
   /** A button can have different colors */
   color: PropTypes.oneOf(Button._meta.props.color),

--- a/src/elements/Button/ButtonContent.js
+++ b/src/elements/Button/ButtonContent.js
@@ -36,17 +36,17 @@ ButtonContent.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Initially visible, hidden on hover */
-  visible: PropTypes.bool,
+  /** Additional classes. */
+  className: PropTypes.string,
+
+  /** Primary content. */
+  children: PropTypes.node,
 
   /** Initially hidden, visible on hover */
   hidden: PropTypes.bool,
 
-  /** Additional classes */
-  className: PropTypes.string,
-
-  /** Primary content, intended to the Button children */
-  children: PropTypes.any,
+  /** Initially visible, hidden on hover */
+  visible: PropTypes.bool,
 }
 
 export default ButtonContent

--- a/src/elements/Button/ButtonGroup.js
+++ b/src/elements/Button/ButtonGroup.js
@@ -60,11 +60,11 @@ ButtonGroup.propTypes = {
   /** Groups can be less pronounced */
   basic: PropTypes.bool,
 
-  /** Additional classes */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content, intended to be Button elements */
-  children: PropTypes.any,
+  /** Primary content. */
+  children: PropTypes.node,
 
   /** Groups can have a shared color */
   color: PropTypes.oneOf(ButtonGroup._meta.props.color),

--- a/src/elements/Button/ButtonOr.js
+++ b/src/elements/Button/ButtonOr.js
@@ -30,7 +30,7 @@ ButtonOr.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Additional classes */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/elements/Container/Container.js
+++ b/src/elements/Container/Container.js
@@ -41,10 +41,10 @@ Container.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the Container */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the container className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Reduce maximum width to more naturally accommodate text */

--- a/src/elements/Divider/Divider.js
+++ b/src/elements/Divider/Divider.js
@@ -45,10 +45,10 @@ Divider.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the Divider */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the divider className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Divider can segment content horizontally */

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -73,7 +73,7 @@ Flag.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Classes that will be added to the Flag className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Flag name, can use the two digit country code, the full name, or a common alias */

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -97,14 +97,14 @@ Header.propTypes = {
   children: PropTypes.node,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** Add an icon by icon name or pass an <Icon /.> */
   icon: customPropTypes.every([
     customPropTypes.disallow(['image']),
     PropTypes.oneOfType([
       PropTypes.bool,
-      customPropTypes.item,
+      customPropTypes.itemShorthand,
     ]),
   ]),
 
@@ -113,7 +113,7 @@ Header.propTypes = {
     customPropTypes.disallow(['icon']),
     PropTypes.oneOfType([
       PropTypes.bool,
-      customPropTypes.item,
+      customPropTypes.itemShorthand,
     ]),
   ]),
 
@@ -148,7 +148,7 @@ Header.propTypes = {
   size: PropTypes.oneOf(Header._meta.props.size),
 
   /** Shorthand for Header.Subheader. */
-  subheader: customPropTypes.item,
+  subheader: customPropTypes.itemShorthand,
 
   /** Align header content */
   textAlign: PropTypes.oneOf(Header._meta.props.textAlign),

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -90,34 +90,31 @@ Header.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Additional classes */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Primary content.  Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
   /** Add an icon by icon name or pass an <Icon /.> */
   icon: customPropTypes.every([
     customPropTypes.disallow(['image']),
-    customPropTypes.givenProps(
-      { icon: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.object]).isRequired },
-      customPropTypes.disallow(['children']),
-    ),
+    PropTypes.oneOfType([
+      PropTypes.bool,
+      customPropTypes.item,
+    ]),
   ]),
 
   /** Add an image by img src or pass an <Image />. */
   image: customPropTypes.every([
     customPropTypes.disallow(['icon']),
-    customPropTypes.givenProps(
-      { image: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.object]).isRequired },
-      customPropTypes.disallow(['children']),
-    ),
+    PropTypes.oneOfType([
+      PropTypes.bool,
+      customPropTypes.item,
+    ]),
   ]),
 
   /** Color of the header. */
@@ -150,11 +147,8 @@ Header.propTypes = {
   /** Content headings are sized with em and are based on the font-size of their container. */
   size: PropTypes.oneOf(Header._meta.props.size),
 
-  /** Shorthand for the Header.Subheader component. Mutually exclusive with children */
-  subheader: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for Header.Subheader. */
+  subheader: customPropTypes.item,
 
   /** Align header content */
   textAlign: PropTypes.oneOf(Header._meta.props.textAlign),

--- a/src/elements/Header/HeaderContent.js
+++ b/src/elements/Header/HeaderContent.js
@@ -30,10 +30,10 @@ HeaderContent.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes that will be added to the HeaderContent className */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/elements/Header/HeaderSubheader.js
+++ b/src/elements/Header/HeaderSubheader.js
@@ -27,20 +27,14 @@ HeaderSubheader.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the HeaderSubheader. Mutually exclusive with content */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes to add to the subheader className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for primary content. Mutually exclusive with children */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default HeaderSubheader

--- a/src/elements/Header/HeaderSubheader.js
+++ b/src/elements/Header/HeaderSubheader.js
@@ -34,7 +34,7 @@ HeaderSubheader.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default HeaderSubheader

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -69,7 +69,7 @@ Icon.propTypes = {
   /** Formatted to appear bordered */
   bordered: PropTypes.bool,
 
-  /** Class names for custom styling. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Icon can formatted to appear circular */

--- a/src/elements/Icon/IconGroup.js
+++ b/src/elements/Icon/IconGroup.js
@@ -41,11 +41,11 @@ IconGroup.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Class names for custom styling. */
-  className: PropTypes.string,
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Icon children for the Icon group */
-  children: PropTypes.any,
+  /** Additional classes. */
+  className: PropTypes.string,
 
   /** Size of the icon group. */
   size: PropTypes.oneOf(IconGroup._meta.props.size),

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -115,7 +115,7 @@ Image.propTypes = {
   /** An image can appear centered in a content block */
   centered: PropTypes.bool,
 
-  /** Class names for custom styling. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** An image can show that it is disabled and cannot be selected */
@@ -145,13 +145,8 @@ Image.propTypes = {
   /** An image may appear inline */
   inline: PropTypes.bool,
 
-  /** Add a Label by text, props object, or pass a <Label /> */
-  label: customPropTypes.some([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.object,
-    PropTypes.element,
-  ]),
+  /** Shorthand for Label. */
+  label: customPropTypes.item,
 
   /** An image may appear rounded or circular */
   shape: PropTypes.oneOf(Image._meta.props.shape),

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -146,7 +146,7 @@ Image.propTypes = {
   inline: PropTypes.bool,
 
   /** Shorthand for Label. */
-  label: customPropTypes.item,
+  label: customPropTypes.itemShorthand,
 
   /** An image may appear rounded or circular */
   shape: PropTypes.oneOf(Image._meta.props.shape),

--- a/src/elements/Image/ImageGroup.js
+++ b/src/elements/Image/ImageGroup.js
@@ -34,10 +34,10 @@ ImageGroup.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Class names for custom styling. */
-  children: PropTypes.any,
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Class names for custom styling. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A group of images can be formatted to have the same size. */

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -143,34 +143,16 @@ Input.propTypes = {
   as: customPropTypes.as,
 
   /** An Input can be formatted to alert the user to an action they may perform */
-  action: customPropTypes.some([
+  action: PropTypes.oneOfType([
     PropTypes.bool,
-    customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.object,
-        PropTypes.element,
-      ]),
-    ]),
+    customPropTypes.item,
   ]),
 
   /** An action can appear along side an Input on the left or right */
   actionPosition: PropTypes.oneOf(Input._meta.props.actionPosition),
 
-  /** Primary content.  Used when there are multiple Labels or multiple Actions. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['input', 'label']),
-    customPropTypes.givenProps(
-      { action: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.element]).isRequired },
-      customPropTypes.disallow(['action']),
-    ),
-    customPropTypes.givenProps(
-      { icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.element]).isRequired },
-      customPropTypes.disallow(['icon']),
-    ),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
   /** Additional classes. */
   className: PropTypes.string,
@@ -188,12 +170,9 @@ Input.propTypes = {
   fluid: PropTypes.bool,
 
   /** Optional Icon to display inside the Input */
-  icon: customPropTypes.some([
+  icon: PropTypes.oneOfType([
     PropTypes.bool,
-    customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.element]),
-    ]),
+    customPropTypes.item,
   ]),
 
   /** An Icon can appear inside an Input on the left or right */
@@ -202,17 +181,11 @@ Input.propTypes = {
   /** Format to appear on dark backgrounds */
   inverted: PropTypes.bool,
 
-  /** Shorthand prop for creating the HTML Input */
-  input: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.element]),
-  ]),
+  /** Shorthand for creating the HTML Input */
+  input: customPropTypes.item,
 
   /** Optional Label to display along side the Input */
-  label: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.element]),
-  ]),
+  label: customPropTypes.item,
 
   /** A Label can appear outside an Input on the left or right */
   labelPosition: PropTypes.oneOf(Input._meta.props.labelPosition),

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -145,7 +145,7 @@ Input.propTypes = {
   /** An Input can be formatted to alert the user to an action they may perform */
   action: PropTypes.oneOfType([
     PropTypes.bool,
-    customPropTypes.item,
+    customPropTypes.itemShorthand,
   ]),
 
   /** An action can appear along side an Input on the left or right */
@@ -172,7 +172,7 @@ Input.propTypes = {
   /** Optional Icon to display inside the Input */
   icon: PropTypes.oneOfType([
     PropTypes.bool,
-    customPropTypes.item,
+    customPropTypes.itemShorthand,
   ]),
 
   /** An Icon can appear inside an Input on the left or right */
@@ -182,10 +182,10 @@ Input.propTypes = {
   inverted: PropTypes.bool,
 
   /** Shorthand for creating the HTML Input */
-  input: customPropTypes.item,
+  input: customPropTypes.itemShorthand,
 
   /** Optional Label to display along side the Input */
-  label: customPropTypes.item,
+  label: customPropTypes.itemShorthand,
 
   /** A Label can appear outside an Input on the left or right */
   labelPosition: PropTypes.oneOf(Input._meta.props.labelPosition),

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -59,7 +59,7 @@ export default class Label extends Component {
     color: PropTypes.oneOf(_meta.props.color),
 
     /** Shorthand for primary content. */
-    content: customPropTypes.content,
+    content: customPropTypes.contentShorthand,
 
     /** A label can position itself in the corner of an element. */
     corner: PropTypes.oneOfType([
@@ -68,7 +68,7 @@ export default class Label extends Component {
     ]),
 
     /** Shorthand for LabelDetail. */
-    detail: customPropTypes.item,
+    detail: customPropTypes.itemShorthand,
 
     /** Formats the label as a dot. */
     empty: customPropTypes.every([
@@ -83,12 +83,12 @@ export default class Label extends Component {
     horizontal: PropTypes.bool,
 
     /** Shorthand for Icon. */
-    icon: customPropTypes.item,
+    icon: customPropTypes.itemShorthand,
 
     /** A label can be formatted to emphasize an image or prop can be used as shorthand for Image. */
     image: PropTypes.oneOfType([
       PropTypes.bool,
-      customPropTypes.item,
+      customPropTypes.itemShorthand,
     ]),
 
     /** A label can point to content next to it. */

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -46,29 +46,20 @@ export default class Label extends Component {
     /** A label can reduce its complexity. */
     basic: PropTypes.bool,
 
-    /** Primary content of the label, same as content. */
-    children: customPropTypes.every([
-      customPropTypes.disallow(['content', 'detail', 'icon']),
-      PropTypes.node,
-    ]),
+    /** Primary content. */
+    children: PropTypes.node,
 
     /** A label can be circular. */
     circular: PropTypes.bool,
 
-    /** Classes to add to the label className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Color of the label. */
     color: PropTypes.oneOf(_meta.props.color),
 
-    /** Shorthand for primary content of the label. Mutually exclusive with children. */
-    content: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.oneOfType([
-        PropTypes.number,
-        PropTypes.string,
-      ]),
-    ]),
+    /** Shorthand for primary content. */
+    content: customPropTypes.content,
 
     /** A label can position itself in the corner of an element. */
     corner: PropTypes.oneOfType([
@@ -76,14 +67,8 @@ export default class Label extends Component {
       PropTypes.oneOf(_meta.props.corner),
     ]),
 
-    /** Shorthand for the LabelDetail component. Mutually exclusive with children. */
-    detail: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.oneOfType([
-        PropTypes.number,
-        PropTypes.string,
-      ]),
-    ]),
+    /** Shorthand for LabelDetail. */
+    detail: customPropTypes.item,
 
     /** Formats the label as a dot. */
     empty: customPropTypes.every([
@@ -97,25 +82,13 @@ export default class Label extends Component {
     /** A horizontal label is formatted to label content along-side it horizontally. */
     horizontal: PropTypes.bool,
 
-    /** A label can be formatted to emphasize an icon or prop can be used as shorthand for Icon. */
-    icon: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.oneOfType([
-        PropTypes.number,
-        PropTypes.string,
-      ]),
-    ]),
+    /** Shorthand for Icon. */
+    icon: customPropTypes.item,
 
     /** A label can be formatted to emphasize an image or prop can be used as shorthand for Image. */
-    image: customPropTypes.every([
-      customPropTypes.givenProps(
-        { children: PropTypes.node.isRequired },
-        PropTypes.bool,
-      ),
-      customPropTypes.givenProps(
-        { image: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.object]) },
-        customPropTypes.disallow(['children']),
-      ),
+    image: PropTypes.oneOfType([
+      PropTypes.bool,
+      customPropTypes.item,
     ]),
 
     /** A label can point to content next to it. */

--- a/src/elements/Label/LabelDetail.js
+++ b/src/elements/Label/LabelDetail.js
@@ -34,7 +34,7 @@ LabelDetail.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default LabelDetail

--- a/src/elements/Label/LabelDetail.js
+++ b/src/elements/Label/LabelDetail.js
@@ -27,20 +27,14 @@ LabelDetail.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the detail. Mutually exclusive with content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes to add to the label className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for primary content of the detail. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default LabelDetail

--- a/src/elements/Label/LabelGroup.js
+++ b/src/elements/Label/LabelGroup.js
@@ -49,16 +49,13 @@ LabelGroup.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the label group. Mutually exclusive with content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
   /** Labels can share shapes. */
   circular: PropTypes.bool,
 
-  /** Classes to add to the label group className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Label group can share colors together. */

--- a/src/elements/List/List.js
+++ b/src/elements/List/List.js
@@ -89,10 +89,10 @@ List.propTypes = {
   /** A list can divide its items into cells. */
   celled: PropTypes.bool,
 
-  /** Primary content of the List. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the List className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A list can show divisions between content. */

--- a/src/elements/List/ListContent.js
+++ b/src/elements/List/ListContent.js
@@ -45,10 +45,10 @@ ListContent.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the ListContent. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the ListContent className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** An list content can be floated left or right. */

--- a/src/elements/List/ListDescription.js
+++ b/src/elements/List/ListDescription.js
@@ -27,10 +27,10 @@ ListDescription.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the ListDescription. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the ListDescription className. */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/elements/List/ListHeader.js
+++ b/src/elements/List/ListHeader.js
@@ -27,10 +27,10 @@ ListHeader.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the ListHeader. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the ListHeader className. */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/elements/List/ListIcon.js
+++ b/src/elements/List/ListIcon.js
@@ -30,7 +30,7 @@ ListIcon._meta = {
 }
 
 ListIcon.propTypes = {
-  /** Classes to add to the ListIcon className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** An element inside a list can be vertically aligned. */

--- a/src/elements/List/ListItem.js
+++ b/src/elements/List/ListItem.js
@@ -44,10 +44,10 @@ ListItem.propTypes = {
   /** A list item can active. */
   active: PropTypes.bool,
 
-  /** Primary content of the ListItem. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the ListItem className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A list item can disabled. */

--- a/src/elements/List/ListList.js
+++ b/src/elements/List/ListList.js
@@ -32,10 +32,10 @@ ListList.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the ListList. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the ListList className. */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/elements/Loader/Loader.js
+++ b/src/elements/Loader/Loader.js
@@ -72,7 +72,7 @@ Loader.propTypes = {
   size: PropTypes.oneOf(Loader._meta.props.size),
 
   /** Shorthand for primary content. */
-  text: customPropTypes.content,
+  text: customPropTypes.contentShorthand,
 }
 
 export default Loader

--- a/src/elements/Loader/Loader.js
+++ b/src/elements/Loader/Loader.js
@@ -47,14 +47,11 @@ Loader.propTypes = {
   /** A loader can be active or visible. */
   active: PropTypes.bool,
 
-  /** Classes that will be added to the Loader className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the Loader. Mutually exclusive with the text. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['text']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
   /** A loader can be disabled or hidden. */
   disabled: PropTypes.bool,
@@ -74,11 +71,8 @@ Loader.propTypes = {
   /** Loaders can have different sizes. */
   size: PropTypes.oneOf(Loader._meta.props.size),
 
-  /** Primary content of the Loader. Mutually exclusive with the children prop. */
-  text: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+  /** Shorthand for primary content. */
+  text: customPropTypes.content,
 }
 
 export default Loader

--- a/src/elements/Rail/Rail.js
+++ b/src/elements/Rail/Rail.js
@@ -51,7 +51,7 @@ Rail.propTypes = {
   /** A rail can appear attached to the main viewport. */
   attached: PropTypes.bool,
 
-  /** Classes that will be added to the Rail className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A rail can appear closer to the main viewport. */
@@ -60,7 +60,7 @@ Rail.propTypes = {
     PropTypes.oneOf(Rail._meta.props.close),
   ]),
 
-  /** Primary content of the Rail. */
+  /** Primary content. */
   children: PropTypes.node,
 
   /** A rail can create a division between itself and a container. */

--- a/src/elements/Segment/Segment.js
+++ b/src/elements/Segment/Segment.js
@@ -101,13 +101,13 @@ Segment.propTypes = {
   /** A basic segment has no special formatting */
   basic: PropTypes.bool,
 
-  /** Segment tag body content. */
-  children: PropTypes.any,
+  /** Primary content. */
+  children: PropTypes.node,
 
   /** A segment can be circular */
   circular: PropTypes.bool,
 
-  /** Class names for custom styling. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A segment can clear floated content */

--- a/src/elements/Segment/SegmentGroup.js
+++ b/src/elements/Segment/SegmentGroup.js
@@ -46,10 +46,10 @@ SegmentGroup.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Class names for custom styling. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Nested segments for this Segment group */
+  /** Primary content. */
   children: PropTypes.node,
 
   /** A segment may take up only as much space as is necessary */

--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -26,32 +26,23 @@ export default class Step extends Component {
     /** A step can be highlighted as active. */
     active: PropTypes.bool,
 
-    /** Classes that will be added to the Step className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
-    /** Primary content of the Step. Mutually exclusive with description and title props. */
-    children: customPropTypes.every([
-      customPropTypes.disallow(['description', 'title']),
-      PropTypes.node,
-    ]),
+    /** Primary content. */
+    children: PropTypes.node,
 
     /** A step can show that a user has completed it. */
     completed: PropTypes.bool,
 
-    /** Shorthand prop for StepDescription. Mutually exclusive with children. */
-    description: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.node,
-    ]),
+    /** Shorthand for StepDescription. */
+    description: customPropTypes.item,
 
     /** Show that the Loader is inactive. */
     disabled: PropTypes.bool,
 
-    /** A step can contain an icon. */
-    icon: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.node,
-    ]),
+    /** Shorthand for Icon. */
+    icon: customPropTypes.item,
 
     /** A step can be link. */
     link: PropTypes.bool,
@@ -65,11 +56,8 @@ export default class Step extends Component {
     /** A step can show a ordered sequence of steps. Passed from StepGroup. */
     ordered: PropTypes.bool,
 
-    /** Shorthand prop for StepTitle. Mutually exclusive with children. */
-    title: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.node,
-    ]),
+    /** Shorthand for StepTitle. */
+    title: customPropTypes.item,
   }
 
   static _meta = {

--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -36,13 +36,13 @@ export default class Step extends Component {
     completed: PropTypes.bool,
 
     /** Shorthand for StepDescription. */
-    description: customPropTypes.item,
+    description: customPropTypes.itemShorthand,
 
     /** Show that the Loader is inactive. */
     disabled: PropTypes.bool,
 
     /** Shorthand for Icon. */
-    icon: customPropTypes.item,
+    icon: customPropTypes.itemShorthand,
 
     /** A step can be link. */
     link: PropTypes.bool,
@@ -57,7 +57,7 @@ export default class Step extends Component {
     ordered: PropTypes.bool,
 
     /** Shorthand for StepTitle. */
-    title: customPropTypes.item,
+    title: customPropTypes.itemShorthand,
   }
 
   static _meta = {

--- a/src/elements/Step/StepContent.js
+++ b/src/elements/Step/StepContent.js
@@ -39,30 +39,17 @@ StepContent.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Classes that will be added to the StepContent className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of StepContent. Mutually exclusive with description and title props. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['description', 'title']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Primary content of the StepDescription. Mutually exclusive with children. */
-  description: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+  /** Shorthand for StepDescription. */
+  description: customPropTypes.item,
 
-  /** Primary content of the StepTitle. Mutually exclusive with children. */
-  title: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.object,
-    ]),
-  ]),
+  /** Shorthand for StepTitle. */
+  title: customPropTypes.item,
 }
 
 export default StepContent

--- a/src/elements/Step/StepContent.js
+++ b/src/elements/Step/StepContent.js
@@ -46,10 +46,10 @@ StepContent.propTypes = {
   children: PropTypes.node,
 
   /** Shorthand for StepDescription. */
-  description: customPropTypes.item,
+  description: customPropTypes.itemShorthand,
 
   /** Shorthand for StepTitle. */
-  title: customPropTypes.item,
+  title: customPropTypes.itemShorthand,
 }
 
 export default StepContent

--- a/src/elements/Step/StepDescription.js
+++ b/src/elements/Step/StepDescription.js
@@ -14,7 +14,7 @@ function StepDescription(props) {
   const rest = getUnhandledProps(StepDescription, props)
   const ElementType = getElementType(StepDescription, props)
 
-  return <ElementType {...rest} className={classes}>{ children || description }</ElementType>
+  return <ElementType {...rest} className={classes}>{children || description}</ElementType>
 }
 
 StepDescription._meta = {
@@ -27,20 +27,14 @@ StepDescription.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Classes that will be added to the StepDescription className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the StepDescription. Mutually exclusive with description prop. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['description']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Primary content of the StepDescription. Mutually exclusive with children. */
-  description: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+  /** Shorthand for primary content. */
+  description: customPropTypes.content,
 }
 
 export default StepDescription

--- a/src/elements/Step/StepDescription.js
+++ b/src/elements/Step/StepDescription.js
@@ -34,7 +34,7 @@ StepDescription.propTypes = {
   children: PropTypes.node,
 
   /** Shorthand for primary content. */
-  description: customPropTypes.content,
+  description: customPropTypes.contentShorthand,
 }
 
 export default StepDescription

--- a/src/elements/Step/StepGroup.js
+++ b/src/elements/Step/StepGroup.js
@@ -28,7 +28,11 @@ function StepGroup(props) {
   const rest = getUnhandledProps(StepGroup, props)
   const ElementType = getElementType(StepGroup, props)
 
-  const content = !items ? children : items.map(item => {
+  if (children) {
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
+  }
+
+  const content = _.map(items, item => {
     const key = item.key || [item.title, item.description].join('-')
     return <Step key={key} {...item} />
   })
@@ -50,28 +54,17 @@ StepGroup.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Classes that will be added to the StepGroup className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the StepGroup. Mutually exclusive with items prop. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['items']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
   /** A fluid step takes up the width of its container. */
   fluid: PropTypes.bool,
 
-  /** Primary content of the StepGroup. Mutually exclusive with items children. */
-  items: customPropTypes.every([
-    customPropTypes.disallow(['description', 'title']),
-    PropTypes.arrayOf(PropTypes.shape({
-      description: PropTypes.node,
-      icon: PropTypes.node,
-      key: PropTypes.string,
-      title: PropTypes.node,
-    })),
-  ]),
+  /** Shorthand array of props for Step. */
+  items: customPropTypes.items,
 
   /** A step can show a ordered sequence of steps. */
   ordered: PropTypes.bool,

--- a/src/elements/Step/StepGroup.js
+++ b/src/elements/Step/StepGroup.js
@@ -64,7 +64,7 @@ StepGroup.propTypes = {
   fluid: PropTypes.bool,
 
   /** Shorthand array of props for Step. */
-  items: customPropTypes.items,
+  items: customPropTypes.collectionShorthand,
 
   /** A step can show a ordered sequence of steps. */
   ordered: PropTypes.bool,

--- a/src/elements/Step/StepTitle.js
+++ b/src/elements/Step/StepTitle.js
@@ -14,7 +14,7 @@ function StepTitle(props) {
   const rest = getUnhandledProps(StepTitle, props)
   const ElementType = getElementType(StepTitle, props)
 
-  return <ElementType {...rest} className={classes}>{ children || title }</ElementType>
+  return <ElementType {...rest} className={classes}>{children || title}</ElementType>
 }
 
 StepTitle._meta = {
@@ -27,20 +27,14 @@ StepTitle.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Classes that will be added to the StepTitle className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the StepTitle. Mutually exclusive with title prop. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['title']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Primary content of the StepTitle. Mutually exclusive with children. */
-  title: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+  /** Shorthand for primary content. */
+  title: customPropTypes.content,
 }
 
 export default StepTitle

--- a/src/elements/Step/StepTitle.js
+++ b/src/elements/Step/StepTitle.js
@@ -34,7 +34,7 @@ StepTitle.propTypes = {
   children: PropTypes.node,
 
   /** Shorthand for primary content. */
-  title: customPropTypes.content,
+  title: customPropTypes.contentShorthand,
 }
 
 export default StepTitle

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -181,6 +181,49 @@ export const demand = (requiredProps) => {
 }
 
 /**
+ * Ensure a component can render as a node passed as a prop value in place of children.
+ */
+export const content = (...args) => every([
+  disallow(['children']),
+  PropTypes.node,
+])(...args)
+
+/**
+ * Item shorthand is a description of a component that can be a literal,
+ * a props object, or an element.
+ */
+export const item = (...args) => every([
+  disallow(['children']),
+  PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.number,
+    PropTypes.object,
+    PropTypes.string,
+  ]),
+])(...args)
+
+/**
+ * ArrayOf shorthand ensures a prop is an array of item shorthand
+ */
+export const items = (...args) => every([
+  disallow(['children']),
+  PropTypes.arrayOf(item),
+])(...args)
+
+/**
+ * Collection shorthand is a description of a component that can be an array of
+ * shorthand for the underlying items, a props object, or an element.
+ */
+export const collection = (...args) => every([
+  disallow(['children']),
+  PropTypes.oneOfType([
+    items,
+    PropTypes.element,
+    PropTypes.object,
+  ]),
+])(...args)
+
+/**
  * Show a deprecated warning for component props with a help message and optional validator.
  * @param {string} help A help message to display with the deprecation warning.
  * @param {function} [validator] A propType function.

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -183,7 +183,7 @@ export const demand = (requiredProps) => {
 /**
  * Ensure a component can render as a node passed as a prop value in place of children.
  */
-export const content = (...args) => every([
+export const contentShorthand = (...args) => every([
   disallow(['children']),
   PropTypes.node,
 ])(...args)
@@ -192,35 +192,20 @@ export const content = (...args) => every([
  * Item shorthand is a description of a component that can be a literal,
  * a props object, or an element.
  */
-export const item = (...args) => every([
+export const itemShorthand = (...args) => every([
   disallow(['children']),
   PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.number,
+    PropTypes.node,
     PropTypes.object,
-    PropTypes.string,
   ]),
 ])(...args)
 
 /**
- * ArrayOf shorthand ensures a prop is an array of item shorthand
+ * Collection shorthand ensures a prop is an array of item shorthand.
  */
-export const items = (...args) => every([
+export const itemsShorthand = (...args) => every([
   disallow(['children']),
-  PropTypes.arrayOf(item),
-])(...args)
-
-/**
- * Collection shorthand is a description of a component that can be an array of
- * shorthand for the underlying items, a props object, or an element.
- */
-export const collection = (...args) => every([
-  disallow(['children']),
-  PropTypes.oneOfType([
-    items,
-    PropTypes.element,
-    PropTypes.object,
-  ]),
+  PropTypes.arrayOf(itemShorthand),
 ])(...args)
 
 /**

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -29,13 +29,10 @@ export default class Accordion extends Component {
     /** Index of the currently active panel. */
     activeIndex: PropTypes.number,
 
-    /** Accordion.Title and Accordion.Content components.  Mutually exclusive with the panels prop. */
-    children: customPropTypes.every([
-      customPropTypes.disallow(['panels']),
-      PropTypes.node,
-    ]),
+    /** Primary content. */
+    children: PropTypes.node,
 
-    /** Classes to add to the Accordion className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Initial activeIndex value. */
@@ -54,6 +51,7 @@ export default class Accordion extends Component {
      * Create simple accordion panels from an array of { text: <string>, content: <string> } objects.
      * Object can optionally define an `active` key to open/close the panel.
      * Mutually exclusive with children.
+     * TODO: AccordionPanel should be a sub-component
      */
     panels: customPropTypes.every([
       customPropTypes.disallow(['children']),

--- a/src/modules/Accordion/AccordionContent.js
+++ b/src/modules/Accordion/AccordionContent.js
@@ -31,10 +31,10 @@ AccordionContent.propTypes = {
   /** Whether or not the content is visible. */
   active: PropTypes.bool,
 
-  /** Primary content of the Content. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the content className. */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -22,10 +22,10 @@ export default class AccordionTitle extends Component {
     /** Whether or not the title is in the open state. */
     active: PropTypes.bool,
 
-    /** Primary content of the Title. */
+    /** Primary content. */
     children: PropTypes.node,
 
-    /** Classes to add to the title className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Called with (event, index) on title click. */

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -66,7 +66,7 @@ export default class Dropdown extends Component {
     /** Initial value of open. */
     defaultOpen: PropTypes.bool,
 
-    /** A Dropdown can contain a single <Dropdown.Menu /> child. */
+    /** Primary content. */
     children: customPropTypes.every([
       customPropTypes.disallow(['options', 'selection']),
       customPropTypes.demand(['text']),
@@ -170,7 +170,7 @@ export default class Dropdown extends Component {
     /** Format the Dropdown to appear as a button. */
     button: PropTypes.bool,
 
-    /** Additional classes added to the root element. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Format the dropdown to only take up as much width as needed. */

--- a/src/modules/Dropdown/DropdownDivider.js
+++ b/src/modules/Dropdown/DropdownDivider.js
@@ -27,8 +27,8 @@ DropdownDivider.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Additional classes */
-  className: PropTypes.node,
+  /** Additional classes. */
+  className: PropTypes.string,
 }
 
 export default DropdownDivider

--- a/src/modules/Dropdown/DropdownHeader.js
+++ b/src/modules/Dropdown/DropdownHeader.js
@@ -44,10 +44,10 @@ DropdownHeader.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** Shorthand for Icon. */
-  icon: customPropTypes.item,
+  icon: customPropTypes.itemShorthand,
 }
 
 export default DropdownHeader

--- a/src/modules/Dropdown/DropdownHeader.js
+++ b/src/modules/Dropdown/DropdownHeader.js
@@ -37,24 +37,17 @@ DropdownHeader.propTypes = {
   /** An element type to render as (string or function) */
   as: customPropTypes.as,
 
-  /** Primary content of the header, same as content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content', 'icon']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Additional classes */
-  className: PropTypes.node,
+  /** Additional classes. */
+  className: PropTypes.string,
 
-  /** Primary content of the header, same as children. */
-  content: PropTypes.node,
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
-  /** Add an icon by icon name or pass an <Icon /> */
-  icon: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.element,
-    PropTypes.object,
-  ]),
+  /** Shorthand for Icon. */
+  icon: customPropTypes.item,
 }
 
 export default DropdownHeader

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -30,7 +30,7 @@ export default class DropdownItem extends Component {
     className: PropTypes.string,
 
     /** Additional text with less emphasis. */
-    description: customPropTypes.item,
+    description: customPropTypes.itemShorthand,
 
     /** A dropdown item can be disabled. */
     disabled: PropTypes.bool,
@@ -45,7 +45,7 @@ export default class DropdownItem extends Component {
     selected: PropTypes.bool,
 
     /** Display text. */
-    text: customPropTypes.content,
+    text: customPropTypes.contentShorthand,
 
     /** Stored value */
     value: PropTypes.oneOfType([

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -24,16 +24,13 @@ export default class DropdownItem extends Component {
     active: PropTypes.bool,
 
     /** Primary content. */
-    children: customPropTypes.every([
-      customPropTypes.disallow(['text']),
-      PropTypes.node,
-    ]),
+    children: PropTypes.node,
 
-    /** Additional className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Additional text with less emphasis. */
-    description: PropTypes.string,
+    description: customPropTypes.item,
 
     /** A dropdown item can be disabled. */
     disabled: PropTypes.bool,
@@ -48,13 +45,7 @@ export default class DropdownItem extends Component {
     selected: PropTypes.bool,
 
     /** Display text. */
-    text: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.oneOfType([
-        PropTypes.number,
-        PropTypes.string,
-      ]),
-    ]),
+    text: customPropTypes.content,
 
     /** Stored value */
     value: PropTypes.oneOfType([
@@ -106,8 +97,7 @@ export default class DropdownItem extends Component {
       <ElementType {...rest} className={classes} onClick={this.handleClick}>
         {createShorthand('span', val => ({ className: 'description', children: val }), description)}
         {Icon.create(iconName)}
-        {text}
-        {children}
+        {children || text}
       </ElementType>
     )
   }

--- a/src/modules/Dropdown/DropdownMenu.js
+++ b/src/modules/Dropdown/DropdownMenu.js
@@ -27,10 +27,10 @@ DropdownMenu.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Should be <Dropdown.Item /> components. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the className. */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -38,10 +38,10 @@ class Modal extends Component {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
 
-    /** Primary content of the modal. Consider using ModalHeader, ModalContent or ModalActions here */
+    /** Primary content. */
     children: PropTypes.node,
 
-    /** Classes to add to the modal className */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** A modal can reduce its complexity */

--- a/src/modules/Modal/ModalActions.js
+++ b/src/modules/Modal/ModalActions.js
@@ -27,10 +27,10 @@ ModalActions.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the modal actions */
-  children: PropTypes.any,
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes to add to the modal actions className */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/modules/Modal/ModalContent.js
+++ b/src/modules/Modal/ModalContent.js
@@ -32,10 +32,10 @@ ModalContent.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the modal content */
-  children: PropTypes.any,
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes to add to the modal content className */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A modal can contain image content */

--- a/src/modules/Modal/ModalDescription.js
+++ b/src/modules/Modal/ModalDescription.js
@@ -27,10 +27,10 @@ ModalDescription.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content */
-  children: PropTypes.any,
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes to add to the className */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/modules/Modal/ModalHeader.js
+++ b/src/modules/Modal/ModalHeader.js
@@ -27,10 +27,10 @@ ModalHeader.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the modal header */
-  children: PropTypes.any,
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes to add to the modal header className */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -100,10 +100,10 @@ Progress.propTypes = {
   /** A progress bar can have different colors. */
   color: PropTypes.oneOf(Progress._meta.props.color),
 
-  /** Displayed as a label immediately below the progress bar. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Additional className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A progress bar be disabled. */

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -35,7 +35,7 @@ export default class Rating extends Component {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
 
-    /** Additional className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /**

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -133,7 +133,7 @@ export default class Search extends Component {
     /** A search can display results from remote content ordered by categories. */
     category: PropTypes.bool,
 
-    /** Additional classes added to the root element. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** A search can have its results take up the width of its container. */

--- a/src/modules/Search/SearchCategory.js
+++ b/src/modules/Search/SearchCategory.js
@@ -44,10 +44,10 @@ SearchCategory.propTypes = {
   /** The item currently selected by keyboard shortcut. */
   active: PropTypes.bool,
 
-  /** Should be <Search.Result /> components. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Display name. */

--- a/src/modules/Search/SearchResult.js
+++ b/src/modules/Search/SearchResult.js
@@ -34,7 +34,7 @@ export default class SearchResult extends Component {
     /** The item currently selected by keyboard shortcut. */
     active: PropTypes.bool,
 
-    /** Additional className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** Additional text with less emphasis. */

--- a/src/modules/Search/SearchResults.js
+++ b/src/modules/Search/SearchResults.js
@@ -27,10 +27,10 @@ SearchResults.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Should be <Search.Result /> components. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes to add to the className. */
+  /** Additional classes. */
   className: PropTypes.string,
 }
 

--- a/src/views/Card/Card.js
+++ b/src/views/Card/Card.js
@@ -36,53 +36,35 @@ export default class Card extends Component {
     /** A Card can center itself inside its container. */
     centered: PropTypes.bool,
 
-    /** Primary content of the Card. */
-    children: customPropTypes.every([
-      customPropTypes.disallow(['description', 'header', 'image', 'meta']),
-      PropTypes.node,
-    ]),
+    /** Primary content. */
+    children: PropTypes.node,
 
-    /** Classes that will be added to the Card className. */
+    /** Additional classes. */
     className: PropTypes.string,
 
     /** A Card can be formatted to display different colors. */
     color: PropTypes.oneOf(_meta.props.color),
 
-    /** Shorthand prop for CardDescription. Mutually exclusive with children. */
-    description: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.node,
-    ]),
+    /** Shorthand for CardDescription. */
+    description: customPropTypes.item,
 
-    /** Shorthand prop for CardContent containing extra prop. Mutually exclusive with children. */
-    extra: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.node,
-    ]),
+    /** Shorthand for primary content of CardContent. */
+    extra: customPropTypes.content,
 
     /** A Card can be formatted to take up the width of its container. */
     fluid: PropTypes.bool,
 
-    /** Shorthand prop for CardHeader. Mutually exclusive with children. */
-    header: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.node,
-    ]),
+    /** Shorthand for CardHeader. */
+    header: customPropTypes.item,
 
     /** Render as an `a` tag instead of a `div` and adds the href attribute. */
     href: PropTypes.string,
 
     /** A card can contain an Image component. */
-    image: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.node,
-    ]),
+    image: customPropTypes.item,
 
-    /** Shorthand prop for CardMeta. Mutually exclusive with children. */
-    meta: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.node,
-    ]),
+    /** Shorthand for CardMeta. */
+    meta: customPropTypes.item,
 
     /** Render as an `a` tag instead of a `div` and called with event on Card click. */
     onClick: PropTypes.func,

--- a/src/views/Card/Card.js
+++ b/src/views/Card/Card.js
@@ -46,25 +46,25 @@ export default class Card extends Component {
     color: PropTypes.oneOf(_meta.props.color),
 
     /** Shorthand for CardDescription. */
-    description: customPropTypes.item,
+    description: customPropTypes.itemShorthand,
 
     /** Shorthand for primary content of CardContent. */
-    extra: customPropTypes.content,
+    extra: customPropTypes.contentShorthand,
 
     /** A Card can be formatted to take up the width of its container. */
     fluid: PropTypes.bool,
 
     /** Shorthand for CardHeader. */
-    header: customPropTypes.item,
+    header: customPropTypes.itemShorthand,
 
     /** Render as an `a` tag instead of a `div` and adds the href attribute. */
     href: PropTypes.string,
 
     /** A card can contain an Image component. */
-    image: customPropTypes.item,
+    image: customPropTypes.itemShorthand,
 
     /** Shorthand for CardMeta. */
-    meta: customPropTypes.item,
+    meta: customPropTypes.itemShorthand,
 
     /** Render as an `a` tag instead of a `div` and called with event on Card click. */
     onClick: PropTypes.func,

--- a/src/views/Card/CardContent.js
+++ b/src/views/Card/CardContent.js
@@ -49,44 +49,23 @@ CardContent.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the CardContent. Mutually exclusive with all shorthand props. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['description', 'header', 'meta']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the CardContent className */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand prop for CardDescription. Mutually exclusive with children. */
-  description: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for CardDescription. */
+  description: customPropTypes.item,
 
   /** A card can contain extra content meant to be formatted separately from the main content */
   extra: PropTypes.bool,
 
-  /** Shorthand prop for CardHeader. Mutually exclusive with children. */
-  header: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for CardHeader. */
+  header: customPropTypes.item,
 
-  /** Shorthand prop for CardMeta. Mutually exclusive with children. */
-  meta: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for CardMeta. */
+  meta: customPropTypes.item,
 }
 
 export default CardContent

--- a/src/views/Card/CardContent.js
+++ b/src/views/Card/CardContent.js
@@ -56,16 +56,16 @@ CardContent.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for CardDescription. */
-  description: customPropTypes.item,
+  description: customPropTypes.itemShorthand,
 
   /** A card can contain extra content meant to be formatted separately from the main content */
   extra: PropTypes.bool,
 
   /** Shorthand for CardHeader. */
-  header: customPropTypes.item,
+  header: customPropTypes.itemShorthand,
 
   /** Shorthand for CardMeta. */
-  meta: customPropTypes.item,
+  meta: customPropTypes.itemShorthand,
 }
 
 export default CardContent

--- a/src/views/Card/CardDescription.js
+++ b/src/views/Card/CardDescription.js
@@ -17,7 +17,7 @@ function CardDescription(props) {
   const rest = getUnhandledProps(CardDescription, props)
   const ElementType = getElementType(CardDescription, props)
 
-  return <ElementType {...rest} className={classes}>{ children || content }</ElementType>
+  return <ElementType {...rest} className={classes}>{children || content}</ElementType>
 }
 
 CardDescription._meta = {
@@ -30,23 +30,14 @@ CardDescription.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the CardDescription. Mutually exclusive with content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the CardDescription className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the CardDescription. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default CardDescription

--- a/src/views/Card/CardDescription.js
+++ b/src/views/Card/CardDescription.js
@@ -37,7 +37,7 @@ CardDescription.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default CardDescription

--- a/src/views/Card/CardGroup.js
+++ b/src/views/Card/CardGroup.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
@@ -27,7 +28,11 @@ function CardGroup(props) {
   const rest = getUnhandledProps(CardGroup, props)
   const ElementType = getElementType(CardGroup, props)
 
-  const content = !items ? children : items.map(item => {
+  if (children) {
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
+  }
+
+  const content = _.map(items, item => {
     const key = item.key || [item.header, item.description].join('-')
     return <Card key={key} {...item} />
   })
@@ -48,28 +53,17 @@ CardGroup.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** A group of Card components. Mutually exclusive with items. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['items']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the CardGroup className */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A group of cards can double its column width for mobile */
   doubling: PropTypes.bool,
 
-  /** Shorthand prop for children. Mutually exclusive with children. */
-  items: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.arrayOf(PropTypes.shape({
-      description: PropTypes.node,
-      meta: PropTypes.node,
-      key: PropTypes.string,
-      header: PropTypes.node,
-    })),
-  ]),
+  /** Shorthand array of props for Card. */
+  items: customPropTypes.items,
 
   /** A group of cards can set how many cards should exist in a row */
   itemsPerRow: PropTypes.oneOf(CardGroup._meta.props.itemsPerRow),

--- a/src/views/Card/CardGroup.js
+++ b/src/views/Card/CardGroup.js
@@ -63,7 +63,7 @@ CardGroup.propTypes = {
   doubling: PropTypes.bool,
 
   /** Shorthand array of props for Card. */
-  items: customPropTypes.items,
+  items: customPropTypes.collectionShorthand,
 
   /** A group of cards can set how many cards should exist in a row */
   itemsPerRow: PropTypes.oneOf(CardGroup._meta.props.itemsPerRow),

--- a/src/views/Card/CardHeader.js
+++ b/src/views/Card/CardHeader.js
@@ -30,20 +30,14 @@ CardHeader.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the CardHeader. Mutually exclusive with content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the CardHeader className */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the CardHeader. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default CardHeader

--- a/src/views/Card/CardHeader.js
+++ b/src/views/Card/CardHeader.js
@@ -37,7 +37,7 @@ CardHeader.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default CardHeader

--- a/src/views/Card/CardMeta.js
+++ b/src/views/Card/CardMeta.js
@@ -37,7 +37,7 @@ CardMeta.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default CardMeta

--- a/src/views/Card/CardMeta.js
+++ b/src/views/Card/CardMeta.js
@@ -30,23 +30,14 @@ CardMeta.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the CardMeta. Mutually exclusive with content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the CardMeta className */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the CardMeta. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default CardMeta

--- a/src/views/Feed/Feed.js
+++ b/src/views/Feed/Feed.js
@@ -59,23 +59,14 @@ Feed.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the Feed. Mutually exclusive with events. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['events']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the Feed className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Array of props for FeedEvent. Mutually exclusive with children. */
-  events: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.arrayOf(PropTypes.shape({
-      childKey: PropTypes.childKey,
-      // allow FeedEvent to validate its own props
-    })),
-  ]),
+  /** Shorthand array of props for FeedEvent. */
+  events: customPropTypes.items,
 
   /** A feed can have different sizes. */
   size: PropTypes.oneOf(Feed._meta.props.size),

--- a/src/views/Feed/Feed.js
+++ b/src/views/Feed/Feed.js
@@ -66,7 +66,7 @@ Feed.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand array of props for FeedEvent. */
-  events: customPropTypes.items,
+  events: customPropTypes.collectionShorthand,
 
   /** A feed can have different sizes. */
   size: PropTypes.oneOf(Feed._meta.props.size),

--- a/src/views/Feed/FeedContent.js
+++ b/src/views/Feed/FeedContent.js
@@ -52,22 +52,22 @@ FeedContent.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** An event can contain a date. */
-  date: customPropTypes.item,
+  date: customPropTypes.itemShorthand,
 
   /** Shorthand for FeedExtra with images. */
   extraImages: FeedExtra.propTypes.images,
 
   /** Shorthand for FeedExtra with text. */
-  extraText: customPropTypes.item,
+  extraText: customPropTypes.itemShorthand,
 
   /** Shorthand for FeedMeta. */
-  meta: customPropTypes.item,
+  meta: customPropTypes.itemShorthand,
 
   /** Shorthand for FeedSummary. */
-  summary: customPropTypes.item,
+  summary: customPropTypes.itemShorthand,
 }
 
 export default FeedContent

--- a/src/views/Feed/FeedContent.js
+++ b/src/views/Feed/FeedContent.js
@@ -45,44 +45,29 @@ FeedContent.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the FeedContent. Mutually exclusive with all shorthand props. */
-  children: customPropTypes.every([
-    customPropTypes.disallow([
-      'date',
-      'extraImages',
-      'extraText',
-      'meta',
-      'summary',
-    ]),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the FeedContent className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
   /** An event can contain a date. */
-  date: FeedDate.propTypes.content,
+  date: customPropTypes.item,
 
-  /** Shorthand for the FeedExtra component with images. Mutually exclusive with children. */
+  /** Shorthand for FeedExtra with images. */
   extraImages: FeedExtra.propTypes.images,
 
-  /** Shorthand for the FeedExtra component with text. Mutually exclusive with children. */
-  extraText: FeedExtra.propTypes.content,
+  /** Shorthand for FeedExtra with text. */
+  extraText: customPropTypes.item,
 
-  /** Shorthand for the FeedMeta component. Mutually exclusive with children. */
-  meta: FeedMeta.propTypes.content,
+  /** Shorthand for FeedMeta. */
+  meta: customPropTypes.item,
 
-  /** Shorthand for the FeedSummary component. Mutually exclusive with children. */
-  summary: FeedSummary.propTypes.content,
+  /** Shorthand for FeedSummary. */
+  summary: customPropTypes.item,
 }
 
 export default FeedContent

--- a/src/views/Feed/FeedDate.js
+++ b/src/views/Feed/FeedDate.js
@@ -36,7 +36,7 @@ FeedDate.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default FeedDate

--- a/src/views/Feed/FeedDate.js
+++ b/src/views/Feed/FeedDate.js
@@ -29,23 +29,14 @@ FeedDate.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the FeedDate. Mutually exclusive with the content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the FeedDate className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default FeedDate

--- a/src/views/Feed/FeedEvent.js
+++ b/src/views/Feed/FeedEvent.js
@@ -59,10 +59,10 @@ FeedEvent.propTypes = {
   extraText: FeedContent.propTypes.extraText,
 
   /** An event can contain icon label. */
-  icon: customPropTypes.item,
+  icon: customPropTypes.itemShorthand,
 
   /** An event can contain image label. */
-  image: customPropTypes.item,
+  image: customPropTypes.itemShorthand,
 
   /** Shorthand for FeedMeta. */
   meta: FeedContent.propTypes.meta,

--- a/src/views/Feed/FeedEvent.js
+++ b/src/views/Feed/FeedEvent.js
@@ -40,61 +40,34 @@ FeedEvent.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the FeedEvent. Mutually exclusive with all shorthand props. */
-  children: customPropTypes.every([
-    customPropTypes.disallow([
-      'date',
-      'extraImages',
-      'extraText',
-      'icon',
-      'image',
-      'meta',
-      'summary',
-    ]),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the FeedEvent className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for FeedContent. Mutually exclusive with children. */
+  /** Shorthand for FeedContent. */
   content: FeedContent.propTypes.content,
 
-  /** Shorthand for FeedDate. Mutually exclusive with children. */
+  /** Shorthand for FeedDate. */
   date: FeedContent.propTypes.date,
 
-  /** Shorthand for FeedExtra with images. Mutually exclusive with children. */
+  /** Shorthand for FeedExtra with images. */
   extraImages: FeedContent.propTypes.extraImages,
 
-  /** Shorthand for FeedExtra with content. Mutually exclusive with children. */
+  /** Shorthand for FeedExtra with content. */
   extraText: FeedContent.propTypes.extraText,
 
-  /** An event can contain icon label. Mutually exclusive with children. */
-  icon: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.object,
-      PropTypes.element,
-    ]),
-  ]),
+  /** An event can contain icon label. */
+  icon: customPropTypes.item,
 
-  /** An event can contain image label. Mutually exclusive with children. */
-  image: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.object,
-      PropTypes.element,
-    ]),
-  ]),
+  /** An event can contain image label. */
+  image: customPropTypes.item,
 
-  /** Shorthand for FeedMeta. Mutually exclusive with children. */
+  /** Shorthand for FeedMeta. */
   meta: FeedContent.propTypes.meta,
 
-  /** Shorthand for FeedSummary. Mutually exclusive with children. */
+  /** Shorthand for FeedSummary. */
   summary: FeedContent.propTypes.summary,
 }
 

--- a/src/views/Feed/FeedExtra.js
+++ b/src/views/Feed/FeedExtra.js
@@ -50,29 +50,22 @@ FeedExtra.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the FeedExtra. Mutually exclusive with content. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Shorthand for children. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
-
-  /** Classes that will be added to the FeedExtra className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** An event can contain additional information like a set of images. Mutually exclusive with children. */
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
+
+  /** An event can contain additional information like a set of images. */
   images: customPropTypes.every([
     customPropTypes.disallow(['text']),
     PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.arrayOf(PropTypes.string),
+      customPropTypes.items,
     ]),
-    customPropTypes.givenProps(
-      { images: PropTypes.arrayOf(PropTypes.string).isRequired },
-      customPropTypes.disallow(['children']),
-    ),
   ]),
 
   /** An event can contain additional text information. */

--- a/src/views/Feed/FeedExtra.js
+++ b/src/views/Feed/FeedExtra.js
@@ -57,14 +57,14 @@ FeedExtra.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** An event can contain additional information like a set of images. */
   images: customPropTypes.every([
     customPropTypes.disallow(['text']),
     PropTypes.oneOfType([
       PropTypes.bool,
-      customPropTypes.items,
+      customPropTypes.collectionShorthand,
     ]),
   ]),
 

--- a/src/views/Feed/FeedLabel.js
+++ b/src/views/Feed/FeedLabel.js
@@ -39,45 +39,20 @@ FeedLabel.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the FeedLabel. Mutually exclusive with all shorthand props. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content', 'icon', 'image']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the FeedLabel className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for children. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
-  /** An event can contain icon label. Mutually exclusive with children. */
-  icon: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.object,
-      PropTypes.element,
-    ]),
-  ]),
+  /** An event can contain icon label. */
+  icon: customPropTypes.item,
 
-  /** An event can contain image label. Mutually exclusive with children. */
-  image: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.object,
-      PropTypes.element,
-    ]),
-  ]),
+  /** An event can contain image label. */
+  image: customPropTypes.item,
 }
 
 export default FeedLabel

--- a/src/views/Feed/FeedLabel.js
+++ b/src/views/Feed/FeedLabel.js
@@ -46,13 +46,13 @@ FeedLabel.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** An event can contain icon label. */
-  icon: customPropTypes.item,
+  icon: customPropTypes.itemShorthand,
 
   /** An event can contain image label. */
-  image: customPropTypes.item,
+  image: customPropTypes.itemShorthand,
 }
 
 export default FeedLabel

--- a/src/views/Feed/FeedLike.js
+++ b/src/views/Feed/FeedLike.js
@@ -41,34 +41,17 @@ FeedLike.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the FeedLike. Mutually exclusive with content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content', 'icon']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the FeedLike className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for children. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
   /** Shorthand for icon. Mutually exclusive with children. */
-  icon: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.object,
-      PropTypes.element,
-    ]),
-  ]),
+  icon: customPropTypes.item,
 }
 
 export default FeedLike

--- a/src/views/Feed/FeedLike.js
+++ b/src/views/Feed/FeedLike.js
@@ -48,10 +48,10 @@ FeedLike.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** Shorthand for icon. Mutually exclusive with children. */
-  icon: customPropTypes.item,
+  icon: customPropTypes.itemShorthand,
 }
 
 export default FeedLike

--- a/src/views/Feed/FeedMeta.js
+++ b/src/views/Feed/FeedMeta.js
@@ -45,10 +45,10 @@ FeedMeta.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** Shorthand for FeedLike. */
-  like: customPropTypes.item,
+  like: customPropTypes.itemShorthand,
 }
 
 export default FeedMeta

--- a/src/views/Feed/FeedMeta.js
+++ b/src/views/Feed/FeedMeta.js
@@ -38,26 +38,17 @@ FeedMeta.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the FeedMeta. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content', 'like']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the FeedMeta className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for children. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
-  /** Shorthand for the FeedLike component. Mutually exclusive with children. */
-  like: FeedLike.propTypes.content,
+  /** Shorthand for FeedLike. */
+  like: customPropTypes.item,
 }
 
 export default FeedMeta

--- a/src/views/Feed/FeedSummary.js
+++ b/src/views/Feed/FeedSummary.js
@@ -40,41 +40,20 @@ FeedSummary.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the FeedSummary. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content', 'date', 'user']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the FeedSummary className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for children. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
-  /** Shorthand for the FeedDate component. Mutually exclusive with children. */
-  date: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for FeedDate. */
+  date: customPropTypes.item,
 
-  /** Shorthand for the FeedUser component. Mutually exclusive with children. */
-  user: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for FeedUser. */
+  user: customPropTypes.item,
 }
 
 export default FeedSummary

--- a/src/views/Feed/FeedSummary.js
+++ b/src/views/Feed/FeedSummary.js
@@ -47,13 +47,13 @@ FeedSummary.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** Shorthand for FeedDate. */
-  date: customPropTypes.item,
+  date: customPropTypes.itemShorthand,
 
   /** Shorthand for FeedUser. */
-  user: customPropTypes.item,
+  user: customPropTypes.itemShorthand,
 }
 
 export default FeedSummary

--- a/src/views/Feed/FeedUser.js
+++ b/src/views/Feed/FeedUser.js
@@ -27,23 +27,14 @@ FeedUser.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the FeedUser. Mutually exclusive with content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the FeedUser className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for children. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 FeedUser.defaultProps = {

--- a/src/views/Feed/FeedUser.js
+++ b/src/views/Feed/FeedUser.js
@@ -34,7 +34,7 @@ FeedUser.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 FeedUser.defaultProps = {

--- a/src/views/Item/Item.js
+++ b/src/views/Item/Item.js
@@ -61,47 +61,29 @@ Item.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the Item. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes that will be added to the Item className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Shorthand for ItemContent component. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  content: customPropTypes.content,
 
   /** Shorthand for ItemDescription component. */
-  description: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  description: customPropTypes.item,
 
   /** Shorthand for ItemExtra component. */
-  extra: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  extra: customPropTypes.item,
 
   /** Shorthand for ItemImage component. */
-  image: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  image: customPropTypes.item,
 
   /** Shorthand for ItemHeader component. */
-  header: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  header: customPropTypes.item,
 
   /** Shorthand for ItemMeta component. */
-  meta: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  meta: customPropTypes.item,
 }
 
 export default Item

--- a/src/views/Item/Item.js
+++ b/src/views/Item/Item.js
@@ -68,22 +68,22 @@ Item.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for ItemContent component. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** Shorthand for ItemDescription component. */
-  description: customPropTypes.item,
+  description: customPropTypes.itemShorthand,
 
   /** Shorthand for ItemExtra component. */
-  extra: customPropTypes.item,
+  extra: customPropTypes.itemShorthand,
 
   /** Shorthand for ItemImage component. */
-  image: customPropTypes.item,
+  image: customPropTypes.itemShorthand,
 
   /** Shorthand for ItemHeader component. */
-  header: customPropTypes.item,
+  header: customPropTypes.itemShorthand,
 
   /** Shorthand for ItemMeta component. */
-  meta: customPropTypes.item,
+  meta: customPropTypes.itemShorthand,
 }
 
 export default Item

--- a/src/views/Item/ItemContent.js
+++ b/src/views/Item/ItemContent.js
@@ -28,13 +28,17 @@ function ItemContent(props) {
   const rest = getUnhandledProps(ItemContent, props)
   const ElementType = getElementType(ItemContent, props)
 
+  if (children) {
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
+  }
+
   return (
     <ElementType {...rest} className={classes}>
       {createShorthand(ItemHeader, val => ({ content: val }), header)}
       {createShorthand(ItemMeta, val => ({ content: val }), meta)}
       {createShorthand(ItemDescription, val => ({ content: val }), description)}
       {createShorthand(ItemExtra, val => ({ content: val }), extra)}
-      {children || content}
+      {content}
     </ElementType>
   )
 }
@@ -52,44 +56,26 @@ ItemContent.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the ItemContent. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the ItemContent className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the ItemContent. Mutually exclusive with the children prop. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 
-  /** Shorthand for of the ItemDescription. Mutually exclusive with the children prop. */
-  description: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for ItemDescription component. */
+  description: customPropTypes.item,
 
-  /** Shorthand for ItemExtra component. Mutually exclusive with the children prop. */
-  extra: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for ItemExtra component. */
+  extra: customPropTypes.item,
 
-  /** Shorthand for ItemHeader component. Mutually exclusive with the children prop. */
-  header: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for ItemHeader component. */
+  header: customPropTypes.item,
 
-  /** Shorthand for ItemMeta component. Mutually exclusive with the children prop. */
-  meta: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for ItemMeta component. */
+  meta: customPropTypes.item,
 
   /** Content can specify its vertical alignment */
   verticalAlign: PropTypes.oneOf(ItemContent._meta.props.verticalAlign),

--- a/src/views/Item/ItemContent.js
+++ b/src/views/Item/ItemContent.js
@@ -63,19 +63,19 @@ ItemContent.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 
   /** Shorthand for ItemDescription component. */
-  description: customPropTypes.item,
+  description: customPropTypes.itemShorthand,
 
   /** Shorthand for ItemExtra component. */
-  extra: customPropTypes.item,
+  extra: customPropTypes.itemShorthand,
 
   /** Shorthand for ItemHeader component. */
-  header: customPropTypes.item,
+  header: customPropTypes.itemShorthand,
 
   /** Shorthand for ItemMeta component. */
-  meta: customPropTypes.item,
+  meta: customPropTypes.itemShorthand,
 
   /** Content can specify its vertical alignment */
   verticalAlign: PropTypes.oneOf(ItemContent._meta.props.verticalAlign),

--- a/src/views/Item/ItemDescription.js
+++ b/src/views/Item/ItemDescription.js
@@ -30,20 +30,14 @@ ItemDescription.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the ItemDescription. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the ItemDescription className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the ItemDescription. Mutually exclusive with the children prop. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default ItemDescription

--- a/src/views/Item/ItemDescription.js
+++ b/src/views/Item/ItemDescription.js
@@ -37,7 +37,7 @@ ItemDescription.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default ItemDescription

--- a/src/views/Item/ItemExtra.js
+++ b/src/views/Item/ItemExtra.js
@@ -37,7 +37,7 @@ ItemExtra.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default ItemExtra

--- a/src/views/Item/ItemExtra.js
+++ b/src/views/Item/ItemExtra.js
@@ -30,20 +30,14 @@ ItemExtra.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the ItemExtra. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the ItemExtra className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the ItemExtra. Mutually exclusive with the children prop. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default ItemExtra

--- a/src/views/Item/ItemGroup.js
+++ b/src/views/Item/ItemGroup.js
@@ -28,7 +28,7 @@ function ItemGroup(props) {
   const rest = getUnhandledProps(ItemGroup, props)
   const ElementType = getElementType(ItemGroup, props)
 
-  if (!items) {
+  if (children) {
     return <ElementType {...rest} className={classes}>{children}</ElementType>
   }
 
@@ -55,27 +55,17 @@ ItemGroup.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the ItemGroup. */
+  /** Primary content. */
   children: PropTypes.node,
 
-  /** Classes that will be added to the ItemGroup className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Items can be divided to better distinguish between grouped content. */
   divided: PropTypes.bool,
 
-  /** Array of props for Item. */
-  items: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.arrayOf(PropTypes.shape({
-      childKey: PropTypes.oneOfType([
-        PropTypes.number,
-        PropTypes.string,
-      ]),
-      // this object is spread on the Item
-      // allow it to validate props instead
-    })),
-  ]),
+  /** Shorthand array of props for Item. */
+  items: customPropTypes.items,
 
   /** An item can be formatted so that the entire contents link to another page. */
   link: PropTypes.bool,

--- a/src/views/Item/ItemGroup.js
+++ b/src/views/Item/ItemGroup.js
@@ -65,7 +65,7 @@ ItemGroup.propTypes = {
   divided: PropTypes.bool,
 
   /** Shorthand array of props for Item. */
-  items: customPropTypes.items,
+  items: customPropTypes.collectionShorthand,
 
   /** An item can be formatted so that the entire contents link to another page. */
   link: PropTypes.bool,

--- a/src/views/Item/ItemHeader.js
+++ b/src/views/Item/ItemHeader.js
@@ -37,7 +37,7 @@ ItemHeader.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default ItemHeader

--- a/src/views/Item/ItemHeader.js
+++ b/src/views/Item/ItemHeader.js
@@ -30,20 +30,14 @@ ItemHeader.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the ItemHeader. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the ItemHeader className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the ItemHeader. Mutually exclusive with the children prop. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default ItemHeader

--- a/src/views/Item/ItemMeta.js
+++ b/src/views/Item/ItemMeta.js
@@ -30,20 +30,14 @@ ItemMeta.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the ItemMeta. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the ItemMeta className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the ItemMeta. Mutually exclusive with the children prop. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  content: customPropTypes.content,
 }
 
 export default ItemMeta

--- a/src/views/Item/ItemMeta.js
+++ b/src/views/Item/ItemMeta.js
@@ -37,7 +37,7 @@ ItemMeta.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  content: customPropTypes.content,
+  content: customPropTypes.contentShorthand,
 }
 
 export default ItemMeta

--- a/src/views/Statistic/Statistic.js
+++ b/src/views/Statistic/Statistic.js
@@ -56,13 +56,10 @@ Statistic.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the Statistic. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['label', 'value']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the Statistic className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A statistic can be formatted to be different colors. */
@@ -77,11 +74,8 @@ Statistic.propTypes = {
   /** A statistic can be formatted to fit on a dark background. */
   inverted: PropTypes.bool,
 
-  /** Label content of the Statistic. Mutually exclusive with the children prop. */
-  label: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Label content of the Statistic. */
+  label: customPropTypes.content,
 
   /** A statistic can vary in size. */
   size: PropTypes.oneOf(Statistic._meta.props.size),
@@ -89,14 +83,8 @@ Statistic.propTypes = {
   /** Format the StatisticValue with smaller font size to fit nicely beside number values. */
   text: PropTypes.bool,
 
-  /** Value content of the Statistic. Mutually exclusive with the children prop. */
-  value: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-  ]),
+  /** Value content of the Statistic. */
+  value: customPropTypes.content,
 }
 
 Statistic.Group = StatisticGroup

--- a/src/views/Statistic/Statistic.js
+++ b/src/views/Statistic/Statistic.js
@@ -75,7 +75,7 @@ Statistic.propTypes = {
   inverted: PropTypes.bool,
 
   /** Label content of the Statistic. */
-  label: customPropTypes.content,
+  label: customPropTypes.contentShorthand,
 
   /** A statistic can vary in size. */
   size: PropTypes.oneOf(Statistic._meta.props.size),
@@ -84,7 +84,7 @@ Statistic.propTypes = {
   text: PropTypes.bool,
 
   /** Value content of the Statistic. */
-  value: customPropTypes.content,
+  value: customPropTypes.contentShorthand,
 }
 
 Statistic.Group = StatisticGroup

--- a/src/views/Statistic/StatisticGroup.js
+++ b/src/views/Statistic/StatisticGroup.js
@@ -29,7 +29,7 @@ function StatisticGroup(props) {
     return <ElementType {...rest} className={classes}>{children}</ElementType>
   }
 
-  let itemsJSX = _.map(items, item => (
+  const itemsJSX = _.map(items, item => (
     <Statistic key={item.childKey || [item.label, item.title].join('-')} {...item} />
   ))
 
@@ -49,27 +49,17 @@ StatisticGroup.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the StatisticGroup. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the StatisticGroup className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** A statistic can present its measurement horizontally. */
   horizontal: PropTypes.bool,
 
   /** Array of props for Statistic. */
-  items: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.arrayOf(PropTypes.shape({
-      childKey: PropTypes.string,
-      // this object is spread on the Statistic
-      // allow it to validate props instead
-    })),
-  ]),
+  items: customPropTypes.items,
 
   /** A statistic group can have its items divided evenly. */
   widths: PropTypes.oneOf(StatisticGroup._meta.props.widths),

--- a/src/views/Statistic/StatisticGroup.js
+++ b/src/views/Statistic/StatisticGroup.js
@@ -59,7 +59,7 @@ StatisticGroup.propTypes = {
   horizontal: PropTypes.bool,
 
   /** Array of props for Statistic. */
-  items: customPropTypes.items,
+  items: customPropTypes.collectionShorthand,
 
   /** A statistic group can have its items divided evenly. */
   widths: PropTypes.oneOf(StatisticGroup._meta.props.widths),

--- a/src/views/Statistic/StatisticLabel.js
+++ b/src/views/Statistic/StatisticLabel.js
@@ -27,20 +27,14 @@ StatisticLabel.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the StatisticLabel. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the StatisticLabel className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
-  /** Primary content of the StatisticLabel. Mutually exclusive with the children prop. */
-  label: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  /** Shorthand for primary content. */
+  label: customPropTypes.content,
 }
 
 export default StatisticLabel

--- a/src/views/Statistic/StatisticLabel.js
+++ b/src/views/Statistic/StatisticLabel.js
@@ -34,7 +34,7 @@ StatisticLabel.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for primary content. */
-  label: customPropTypes.content,
+  label: customPropTypes.contentShorthand,
 }
 
 export default StatisticLabel

--- a/src/views/Statistic/StatisticValue.js
+++ b/src/views/Statistic/StatisticValue.js
@@ -38,7 +38,7 @@ StatisticValue.propTypes = {
   text: PropTypes.bool,
 
   /** Primary content of the StatisticValue. Mutually exclusive with the children prop. */
-  value: customPropTypes.content,
+  value: customPropTypes.contentShorthand,
 }
 
 export default StatisticValue

--- a/src/views/Statistic/StatisticValue.js
+++ b/src/views/Statistic/StatisticValue.js
@@ -28,23 +28,17 @@ StatisticValue.propTypes = {
   /** An element type to render as (string or function). */
   as: customPropTypes.as,
 
-  /** Primary content of the StatisticValue. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+  /** Primary content. */
+  children: PropTypes.node,
 
-  /** Classes that will be added to the StatisticValue className. */
+  /** Additional classes. */
   className: PropTypes.string,
 
   /** Format the value with smaller font size to fit nicely beside number values. */
   text: PropTypes.bool,
 
   /** Primary content of the StatisticValue. Mutually exclusive with the children prop. */
-  value: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+  value: customPropTypes.content,
 }
 
 export default StatisticValue


### PR DESCRIPTION
This adds a few new customPropTypes (took some code and ideas from #452, thanks @levithomason :+1:). It's very much WIP but wanted to get it up and get some feedback before I go too crazy here. The new propTypes are:
- `itemShorthand`
  - disallows children
  - one of: string, number, object, element
- `arrayOfShorthand` (better name?)
  - disallows children
  - arrayOf(itemShorthand)
- `collectionShorthand`
  - disallows children
  - one of: arrayOfShorthand, object, element
- `nodeShorthand`
  - disallows children
  - node

The large majority of our components have a `content` prop that can be rendered in place of the children. This was validated differently in various components as strings/numbers/elements, but really it can be any renderable thing. This is where the `nodeShorthand` came from. We could theoretically just use `node` but I wanted to be able to disallow children.

I also wound up simplifying/standardizing the doc blocks for common propTypes (there was like 10 ways we described the `className` prop haha). I did it via regex so it's super easy to change so let me know if you think the descriptions could be improved.

Open questions:
- We double-disallow right now, e.g. content disallows children, children disallows content. Is there anything wrong with only disallowing on one side? Assuming all shorthands disallow children, children could just be `PropTypes.node` which is definitely simpler. Currently it's a customPropType that disallows any shorthands (inferring which are shorthand props from Component.propTypes)

cc @levithomason @layershifter 
