### PR TITLE
refactor(Components): use a class if there are event handlers

### DIFF
--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 
 import {
   customPropTypes,
@@ -10,64 +10,62 @@ import {
 } from '../../lib'
 
 /**
- * A section sub-component for Breadcrumb component.
+ * A section sub-component for Breadcrumb component
  */
-function BreadcrumbSection(props) {
-  const { active, children, className, href, link, onClick } = props
-  const classes = cx(
-    useKeyOnly(active, 'active'),
-    className,
-    'section',
-  )
-  const rest = getUnhandledProps(BreadcrumbSection, props)
-  const ElementType = getElementType(BreadcrumbSection, props, () => {
-    if (link || onClick) return 'a'
-  })
+export default class BreadcrumbSection extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-  const handleClick = (e) => {
+    /** Style as the currently active section. */
+    active: PropTypes.bool,
+
+    /** Primary content of the Breadcrumb.Section. */
+    children: PropTypes.node,
+
+    /** Classes that will be added to the BreadcrumbSection className. */
+    className: PropTypes.string,
+
+    /** Render as an `a` tag instead of a `div`. */
+    link: customPropTypes.every([
+      customPropTypes.disallow(['href']),
+      PropTypes.bool,
+    ]),
+
+    /** Render as an `a` tag instead of a `div` and adds the href attribute. */
+    href: customPropTypes.every([
+      customPropTypes.disallow(['link']),
+      PropTypes.string,
+    ]),
+
+    /** Render as an `a` tag instead of a `div` and called with event on Section click. */
+    onClick: PropTypes.func,
+  }
+
+  static _meta = {
+    name: 'BreadcrumbSection',
+    type: META.TYPES.COLLECTION,
+    parent: 'Breadcrumb',
+  }
+
+  handleClick = (e) => {
+    const { onClick } = this.props
+
     if (onClick) onClick(e)
   }
 
-  return (
-    <ElementType {...rest} className={classes} href={href} onClick={handleClick}>
-      {children}
-    </ElementType>
-  )
+  render() {
+    const { active, children, className, href, link, onClick } = this.props
+    const classes = cx(
+      useKeyOnly(active, 'active'),
+      'section',
+      className,
+    )
+    const rest = getUnhandledProps(BreadcrumbSection, this.props)
+    const ElementType = getElementType(BreadcrumbSection, this.props, () => {
+      if (link || onClick) return 'a'
+    })
+
+    return <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>{children}</ElementType>
+  }
 }
-
-BreadcrumbSection._meta = {
-  name: 'BreadcrumbSection',
-  type: META.TYPES.COLLECTION,
-  parent: 'Breadcrumb',
-}
-
-BreadcrumbSection.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
-
-  /** Style as the currently active section. */
-  active: PropTypes.bool,
-
-  /** Primary content of the Breadcrumb.Section. */
-  children: PropTypes.node,
-
-  /** Classes that will be added to the BreadcrumbSection className. */
-  className: PropTypes.string,
-
-  /** Render as an `a` tag instead of a `div`. */
-  link: customPropTypes.every([
-    customPropTypes.disallow(['href']),
-    PropTypes.bool,
-  ]),
-
-  /** Render as an `a` tag instead of a `div` and adds the href attribute. */
-  href: customPropTypes.every([
-    customPropTypes.disallow(['link']),
-    PropTypes.string,
-  ]),
-
-  /** Render as an `a` tag instead of a `div` and called with event on Section click. */
-  onClick: PropTypes.func,
-}
-
-export default BreadcrumbSection

--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -55,7 +55,15 @@ export default class BreadcrumbSection extends Component {
   }
 
   render() {
-    const { active, children, className, href, link, onClick } = this.props
+    const {
+      active,
+      children,
+      className,
+      href,
+      link,
+      onClick,
+    } = this.props
+
     const classes = cx(
       useKeyOnly(active, 'active'),
       'section',

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -1,6 +1,6 @@
-import cx from 'classnames'
 import _ from 'lodash'
-import React, { PropTypes } from 'react'
+import cx from 'classnames'
+import React, { Component, PropTypes } from 'react'
 
 import {
   customPropTypes,
@@ -156,6 +156,15 @@ function formSerializer(formNode) {
   return json
 }
 
+const _meta = {
+  name: 'Form',
+  type: META.TYPES.COLLECTION,
+  props: {
+    widths: ['equal'],
+    size: _.without(SUI.SIZES, 'medium'),
+  },
+}
+
 /**
  * A Form displays a set of related user input fields in a structured way.
  * @see Button
@@ -167,96 +176,99 @@ function formSerializer(formNode) {
  * @see Select
  * @see TextArea
  */
-function Form(props) {
-  const { children, className, error, loading, onSubmit, size, success, warning, widths } = props
-  const classes = cx(
-    'ui',
-    size,
-    useKeyOnly(loading, 'loading'),
-    useKeyOnly(success, 'success'),
-    useKeyOnly(error, 'error'),
-    useKeyOnly(warning, 'warning'),
-    useWidthProp(widths, null, true),
-    'form',
-    className,
-  )
-  const rest = getUnhandledProps(Form, props)
-  const ElementType = getElementType(Form, props)
-  let _form
-
-  const handleSubmit = (e) => {
-    if (onSubmit) onSubmit(e, props.serializer(_form))
+export default class Form extends Component {
+  static defaultProps = {
+    as: 'form',
+    serializer: formSerializer,
   }
 
-  return (
-    <ElementType
-      {...rest}
-      className={classes}
-      onSubmit={handleSubmit}
-      ref={(c) => (_form = _form || c)}
-    >
-      {children}
-    </ElementType>
-  )
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
+
+    /** Primary content */
+    children: PropTypes.node,
+
+    /** Additional classes */
+    className: PropTypes.string,
+
+    /** Automatically show any error Message children */
+    error: PropTypes.bool,
+
+    /** Automatically show a loading indicator */
+    loading: PropTypes.bool,
+
+    /** Called with (event, jsonSerializedForm) on submit */
+    onSubmit: PropTypes.func,
+
+    /** Called onSubmit with the form node that returns the serialized form object */
+    serializer: PropTypes.func,
+
+    /** A form can vary in size */
+    size: PropTypes.oneOf(_meta.props.size),
+
+    /** Automatically show any success Message children */
+    success: PropTypes.bool,
+
+    /** Automatically show any warning Message children */
+    warning: PropTypes.bool,
+
+    /** Forms can automatically divide fields to be equal width */
+    widths: PropTypes.oneOf(_meta.props.widths),
+  }
+
+  static _meta = _meta
+
+  static Field = FormField
+  static Button = FormButton
+  static Checkbox = FormCheckbox
+  static Dropdown = FormDropdown
+  static Group = FormGroup
+  static Input = FormInput
+  static Radio = FormRadio
+  static Select = FormSelect
+  static TextArea = FormTextArea
+
+  _form = null
+
+  handleRef = (c) => (this._form = this._form || c)
+
+  handleSubmit = (e) => {
+    const { onSubmit, serializer } = this.props
+
+    if (onSubmit) onSubmit(e, serializer(this._form))
+  }
+
+  render() {
+    const {
+      children,
+      className,
+      error,
+      loading,
+      size,
+      success,
+      warning,
+      widths,
+    } = this.props
+
+    const classes = cx(
+      'ui',
+      size,
+      useKeyOnly(loading, 'loading'),
+      useKeyOnly(success, 'success'),
+      useKeyOnly(error, 'error'),
+      useKeyOnly(warning, 'warning'),
+      useWidthProp(widths, null, true),
+      'form',
+      className,
+    )
+    const rest = getUnhandledProps(Form, this.props)
+    const ElementType = getElementType(Form, this.props)
+
+    return (
+      <ElementType {...rest} className={classes} ref={this.handleRef} onSubmit={this.handleSubmit}>
+        {children}
+      </ElementType>
+    )
+  }
 }
-
-Form.Field = FormField
-Form.Button = FormButton
-Form.Checkbox = FormCheckbox
-Form.Dropdown = FormDropdown
-Form.Group = FormGroup
-Form.Input = FormInput
-Form.Radio = FormRadio
-Form.Select = FormSelect
-Form.TextArea = FormTextArea
-
-Form._meta = {
-  name: 'Form',
-  type: META.TYPES.COLLECTION,
-  props: {
-    widths: ['equal'],
-    size: _.without(SUI.SIZES, 'medium'),
-  },
-}
-
-Form.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
-
-  /** Primary content */
-  children: PropTypes.node,
-
-  /** Additional classes */
-  className: PropTypes.string,
-
-  /** Automatically show a loading indicator */
-  loading: PropTypes.bool,
-
-  /** Automatically show any success Message children */
-  success: PropTypes.bool,
-
-  /** Automatically show any error Message children */
-  error: PropTypes.bool,
-
-  /** Automatically show any warning Message children */
-  warning: PropTypes.bool,
-
-  /** A form can vary in size */
-  size: PropTypes.oneOf(Form._meta.props.size),
-
-  /** Forms can automatically divide fields to be equal width */
-  widths: PropTypes.oneOf(Form._meta.props.widths),
-
-  /** Called onSubmit with the form node that returns the serialized form object */
-  serializer: PropTypes.func,
-
-  /** Called with (event, jsonSerializedForm) on submit */
-  onSubmit: PropTypes.func,
-}
-
-Form.defaultProps = {
-  as: 'form',
-  serializer: formSerializer,
-}
-
-export default Form

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -254,9 +254,9 @@ export default class Form extends Component {
     const classes = cx(
       'ui',
       size,
+      useKeyOnly(error, 'error'),
       useKeyOnly(loading, 'loading'),
       useKeyOnly(success, 'success'),
-      useKeyOnly(error, 'error'),
       useKeyOnly(warning, 'warning'),
       useWidthProp(widths, null, true),
       'form',

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import cx from 'classnames'
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 
 import {
   customPropTypes,
@@ -13,42 +13,7 @@ import {
 } from '../../lib'
 import Icon from '../../elements/Icon'
 
-function MenuItem(props) {
-  const {
-    active, children, className, color, content, fitted, header, icon, index, link, name, onClick, position,
-  } = props
-  const classes = cx(
-    useKeyOnly(active, 'active'),
-    useKeyOrValueAndKey(fitted, 'fitted'),
-    useKeyOnly(icon === true || icon && !(name || content), 'icon'),
-    useKeyOnly(header, 'header'),
-    useKeyOnly(link, 'link'),
-    color,
-    position,
-    className,
-    'item',
-  )
-  const ElementType = getElementType(MenuItem, props, () => {
-    if (onClick) return 'a'
-  })
-  const handleClick = (e) => {
-    if (onClick) onClick(e, { name, index })
-  }
-  const rest = getUnhandledProps(MenuItem, props)
-
-  if (children) {
-    return <ElementType {...rest} className={classes} onClick={handleClick}>{children}</ElementType>
-  }
-
-  return (
-    <ElementType {...rest} className={classes} onClick={handleClick}>
-      {Icon.create(icon)}
-      {content || _.startCase(name)}
-    </ElementType>
-  )
-}
-
-MenuItem._meta = {
+const _meta = {
   name: 'MenuItem',
   type: META.TYPES.COLLECTION,
   parent: 'Menu',
@@ -59,57 +24,109 @@ MenuItem._meta = {
   },
 }
 
-MenuItem.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+export default class MenuItem extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-  /** A menu item can be active. */
-  active: PropTypes.bool,
+    /** A menu item can be active. */
+    active: PropTypes.bool,
 
-  /** Primary content of the MenuItem. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content']),
-    PropTypes.node,
-  ]),
+    /** Primary content of the MenuItem. */
+    children: customPropTypes.every([
+      customPropTypes.disallow(['content']),
+      PropTypes.node,
+    ]),
 
-  /** Classes that will be added to the MenuItem className. */
-  className: PropTypes.string,
+    /** Classes that will be added to the MenuItem className. */
+    className: PropTypes.string,
 
-  /** Additional colors can be specified. */
-  color: PropTypes.oneOf(MenuItem._meta.props.color),
+    /** Additional colors can be specified. */
+    color: PropTypes.oneOf(_meta.props.color),
 
-  /** Shorthand for primary content of the MenuItem. Mutually exclusive with the children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.string,
-  ]),
+    /** Shorthand for primary content of the MenuItem. Mutually exclusive with the children. */
+    content: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.string,
+    ]),
 
-  /** A menu item or menu can remove element padding, vertically or horizontally. */
-  fitted: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.oneOf(MenuItem._meta.props.fitted),
-  ]),
+    /** A menu item or menu can remove element padding, vertically or horizontally. */
+    fitted: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(_meta.props.fitted),
+    ]),
 
-  /** A menu item may include a header or may itself be a header. */
-  header: PropTypes.bool,
+    /** A menu item may include a header or may itself be a header. */
+    header: PropTypes.bool,
 
-  /** MenuItem can be only icon. */
-  icon: PropTypes.bool,
+    /** MenuItem can be only icon. */
+    icon: PropTypes.bool,
 
-  /** MenuItem index inside Menu. */
-  index: PropTypes.number,
+    /** MenuItem index inside Menu. */
+    index: PropTypes.number,
 
-  /** A menu item can be link. */
-  link: PropTypes.bool,
+    /** A menu item can be link. */
+    link: PropTypes.bool,
 
-  /** Internal name of the MenuItem. */
-  name: PropTypes.string,
+    /** Internal name of the MenuItem. */
+    name: PropTypes.string,
 
-  /** Render as an `a` tag instead of a `div` and called with event on MenuItem click. */
-  onClick: PropTypes.func,
+    /** Render as an `a` tag instead of a `div` and called with event on MenuItem click. */
+    onClick: PropTypes.func,
 
-  /** A menu item can take right position. */
-  position: PropTypes.oneOf(MenuItem._meta.props.position),
+    /** A menu item can take right position. */
+    position: PropTypes.oneOf(_meta.props.position),
+  }
+
+  static _meta = _meta
+
+  handleClick = (e) => {
+    const { index, name, onClick } = this.props
+
+    if (onClick) onClick(e, { name, index })
+  }
+
+  render() {
+    const {
+      active,
+      children,
+      className,
+      color,
+      content,
+      fitted,
+      header,
+      icon,
+      link,
+      name,
+      onClick,
+      position,
+    } = this.props
+
+    const classes = cx(
+      color,
+      position,
+      useKeyOnly(active, 'active'),
+      useKeyOnly(icon === true || icon && !(name || content), 'icon'),
+      useKeyOnly(header, 'header'),
+      useKeyOnly(link, 'link'),
+      useKeyOrValueAndKey(fitted, 'fitted'),
+      'item',
+      className,
+    )
+    const ElementType = getElementType(MenuItem, this.props, () => {
+      if (onClick) return 'a'
+    })
+    const rest = getUnhandledProps(MenuItem, this.props)
+
+    if (children) {
+      return <ElementType {...rest} className={classes} onClick={this.handleClick}>{children}</ElementType>
+    }
+
+    return (
+      <ElementType {...rest} className={classes} onClick={this.handleClick}>
+        {Icon.create(icon)}
+        {content || _.startCase(name)}
+      </ElementType>
+    )
+  }
 }
-
-export default MenuItem

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 
 import {
   createShorthand,
@@ -19,80 +19,7 @@ import Image from '../Image/Image'
 import LabelDetail from './LabelDetail'
 import LabelGroup from './LabelGroup'
 
-/**
- * A label displays content classification
- */
-function Label(props) {
-  const {
-    attached,
-    basic,
-    children,
-    circular,
-    className,
-    color,
-    content,
-    corner,
-    detail,
-    empty,
-    floating,
-    horizontal,
-    icon,
-    image,
-    onClick,
-    onRemove,
-    pointing,
-    removable,
-    ribbon,
-    size,
-    tag,
-  } = props
-
-  const handleClick = e => onClick && onClick(e, props)
-  const handleRemove = e => onRemove && onRemove(e, props)
-
-  const pointingClass = pointing === true && 'pointing'
-    || (pointing === 'left' || pointing === 'right') && `${pointing} pointing`
-    || (pointing === 'above' || pointing === 'below') && `pointing ${pointing}`
-
-  const classes = cx(
-    'ui',
-    color,
-    pointingClass,
-    size,
-    useKeyOnly(basic, 'basic'),
-    useKeyOnly(circular, 'circular'),
-    useKeyOnly(empty, 'empty'),
-    useKeyOnly(floating, 'floating'),
-    useKeyOnly(horizontal, 'horizontal'),
-    useKeyOnly(image === true, 'image'),
-    useKeyOnly(tag, 'tag'),
-    useKeyOrValueAndKey(corner, 'corner'),
-    useKeyOrValueAndKey(ribbon, 'ribbon'),
-    useValueAndKey(attached, 'attached'),
-    'label',
-    className,
-  )
-  const rest = getUnhandledProps(Label, props)
-  const ElementType = getElementType(Label, props)
-
-  if (children) {
-    return <ElementType {...rest} className={classes} onClick={handleClick}>{children}</ElementType>
-  }
-
-  return (
-    <ElementType className={classes} onClick={handleClick} {...rest}>
-      {Icon.create(icon)}
-      {typeof image !== 'boolean' && Image.create(image)}
-      {content}
-      {createShorthand(LabelDetail, val => ({ content: val }), detail)}
-      {(removable || onRemove) && (
-        <Icon name='delete' onClick={handleRemove} />
-      )}
-    </ElementType>
-  )
-}
-
-Label._meta = {
+const _meta = {
   name: 'Label',
   type: META.TYPES.ELEMENT,
   props: {
@@ -105,118 +32,201 @@ Label._meta = {
   },
 }
 
-Label.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+/**
+ * A label displays content classification
+ */
+export default class Label extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-  /** A label can attach to a content segment. */
-  attached: PropTypes.oneOf(Label._meta.props.attached),
+    /** A label can attach to a content segment. */
+    attached: PropTypes.oneOf(_meta.props.attached),
 
-  /** A label can reduce its complexity. */
-  basic: PropTypes.bool,
+    /** A label can reduce its complexity. */
+    basic: PropTypes.bool,
 
-  /** Primary content of the label, same as content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['content', 'detail', 'icon']),
-    PropTypes.node,
-  ]),
-
-  /** A label can be circular. */
-  circular: PropTypes.bool,
-
-  /** Classes to add to the label className. */
-  className: PropTypes.string,
-
-  /** Color of the label. */
-  color: PropTypes.oneOf(Label._meta.props.color),
-
-  /** Shorthand for primary content of the label. Mutually exclusive with children. */
-  content: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.string,
+    /** Primary content of the label, same as content. */
+    children: customPropTypes.every([
+      customPropTypes.disallow(['content', 'detail', 'icon']),
+      PropTypes.node,
     ]),
-  ]),
 
-  /** A label can position itself in the corner of an element. */
-  corner: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.oneOf(Label._meta.props.corner),
-  ]),
+    /** A label can be circular. */
+    circular: PropTypes.bool,
 
-  /** Shorthand for the LabelDetail component. Mutually exclusive with children. */
-  detail: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.string,
-    ]),
-  ]),
+    /** Classes to add to the label className. */
+    className: PropTypes.string,
 
-  /** Formats the label as a dot. */
-  empty: customPropTypes.every([
-    customPropTypes.demand(['circular']),
-    PropTypes.bool,
-  ]),
+    /** Color of the label. */
+    color: PropTypes.oneOf(_meta.props.color),
 
-  /** Float above another element in the upper right corner. */
-  floating: PropTypes.bool,
-
-  /** A horizontal label is formatted to label content along-side it horizontally. */
-  horizontal: PropTypes.bool,
-
-  /** A label can be formatted to emphasize an icon or prop can be used as shorthand for Icon. */
-  icon: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.string,
-    ]),
-  ]),
-
-  /** A label can be formatted to emphasize an image or prop can be used as shorthand for Image. */
-  image: customPropTypes.every([
-    customPropTypes.givenProps(
-      { children: PropTypes.node.isRequired },
-      PropTypes.bool,
-    ),
-    customPropTypes.givenProps(
-      { image: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.object]) },
+    /** Shorthand for primary content of the label. Mutually exclusive with children. */
+    content: customPropTypes.every([
       customPropTypes.disallow(['children']),
-    ),
-  ]),
+      PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+      ]),
+    ]),
 
-  /** A label can point to content next to it. */
-  pointing: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.oneOf(Label._meta.props.pointing),
-  ]),
+    /** A label can position itself in the corner of an element. */
+    corner: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(_meta.props.corner),
+    ]),
 
-  /** Adds the link style when present, called with (event, props). */
-  onClick: PropTypes.func,
+    /** Shorthand for the LabelDetail component. Mutually exclusive with children. */
+    detail: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+      ]),
+    ]),
 
-  /** Adds an "x" icon, called with (event, props) when "x" is clicked. */
-  onRemove: PropTypes.func,
+    /** Formats the label as a dot. */
+    empty: customPropTypes.every([
+      customPropTypes.demand(['circular']),
+      PropTypes.bool,
+    ]),
 
-  /** Add an "x" icon that calls onRemove when clicked. */
-  removable: PropTypes.bool,
+    /** Float above another element in the upper right corner. */
+    floating: PropTypes.bool,
 
-  /** A label can appear as a ribbon attaching itself to an element. */
-  ribbon: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.oneOf(Label._meta.props.ribbon),
-  ]),
+    /** A horizontal label is formatted to label content along-side it horizontally. */
+    horizontal: PropTypes.bool,
 
-  /** A label can have different sizes. */
-  size: PropTypes.oneOf(Label._meta.props.size),
+    /** A label can be formatted to emphasize an icon or prop can be used as shorthand for Icon. */
+    icon: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+      ]),
+    ]),
 
-  /** A label can appear as a tag. */
-  tag: PropTypes.bool,
+    /** A label can be formatted to emphasize an image or prop can be used as shorthand for Image. */
+    image: customPropTypes.every([
+      customPropTypes.givenProps(
+        { children: PropTypes.node.isRequired },
+        PropTypes.bool,
+      ),
+      customPropTypes.givenProps(
+        { image: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.object]) },
+        customPropTypes.disallow(['children']),
+      ),
+    ]),
+
+    /** A label can point to content next to it. */
+    pointing: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(_meta.props.pointing),
+    ]),
+
+    /** Adds the link style when present, called with (event, props). */
+    onClick: PropTypes.func,
+
+    /** Adds an "x" icon, called with (event, props) when "x" is clicked. */
+    onRemove: PropTypes.func,
+
+    /** Add an "x" icon that calls onRemove when clicked. */
+    removable: PropTypes.bool,
+
+    /** A label can appear as a ribbon attaching itself to an element. */
+    ribbon: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(_meta.props.ribbon),
+    ]),
+
+    /** A label can have different sizes. */
+    size: PropTypes.oneOf(_meta.props.size),
+
+    /** A label can appear as a tag. */
+    tag: PropTypes.bool,
+  }
+
+  static _meta = _meta
+
+  static create = createShorthandFactory(Label, value => ({ content: value }))
+  static Detail = LabelDetail
+  static Group = LabelGroup
+
+  handleClick = (e) => {
+    const { onClick } = this.props
+
+    if (onClick) onClick(e, this.props)
+  }
+
+  handleRemove = (e) => {
+    const { onRemove } = this.props
+
+    if (onRemove) onRemove(e, this.props)
+  }
+
+  render() {
+    const {
+      attached,
+      basic,
+      children,
+      circular,
+      className,
+      color,
+      content,
+      corner,
+      detail,
+      empty,
+      floating,
+      horizontal,
+      icon,
+      image,
+      onRemove,
+      pointing,
+      removable,
+      ribbon,
+      size,
+      tag,
+    } = this.props
+
+    const pointingClass = pointing === true && 'pointing'
+      || (pointing === 'left' || pointing === 'right') && `${pointing} pointing`
+      || (pointing === 'above' || pointing === 'below') && `pointing ${pointing}`
+
+    const classes = cx(
+      'ui',
+      color,
+      pointingClass,
+      size,
+      useKeyOnly(basic, 'basic'),
+      useKeyOnly(circular, 'circular'),
+      useKeyOnly(empty, 'empty'),
+      useKeyOnly(floating, 'floating'),
+      useKeyOnly(horizontal, 'horizontal'),
+      useKeyOnly(image === true, 'image'),
+      useKeyOnly(tag, 'tag'),
+      useKeyOrValueAndKey(corner, 'corner'),
+      useKeyOrValueAndKey(ribbon, 'ribbon'),
+      useValueAndKey(attached, 'attached'),
+      'label',
+      className,
+    )
+    const rest = getUnhandledProps(Label, this.props)
+    const ElementType = getElementType(Label, this.props)
+
+    if (children) {
+      return <ElementType {...rest} className={classes} onClick={this.handleClick}>{children}</ElementType>
+    }
+
+    return (
+      <ElementType className={classes} onClick={this.handleClick} {...rest}>
+        {Icon.create(icon)}
+        {typeof image !== 'boolean' && Image.create(image)}
+        {content}
+        {createShorthand(LabelDetail, val => ({ content: val }), detail)}
+        {(removable || onRemove) && (
+          <Icon name='delete' onClick={this.handleRemove} />
+        )}
+      </ElementType>
+    )
+  }
 }
-
-Label.create = createShorthandFactory(Label, value => ({ content: value }))
-Label.Detail = LabelDetail
-Label.Group = LabelGroup
-
-export default Label

--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 
 import {
   customPropTypes,
@@ -16,103 +16,115 @@ import StepGroup from './StepGroup'
 import StepTitle from './StepTitle'
 
 /**
- * A step shows the completion status of an activity in a series of activities.
+ * A step shows the completion status of an activity in a series of activities
  */
-function Step(props) {
-  const {
-    active, children, className, completed, description, disabled, icon, href, link, onClick, title,
-  } = props
-  const classes = cx(
-    useKeyOnly(active, 'active'),
-    useKeyOnly(completed, 'completed'),
-    useKeyOnly(disabled, 'disabled'),
-    useKeyOnly(link, 'link'),
-    className,
-    'step',
-  )
-  const rest = getUnhandledProps(Step, props)
+export default class Step extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-  const handleClick = (e) => {
+    /** A step can be highlighted as active. */
+    active: PropTypes.bool,
+
+    /** Classes that will be added to the Step className. */
+    className: PropTypes.string,
+
+    /** Primary content of the Step. Mutually exclusive with description and title props. */
+    children: customPropTypes.every([
+      customPropTypes.disallow(['description', 'title']),
+      PropTypes.node,
+    ]),
+
+    /** A step can show that a user has completed it. */
+    completed: PropTypes.bool,
+
+    /** Shorthand prop for StepDescription. Mutually exclusive with children. */
+    description: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.node,
+    ]),
+
+    /** Show that the Loader is inactive. */
+    disabled: PropTypes.bool,
+
+    /** A step can contain an icon. */
+    icon: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.node,
+    ]),
+
+    /** A step can be link. */
+    link: PropTypes.bool,
+
+    /** Render as an `a` tag instead of a `div` and adds the href attribute. */
+    href: PropTypes.string,
+
+    /** Render as an `a` tag instead of a `div` and called with event on Step click. */
+    onClick: PropTypes.func,
+
+    /** A step can show a ordered sequence of steps. Passed from StepGroup. */
+    ordered: PropTypes.bool,
+
+    /** Shorthand prop for StepTitle. Mutually exclusive with children. */
+    title: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.node,
+    ]),
+  }
+
+  static _meta = {
+    name: 'Step',
+    type: META.TYPES.ELEMENT,
+  }
+
+  static Content = StepContent
+  static Description = StepDescription
+  static Group = StepGroup
+  static Title = StepTitle
+
+  handleClick = (e) => {
+    const { onClick } = this.props
+
     if (onClick) onClick(e)
   }
-  const ElementType = getElementType(Step, props, () => {
-    if (onClick) return 'a'
-  })
 
-  return (
-    <ElementType
-      {...rest}
-      className={classes}
-      href={href}
-      onClick={handleClick}
-    >
-      {!children && Icon.create(icon)}
-      {children || <StepContent description={description} title={title} />}
-    </ElementType>
-  )
+  render() {
+    const {
+      active,
+      children,
+      className,
+      completed,
+      description,
+      disabled,
+      href,
+      icon,
+      link,
+      onClick,
+      title,
+    } = this.props
+
+    const classes = cx(
+      useKeyOnly(active, 'active'),
+      useKeyOnly(completed, 'completed'),
+      useKeyOnly(disabled, 'disabled'),
+      useKeyOnly(link, 'link'),
+      'step',
+      className,
+    )
+    const rest = getUnhandledProps(Step, this.props)
+    const ElementType = getElementType(Step, this.props, () => {
+      if (onClick) return 'a'
+    })
+
+    if (children) {
+      return <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>{children}</ElementType>
+    }
+
+    return (
+      <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>
+        {Icon.create(icon)}
+        <StepContent description={description} title={title} />
+      </ElementType>
+    )
+  }
 }
-
-Step._meta = {
-  name: 'Step',
-  type: META.TYPES.ELEMENT,
-}
-
-Step.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
-
-  /** A step can be highlighted as active. */
-  active: PropTypes.bool,
-
-  /** Classes that will be added to the Step className. */
-  className: PropTypes.string,
-
-  /** Primary content of the Step. Mutually exclusive with description and title props. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['description', 'title']),
-    PropTypes.node,
-  ]),
-
-  /** A step can show that a user has completed it. */
-  completed: PropTypes.bool,
-
-  /** Shorthand prop for StepDescription. Mutually exclusive with children. */
-  description: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
-
-  /** Show that the Loader is inactive. */
-  disabled: PropTypes.bool,
-
-  /** A step can contain an icon. */
-  icon: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
-
-  /** A step can be link. */
-  link: PropTypes.bool,
-
-  /** Render as an `a` tag instead of a `div` and adds the href attribute. */
-  href: PropTypes.string,
-
-  /** Render as an `a` tag instead of a `div` and called with event on Step click. */
-  onClick: PropTypes.func,
-
-  /** A step can show a ordered sequence of steps. Passed from StepGroup. */
-  ordered: PropTypes.bool,
-
-  /** Shorthand prop for StepTitle. Mutually exclusive with children. */
-  title: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
-}
-
-Step.Content = StepContent
-Step.Description = StepDescription
-Step.Group = StepGroup
-Step.Title = StepTitle
-
-export default Step

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -152,15 +152,21 @@ export default class Accordion extends Component {
   }
 
   render() {
-    const { className, fluid, inverted, panels, styled } = this.props
+    const {
+      className,
+      fluid,
+      inverted,
+      panels,
+      styled,
+    } = this.props
 
     const classes = cx(
-      className,
       'ui',
       useKeyOnly(fluid, 'fluid'),
       useKeyOnly(inverted, 'inverted'),
       useKeyOnly(styled, 'styled'),
-      'accordion'
+      'accordion',
+      className,
     )
     const rest = _.omit(this.props, _.keys(Accordion.propTypes))
     const ElementType = getElementType(Accordion, this.props)

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -1,5 +1,5 @@
-import React, { PropTypes } from 'react'
 import cx from 'classnames'
+import React, { Component, PropTypes } from 'react'
 
 import {
   customPropTypes,
@@ -9,51 +9,51 @@ import {
   useKeyOnly,
 } from '../../lib'
 
-function AccordionTitle(props) {
-  const { active, children, className, onClick } = props
-  const classes = cx(
-    'title',
-    useKeyOnly(active, 'active'),
-    className
-  )
+/**
+ * A title sub-component for Accordion component
+ */
+export default class AccordionTitle extends Component {
+  static displayName = 'AccordionTitle'
 
-  const handleClick = (e) => {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
+
+    /** Whether or not the title is in the open state. */
+    active: PropTypes.bool,
+
+    /** Primary content of the Title. */
+    children: PropTypes.node,
+
+    /** Classes to add to the title className. */
+    className: PropTypes.string,
+
+    /** Called with (event, index) on title click. */
+    onClick: PropTypes.func,
+  }
+
+  static _meta = {
+    name: 'AccordionTitle',
+    type: META.TYPES.MODULE,
+    parent: 'Accordion',
+  }
+
+  handleClick = (e) => {
+    const { onClick } = this.props
+
     if (onClick) onClick(e)
   }
 
-  const rest = getUnhandledProps(AccordionTitle, props)
-  const ElementType = getElementType(AccordionTitle, props)
+  render() {
+    const { active, children, className } = this.props
+    const classes = cx(
+      'title',
+      useKeyOnly(active, 'active'),
+      className
+    )
+    const rest = getUnhandledProps(AccordionTitle, this.props)
+    const ElementType = getElementType(AccordionTitle, this.props)
 
-  return (
-    <ElementType {...rest} className={classes} onClick={handleClick}>
-      {children}
-    </ElementType>
-  )
+    return <ElementType {...rest} className={classes} onClick={this.handleClick}>{children}</ElementType>
+  }
 }
-
-AccordionTitle.displayName = 'AccordionTitle'
-
-AccordionTitle.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
-
-  /** Whether or not the title is in the open state. */
-  active: PropTypes.bool,
-
-  /** Primary content of the Title. */
-  children: PropTypes.node,
-
-  /** Classes to add to the title className. */
-  className: PropTypes.string,
-
-  /** Called with (event, index) on title click. */
-  onClick: PropTypes.func,
-}
-
-AccordionTitle._meta = {
-  name: 'AccordionTitle',
-  type: META.TYPES.MODULE,
-  parent: 'Accordion',
-}
-
-export default AccordionTitle

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -45,10 +45,15 @@ export default class AccordionTitle extends Component {
   }
 
   render() {
-    const { active, children, className } = this.props
+    const {
+      active,
+      children,
+      className,
+    } = this.props
+
     const classes = cx(
-      'title',
       useKeyOnly(active, 'active'),
+      'title',
       className
     )
     const rest = getUnhandledProps(AccordionTitle, this.props)

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -1,5 +1,5 @@
-import React, { PropTypes } from 'react'
 import cx from 'classnames'
+import React, { Component, PropTypes } from 'react'
 
 import {
   childrenUtils,
@@ -12,100 +12,103 @@ import {
 } from '../../lib'
 import Icon from '../../elements/Icon'
 
-function DropdownItem(props) {
-  const {
-    active,
-    children,
-    className,
-    disabled,
-    description,
-    icon,
-    onClick,
-    selected,
-    text,
-    value,
-  } = props
+/**
+ * An item sub-component for Dropdown component
+ */
+export default class DropdownItem extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-  const handleClick = (e) => {
-    if (onClick) onClick(e, value)
-  }
+    /** Style as the currently chosen item. */
+    active: PropTypes.bool,
 
-  const classes = cx(
-    useKeyOnly(active, 'active'),
-    useKeyOnly(disabled, 'disabled'),
-    useKeyOnly(selected, 'selected'),
-    'item',
-    className,
-  )
-  // add default dropdown icon if item contains another menu
-  const iconName = icon || childrenUtils.someByType(children, 'DropdownMenu') && 'dropdown'
-  const rest = getUnhandledProps(DropdownItem, props)
-  const ElementType = getElementType(DropdownItem, props)
+    /** Primary content. */
+    children: customPropTypes.every([
+      customPropTypes.disallow(['text']),
+      PropTypes.node,
+    ]),
 
-  return (
-    <ElementType {...rest} className={classes} onClick={handleClick}>
-      {createShorthand('span', val => ({ className: 'description', children: val }), description)}
-      {Icon.create(iconName)}
-      {text}
-      {children}
-    </ElementType>
-  )
-}
+    /** Additional className. */
+    className: PropTypes.string,
 
-DropdownItem._meta = {
-  name: 'DropdownItem',
-  parent: 'Dropdown',
-  type: META.TYPES.MODULE,
-}
+    /** Additional text with less emphasis. */
+    description: PropTypes.string,
 
-DropdownItem.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+    /** A dropdown item can be disabled. */
+    disabled: PropTypes.bool,
 
-  /** Style as the currently chosen item. */
-  active: PropTypes.bool,
+    /** Add an icon to the item. */
+    icon: PropTypes.string,
 
-  /** Primary content. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['text']),
-    PropTypes.node,
-  ]),
+    /**
+     * The item currently selected by keyboard shortcut.
+     * This is not the active item.
+     */
+    selected: PropTypes.bool,
 
-  /** Additional className. */
-  className: PropTypes.string,
+    /** Display text. */
+    text: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+      ]),
+    ]),
 
-  /** Additional text with less emphasis. */
-  description: PropTypes.string,
-
-  /** A dropdown item can be disabled. */
-  disabled: PropTypes.bool,
-
-  /** Add an icon to the item. */
-  icon: PropTypes.string,
-
-  /**
-   * The item currently selected by keyboard shortcut.
-   * This is not the active item.
-   */
-  selected: PropTypes.bool,
-
-  /** Display text. */
-  text: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.oneOfType([
+    /** Stored value */
+    value: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string,
     ]),
-  ]),
 
-  /** Stored value */
-  value: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-  ]),
+    /** Called on click with (event, value, text). */
+    onClick: PropTypes.func,
+  }
 
-  /** Called on click with (event, value, text). */
-  onClick: PropTypes.func,
+  static _meta = {
+    name: 'DropdownItem',
+    parent: 'Dropdown',
+    type: META.TYPES.MODULE,
+  }
+
+  handleClick = (e) => {
+    const { onClick, value } = this.props
+
+    if (onClick) onClick(e, value)
+  }
+
+  render() {
+    const {
+      active,
+      children,
+      className,
+      disabled,
+      description,
+      icon,
+      selected,
+      text,
+    } = this.props
+
+    const classes = cx(
+      useKeyOnly(active, 'active'),
+      useKeyOnly(disabled, 'disabled'),
+      useKeyOnly(selected, 'selected'),
+      'item',
+      className,
+    )
+    // add default dropdown icon if item contains another menu
+    const iconName = icon || childrenUtils.someByType(children, 'DropdownMenu') && 'dropdown'
+    const rest = getUnhandledProps(DropdownItem, this.props)
+    const ElementType = getElementType(DropdownItem, this.props)
+
+    return (
+      <ElementType {...rest} className={classes} onClick={this.handleClick}>
+        {createShorthand('span', val => ({ className: 'description', children: val }), description)}
+        {Icon.create(iconName)}
+        {text}
+        {children}
+      </ElementType>
+    )
+  }
 }
-
-export default DropdownItem

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -21,7 +21,16 @@ const _meta = {
   },
 }
 
-class Rating extends Component {
+export default class Rating extends Component {
+  static autoControlledProps = [
+    'rating',
+  ]
+
+  static defaultProps = {
+    clearable: 'auto',
+    maxRating: 1,
+  }
+
   static propTypes = {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
@@ -70,30 +79,7 @@ class Rating extends Component {
     onRate: PropTypes.func,
   }
 
-  static defaultProps = {
-    clearable: 'auto',
-    maxRating: 1,
-  }
-
   static _meta = _meta
-
-  static autoControlledProps = [
-    'rating',
-  ]
-
-  handleMouseLeave = (...args) => {
-    _.invoke(this.props, 'onMouseLeave', ...args)
-
-    if (this.props.disabled) return
-
-    this.setState({ selectedIndex: -1, isSelecting: false })
-  }
-
-  handleIconMouseEnter = (index) => {
-    if (this.props.disabled) return
-
-    this.setState({ selectedIndex: index, isSelecting: true })
-  }
 
   handleIconClick = (e, index) => {
     const { clearable, disabled, maxRating, onRate } = this.props
@@ -113,6 +99,20 @@ class Rating extends Component {
     // set rating
     this.trySetState({ rating: newRating }, { isSelecting: false })
     if (onRate) onRate(e, { rating: newRating, maxRating })
+  }
+
+  handleIconMouseEnter = (index) => {
+    if (this.props.disabled) return
+
+    this.setState({ selectedIndex: index, isSelecting: true })
+  }
+
+  handleMouseLeave = (...args) => {
+    _.invoke(this.props, 'onMouseLeave', ...args)
+
+    if (this.props.disabled) return
+
+    this.setState({ selectedIndex: -1, isSelecting: false })
   }
 
   renderIcons = () => {
@@ -137,15 +137,20 @@ class Rating extends Component {
   }
 
   render() {
-    const { className, disabled, icon, size } = this.props
+    const {
+      className,
+      disabled,
+      icon,
+      size,
+    } = this.props
     const { selectedIndex, isSelecting } = this.state
 
     const classes = cx(
       'ui',
-      size,
-      icon,
       disabled && 'disabled',
+      icon,
       isSelecting && !disabled && selectedIndex >= 0 && 'selected',
+      size,
       'rating',
       className,
     )
@@ -159,5 +164,3 @@ class Rating extends Component {
     )
   }
 }
-
-export default Rating

--- a/src/modules/Search/SearchResult.js
+++ b/src/modules/Search/SearchResult.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 import cx from 'classnames'
 
 import {
@@ -26,77 +26,77 @@ const defaultRenderer = ({ image, price, title, description }) => [
   </div>,
 ]
 
-function SearchResult(props) {
-  const {
-    active,
-    className,
-    id,
-    onClick,
-    renderer,
-  } = props
+export default class SearchResult extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-  const handleClick = (e) => {
+    /** The item currently selected by keyboard shortcut. */
+    active: PropTypes.bool,
+
+    /** Additional className. */
+    className: PropTypes.string,
+
+    /** Additional text with less emphasis. */
+    description: PropTypes.string,
+
+    /** A unique identifier. */
+    id: PropTypes.number,
+
+    /** Add an image to the item. */
+    image: PropTypes.string,
+
+    /** Called on click with (event, value, text). */
+    onClick: PropTypes.func,
+
+    /** Customized text for price. */
+    price: PropTypes.string,
+
+    /**
+     * A function that returns the result contents.
+     * Receives all SearchResult props.
+     */
+    renderer: PropTypes.func,
+
+    /** Display title. */
+    title: PropTypes.string,
+  }
+
+  handleClick = (e) => {
+    const { id, onClick } = this.props
+
     if (onClick) onClick(e, id)
   }
 
-  const classes = cx(
-    useKeyOnly(active, 'active'),
-    'result',
-    className,
-  )
-  const rest = getUnhandledProps(SearchResult, props)
-  const ElementType = getElementType(SearchResult, props)
+  static _meta = {
+    name: 'SearchResult',
+    parent: 'Search',
+    type: META.TYPES.MODULE,
+  }
 
-  // Note: You technically only need the 'content' wrapper when there's an
-  // image. However, optionally wrapping it makes this function a lot more
-  // complicated and harder to read. Since always wrapping it doesn't affect
-  // the style in any way let's just do that.
-  return (
-    <ElementType {...rest} className={classes} onClick={handleClick}>
-      {renderer ? renderer(props) : defaultRenderer(props)}
-    </ElementType>
-  )
+  render() {
+    const {
+      active,
+      className,
+      renderer,
+    } = this.props
+
+    const classes = cx(
+      useKeyOnly(active, 'active'),
+      'result',
+      className,
+    )
+    const rest = getUnhandledProps(SearchResult, this.props)
+    const ElementType = getElementType(SearchResult, this.props)
+
+    // Note: You technically only need the 'content' wrapper when there's an
+    // image. However, optionally wrapping it makes this function a lot more
+    // complicated and harder to read. Since always wrapping it doesn't affect
+    // the style in any way let's just do that.
+    return (
+      <ElementType {...rest} className={classes} onClick={this.handleClick}>
+        {renderer ? renderer(this.props) : defaultRenderer(this.props)}
+      </ElementType>
+    )
+  }
 }
-
-SearchResult._meta = {
-  name: 'SearchResult',
-  parent: 'Search',
-  type: META.TYPES.MODULE,
-}
-
-SearchResult.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
-
-  /** The item currently selected by keyboard shortcut. */
-  active: PropTypes.bool,
-
-  /** Additional className. */
-  className: PropTypes.string,
-
-  /** Additional text with less emphasis. */
-  description: PropTypes.string,
-
-  /** A unique identifier. */
-  id: PropTypes.number,
-
-  /** Add an image to the item. */
-  image: PropTypes.string,
-
-  /** Customized text for price. */
-  price: PropTypes.string,
-
-  /**
-   * A function that returns the result contents.
-   * Receives all SearchResult props.
-   */
-  renderer: PropTypes.func,
-
-  /** Display title. */
-  title: PropTypes.string,
-
-  /** Called on click with (event, value, text). */
-  onClick: PropTypes.func,
-}
-
-export default SearchResult

--- a/src/views/Card/Card.js
+++ b/src/views/Card/Card.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 
 import {
   customPropTypes,
@@ -17,59 +17,7 @@ import CardGroup from './CardGroup'
 import CardHeader from './CardHeader'
 import CardMeta from './CardMeta'
 
-/**
- * A card displays site content in a manner similar to a playing card
- */
-function Card(props) {
-  const {
-    centered,
-    children,
-    className,
-    color,
-    description,
-    extra,
-    fluid,
-    header,
-    href,
-    image,
-    meta,
-    onClick,
-    raised,
-  } = props
-
-  const classes = cx('ui',
-    useKeyOnly(centered, 'centered'),
-    useKeyOnly(fluid, 'fluid'),
-    useKeyOnly(raised, 'raised'),
-    color,
-    'card',
-    className,
-  )
-  const rest = getUnhandledProps(Card, props)
-
-  const handleClick = (e) => {
-    if (onClick) onClick(e)
-  }
-  const ElementType = getElementType(Card, props, () => {
-    if (onClick) return 'a'
-  })
-
-  if (children) {
-    return <ElementType {...rest} className={classes} href={href} onClick={handleClick}>{children}</ElementType>
-  }
-
-  return (
-    <ElementType {...rest} className={classes} href={href} onClick={handleClick}>
-      {Image.create(image)}
-      {(description || header || meta) && (
-        <CardContent description={description} header={header} meta={meta} />
-      )}
-      {extra && <CardContent extra>{extra}</CardContent>}
-    </ElementType>
-  )
-}
-
-Card._meta = {
+const _meta = {
   name: 'Card',
   type: META.TYPES.VIEW,
   props: {
@@ -77,72 +25,129 @@ Card._meta = {
   },
 }
 
-Card.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+/**
+ * A card displays site content in a manner similar to a playing card
+ */
+export default class Card extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-  /** A Card can center itself inside its container. */
-  centered: PropTypes.bool,
+    /** A Card can center itself inside its container. */
+    centered: PropTypes.bool,
 
-  /** Primary content of the Card. */
-  children: customPropTypes.every([
-    customPropTypes.disallow(['description', 'header', 'image', 'meta']),
-    PropTypes.node,
-  ]),
+    /** Primary content of the Card. */
+    children: customPropTypes.every([
+      customPropTypes.disallow(['description', 'header', 'image', 'meta']),
+      PropTypes.node,
+    ]),
 
-  /** Classes that will be added to the Card className. */
-  className: PropTypes.string,
+    /** Classes that will be added to the Card className. */
+    className: PropTypes.string,
 
-  /** A Card can be formatted to display different colors. */
-  color: PropTypes.oneOf(Card._meta.props.color),
+    /** A Card can be formatted to display different colors. */
+    color: PropTypes.oneOf(_meta.props.color),
 
-  /** Shorthand prop for CardDescription. Mutually exclusive with children. */
-  description: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+    /** Shorthand prop for CardDescription. Mutually exclusive with children. */
+    description: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.node,
+    ]),
 
-  /** Shorthand prop for CardContent containing extra prop. Mutually exclusive with children. */
-  extra: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+    /** Shorthand prop for CardContent containing extra prop. Mutually exclusive with children. */
+    extra: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.node,
+    ]),
 
-  /** A Card can be formatted to take up the width of its container. */
-  fluid: PropTypes.bool,
+    /** A Card can be formatted to take up the width of its container. */
+    fluid: PropTypes.bool,
 
-  /** Shorthand prop for CardHeader. Mutually exclusive with children. */
-  header: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+    /** Shorthand prop for CardHeader. Mutually exclusive with children. */
+    header: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.node,
+    ]),
 
-  /** Render as an `a` tag instead of a `div` and adds the href attribute. */
-  href: PropTypes.string,
+    /** Render as an `a` tag instead of a `div` and adds the href attribute. */
+    href: PropTypes.string,
 
-  /** A card can contain an Image component. */
-  image: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+    /** A card can contain an Image component. */
+    image: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.node,
+    ]),
 
-  /** Shorthand prop for CardMeta. Mutually exclusive with children. */
-  meta: customPropTypes.every([
-    customPropTypes.disallow(['children']),
-    PropTypes.node,
-  ]),
+    /** Shorthand prop for CardMeta. Mutually exclusive with children. */
+    meta: customPropTypes.every([
+      customPropTypes.disallow(['children']),
+      PropTypes.node,
+    ]),
 
-  /** Render as an `a` tag instead of a `div` and called with event on Card click. */
-  onClick: PropTypes.func,
+    /** Render as an `a` tag instead of a `div` and called with event on Card click. */
+    onClick: PropTypes.func,
 
-  /** A Card can be formatted to raise above the page. */
-  raised: PropTypes.bool,
+    /** A Card can be formatted to raise above the page. */
+    raised: PropTypes.bool,
+  }
+
+  static _meta = _meta
+
+  static Content = CardContent
+  static Description = CardDescription
+  static Group = CardGroup
+  static Header = CardHeader
+  static Meta = CardMeta
+
+  handleClick = (e) => {
+    const { onClick } = this.props
+
+    if (onClick) onClick(e)
+  }
+
+  render() {
+    const {
+      centered,
+      children,
+      className,
+      color,
+      description,
+      extra,
+      fluid,
+      header,
+      href,
+      image,
+      meta,
+      onClick,
+      raised,
+    } = this.props
+
+    const classes = cx(
+      'ui',
+      color,
+      useKeyOnly(centered, 'centered'),
+      useKeyOnly(fluid, 'fluid'),
+      useKeyOnly(raised, 'raised'),
+      'card',
+      className,
+    )
+    const rest = getUnhandledProps(Card, this.props)
+    const ElementType = getElementType(Card, this.props, () => {
+      if (onClick) return 'a'
+    })
+
+    if (children) {
+      return <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>{children}</ElementType>
+    }
+
+    return (
+      <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>
+        {Image.create(image)}
+        {(description || header || meta) && (
+          <CardContent description={description} header={header} meta={meta} />
+        )}
+        {extra && <CardContent extra>{extra}</CardContent>}
+      </ElementType>
+    )
+  }
 }
-
-Card.Content = CardContent
-Card.Description = CardDescription
-Card.Group = CardGroup
-Card.Header = CardHeader
-Card.Meta = CardMeta
-
-export default Card

--- a/test/specs/collections/Breadcrumb/BreadcrumbSection-test.js
+++ b/test/specs/collections/Breadcrumb/BreadcrumbSection-test.js
@@ -13,14 +13,14 @@ describe('BreadcrumbSection', () => {
       .should.have.tagName('div')
   })
 
-  describe('link prop', () => {
+  describe('link', () => {
     it('is should be `a` when has prop link', () => {
       shallow(<BreadcrumbSection link>Home</BreadcrumbSection>)
         .should.have.tagName('a')
     })
   })
 
-  describe('href prop', () => {
+  describe('href', () => {
     it('is not present by default', () => {
       shallow(<BreadcrumbSection>Home</BreadcrumbSection>)
         .should.not.have.attr('href')
@@ -34,15 +34,15 @@ describe('BreadcrumbSection', () => {
     })
   })
 
-  describe('onClick prop', () => {
-    it('can be omitted', () => {
-      const click = () => mount(<BreadcrumbSection>Home</BreadcrumbSection>).simulate('click')
+  describe('onClick', () => {
+    it('omitted when not defined', () => {
+      const click = () => shallow(<BreadcrumbSection />).simulate('click')
       expect(click).to.not.throw()
     })
 
     it('is called with (event) on click', () => {
       const handleClick = sandbox.spy()
-      const section = mount(<BreadcrumbSection onClick={handleClick}>Home</BreadcrumbSection>)
+      const section = mount(<BreadcrumbSection onClick={handleClick} />)
 
       section.should.have.tagName('a')
       section.simulate('click')

--- a/test/specs/collections/Form/Form-test.js
+++ b/test/specs/collections/Form/Form-test.js
@@ -127,6 +127,11 @@ describe('Form', () => {
   })
 
   describe('onSubmit', () => {
+    it('omitted when not defined', () => {
+      const submit = () => shallow(<Form />).simulate('submit')
+      expect(submit).to.not.throw()
+    })
+
     let spy
     const spyFormSubmit = (children) => {
       mount(<Form onSubmit={spy}>{children}</Form>).simulate('submit')

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -54,9 +54,8 @@ describe('MenuItem', () => {
   })
 
   describe('onClick', () => {
-    it('can be omitted', () => {
-      const click = () => mount(<MenuItem />).simulate('click')
-
+    it('omitted when not defined', () => {
+      const click = () => shallow(<MenuItem />).simulate('click')
       expect(click).to.not.throw()
     })
 

--- a/test/specs/elements/Label/Label-test.js
+++ b/test/specs/elements/Label/Label-test.js
@@ -68,9 +68,8 @@ describe('Label', () => {
   })
 
   describe('onClick', () => {
-    it('can be omitted', () => {
-      const click = () => mount(<Label />).simulate('click')
-
+    it('omitted when not defined', () => {
+      const click = () => shallow(<Label />).simulate('click')
       expect(click).to.not.throw()
     })
 

--- a/test/specs/elements/Step/Step-test.js
+++ b/test/specs/elements/Step/Step-test.js
@@ -51,8 +51,8 @@ describe('Step', () => {
     })
 
     describe('onClick prop', () => {
-      it('can be omitted', () => {
-        const click = () => mount(<Step>{faker.hacker.phrase()}</Step>).simulate('click')
+      it('omitted when not defined', () => {
+        const click = () => shallow(<Step />).simulate('click')
         expect(click).to.not.throw()
       })
 

--- a/test/specs/modules/Accordion/AccordionTitle-test.js
+++ b/test/specs/modules/Accordion/AccordionTitle-test.js
@@ -11,9 +11,8 @@ describe('AccordionTitle', () => {
   common.propKeyOnlyToClassName(AccordionTitle, 'active')
 
   describe('onClick', () => {
-    it('can be omitted', () => {
-      const wrapper = shallow(<AccordionTitle />)
-      const click = () => wrapper.simulate('click')
+    it('omitted when not defined', () => {
+      const click = () => shallow(<AccordionTitle />).simulate('click')
       expect(click).to.not.throw()
     })
     it('is called with (event, undefined) when not a child of Accordion', () => {

--- a/test/specs/modules/Dropdown/DropdownItem-test.js
+++ b/test/specs/modules/Dropdown/DropdownItem-test.js
@@ -1,8 +1,17 @@
+import faker from 'faker'
+import React from 'react'
+
 import DropdownItem from 'src/modules/Dropdown/DropdownItem'
 import * as common from 'test/specs/commonTests'
+import { sandbox } from 'test/utils'
 
 describe('DropdownItem', () => {
   common.isConformant(DropdownItem)
+  common.rendersChildren(DropdownItem)
+
+  common.propKeyOnlyToClassName(DropdownItem, 'selected')
+  common.propKeyOnlyToClassName(DropdownItem, 'active')
+
   common.implementsShorthandProp(DropdownItem, {
     propKey: 'description',
     ShorthandComponent: 'span',
@@ -11,7 +20,25 @@ describe('DropdownItem', () => {
       children: val,
     }),
   })
-  common.rendersChildren(DropdownItem)
-  common.propKeyOnlyToClassName(DropdownItem, 'selected')
-  common.propKeyOnlyToClassName(DropdownItem, 'active')
+
+  describe('onClick', () => {
+    it('omitted when not defined', () => {
+      const click = () => shallow(<DropdownItem />).simulate('click')
+      expect(click).to.not.throw()
+    })
+
+    it('is called with (e, value) when clicked', () => {
+      const spy = sandbox.spy()
+
+      const value = faker.hacker.phrase()
+      const event = { target: null }
+      const props = { value }
+
+      shallow(<DropdownItem onClick={spy} {...props} />)
+        .simulate('click', event)
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(event, value)
+    })
+  })
 })

--- a/test/specs/modules/Search/SearchResult-test.js
+++ b/test/specs/modules/Search/SearchResult-test.js
@@ -1,7 +1,32 @@
+import facker from 'faker'
+import React from 'react'
+
 import SearchResult from 'src/modules/Search/SearchResult'
 import * as common from 'test/specs/commonTests'
+import { sandbox } from 'test/utils'
 
 describe('SearchResult', () => {
   common.isConformant(SearchResult)
   common.propKeyOnlyToClassName(SearchResult, 'active')
+
+  describe('onClick', () => {
+    it('omitted when not defined', () => {
+      const click = () => shallow(<SearchResult />).simulate('click')
+      expect(click).to.not.throw()
+    })
+
+    it('is called with (e, id) when clicked', () => {
+      const spy = sandbox.spy()
+
+      const id = facker.random.number()
+      const event = { target: null }
+      const props = { id }
+
+      shallow(<SearchResult onClick={spy} {...props} />)
+        .simulate('click', event)
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(event, id)
+    })
+  })
 })

--- a/test/specs/views/Card/Card-test.js
+++ b/test/specs/views/Card/Card-test.js
@@ -23,7 +23,7 @@ describe('Card', () => {
     shallow(<Card />).should.have.tagName('div')
   })
 
-  describe('href prop', () => {
+  describe('href', () => {
     it('renders an <a> with an href attr', () => {
       const url = faker.internet.url()
       const wrapper = shallow(<Card href={url} />)
@@ -33,9 +33,9 @@ describe('Card', () => {
     })
   })
 
-  describe('onClick prop', () => {
-    it('can be omitted', () => {
-      const click = () => mount(<Card>{faker.hacker.phrase()}</Card>).simulate('click')
+  describe('onClick', () => {
+    it('omitted when not defined', () => {
+      const click = () => shallow(<Card />).simulate('click')
       expect(click).to.not.throw()
     })
 
@@ -57,7 +57,7 @@ describe('Card', () => {
     })
   })
 
-  describe('extra prop', () => {
+  describe('extra', () => {
     it('renders a CardContent', () => {
       const wrapper = shallow(<Card extra={faker.hacker.phrase()} />)
 


### PR DESCRIPTION
Functional components that need to be turned into a class (Found via grep: `const handle`):
- [x] AccordionTitle
- [x] BreadcrumbSection
- [x] Card
- [x] DropdownItem
- [x] Form
- [x] Label
- [x] MenuItem
- [x] SearchResult
- [x] Step
