### PR TITLE
feat(List): Shorthand for list and list items

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentProps.js
+++ b/docs/app/Components/ComponentDoc/ComponentProps.js
@@ -54,7 +54,9 @@ export default class ComponentProps extends Component {
         value,
         required: config.required,
         defaultValue: config.defaultValue,
-        description: _.get(config, 'docBlock.description'),
+        description: _.get(config, 'docBlock.description', '')
+          .split('\n')
+          .map((l) => ([l, <br key={l} />])),
       }
     }), 'name')
     return (

--- a/docs/app/Examples/elements/List/Types/ListExampleBasicShorthand.js
+++ b/docs/app/Examples/elements/List/Types/ListExampleBasicShorthand.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { List } from 'semantic-ui-react'
+
+const ListExampleBasicShorthand = () => (
+  <List items={['Apples', 'Pears', 'Oranges']} />
+)
+
+export default ListExampleBasicShorthand

--- a/docs/app/Examples/elements/List/Types/ListExampleBulleted.js
+++ b/docs/app/Examples/elements/List/Types/ListExampleBulleted.js
@@ -6,7 +6,7 @@ const ListExampleBulleted = () => (
     <List.Item>Gaining Access</List.Item>
     <List.Item>Inviting Friends</List.Item>
     <List.Item>
-      <div>Benefits</div>
+      Benefits
 
       <List.List>
         <List.Item href='#'>Link to somewhere</List.Item>

--- a/docs/app/Examples/elements/List/Types/ListExampleBulletedSimple.js
+++ b/docs/app/Examples/elements/List/Types/ListExampleBulletedSimple.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { List } from 'semantic-ui-react'
 
 const ListExampleBulletedSimple = () => (
-  <List as='ul' bulleted>
+  <List as='ul'>
     <List.Item as='li'>Gaining Access</List.Item>
     <List.Item as='li'>Inviting Friends</List.Item>
     <List.Item as='li'>

--- a/docs/app/Examples/elements/List/Types/ListExampleIconShorthand.js
+++ b/docs/app/Examples/elements/List/Types/ListExampleIconShorthand.js
@@ -1,15 +1,13 @@
 import React from 'react'
 import { List } from 'semantic-ui-react'
 
-const items = [
-  { icon: 'users', content: 'Semantic UI' },
-  { icon: 'marker', content: 'New York, NY' },
-  { icon: 'mail', content: <a href='mailto:jack@semantic-ui.com'>jack@semantic-ui.com</a> },
-  { icon: 'linkify', content: <a href='http://www.semantic-ui.com'>semantic-ui.com</a> },
-]
-
 const ListExampleIconShorthand = () => (
-  <List items={items} />
+  <List>
+    <List.Item icon='users' content='Semantic UI' />
+    <List.Item icon='marker' content='New York, NY' />
+    <List.Item icon='mail' content={<a href='mailto:jack@semantic-ui.com'>jack@semantic-ui.com</a>} />
+    <List.Item icon='linkify' content={<a href='http://www.semantic-ui.com'>semantic-ui.com</a>} />
+  </List>
 )
 
 export default ListExampleIconShorthand

--- a/docs/app/Examples/elements/List/Types/ListExampleIconShorthand.js
+++ b/docs/app/Examples/elements/List/Types/ListExampleIconShorthand.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { List } from 'semantic-ui-react'
+
+const items = [
+  { icon: 'users', content: 'Semantic UI' },
+  { icon: 'marker', content: 'New York, NY' },
+  { icon: 'mail', content: <a href='mailto:jack@semantic-ui.com'>jack@semantic-ui.com</a> },
+  { icon: 'linkify', content: <a href='http://www.semantic-ui.com'>semantic-ui.com</a> },
+]
+
+const ListExampleIconShorthand = () => (
+  <List items={items} />
+)
+
+export default ListExampleIconShorthand

--- a/docs/app/Examples/elements/List/Types/index.js
+++ b/docs/app/Examples/elements/List/Types/index.js
@@ -44,7 +44,10 @@ const ListTypes = () => (
       description='A list can be ordered numerically'
       examplePath='elements/List/Types/ListExampleOrdered'
     />
-    <ComponentExample examplePath='elements/List/Types/ListExampleOrderedSimple' />
+    <ComponentExample
+      description='You can also use an `ol` and `li` to render an ordered list'
+      examplePath='elements/List/Types/ListExampleOrderedSimple'
+    />
     <ComponentExample examplePath='elements/List/Types/ListExampleOrderedValue'>
       <Message info>
         You can also manually specify a value for an ordered list using <code>value</code>.

--- a/docs/app/Examples/elements/List/Types/index.js
+++ b/docs/app/Examples/elements/List/Types/index.js
@@ -11,7 +11,11 @@ const ListTypes = () => (
       description='A list groups related content'
       examplePath='elements/List/Types/ListExampleBasic'
     />
+    <ComponentExample examplePath='elements/List/Types/ListExampleBasicShorthand' />
+
     <ComponentExample examplePath='elements/List/Types/ListExampleIcon' />
+    <ComponentExample examplePath='elements/List/Types/ListExampleIconShorthand' />
+
     <ComponentExample examplePath='elements/List/Types/ListExampleDivided' />
     <ComponentExample examplePath='elements/List/Types/ListExampleTree' />
 

--- a/docs/app/Examples/elements/List/Types/index.js
+++ b/docs/app/Examples/elements/List/Types/index.js
@@ -11,10 +11,19 @@ const ListTypes = () => (
       description='A list groups related content'
       examplePath='elements/List/Types/ListExampleBasic'
     />
-    <ComponentExample examplePath='elements/List/Types/ListExampleBasicShorthand' />
+    <ComponentExample
+      description='You can also pass an array of items as props'
+      examplePath='elements/List/Types/ListExampleBasicShorthand'
+    />
 
-    <ComponentExample examplePath='elements/List/Types/ListExampleIcon' />
-    <ComponentExample examplePath='elements/List/Types/ListExampleIconShorthand' />
+    <ComponentExample
+      description='A list item can contain an icon'
+      examplePath='elements/List/Types/ListExampleIcon'
+    />
+    <ComponentExample
+      description='You can also define a list item icon via props'
+      examplePath='elements/List/Types/ListExampleIconShorthand'
+    />
 
     <ComponentExample examplePath='elements/List/Types/ListExampleDivided' />
     <ComponentExample examplePath='elements/List/Types/ListExampleTree' />

--- a/docs/app/Examples/elements/List/Types/index.js
+++ b/docs/app/Examples/elements/List/Types/index.js
@@ -33,7 +33,10 @@ const ListTypes = () => (
       description='A list can mark items with a bullet'
       examplePath='elements/List/Types/ListExampleBulleted'
     />
-    <ComponentExample examplePath='elements/List/Types/ListExampleBulletedSimple' />
+    <ComponentExample
+      description='You can also use an `ul` and `li` to render a bulleted list'
+      examplePath='elements/List/Types/ListExampleBulletedSimple'
+    />
     <ComponentExample examplePath='elements/List/Types/ListExampleBulletedHorizontal' />
 
     <ComponentExample

--- a/docs/app/Views/Introduction.js
+++ b/docs/app/Views/Introduction.js
@@ -59,8 +59,8 @@ const RatingHTML = `<div
   data-max-rating="3"
 ></div>`
 
-const MessageIconJSX = `<Message 
-  success 
+const MessageIconJSX = `<Message
+  success
   icon='thumbs up'
   header='Nice job!'
   content='Your profile is complete.'
@@ -155,12 +155,12 @@ const Introduction = () => (
         <pre>$ npm install {pkg.name}</pre>
       </Segment>
       <List>
-        <List.Item icon='check mark'>jQuery Free</List.Item>
-        <List.Item icon='check mark'>Declarative API</List.Item>
-        <List.Item icon='check mark'>Augmentation</List.Item>
-        <List.Item icon='check mark'>Shorthand Props</List.Item>
-        <List.Item icon='check mark'>Sub Components</List.Item>
-        <List.Item icon='check mark'>Auto Controlled State</List.Item>
+        <List.Item icon='check mark' content='jQuery Free' />
+        <List.Item icon='check mark' content='Declarative API' />
+        <List.Item icon='check mark' content='Augmentation' />
+        <List.Item icon='check mark' content='Shorthand Props' />
+        <List.Item icon='check mark' content='Sub Components' />
+        <List.Item icon='check mark' content='Auto Controlled State' />
       </List>
     </Segment>
 

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -52,13 +52,13 @@ function Header(props) {
     return <ElementType {...rest} className={classes}>{children}</ElementType>
   }
 
-  const iconNode = Icon.create(icon)
-  const imageNode = Image.create(image)
+  const iconElement = Icon.create(icon)
+  const imageElement = Image.create(image)
 
-  if (iconNode || imageNode) {
+  if (iconElement || imageElement) {
     return (
       <ElementType {...rest} className={classes}>
-        {iconNode || imageNode}
+        {iconElement || imageElement}
         {(content || subheader) && (
           <HeaderContent>
             {content}

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -52,10 +52,13 @@ function Header(props) {
     return <ElementType {...rest} className={classes}>{children}</ElementType>
   }
 
-  if ((image && typeof image !== 'boolean') || (icon && typeof icon !== 'boolean')) {
+  const iconNode = Icon.create(icon)
+  const imageNode = Image.create(image)
+
+  if (iconNode || imageNode) {
     return (
       <ElementType {...rest} className={classes}>
-        {Icon.create(icon) || Image.create(image)}
+        {iconNode || imageNode}
         {(content || subheader) && (
           <HeaderContent>
             {content}

--- a/src/elements/List/List.js
+++ b/src/elements/List/List.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
@@ -33,6 +34,7 @@ function List(props) {
     floated,
     horizontal,
     inverted,
+    items,
     link,
     ordered,
     relaxed,
@@ -62,7 +64,15 @@ function List(props) {
   const rest = getUnhandledProps(List, props)
   const ElementType = getElementType(List, props)
 
-  return <ElementType {...rest} className={classes}>{children}</ElementType>
+  if (children) {
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
+  }
+
+  return (
+    <ElementType {...rest} className={classes}>
+      {_.map(items, (item) => ListItem.create(item))}
+    </ElementType>
+  )
 }
 
 List._meta = {
@@ -106,6 +116,9 @@ List.propTypes = {
 
   /** A list can be inverted to appear on a dark background. */
   inverted: PropTypes.bool,
+
+  /** Shorthand array of props for ListItem. */
+  items: customPropTypes.collectionShorthand,
 
   /** A list can be specially formatted for navigation links. */
   link: PropTypes.bool,

--- a/src/elements/List/ListContent.js
+++ b/src/elements/List/ListContent.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -11,11 +12,17 @@ import {
   useVerticalAlignProp,
 } from '../../lib'
 
+import ListDescription from './ListDescription'
+import ListHeader from './ListHeader'
+
 function ListContent(props) {
   const {
     children,
     className,
+    content,
+    description,
     floated,
+    header,
     verticalAlign,
   } = props
 
@@ -28,7 +35,17 @@ function ListContent(props) {
   const rest = getUnhandledProps(ListContent, props)
   const ElementType = getElementType(ListContent, props)
 
-  return <ElementType {...rest} className={classes}>{children}</ElementType>
+  if (children) {
+    return <ElementType {...rest} className={classes}>{children}</ElementType>
+  }
+
+  return (
+    <ElementType {...rest} className={classes}>
+      {ListHeader.create(header)}
+      {ListDescription.create(description)}
+      {content}
+    </ElementType>
+  )
 }
 
 ListContent._meta = {
@@ -51,11 +68,22 @@ ListContent.propTypes = {
   /** Additional classes. */
   className: PropTypes.string,
 
+  /** Shorthand for primary content. */
+  content: customPropTypes.contentShorthand,
+
+  /** Shorthand for ListDescription. */
+  description: customPropTypes.itemShorthand,
+
   /** An list content can be floated left or right. */
   floated: PropTypes.oneOf(ListContent._meta.props.floated),
+
+  /** Shorthand for ListHeader. */
+  header: customPropTypes.itemShorthand,
 
   /** An element inside a list can be vertically aligned. */
   verticalAlign: PropTypes.oneOf(ListContent._meta.props.verticalAlign),
 }
+
+ListContent.create = createShorthandFactory(ListContent, content => ({ content }))
 
 export default ListContent

--- a/src/elements/List/ListDescription.js
+++ b/src/elements/List/ListDescription.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -9,12 +10,12 @@ import {
 } from '../../lib'
 
 function ListDescription(props) {
-  const { children, className } = props
+  const { children, className, content } = props
   const classes = cx(className, 'description')
   const rest = getUnhandledProps(ListDescription, props)
   const ElementType = getElementType(ListDescription, props)
 
-  return <ElementType {...rest} className={classes}>{children}</ElementType>
+  return <ElementType {...rest} className={classes}>{children || content}</ElementType>
 }
 
 ListDescription._meta = {
@@ -32,6 +33,11 @@ ListDescription.propTypes = {
 
   /** Additional classes. */
   className: PropTypes.string,
+
+  /** Shorthand for primary content. */
+  content: customPropTypes.contentShorthand,
 }
+
+ListDescription.create = createShorthandFactory(ListDescription, content => ({ content }))
 
 export default ListDescription

--- a/src/elements/List/ListHeader.js
+++ b/src/elements/List/ListHeader.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -9,12 +10,12 @@ import {
 } from '../../lib'
 
 function ListHeader(props) {
-  const { children, className } = props
+  const { children, className, content } = props
   const classes = cx(className, 'header')
   const rest = getUnhandledProps(ListHeader, props)
   const ElementType = getElementType(ListHeader, props)
 
-  return <ElementType {...rest} className={classes}>{children}</ElementType>
+  return <ElementType {...rest} className={classes}>{children || content}</ElementType>
 }
 
 ListHeader._meta = {
@@ -32,6 +33,11 @@ ListHeader.propTypes = {
 
   /** Additional classes. */
   className: PropTypes.string,
+
+  /** Shorthand for primary content. */
+  content: customPropTypes.contentShorthand,
 }
+
+ListHeader.create = createShorthandFactory(ListHeader, content => ({ content }))
 
 export default ListHeader

--- a/src/elements/List/ListIcon.js
+++ b/src/elements/List/ListIcon.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  createShorthandFactory,
   getUnhandledProps,
   META,
   SUI,
@@ -36,5 +37,7 @@ ListIcon.propTypes = {
   /** An element inside a list can be vertically aligned. */
   verticalAlign: PropTypes.oneOf(ListIcon._meta.props.verticalAlign),
 }
+
+ListIcon.create = createShorthandFactory(ListIcon, name => ({ name }))
 
 export default ListIcon

--- a/src/elements/List/ListItem.js
+++ b/src/elements/List/ListItem.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
@@ -46,6 +47,15 @@ function ListItem(props) {
 
   const iconNode = ListIcon.create(icon)
   const imageNode = Image.create(image)
+
+  if (_.isPlainObject(content)) {
+    return (
+      <ElementType {...rest} className={classes} {...valueProp}>
+        {iconNode || imageNode}
+        {ListContent.create(content, { header, description })}
+      </ElementType>
+    )
+  }
 
   const headerNode = ListHeader.create(header)
   const descriptionNode = ListDescription.create(description)

--- a/src/elements/List/ListItem.js
+++ b/src/elements/List/ListItem.js
@@ -2,19 +2,31 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
   META,
   useKeyOnly,
 } from '../../lib'
+import Image from '../../elements/Image'
+
+import ListContent from './ListContent'
+import ListDescription from './ListDescription'
+import ListHeader from './ListHeader'
+import ListIcon from './ListIcon'
 
 function ListItem(props) {
   const {
     active,
     children,
     className,
+    content,
+    description,
     disabled,
+    header,
+    icon,
+    image,
     value,
   } = props
 
@@ -28,7 +40,38 @@ function ListItem(props) {
   const rest = getUnhandledProps(ListItem, props)
   const valueProp = ElementType === 'li' ? { value } : { 'data-value': value }
 
-  return <ElementType {...rest} {...valueProp} className={classes}>{children}</ElementType>
+  if (children) {
+    return <ElementType {...rest} className={classes} {...valueProp}>{children}</ElementType>
+  }
+
+  const iconNode = ListIcon.create(icon)
+  const imageNode = Image.create(image)
+
+  const headerNode = ListHeader.create(header)
+  const descriptionNode = ListDescription.create(description)
+
+  if (iconNode || imageNode) {
+    return (
+      <ElementType {...rest} className={classes} {...valueProp}>
+        {iconNode || imageNode}
+        {(content || headerNode || descriptionNode) && (
+          <ListContent>
+            {headerNode}
+            {descriptionNode}
+            {content}
+          </ListContent>
+        )}
+      </ElementType>
+    )
+  }
+
+  return (
+    <ElementType {...rest} className={classes} {...valueProp}>
+      {headerNode}
+      {descriptionNode}
+      {content}
+    </ElementType>
+  )
 }
 
 ListItem._meta = {
@@ -50,11 +93,34 @@ ListItem.propTypes = {
   /** Additional classes. */
   className: PropTypes.string,
 
+  /** Shorthand for primary content. */
+  content: customPropTypes.contentShorthand,
+
+  /** Shorthand for ListDescription. */
+  description: customPropTypes.itemShorthand,
+
   /** A list item can disabled. */
   disabled: PropTypes.bool,
+
+  /** Shorthand for ListHeader. */
+  header: customPropTypes.itemShorthand,
+
+  /** Shorthand for ListIcon. */
+  icon: customPropTypes.every([
+    customPropTypes.disallow(['image']),
+    customPropTypes.itemShorthand,
+  ]),
+
+  /** Shorthand for Image. */
+  image: customPropTypes.every([
+    customPropTypes.disallow(['icon']),
+    customPropTypes.itemShorthand,
+  ]),
 
   /** A value for an ordered list. */
   value: PropTypes.string,
 }
+
+ListItem.create = createShorthandFactory(ListItem, content => ({ content }))
 
 export default ListItem

--- a/src/elements/List/ListItem.js
+++ b/src/elements/List/ListItem.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import cx from 'classnames'
-import React, { PropTypes } from 'react'
+import React, { isValidElement, PropTypes } from 'react'
 
 import {
   createShorthandFactory,
@@ -45,29 +45,30 @@ function ListItem(props) {
     return <ElementType {...rest} className={classes} {...valueProp}>{children}</ElementType>
   }
 
-  const iconNode = ListIcon.create(icon)
-  const imageNode = Image.create(image)
+  const iconElement = ListIcon.create(icon)
+  const imageElement = Image.create(image)
 
-  if (_.isPlainObject(content)) {
+  // See description of `content` prop for explanation about why this is necessary.
+  if (!isValidElement(content) && _.isPlainObject(content)) {
     return (
       <ElementType {...rest} className={classes} {...valueProp}>
-        {iconNode || imageNode}
+        {iconElement || imageElement}
         {ListContent.create(content, { header, description })}
       </ElementType>
     )
   }
 
-  const headerNode = ListHeader.create(header)
-  const descriptionNode = ListDescription.create(description)
+  const headerElement = ListHeader.create(header)
+  const descriptionElement = ListDescription.create(description)
 
-  if (iconNode || imageNode) {
+  if (iconElement || imageElement) {
     return (
       <ElementType {...rest} className={classes} {...valueProp}>
-        {iconNode || imageNode}
-        {(content || headerNode || descriptionNode) && (
+        {iconElement || imageElement}
+        {(content || headerElement || descriptionElement) && (
           <ListContent>
-            {headerNode}
-            {descriptionNode}
+            {headerElement}
+            {descriptionElement}
             {content}
           </ListContent>
         )}
@@ -77,8 +78,8 @@ function ListItem(props) {
 
   return (
     <ElementType {...rest} className={classes} {...valueProp}>
-      {headerNode}
-      {descriptionNode}
+      {headerElement}
+      {descriptionElement}
       {content}
     </ElementType>
   )
@@ -103,8 +104,22 @@ ListItem.propTypes = {
   /** Additional classes. */
   className: PropTypes.string,
 
-  /** Shorthand for primary content. */
-  content: customPropTypes.contentShorthand,
+  /**
+   * Shorthand for primary content.
+   *
+   * Heads up!
+   *
+   * This is handled slightly differently than the typical `content` prop since
+   * the wrapping ListContent is not used when there's no icon or image.
+   *
+   * If you pass content as:
+   * - an element/literal, it's treated as the sibling node to
+   * header/description (whether wrapped in Item.Content or not).
+   * - a props object, it forces the presence of Item.Content and passes those
+   * props to it. If you pass a content prop within that props object, it
+   * will be treated as the sibling node to header/description.
+   */
+  content: customPropTypes.itemShorthand,
 
   /** Shorthand for ListDescription. */
   description: customPropTypes.itemShorthand,

--- a/test/specs/elements/List/List-test.js
+++ b/test/specs/elements/List/List-test.js
@@ -1,3 +1,5 @@
+import React from 'react'
+
 import * as common from 'test/specs/commonTests'
 import List from 'src/elements/List/List'
 import ListContent from 'src/elements/List/ListContent'
@@ -27,4 +29,20 @@ describe('List', () => {
   common.propKeyOrValueAndKeyToClassName(List, 'relaxed')
   common.propValueOnlyToClassName(List, 'size')
   common.implementsVerticalAlignProp(List)
+
+  describe('shorthand', () => {
+    const items = ['Name', 'Status', 'Notes']
+
+    it('renders empty tr with no shorthand', () => {
+      const wrapper = shallow(<List />)
+
+      wrapper.find('ListItem').should.have.lengthOf(0)
+    })
+
+    it('renders the items', () => {
+      const wrapper = shallow(<List items={items} />)
+
+      wrapper.find('ListItem').should.have.lengthOf(items.length)
+    })
+  })
 })

--- a/test/specs/elements/List/ListContent-test.js
+++ b/test/specs/elements/List/ListContent-test.js
@@ -1,4 +1,7 @@
+import faker from 'faker'
+import React from 'react'
 import * as common from 'test/specs/commonTests'
+
 import ListContent from 'src/elements/List/ListContent'
 
 describe('ListContent', () => {
@@ -7,4 +10,20 @@ describe('ListContent', () => {
 
   common.implementsVerticalAlignProp(ListContent)
   common.propKeyAndValueToClassName(ListContent, 'floated')
+
+  describe('shorthand', () => {
+    const baseProps = {
+      content: faker.hacker.phrase(),
+      description: faker.hacker.phrase(),
+      header: faker.hacker.phrase(),
+    }
+
+    it('renders content without wrapping ListContent', () => {
+      const wrapper = shallow(<ListContent {...baseProps} />)
+
+      wrapper.find('ListHeader').should.have.prop('content', baseProps.header)
+      wrapper.find('ListDescription').should.have.prop('content', baseProps.description)
+      wrapper.should.contain.text(baseProps.content)
+    })
+  })
 })

--- a/test/specs/elements/List/ListItem-test.js
+++ b/test/specs/elements/List/ListItem-test.js
@@ -1,8 +1,11 @@
+import _ from 'lodash'
 import faker from 'faker'
 import React from 'react'
 import * as common from 'test/specs/commonTests'
+import { sandbox } from 'test/utils'
 
 import ListItem from 'src/elements/List/ListItem'
+import ListContent from 'src/elements/List/ListContent'
 
 describe('ListItem', () => {
   common.isConformant(ListItem)
@@ -31,6 +34,49 @@ describe('ListItem', () => {
 
       shallow(<ListItem as='li' value={value} />)
         .should.have.attr('value', value)
+    })
+  })
+
+  describe('shorthand', () => {
+    const baseProps = {
+      content: faker.hacker.phrase(),
+      description: faker.hacker.phrase(),
+      header: faker.hacker.phrase(),
+    }
+
+    it('renders without wrapping ListContent', () => {
+      const wrapper = shallow(<ListItem {...baseProps} />)
+
+      wrapper.find('ListContent').should.have.lengthOf(0)
+    })
+
+    it('renders without wrapping ListContent when content passed as element', () => {
+      const spy = sandbox.spy(ListContent, 'create')
+      shallow(<ListItem {...baseProps} content={<div />} />)
+
+      spy.should.not.have.been.called()
+    })
+
+    it('renders wrapping ListContent when content passed as props', () => {
+      const wrapper = shallow(<ListItem content={baseProps} />)
+
+      wrapper.find('ListContent').should.have.lengthOf(1)
+    })
+
+    _.each(baseProps, (value, key) => {
+      it(`renders wrapping ListContent when icon and ${key} present`, () => {
+        const wrapper = shallow(<ListItem {..._.pick(baseProps, key)} icon='user' />)
+
+        wrapper.find('ListIcon').should.have.lengthOf(1)
+        wrapper.find('ListContent').should.have.lengthOf(1)
+      })
+
+      it(`renders wrapping ListContent when image and ${key} present`, () => {
+        const wrapper = shallow(<ListItem {..._.pick(baseProps, key)} image='foo.png' />)
+
+        wrapper.find('Image').should.have.lengthOf(1)
+        wrapper.find('ListContent').should.have.lengthOf(1)
+      })
     })
   })
 })


### PR DESCRIPTION
Fixes #589

This adds shorthand for list and list item. Still somewhat WIP:
- [x] Add missing test coverage
- [x] ~~Add pass-through props to item-content~~ Solved a different way

Only open question is regarding documentation. How do we want to handle shorthand documentation? I added a few examples here but there's a lot of them for List so I wanted to clarify our approach before going much further. Some thoughts:
- I definitely think we should write shorthand for all examples.
- I think the best idea would be to just show the example once and show the shorthand side-by-side with the regular code. 
  - Showing the shorthand in separate section makes it less discoverable.
  - Showing the same exact example twice is redundant and makes the docs hard to read.

This (more advanced shorthand documentation) may be something we leave for a separate PR, just wanted to get thoughts.
