### PR TITLE
BREAKING CHANGE: update Confirm to Modal v1 API

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentExample.js
+++ b/docs/app/Components/ComponentDoc/ComponentExample.js
@@ -91,7 +91,7 @@ export default class ComponentExample extends Component {
   resetJSX = () => {
     const { sourceCode } = this.state
     const original = this.getOriginalSourceCode()
-    if (sourceCode !== original && confirm('Loose your changes?')) {
+    if (sourceCode !== original && confirm('Loose your changes?')) { // eslint-disable-line no-alert
       this.setState({ sourceCode: original })
       this.renderSourceCode()
     }

--- a/docs/app/Examples/addons/Confirm/Types/ConfirmExampleCallbacks.js
+++ b/docs/app/Examples/addons/Confirm/Types/ConfirmExampleCallbacks.js
@@ -2,14 +2,14 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleCallbacks extends Component {
-  state = { active: false, result: 'show the modal to capture a result' }
+  state = { open: false, result: 'show the modal to capture a result' }
 
-  show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ result: 'confirmed', active: false })
-  handleCancel = () => this.setState({ result: 'cancelled', active: false })
+  show = () => this.setState({ open: true })
+  handleConfirm = () => this.setState({ result: 'confirmed', open: false })
+  handleCancel = () => this.setState({ result: 'cancelled', open: false })
 
   render() {
-    const { active, result } = this.state
+    const { open, result } = this.state
 
     return (
       <div>
@@ -17,7 +17,7 @@ class ConfirmExampleCallbacks extends Component {
 
         <Button onClick={this.show}>Show</Button>
         <Confirm
-          active={active}
+          open={open}
           onCancel={this.handleCancel}
           onConfirm={this.handleConfirm}
         />

--- a/docs/app/Examples/addons/Confirm/Types/ConfirmExampleConfirm.js
+++ b/docs/app/Examples/addons/Confirm/Types/ConfirmExampleConfirm.js
@@ -2,18 +2,18 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleConfirm extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ active: false })
-  handleCancel = () => this.setState({ active: false })
+  show = () => this.setState({ open: true })
+  handleConfirm = () => this.setState({ open: false })
+  handleCancel = () => this.setState({ open: false })
 
   render() {
     return (
       <div>
         <Button onClick={this.show}>Show</Button>
         <Confirm
-          active={this.state.active}
+          open={this.state.open}
           onCancel={this.handleCancel}
           onConfirm={this.handleConfirm}
         />

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleButtons.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleButtons.js
@@ -2,18 +2,18 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleHeader extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ active: false })
-  handleCancel = () => this.setState({ active: false })
+  show = () => this.setState({ open: true })
+  handleConfirm = () => this.setState({ open: false })
+  handleCancel = () => this.setState({ open: false })
 
   render() {
     return (
       <div>
         <Button onClick={this.show}>Show</Button>
         <Confirm
-          active={this.state.active}
+          open={this.state.open}
           cancelButton='Never mind'
           confirmButton="Let's do it"
           onCancel={this.handleCancel}

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleContent.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleContent.js
@@ -2,18 +2,18 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleContent extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ active: false })
-  handleCancel = () => this.setState({ active: false })
+  show = () => this.setState({ open: true })
+  handleConfirm = () => this.setState({ open: false })
+  handleCancel = () => this.setState({ open: false })
 
   render() {
     return (
       <div>
         <Button onClick={this.show}>Show</Button>
         <Confirm
-          active={this.state.active}
+          open={this.state.open}
           content='This is a custom message'
           onCancel={this.handleCancel}
           onConfirm={this.handleConfirm}

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleHeader.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleHeader.js
@@ -2,18 +2,18 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleHeader extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ active: false })
-  handleCancel = () => this.setState({ active: false })
+  show = () => this.setState({ open: true })
+  handleConfirm = () => this.setState({ open: false })
+  handleCancel = () => this.setState({ open: false })
 
   render() {
     return (
       <div>
         <Button onClick={this.show}>Show</Button>
         <Confirm
-          active={this.state.active}
+          open={this.state.open}
           header='This is a custom header'
           onCancel={this.handleCancel}
           onConfirm={this.handleConfirm}

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -9,11 +9,11 @@ import Modal from '../../modules/Modal'
  * @see Modal
  */
 function Confirm(props) {
-  const { active, cancelButton, confirmButton, header, content, onConfirm, onCancel } = props
+  const { open, cancelButton, confirmButton, header, content, onConfirm, onCancel } = props
   const rest = getUnhandledProps(Confirm, props)
 
   return (
-    <Modal active={active} size='small' onHide={onCancel} {...rest}>
+    <Modal open={open} size='small' onClose={onCancel} {...rest}>
       {header && <Modal.Header>{header}</Modal.Header>}
       {content && <Modal.Content>{content}</Modal.Content>}
       <Modal.Actions>
@@ -31,7 +31,7 @@ Confirm._meta = {
 
 Confirm.propTypes = {
   /** Whether or not the modal is visible */
-  active: PropTypes.bool,
+  open: PropTypes.bool,
 
   /** The cancel button text */
   cancelButton: PropTypes.string,

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import React, { PropTypes } from 'react'
 
 import { getUnhandledProps, META } from '../../lib'
@@ -12,8 +13,14 @@ function Confirm(props) {
   const { open, cancelButton, confirmButton, header, content, onConfirm, onCancel } = props
   const rest = getUnhandledProps(Confirm, props)
 
+  // `open` is auto controlled by the Modal
+  // It cannot be present (even undefined) with `defaultOpen`
+  // only apply it if the user provided an open prop
+  const openProp = {}
+  if (_.has(props, 'open')) openProp.open = open
+
   return (
-    <Modal open={open} size='small' onClose={onCancel} {...rest}>
+    <Modal {...openProp} size='small' onClose={onCancel} {...rest}>
       {header && <Modal.Header>{header}</Modal.Header>}
       {content && <Modal.Content>{content}</Modal.Content>}
       <Modal.Actions>

--- a/test/specs/addons/Confirm-test.js
+++ b/test/specs/addons/Confirm-test.js
@@ -92,12 +92,12 @@ describe('Confirm', () => {
       spy.should.have.been.calledOnce()
     })
 
-    it('is passed to the Modal onHide prop', () => {
+    it('is passed to the Modal onClose prop', () => {
       const func = () => null
 
       shallow(<Confirm onCancel={func} />)
         .find('Modal')
-        .prop('onHide', func)
+        .prop('onClose', func)
     })
   })
 

--- a/test/specs/addons/Confirm-test.js
+++ b/test/specs/addons/Confirm-test.js
@@ -1,15 +1,36 @@
+import _ from 'lodash'
 import React from 'react'
 
 import Confirm from 'src/addons/Confirm/Confirm'
 import Modal from 'src/modules/Modal/Modal'
-import { sandbox } from 'test/utils'
+import { keyboardKey } from 'src/lib'
+import { sandbox, domEvent, assertBodyContains } from 'test/utils'
 import * as common from 'test/specs/commonTests'
 
+// ----------------------------------------
+// Wrapper
+// ----------------------------------------
+let wrapper
+
+// we need to unmount the modal after every test to remove it from the document
+// wrap the render methods to update a global wrapper that is unmounted after each test
+const wrapperMount = (...args) => (wrapper = mount(...args))
+const wrapperShallow = (...args) => (wrapper = shallow(...args))
+
 describe('Confirm', () => {
+  beforeEach(() => {
+    wrapper = undefined
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    if (wrapper && wrapper.unmount) wrapper.unmount()
+  })
+
   common.isConformant(Confirm)
 
   it('renders a small Modal', () => {
-    const wrapper = shallow(<Confirm />)
+    wrapperShallow(<Confirm />)
     wrapper
       .type()
       .should.equal(Modal)
@@ -50,8 +71,7 @@ describe('Confirm', () => {
         .should.not.have.descendants('ModalHeader')
     })
     it('sets the header text', () => {
-      const wrapper = shallow(<Confirm header='foo' />)
-      wrapper
+      wrapperShallow(<Confirm header='foo' />)
         .should.have.descendants('ModalHeader')
       wrapper
         .find('ModalHeader')
@@ -62,8 +82,7 @@ describe('Confirm', () => {
 
   describe('content', () => {
     it('is "Are you sure?" by default', () => {
-      const wrapper = shallow(<Confirm />)
-      wrapper
+      wrapperShallow(<Confirm />)
         .should.have.descendants('ModalContent')
       wrapper
         .find('ModalContent')
@@ -71,8 +90,7 @@ describe('Confirm', () => {
         .should.have.text('Are you sure?')
     })
     it('sets the content text', () => {
-      const wrapper = shallow(<Confirm content='foo' />)
-      wrapper
+      wrapperShallow(<Confirm content='foo' />)
         .should.have.descendants('ModalContent')
       wrapper
         .find('ModalContent')
@@ -82,8 +100,14 @@ describe('Confirm', () => {
   })
 
   describe('onCancel', () => {
+    let spy
+
+    beforeEach(() => {
+      spy = sandbox.spy()
+      wrapperMount(<Confirm onCancel={spy} defaultOpen />)
+    })
+
     it('is called on Cancel button click', () => {
-      const spy = sandbox.spy()
       shallow(<Confirm onCancel={spy} />)
         .find('Button')
         .first()
@@ -99,6 +123,46 @@ describe('Confirm', () => {
         .find('Modal')
         .prop('onClose', func)
     })
+
+    it('is called on dimmer click', () => {
+      domEvent.click('.ui.dimmer')
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is called on click outside of the modal', () => {
+      domEvent.click(document.querySelector('.ui.modal').parentNode)
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is not called on click inside of the modal', () => {
+      domEvent.click(document.querySelector('.ui.modal'))
+      spy.should.not.have.been.calledOnce()
+    })
+
+    it('is called on body click', () => {
+      domEvent.click('body')
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is called when pressing escape', () => {
+      domEvent.keyDown(document, { key: 'Escape' })
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is not called when pressing a key other than "Escape"', () => {
+      _.each(keyboardKey, (val, key) => {
+        // skip Escape key
+        if (val === keyboardKey.Escape) return
+
+        domEvent.keyDown(document, { key })
+        spy.should.not.have.been.called(`onClose was called when pressing "${key}"`)
+      })
+    })
+
+    it('is not called when the open prop changes to false', () => {
+      wrapper.setProps({ open: false })
+      spy.should.not.have.been.called()
+    })
   })
 
   describe('onConfirm', () => {
@@ -109,6 +173,41 @@ describe('Confirm', () => {
         .simulate('click')
 
       spy.should.have.been.calledOnce()
+    })
+  })
+
+  describe('open', () => {
+    it('is not open by default', () => {
+      wrapperMount(<Confirm />)
+      assertBodyContains('.ui.modal.open', false)
+    })
+
+    it('does not show the modal when false', () => {
+      wrapperMount(<Confirm open={false} />)
+      assertBodyContains('.ui.modal', false)
+    })
+
+    it('shows the modal when true', () => {
+      wrapperMount(<Confirm open />)
+      assertBodyContains('.ui.modal')
+    })
+
+    it('shows the modal on changing from false to true', () => {
+      wrapperMount(<Confirm open={false} />)
+      assertBodyContains('.ui.modal', false)
+
+      wrapper.setProps({ open: true })
+
+      assertBodyContains('.ui.modal')
+    })
+
+    it('hides the modal on changing from true to false', () => {
+      wrapperMount(<Confirm open />)
+      assertBodyContains('.ui.modal')
+
+      wrapper.setProps({ open: false })
+
+      assertBodyContains('.ui.modal', false)
     })
   })
 })

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -9,7 +9,7 @@ import ModalDescription from 'src/modules/Modal/ModalDescription'
 import Portal from 'src/addons/Portal/Portal'
 
 import { keyboardKey } from 'src/lib'
-import { domEvent, sandbox } from 'test/utils'
+import { assertNodeContains, assertBodyContains, domEvent, sandbox } from 'test/utils'
 import * as common from 'test/specs/commonTests'
 
 // ----------------------------------------
@@ -21,13 +21,6 @@ let wrapper
 // wrap the render methods to update a global wrapper that is unmounted after each test
 const wrapperMount = (...args) => (wrapper = mount(...args))
 const wrapperShallow = (...args) => (wrapper = shallow(...args))
-
-const assertIn = (node, selector, isPresent = true) => {
-  const didFind = node.querySelector(selector) !== null
-  didFind.should.equal(isPresent, `${didFind ? 'Found' : 'Did not find'} "${selector}" in the ${node}.`)
-}
-
-const assertInBody = (...args) => assertIn(document.body, ...args)
 
 const assertBodyClasses = (...rest) => {
   const hasClasses = typeof rest[rest.length - 1] === 'boolean' ? rest.pop() : true
@@ -69,7 +62,7 @@ describe('Modal', () => {
 
   it('renders to the document body', () => {
     wrapperMount(<Modal open />)
-    assertInBody('.ui.modal')
+    assertBodyContains('.ui.modal')
   })
 
   it('renders child text', () => {
@@ -93,7 +86,7 @@ describe('Modal', () => {
   describe('open', () => {
     it('is not open by default', () => {
       wrapperMount(<Modal />)
-      assertInBody('.ui.modal.open', false)
+      assertBodyContains('.ui.modal.open', false)
     })
 
     it('is passed to Portal open', () => {
@@ -120,51 +113,51 @@ describe('Modal', () => {
 
     it('does not show the modal when false', () => {
       wrapperMount(<Modal open={false} />)
-      assertInBody('.ui.modal', false)
+      assertBodyContains('.ui.modal', false)
     })
 
     it('does not show the dimmer when false', () => {
       wrapperMount(<Modal open={false} />)
-      assertInBody('.ui.dimmer', false)
+      assertBodyContains('.ui.dimmer', false)
     })
 
     it('shows the dimmer when true', () => {
       wrapperMount(<Modal open dimmer />)
-      assertInBody('.ui.dimmer')
+      assertBodyContains('.ui.dimmer')
     })
 
     it('shows the modal when true', () => {
       wrapperMount(<Modal open />)
-      assertInBody('.ui.modal')
+      assertBodyContains('.ui.modal')
     })
 
     it('shows the modal and dimmer on changing from false to true', () => {
       wrapperMount(<Modal open={false} />)
-      assertInBody('.ui.modal', false)
-      assertInBody('.ui.dimmer', false)
+      assertBodyContains('.ui.modal', false)
+      assertBodyContains('.ui.dimmer', false)
 
       wrapper.setProps({ open: true })
 
-      assertInBody('.ui.modal')
-      assertInBody('.ui.dimmer')
+      assertBodyContains('.ui.modal')
+      assertBodyContains('.ui.dimmer')
     })
 
     it('hides the modal and dimmer on changing from true to false', () => {
       wrapperMount(<Modal open />)
-      assertInBody('.ui.modal')
-      assertInBody('.ui.dimmer')
+      assertBodyContains('.ui.modal')
+      assertBodyContains('.ui.dimmer')
 
       wrapper.setProps({ open: false })
 
-      assertInBody('.ui.modal', false)
-      assertInBody('.ui.dimmer', false)
+      assertBodyContains('.ui.modal', false)
+      assertBodyContains('.ui.dimmer', false)
     })
   })
 
   describe('basic', () => {
     it('adds basic to the modal className', () => {
       wrapperMount(<Modal basic open />)
-      assertInBody('.ui.basic.modal')
+      assertBodyContains('.ui.basic.modal')
     })
   })
 
@@ -177,7 +170,7 @@ describe('Modal', () => {
     it('adds the size to the modal className', () => {
       Modal._meta.props.size.forEach(size => {
         wrapperMount(<Modal size={size} open />)
-        assertInBody(`.ui.${size}.modal`)
+        assertBodyContains(`.ui.${size}.modal`)
       })
     })
   })
@@ -191,7 +184,7 @@ describe('Modal', () => {
 
       it('is present by default', () => {
         wrapperMount(<Modal open />)
-        assertInBody('.ui.dimmer')
+        assertBodyContains('.ui.dimmer')
       })
     })
 
@@ -203,7 +196,7 @@ describe('Modal', () => {
 
       it('adds a dimmer to the body', () => {
         wrapperMount(<Modal open dimmer />)
-        assertInBody('.ui.page.modals.dimmer.transition.visible.active')
+        assertBodyContains('.ui.page.modals.dimmer.transition.visible.active')
       })
     })
 
@@ -227,7 +220,7 @@ describe('Modal', () => {
 
       it('adds a dimmer to the body', () => {
         wrapperMount(<Modal open dimmer='blurring' />)
-        assertInBody('.ui.page.modals.dimmer.transition.visible.active')
+        assertBodyContains('.ui.page.modals.dimmer.transition.visible.active')
       })
     })
 
@@ -240,7 +233,7 @@ describe('Modal', () => {
 
       it('adds an inverted dimmer to the body', () => {
         wrapperMount(<Modal open dimmer='inverted' />)
-        assertInBody('.ui.inverted.page.modals.dimmer.transition.visible.active')
+        assertBodyContains('.ui.inverted.page.modals.dimmer.transition.visible.active')
       })
     })
   })
@@ -349,7 +342,7 @@ describe('Modal', () => {
       document.body.appendChild(mountNode)
 
       wrapperMount(<Modal mountNode={mountNode} open>foo</Modal>)
-      assertIn(mountNode, '.ui.modal')
+      assertNodeContains(mountNode, '.ui.modal')
     })
   })
 

--- a/test/utils/assertNodeContains.js
+++ b/test/utils/assertNodeContains.js
@@ -1,0 +1,19 @@
+/**
+ * Assert whether a child selector is or is not present in a parent node.
+ *
+ * @param {object} parentNode A parent DOM node
+ * @param {string} childSelector A DOM selector for the child node
+ * @param {boolean} isPresent Indicating whether to assert is present or is not present
+ */
+export const assertNodeContains = (parentNode, childSelector, isPresent = true) => {
+  const didFind = parentNode.querySelector(childSelector) !== null
+  didFind.should.equal(isPresent, `${didFind ? 'Found' : 'Did not find'} "${childSelector}" in the ${parentNode}.`)
+}
+
+/**
+ * Assert whether node is or is not a child of the document.body.
+ *
+ * @param {string} selector A DOM selector for the parent node
+ * @param {boolean} isPresent Indicating whether to assert is present or is not present
+ */
+export const assertBodyContains = (selector, isPresent) => assertNodeContains(document.body, selector, isPresent)

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,3 +1,4 @@
+export * from './assertNodeContains'
 export { default as consoleUtil } from './consoleUtil'
 export { default as domEvent } from './domEvent'
 export { default as sandbox } from './sandbox'


### PR DESCRIPTION
This PR updates the Confirm addon to use the Modal v1 API.  It is currently broken.

`active` => `open`
`onHide` => `onClose`
