### PR TITLE
fix(customPropTypes): itemsShorthand -> collectionShorthand

### DIFF
--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -203,7 +203,7 @@ export const itemShorthand = (...args) => every([
 /**
  * Collection shorthand ensures a prop is an array of item shorthand.
  */
-export const itemsShorthand = (...args) => every([
+export const collectionShorthand = (...args) => every([
   disallow(['children']),
   PropTypes.arrayOf(itemShorthand),
 ])(...args)


### PR DESCRIPTION
This prop type checker was renamed in all components, but the customPropType method itself somehow remained with the old name.  Fixes these issues:

![image](https://cloud.githubusercontent.com/assets/5067638/19139284/355286d2-8b38-11e6-9c36-de6cfe02b707.png)

Where:

``` jsx
    /** Shorthand array of props for Menu. */
    items: customPropTypes.collectionShorthand,
```
