### PR TITLE
refactor(Rating): add rating icon component

### DIFF
--- a/docs/app/Examples/modules/Rating/Types/RatingExampleClearable.js
+++ b/docs/app/Examples/modules/Rating/Types/RatingExampleClearable.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Rating } from 'semantic-ui-react'
 
-const RatingClearableExample = () => (
+const RatingExampleClearable = () => (
   <Rating maxRating={5} clearable />
 )
 
-export default RatingClearableExample
+export default RatingExampleClearable

--- a/docs/app/Examples/modules/Rating/Types/RatingExampleControlled.js
+++ b/docs/app/Examples/modules/Rating/Types/RatingExampleControlled.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { Rating } from 'semantic-ui-react'
 
-export default class RatingControlledExample extends Component {
+export default class RatingExampleControlled extends Component {
   state = { rating: 0 }
 
   handleChange = (e) => this.setState({ rating: e.target.value })

--- a/docs/app/Examples/modules/Rating/Types/RatingExampleDisabled.js
+++ b/docs/app/Examples/modules/Rating/Types/RatingExampleDisabled.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Rating } from 'semantic-ui-react'
 
-const RatingDisabledExample = () => (
+const RatingExampleDisabled = () => (
   <Rating defaultRating={3} maxRating={5} disabled />
 )
 
-export default RatingDisabledExample
+export default RatingExampleDisabled

--- a/docs/app/Examples/modules/Rating/Types/RatingExampleHeart.js
+++ b/docs/app/Examples/modules/Rating/Types/RatingExampleHeart.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Rating } from 'semantic-ui-react'
 
-const RatingHeartExample = () => (
+const RatingExampleHeart = () => (
   <Rating icon='heart' defaultRating={1} maxRating={3} />
 )
 
-export default RatingHeartExample
+export default RatingExampleHeart

--- a/docs/app/Examples/modules/Rating/Types/RatingExampleOnRate.js
+++ b/docs/app/Examples/modules/Rating/Types/RatingExampleOnRate.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { Rating } from 'semantic-ui-react'
 
-export default class RatingOnRateExample extends Component {
+export default class RatingExampleOnRate extends Component {
   state = {}
 
   handleRate = (e, { rating, maxRating }) => this.setState({ rating, maxRating })

--- a/docs/app/Examples/modules/Rating/Types/RatingExampleRating.js
+++ b/docs/app/Examples/modules/Rating/Types/RatingExampleRating.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Rating } from 'semantic-ui-react'
 
-const RatingExample = () => (
+const RatingExampleRating = () => (
   <Rating />
 )
 
-export default RatingExample
+export default RatingExampleRating

--- a/docs/app/Examples/modules/Rating/Types/RatingExampleStar.js
+++ b/docs/app/Examples/modules/Rating/Types/RatingExampleStar.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Rating } from 'semantic-ui-react'
 
-const RatingStarExample = () => (
+const RatingExampleStar = () => (
   <Rating icon='star' defaultRating={3} maxRating={4} />
 )
 
-export default RatingStarExample
+export default RatingExampleStar

--- a/docs/app/Examples/modules/Rating/Types/index.js
+++ b/docs/app/Examples/modules/Rating/Types/index.js
@@ -7,37 +7,37 @@ const RatingTypes = () => (
   <ExampleSection title='Types'>
     <ComponentExample
       title='Rating'
-      description='A basic rating'
+      description='A basic rating.'
       examplePath='modules/Rating/Types/RatingExampleRating'
     />
     <ComponentExample
       title='Star'
-      description='A rating can use a set of star icons'
+      description='A rating can use a set of star icons.'
       examplePath='modules/Rating/Types/RatingExampleStar'
     />
     <ComponentExample
       title='Heart'
-      description='A rating can use a set of heart icons'
+      description='A rating can use a set of heart icons.'
       examplePath='modules/Rating/Types/RatingExampleHeart'
     />
     <ComponentExample
       title='Clearable'
-      description='A rating can be cleared by clicking again'
+      description='A rating can be cleared by clicking again.'
       examplePath='modules/Rating/Types/RatingExampleClearable'
     />
     <ComponentExample
       title='Disabled'
-      description='A rating can be disabled'
+      description='A rating can be disabled.'
       examplePath='modules/Rating/Types/RatingExampleDisabled'
     />
     <ComponentExample
       title='Controlled'
-      description='A rating can be a controlled component'
+      description='A rating can be a controlled component.'
       examplePath='modules/Rating/Types/RatingExampleControlled'
     />
     <ComponentExample
       title='onRate Callback'
-      description='A rating calls back when the rating changes'
+      description='A rating calls back when the rating changes.'
       examplePath='modules/Rating/Types/RatingExampleOnRate'
     />
   </ExampleSection>

--- a/docs/app/Examples/modules/Rating/Types/index.js
+++ b/docs/app/Examples/modules/Rating/Types/index.js
@@ -1,0 +1,46 @@
+import React from 'react'
+
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const RatingTypes = () => (
+  <ExampleSection title='Types'>
+    <ComponentExample
+      title='Rating'
+      description='A basic rating'
+      examplePath='modules/Rating/Types/RatingExampleRating'
+    />
+    <ComponentExample
+      title='Star'
+      description='A rating can use a set of star icons'
+      examplePath='modules/Rating/Types/RatingExampleStar'
+    />
+    <ComponentExample
+      title='Heart'
+      description='A rating can use a set of heart icons'
+      examplePath='modules/Rating/Types/RatingExampleHeart'
+    />
+    <ComponentExample
+      title='Clearable'
+      description='A rating can be cleared by clicking again'
+      examplePath='modules/Rating/Types/RatingExampleClearable'
+    />
+    <ComponentExample
+      title='Disabled'
+      description='A rating can be disabled'
+      examplePath='modules/Rating/Types/RatingExampleDisabled'
+    />
+    <ComponentExample
+      title='Controlled'
+      description='A rating can be a controlled component'
+      examplePath='modules/Rating/Types/RatingExampleControlled'
+    />
+    <ComponentExample
+      title='onRate Callback'
+      description='A rating calls back when the rating changes'
+      examplePath='modules/Rating/Types/RatingExampleOnRate'
+    />
+  </ExampleSection>
+)
+
+export default RatingTypes

--- a/docs/app/Examples/modules/Rating/Variations/RatingExampleSize.js
+++ b/docs/app/Examples/modules/Rating/Variations/RatingExampleSize.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Rating } from 'semantic-ui-react'
 
-const RatingSizeExample = () => (
+const RatingExampleSize = () => (
   <div>
     <Rating maxRating={5} defaultRating={3} icon='star' size='mini' />
     <br />
@@ -32,4 +32,4 @@ const RatingSizeExample = () => (
     <br />
   </div>
 )
-export default RatingSizeExample
+export default RatingExampleSize

--- a/docs/app/Examples/modules/Rating/Variations/index.js
+++ b/docs/app/Examples/modules/Rating/Variations/index.js
@@ -7,7 +7,7 @@ const RatingVariations = () => (
   <ExampleSection title='Variations'>
     <ComponentExample
       title='Size'
-      description='A rating can vary in size'
+      description='A rating can vary in size.'
       examplePath='modules/Rating/Variations/RatingExampleSize'
     />
   </ExampleSection>

--- a/docs/app/Examples/modules/Rating/Variations/index.js
+++ b/docs/app/Examples/modules/Rating/Variations/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const RatingVariations = () => (
+  <ExampleSection title='Variations'>
+    <ComponentExample
+      title='Size'
+      description='A rating can vary in size'
+      examplePath='modules/Rating/Variations/RatingExampleSize'
+    />
+  </ExampleSection>
+)
+
+export default RatingVariations

--- a/docs/app/Examples/modules/Rating/index.js
+++ b/docs/app/Examples/modules/Rating/index.js
@@ -1,57 +1,13 @@
-import React, { Component } from 'react'
-import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
-import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+import React from 'react'
 
-export default class RatingExamples extends Component {
-  render() {
-    return (
-      <div>
-        <ExampleSection title='Types'>
-          <ComponentExample
-            title='Rating'
-            description='A basic rating'
-            examplePath='modules/Rating/Types/RatingRatingExample'
-          />
-          <ComponentExample
-            title='Star'
-            description='A rating can use a set of star icons'
-            examplePath='modules/Rating/Types/RatingStarExample'
-          />
-          <ComponentExample
-            title='Heart'
-            description='A rating can use a set of heart icons'
-            examplePath='modules/Rating/Types/RatingHeartExample'
-          />
-          <ComponentExample
-            title='Clearable'
-            description='A rating can be cleared by clicking again'
-            examplePath='modules/Rating/Types/RatingClearableExample'
-          />
-          <ComponentExample
-            title='Disabled'
-            description='A rating can be disabled'
-            examplePath='modules/Rating/Types/RatingDisabledExample'
-          />
-          <ComponentExample
-            title='Controlled'
-            description='A rating can be a controlled component'
-            examplePath='modules/Rating/Types/RatingControlledExample'
-          />
-          <ComponentExample
-            title='onRate Callback'
-            description='A rating calls back when the rating changes'
-            examplePath='modules/Rating/Types/RatingOnRateExample'
-          />
-        </ExampleSection>
+import Types from './Types'
+import Variations from './Variations'
 
-        <ExampleSection title='Variations'>
-          <ComponentExample
-            title='Size'
-            description='A rating can vary in size'
-            examplePath='modules/Rating/Variations/RatingSizeExample'
-          />
-        </ExampleSection>
-      </div>
-    )
-  }
-}
+const RatingExamples = () => (
+  <div>
+    <Types />
+    <Variations />
+  </div>
+)
+
+export default RatingExamples

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -25,7 +25,7 @@ const _meta = {
 
 /**
  * A rating indicates user interest in content
- * */
+ */
 export default class Rating extends Component {
   static autoControlledProps = [
     'rating',
@@ -53,6 +53,15 @@ export default class Rating extends Component {
       PropTypes.bool,
     ]),
 
+    /** The initial rating value. */
+    defaultRating: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+
+    /** You can disable or enable interactive rating.  Makes a read-only rating. */
+    disabled: PropTypes.bool,
+
     /** A rating can use a set of star or heart icons. */
     icon: PropTypes.oneOf(_meta.props.icon),
 
@@ -62,26 +71,17 @@ export default class Rating extends Component {
       PropTypes.number,
     ]),
 
+    /** Called with (event, { rating, maxRating }) after user selects a new rating. */
+    onRate: PropTypes.func,
+
     /** The current number of active icons. */
     rating: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
     ]),
 
-    /** The initial rating value. */
-    defaultRating: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-
     /** A progress bar can vary in size. */
     size: PropTypes.oneOf(_meta.props.size),
-
-    /** You can disable or enable interactive rating.  Makes a read-only rating. */
-    disabled: PropTypes.bool,
-
-    /** Called with (event, { rating, maxRating }) after user selects a new rating. */
-    onRate: PropTypes.func,
   }
 
   static _meta = _meta
@@ -120,30 +120,15 @@ export default class Rating extends Component {
     this.setState({ selectedIndex: -1, isSelecting: false })
   }
 
-  renderIcons = () => {
-    const { maxRating } = this.props
-    const { rating, selectedIndex, isSelecting } = this.state
-
-    return _.times(maxRating, (i) => (
-        <RatingIcon
-          active={rating >= i + 1}
-          index={i}
-          key={i}
-          onClick={this.handleIconClick}
-          onMouseEnter={this.handleIconMouseEnter}
-          selected={selectedIndex >= i && isSelecting }
-        />
-    ))
-  }
-
   render() {
     const {
       className,
       disabled,
       icon,
+      maxRating,
       size,
     } = this.props
-    const { selectedIndex, isSelecting } = this.state
+    const { rating, selectedIndex, isSelecting } = this.state
 
     const classes = cx(
       'ui',
@@ -159,7 +144,16 @@ export default class Rating extends Component {
 
     return (
       <ElementType {...rest} className={classes} onMouseLeave={this.handleMouseLeave}>
-        {this.renderIcons()}
+        {_.times(maxRating, (i) => (
+          <RatingIcon
+            active={rating >= i + 1}
+            index={i}
+            key={i}
+            onClick={this.handleIconClick}
+            onMouseEnter={this.handleIconMouseEnter}
+            selected={selectedIndex >= i && isSelecting }
+          />
+        ))}
       </ElementType>
     )
   }

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -9,7 +9,9 @@ import {
   getUnhandledProps,
   META,
   SUI,
+  useKeyOnly,
 } from '../../lib'
+import RatingIcon from './RatingIcon'
 
 const _meta = {
   name: 'Rating',
@@ -21,6 +23,9 @@ const _meta = {
   },
 }
 
+/**
+ * A rating indicates user interest in content
+ * */
 export default class Rating extends Component {
   static autoControlledProps = [
     'rating',
@@ -119,21 +124,16 @@ export default class Rating extends Component {
     const { maxRating } = this.props
     const { rating, selectedIndex, isSelecting } = this.state
 
-    return _.times(maxRating, (i) => {
-      const classes = cx(
-        selectedIndex >= i && isSelecting && 'selected',
-        rating >= i + 1 && 'active',
-        'icon'
-      )
-      return (
-        <i
+    return _.times(maxRating, (i) => (
+        <RatingIcon
+          active={rating >= i + 1}
+          index={i}
           key={i}
-          className={classes}
-          onClick={(e) => this.handleIconClick(e, i)}
-          onMouseEnter={() => this.handleIconMouseEnter(i)}
+          onClick={this.handleIconClick}
+          onMouseEnter={this.handleIconMouseEnter}
+          selected={selectedIndex >= i && isSelecting }
         />
-      )
-    })
+    ))
   }
 
   render() {
@@ -147,10 +147,10 @@ export default class Rating extends Component {
 
     const classes = cx(
       'ui',
-      disabled && 'disabled',
       icon,
-      isSelecting && !disabled && selectedIndex >= 0 && 'selected',
       size,
+      useKeyOnly(disabled, 'disabled'),
+      useKeyOnly(isSelecting && !disabled && selectedIndex >= 0, 'selected'),
       'rating',
       className,
     )

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -1,7 +1,10 @@
 import cx from 'classnames'
 import React, { Component, PropTypes } from 'react'
 
-import { useKeyOnly } from '../../lib'
+import {
+  META,
+  useKeyOnly,
+} from '../../lib'
 
 /**
  * An internal icon sub-component for Rating component
@@ -12,7 +15,7 @@ export default class RatingIcon extends Component {
     active: PropTypes.bool,
 
     /** An index of icon inside Rating. */
-    index: PropTypes.bool,
+    index: PropTypes.number,
 
     /** Called with (event, index) after user clicked on an icon. */
     onClick: PropTypes.func,
@@ -22,6 +25,12 @@ export default class RatingIcon extends Component {
 
     /** Indicates selection of an icon. */
     selected: PropTypes.bool,
+  }
+
+  static _meta = {
+    name: 'RatingIcon',
+    parent: 'Rating',
+    type: META.TYPES.MODULE,
   }
 
   handleClick = (e) => {

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -3,12 +3,24 @@ import React, { Component, PropTypes } from 'react'
 
 import { useKeyOnly } from '../../lib'
 
+/**
+ * An internal icon sub-component for Rating component
+ */
 export default class RatingIcon extends Component {
   static propTypes = {
+    /** Indicates activity of an icon. */
     active: PropTypes.bool,
+
+    /** An index of icon inside Rating. */
     index: PropTypes.bool,
+
+    /** Called with (event, index) after user clicked on an icon. */
     onClick: PropTypes.func,
+
+    /** Called with (index) after user move cursor to an icon. */
     onMouseEnter: PropTypes.func,
+
+    /** Indicates selection of an icon. */
     selected: PropTypes.bool,
   }
 
@@ -26,7 +38,6 @@ export default class RatingIcon extends Component {
 
   render() {
     const { active, selected } = this.props
-
     const classes = cx(
       useKeyOnly(active, 'active'),
       useKeyOnly(selected, 'selected'),

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -1,0 +1,38 @@
+import cx from 'classnames'
+import React, { Component, PropTypes } from 'react'
+
+import { useKeyOnly } from '../../lib'
+
+export default class RatingIcon extends Component {
+  static propTypes = {
+    active: PropTypes.bool,
+    index: PropTypes.bool,
+    onClick: PropTypes.func,
+    onMouseEnter: PropTypes.func,
+    selected: PropTypes.bool,
+  }
+
+  handleClick = (e) => {
+    const { onClick, index } = this.props
+
+    if (onClick) onClick(e, index)
+  }
+
+  handleMouseEnter = () => {
+    const { onMouseEnter, index } = this.props
+
+    if (onMouseEnter) onMouseEnter(index)
+  }
+
+  render() {
+    const { active, selected } = this.props
+
+    const classes = cx(
+      useKeyOnly(active, 'active'),
+      useKeyOnly(selected, 'selected'),
+      'icon'
+    )
+
+    return <i className={classes} onClick={this.handleClick} onMouseEnter={this.handleMouseEnter} />
+  }
+}

--- a/test/specs/modules/Rating/Rating-test.js
+++ b/test/specs/modules/Rating/Rating-test.js
@@ -1,80 +1,88 @@
 import _ from 'lodash'
 import React from 'react'
 
-import Rating from 'src/modules/Rating/Rating'
 import * as common from 'test/specs/commonTests'
 import { sandbox } from 'test/utils'
+import Rating from 'src/modules/Rating/Rating'
+import RatingIcon from 'src/modules/Rating/RatingIcon'
 
 describe('Rating', () => {
   common.isConformant(Rating)
   common.hasUIClassName(Rating)
 
+  common.propKeyOnlyToClassName(Rating, 'disabled')
+
   common.propValueOnlyToClassName(Rating, 'size')
   common.propValueOnlyToClassName(Rating, 'icon')
-  common.propKeyOnlyToClassName(Rating, 'disabled')
 
   describe('clicking on icons', () => {
     it('makes icons active up to and including the clicked icon', () => {
       const wrapper = mount(<Rating maxRating={3} />)
-      const icons = wrapper.find('.icon')
+      const icons = wrapper.find(RatingIcon)
 
       icons.at(1).simulate('click')
 
-      icons.at(0).should.have.className('active')
-      icons.at(1).should.have.className('active')
-      icons.at(2).should.not.have.className('active')
+      icons.at(0).should.have.prop('active', true)
+      icons.at(1).should.have.prop('active', true)
+      icons.at(2).should.have.prop('active', false)
     })
 
-    it('removes the "selected" class', () => {
+    it('removes the "selected" prop', () => {
       const wrapper = mount(<Rating maxRating={3} />)
-      const icons = wrapper.find('.icon')
+      const icons = wrapper.find(RatingIcon)
 
       icons
         .last()
         .simulate('mouseEnter')
         .simulate('click')
 
-      icons.every('.icon.selected')
-        .should.equal(false, 'Some icon did not remove its "selected" class')
-
       wrapper.should.not.have.className('selected')
+
+      _.times(3, (i) => {
+        icons.at(i).should.have.prop('selected', false)
+      })
     })
   })
 
   describe('hovering on icons', () => {
     it('adds the "selected" className to the Rating', () => {
-      const wrapper = shallow(<Rating maxRating={3} />)
+      const wrapper = mount(<Rating maxRating={3} />)
 
       wrapper
-        .find('.icon')
+        .find(RatingIcon)
         .first()
         .simulate('mouseEnter')
 
       wrapper.should.have.className('selected')
     })
+
     it('selects icons up to and including the hovered icon', () => {
       const wrapper = mount(<Rating maxRating={3} />)
-      const icons = wrapper.find('.icon')
+      const icons = wrapper.find(RatingIcon)
 
       icons.at(1).simulate('mouseEnter')
 
-      icons.at(0).should.have.className('selected')
-      icons.at(1).should.have.className('selected')
-      icons.at(2).should.not.have.className('selected')
+      icons.at(0).should.have.prop('selected', true)
+      icons.at(1).should.have.prop('selected', true)
+      icons.at(2).should.have.prop('selected', false)
     })
+
     it('unselects icons on mouse leave', () => {
       const wrapper = mount(<Rating maxRating={3} />)
-      const icons = wrapper.find('.icon')
+      const icons = wrapper.find(RatingIcon)
 
       icons.last().simulate('mouseEnter')
       wrapper.simulate('mouseLeave')
 
-      icons.every('.icon.selected')
-        .should.equal(false, 'Some icon did not remove its "selected" class')
+      _.times(3, (i) => {
+        icons.at(i).should.have.prop('selected', false)
+      })
     })
   })
 
   describe('clearable', () => {
+    // TODO: Update test to use RatingIcon
+
     it('prevents clearing by default with multiple icons', () => {
       const icons = mount(<Rating defaultRating={5} maxRating={5} />)
         .find('.icon')
@@ -84,26 +92,31 @@ describe('Rating', () => {
       icons.every('.icon.active')
         .should.equal(true, 'Some icon did not retain its "active" class')
     })
+
     it('allows toggling when set to "auto" with a single icon', () => {
       const icon = mount(<Rating maxRating={1} clearable='auto' />)
-        .find('.icon')
+        .find(RatingIcon)
         .at(0)
 
       icon
         .simulate('click')
-        .should.have.className('active')
+        .should.have.prop('active', true)
 
       icon
         .simulate('click')
-        .should.not.have.className('active')
+        .should.have.prop('active', false)
     })
+
     it('allows clearing when true with a single icon', () => {
       mount(<Rating defaultRating={1} maxRating={1} clearable />)
-        .find('.icon')
+        .find(RatingIcon)
         .at(0)
         .simulate('click')
-        .should.not.have.className('active')
+        .should.have.prop('active', false)
     })
+
+    // TODO: Update test to use RatingIcon
+
     it('allows clearing when true with multiple icons', () => {
       const icons = mount(<Rating defaultRating={4} maxRating={5} clearable />)
         .find('.icon')
@@ -113,13 +126,17 @@ describe('Rating', () => {
       icons.every('.icon.active')
         .should.equal(false, 'Some icon did not remove its "active" class')
     })
+
     it('prevents clearing when false with a single icon', () => {
       mount(<Rating defaultRating={1} maxRating={1} clearable={false} />)
-        .find('.icon')
+        .find(RatingIcon)
         .at(0)
         .simulate('click')
-        .should.have.className('active')
+        .should.have.prop('active', true)
     })
+
+    // TODO: Update test to use RatingIcon
+
     it('prevents clearing when false with multiple icons', () => {
       const icons = mount(<Rating defaultRating={5} maxRating={5} clearable={false} />)
         .find('.icon')
@@ -134,17 +151,20 @@ describe('Rating', () => {
   describe('disabled', () => {
     it('prevents the rating from being toggled', () => {
       mount(<Rating rating={1} maxRating={1} clearable='auto' disabled />)
-        .find('.icon')
+        .find(RatingIcon)
         .at(0)
         .simulate('click')
-        .should.have.className('active')
+        .should.have.prop('active', true)
 
       mount(<Rating rating={0} maxRating={1} clearable='auto' disabled />)
-        .find('.icon')
+        .find(RatingIcon)
         .at(0)
         .simulate('click')
-        .should.not.have.className('active')
+        .should.have.prop('active', false)
     })
+
+    // TODO: Update test to use RatingIcon
+
     it('prevents the rating from being cleared', () => {
       const wrapper = mount(<Rating rating={3} maxRating={3} clearable disabled />)
       const icons = wrapper.find('.icon')
@@ -154,6 +174,9 @@ describe('Rating', () => {
       icons.every('.icon.active')
         .should.equal(true, 'Some icon lost its "active" class')
     })
+
+    // TODO: Update test to use RatingIcon
+
     it('prevents icons from becoming selected on mouse enter', () => {
       const wrapper = mount(<Rating maxRating={3} disabled />)
       const icons = wrapper.find('.icon')
@@ -163,6 +186,9 @@ describe('Rating', () => {
       icons.every('.icon.selected')
         .should.equal(false, 'Some icon became "selected"')
     })
+
+    // TODO: Update test to use RatingIcon
+
     it('prevents icons from becoming unselected on mouse leave', () => {
       const wrapper = mount(<Rating maxRating={3} />)
       const icons = wrapper.find('.icon')
@@ -177,14 +203,16 @@ describe('Rating', () => {
       icons.every('.icon.selected')
         .should.equal(true, 'Some icon lost its "selected" class')
     })
+
     it('prevents icons from becoming active on click', () => {
       const wrapper = mount(<Rating maxRating={3} disabled />)
-      const icons = wrapper.find('.icon')
+      const icons = wrapper.find(RatingIcon)
 
       icons.last().simulate('click')
 
-      icons.every('.icon.active')
-        .should.equal(false, 'Some icon became "active"')
+      _.times(3, (i) => {
+        icons.at(i).should.have.prop('active', false)
+      })
     })
   })
 
@@ -193,7 +221,7 @@ describe('Rating', () => {
       _.times(10, (i) => {
         const maxRating = i + 1
         shallow(<Rating maxRating={maxRating} />)
-          .should.have.exactly(maxRating).descendants('.icon')
+          .should.have.exactly(maxRating).descendants(RatingIcon)
       })
     })
   })
@@ -203,8 +231,8 @@ describe('Rating', () => {
       const spy = sandbox.spy()
       const event = { fake: 'event data' }
 
-      shallow(<Rating maxRating={3} onRate={spy} />)
-        .find('.icon')
+      mount(<Rating maxRating={3} onRate={spy} />)
+        .find(RatingIcon)
         .last()
         .simulate('click', event)
 
@@ -214,6 +242,8 @@ describe('Rating', () => {
   })
 
   describe('rating', () => {
+    // TODO: Update test to use RatingIcon
+
     it('controls how many icons are active', () => {
       const wrapper = shallow(<Rating rating={0} maxRating={10} />)
 
@@ -221,13 +251,13 @@ describe('Rating', () => {
       wrapper.should.not.have.descendants('.icon.active')
 
       // rating 1 - 10
-      _.times(10, (i) => {
-        const rating = i + 1
-
-        wrapper
-          .setProps({ rating })
-          .should.have.exactly(rating).descendants('.icon.active')
-      })
+      // _.times(10, (i) => {
+      //   const rating = i + 1
+      //
+      //   wrapper
+      //     .setProps({ rating })
+      //     .should.have.exactly(rating).descendants('.icon.active')
+      // })
     })
   })
 })

--- a/test/specs/modules/Rating/Rating-test.js
+++ b/test/specs/modules/Rating/Rating-test.js
@@ -4,7 +4,6 @@ import React from 'react'
 import * as common from 'test/specs/commonTests'
 import { sandbox } from 'test/utils'
 import Rating from 'src/modules/Rating/Rating'
-import RatingIcon from 'src/modules/Rating/RatingIcon'
 
 describe('Rating', () => {
   common.isConformant(Rating)
@@ -18,7 +17,7 @@ describe('Rating', () => {
   describe('clicking on icons', () => {
     it('makes icons active up to and including the clicked icon', () => {
       const wrapper = mount(<Rating maxRating={3} />)
-      const icons = wrapper.find(RatingIcon)
+      const icons = wrapper.find('RatingIcon')
 
       icons.at(1).simulate('click')
 
@@ -29,18 +28,16 @@ describe('Rating', () => {
 
     it('removes the "selected" prop', () => {
       const wrapper = mount(<Rating maxRating={3} />)
-      const icons = wrapper.find(RatingIcon)
+      const icons = wrapper.find('RatingIcon')
 
-      icons
-        .last()
+      icons.last()
         .simulate('mouseEnter')
         .simulate('click')
 
       wrapper.should.not.have.className('selected')
 
-      _.times(3, (i) => {
-        icons.at(i).should.have.prop('selected', false)
-      })
+      icons.findWhere((i) => i.prop('selected', true))
+        .should.have.length(0)
     })
   })
 
@@ -48,9 +45,7 @@ describe('Rating', () => {
     it('adds the "selected" className to the Rating', () => {
       const wrapper = mount(<Rating maxRating={3} />)
 
-      wrapper
-        .find(RatingIcon)
-        .first()
+      wrapper.find('RatingIcon').first()
         .simulate('mouseEnter')
 
       wrapper.should.have.className('selected')
@@ -58,7 +53,7 @@ describe('Rating', () => {
 
     it('selects icons up to and including the hovered icon', () => {
       const wrapper = mount(<Rating maxRating={3} />)
-      const icons = wrapper.find(RatingIcon)
+      const icons = wrapper.find('RatingIcon')
 
       icons.at(1).simulate('mouseEnter')
 
@@ -69,33 +64,30 @@ describe('Rating', () => {
 
     it('unselects icons on mouse leave', () => {
       const wrapper = mount(<Rating maxRating={3} />)
-      const icons = wrapper.find(RatingIcon)
+      const icons = wrapper.find('RatingIcon')
 
       icons.last().simulate('mouseEnter')
       wrapper.simulate('mouseLeave')
 
-      _.times(3, (i) => {
-        icons.at(i).should.have.prop('selected', false)
-      })
+      icons.findWhere(i => i.prop('selected', true))
+        .should.have.length(0)
     })
   })
 
   describe('clearable', () => {
-    // TODO: Update test to use RatingIcon
-
     it('prevents clearing by default with multiple icons', () => {
       const icons = mount(<Rating defaultRating={5} maxRating={5} />)
-        .find('.icon')
+        .find('RatingIcon')
 
-      icons.find('.active').last().simulate('click')
+      icons.last().simulate('click')
 
-      icons.every('.icon.active')
-        .should.equal(true, 'Some icon did not retain its "active" class')
+      icons.findWhere((i) => i.prop('active', true))
+        .should.have.length(5)
     })
 
     it('allows toggling when set to "auto" with a single icon', () => {
       const icon = mount(<Rating maxRating={1} clearable='auto' />)
-        .find(RatingIcon)
+        .find('RatingIcon')
         .at(0)
 
       icon
@@ -109,110 +101,99 @@ describe('Rating', () => {
 
     it('allows clearing when true with a single icon', () => {
       mount(<Rating defaultRating={1} maxRating={1} clearable />)
-        .find(RatingIcon)
+        .find('RatingIcon')
         .at(0)
         .simulate('click')
         .should.have.prop('active', false)
     })
 
-    // TODO: Update test to use RatingIcon
-
     it('allows clearing when true with multiple icons', () => {
       const icons = mount(<Rating defaultRating={4} maxRating={5} clearable />)
-        .find('.icon')
+        .find('RatingIcon')
 
-      icons.find('.active').last().simulate('click')
+      icons.at(3).simulate('click')
 
-      icons.every('.icon.active')
-        .should.equal(false, 'Some icon did not remove its "active" class')
+      icons.findWhere((i) => i.prop('active', true))
+        .should.have.length(0)
     })
 
     it('prevents clearing when false with a single icon', () => {
       mount(<Rating defaultRating={1} maxRating={1} clearable={false} />)
-        .find(RatingIcon)
+        .find('RatingIcon')
         .at(0)
         .simulate('click')
         .should.have.prop('active', true)
     })
 
-    // TODO: Update test to use RatingIcon
-
     it('prevents clearing when false with multiple icons', () => {
       const icons = mount(<Rating defaultRating={5} maxRating={5} clearable={false} />)
-        .find('.icon')
+        .find('RatingIcon')
 
-      icons.find('.active').last().simulate('click')
+      icons.last().simulate('click')
 
-      icons.every('.icon.active')
-        .should.equal(true, 'Some icon did not retain its "active" class')
+      icons.findWhere((i) => i.prop('active', true))
+        .should.have.length(5)
     })
   })
 
   describe('disabled', () => {
     it('prevents the rating from being toggled', () => {
       mount(<Rating rating={1} maxRating={1} clearable='auto' disabled />)
-        .find(RatingIcon)
+        .find('RatingIcon')
         .at(0)
         .simulate('click')
         .should.have.prop('active', true)
 
       mount(<Rating rating={0} maxRating={1} clearable='auto' disabled />)
-        .find(RatingIcon)
+        .find('RatingIcon')
         .at(0)
         .simulate('click')
         .should.have.prop('active', false)
     })
 
-    // TODO: Update test to use RatingIcon
-
     it('prevents the rating from being cleared', () => {
-      const wrapper = mount(<Rating rating={3} maxRating={3} clearable disabled />)
-      const icons = wrapper.find('.icon')
+      const wrapper = mount(<Rating rating={3} maxRating={3} disabled />)
+      const icons = wrapper.find('RatingIcon')
 
-      icons.find('.active').last().simulate('click')
+      icons.last().simulate('click')
 
-      icons.every('.icon.active')
-        .should.equal(true, 'Some icon lost its "active" class')
+      icons.findWhere((i) => i.prop('active', true))
+        .should.have.length(3)
     })
-
-    // TODO: Update test to use RatingIcon
 
     it('prevents icons from becoming selected on mouse enter', () => {
       const wrapper = mount(<Rating maxRating={3} disabled />)
-      const icons = wrapper.find('.icon')
+      const icons = wrapper.find('RatingIcon')
 
       icons.last().simulate('mouseEnter')
 
-      icons.every('.icon.selected')
-        .should.equal(false, 'Some icon became "selected"')
+      icons.findWhere((i) => i.prop('selected', true))
+        .should.have.length(0)
     })
-
-    // TODO: Update test to use RatingIcon
 
     it('prevents icons from becoming unselected on mouse leave', () => {
       const wrapper = mount(<Rating maxRating={3} />)
-      const icons = wrapper.find('.icon')
+      const icons = wrapper.find('RatingIcon')
 
       icons.last().simulate('mouseEnter')
-      icons.every('.icon.selected')
-        .should.equal(true, 'Not every icon was selected on mouseEnter')
+      icons.findWhere((i) => i.prop('selected', true))
+        .should.have.length(3)
 
       wrapper.setProps({ disabled: true })
       wrapper.simulate('mouseLeave')
 
-      icons.every('.icon.selected')
-        .should.equal(true, 'Some icon lost its "selected" class')
+      icons.findWhere((i) => i.prop('selected', true))
+        .should.have.length(3)
     })
 
     it('prevents icons from becoming active on click', () => {
       const wrapper = mount(<Rating maxRating={3} disabled />)
-      const icons = wrapper.find(RatingIcon)
+      const icons = wrapper.find('RatingIcon')
 
       icons.last().simulate('click')
 
-      _.times(3, (i) => {
-        icons.at(i).should.have.prop('active', false)
-      })
+      icons.findWhere((i) => i.prop('active', true))
+        .should.have.length(0)
     })
   })
 
@@ -221,7 +202,7 @@ describe('Rating', () => {
       _.times(10, (i) => {
         const maxRating = i + 1
         shallow(<Rating maxRating={maxRating} />)
-          .should.have.exactly(maxRating).descendants(RatingIcon)
+          .should.have.exactly(maxRating).descendants('RatingIcon')
       })
     })
   })
@@ -232,7 +213,7 @@ describe('Rating', () => {
       const event = { fake: 'event data' }
 
       mount(<Rating maxRating={3} onRate={spy} />)
-        .find(RatingIcon)
+        .find('RatingIcon')
         .last()
         .simulate('click', event)
 
@@ -242,22 +223,23 @@ describe('Rating', () => {
   })
 
   describe('rating', () => {
-    // TODO: Update test to use RatingIcon
-
     it('controls how many icons are active', () => {
-      const wrapper = shallow(<Rating rating={0} maxRating={10} />)
+      const wrapper = mount(<Rating rating={0} maxRating={10} />)
+      const icons = wrapper.find('RatingIcon')
 
       // rating 0
-      wrapper.should.not.have.descendants('.icon.active')
+
+      icons.findWhere((i) => i.prop('active', true))
+        .should.have.length(0)
 
       // rating 1 - 10
-      // _.times(10, (i) => {
-      //   const rating = i + 1
-      //
-      //   wrapper
-      //     .setProps({ rating })
-      //     .should.have.exactly(rating).descendants('.icon.active')
-      // })
+      _.times(10, (i) => {
+        const rating = i + 1
+
+        wrapper.setProps({ rating })
+        icons.findWhere((icon) => icon.prop('active', true))
+          .should.have.length(rating)
+      })
     })
   })
 })

--- a/test/specs/modules/Rating/Rating-test.js
+++ b/test/specs/modules/Rating/Rating-test.js
@@ -37,7 +37,7 @@ describe('Rating', () => {
       wrapper.should.not.have.className('selected')
 
       icons.findWhere((i) => i.prop('selected', true))
-        .should.have.length(0)
+        .should.have.length(0, 'Some RatingIcons did not remove its "selected" prop')
     })
   })
 
@@ -70,7 +70,7 @@ describe('Rating', () => {
       wrapper.simulate('mouseLeave')
 
       icons.findWhere(i => i.prop('selected', true))
-        .should.have.length(0)
+        .should.have.length(0, 'Some RatingIcons did not remove its "selected" prop')
     })
   })
 
@@ -82,7 +82,7 @@ describe('Rating', () => {
       icons.last().simulate('click')
 
       icons.findWhere((i) => i.prop('active', true))
-        .should.have.length(5)
+        .should.have.length(5, 'Some RatingIcons did not retain its "active" prop')
     })
 
     it('allows toggling when set to "auto" with a single icon', () => {
@@ -114,7 +114,7 @@ describe('Rating', () => {
       icons.at(3).simulate('click')
 
       icons.findWhere((i) => i.prop('active', true))
-        .should.have.length(0)
+        .should.have.length(0, 'Some RatingIcons did not remove its "active" prop')
     })
 
     it('prevents clearing when false with a single icon', () => {
@@ -132,7 +132,7 @@ describe('Rating', () => {
       icons.last().simulate('click')
 
       icons.findWhere((i) => i.prop('active', true))
-        .should.have.length(5)
+        .should.have.length(5, 'Some RatingIcons did not retain its "active" prop')
     })
   })
 
@@ -158,7 +158,7 @@ describe('Rating', () => {
       icons.last().simulate('click')
 
       icons.findWhere((i) => i.prop('active', true))
-        .should.have.length(3)
+        .should.have.length(3, 'Some RatingIcons lost its "active" prop')
     })
 
     it('prevents icons from becoming selected on mouse enter', () => {
@@ -168,7 +168,7 @@ describe('Rating', () => {
       icons.last().simulate('mouseEnter')
 
       icons.findWhere((i) => i.prop('selected', true))
-        .should.have.length(0)
+        .should.have.length(0, 'Some RatingIcons became "selected"')
     })
 
     it('prevents icons from becoming unselected on mouse leave', () => {
@@ -177,13 +177,13 @@ describe('Rating', () => {
 
       icons.last().simulate('mouseEnter')
       icons.findWhere((i) => i.prop('selected', true))
-        .should.have.length(3)
+        .should.have.length(3, 'Not every RatingIcon was selected on mouseEnter')
 
       wrapper.setProps({ disabled: true })
       wrapper.simulate('mouseLeave')
 
       icons.findWhere((i) => i.prop('selected', true))
-        .should.have.length(3)
+        .should.have.length(3, 'Some RatingIcons lost its "selected" prop')
     })
 
     it('prevents icons from becoming active on click', () => {
@@ -193,7 +193,7 @@ describe('Rating', () => {
       icons.last().simulate('click')
 
       icons.findWhere((i) => i.prop('active', true))
-        .should.have.length(0)
+        .should.have.length(0, 'Some RatingIcons became "active"')
     })
   })
 
@@ -230,7 +230,7 @@ describe('Rating', () => {
       // rating 0
 
       icons.findWhere((i) => i.prop('active', true))
-        .should.have.length(0)
+        .should.have.length(0, 'Some RatingIcons have "active" prop')
 
       // rating 1 - 10
       _.times(10, (i) => {
@@ -238,7 +238,7 @@ describe('Rating', () => {
 
         wrapper.setProps({ rating })
         icons.findWhere((icon) => icon.prop('active', true))
-          .should.have.length(rating)
+          .should.have.length(rating, 'Some RatingIcons did not have "active" prop')
       })
     })
   })

--- a/test/specs/modules/Rating/RatingIcon-test.js
+++ b/test/specs/modules/Rating/RatingIcon-test.js
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import * as common from 'test/specs/commonTests'
+import { sandbox } from 'test/utils'
+import RatingIcon from 'src/modules/Rating/RatingIcon'
+
+describe('RatingIcon', () => {
+  common.propKeyOnlyToClassName(RatingIcon, 'active')
+  common.propKeyOnlyToClassName(RatingIcon, 'selected')
+
+  describe('onClick', () => {
+    it('omitted when not defined', () => {
+      const click = () => shallow(<RatingIcon />).simulate('click')
+      expect(click).to.not.throw()
+    })
+
+    it('is called with (e, index) when clicked', () => {
+      const spy = sandbox.spy()
+      const event = { target: null }
+
+      shallow(<RatingIcon index={0} onClick={spy} />)
+        .simulate('click', event)
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(event, 0)
+    })
+  })
+
+  describe('onMouseEnter', () => {
+    it('omitted when not defined', () => {
+      const click = () => shallow(<RatingIcon />).simulate('mouseEnter')
+      expect(click).to.not.throw()
+    })
+
+    it('is called with (index) when clicked', () => {
+      const spy = sandbox.spy()
+
+      shallow(<RatingIcon index={0} onMouseEnter={spy} />)
+        .simulate('mouseEnter')
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(0)
+    })
+  })
+})


### PR DESCRIPTION
This PR:
- splites `Rating`'s icon to separate internal component;
- updates docs to unified format;
- minor refactors.
