### PR TITLE
fix(Label): fix shorthand create method

### DIFF
--- a/docs/app/Examples/collections/Table/Types/TableApprove.js
+++ b/docs/app/Examples/collections/Table/Types/TableApprove.js
@@ -48,7 +48,7 @@ const TableApprove = () => {
         <Table.Row>
           <Table.HeaderCell />
           <Table.HeaderCell colSpan='4'>
-            <Button floated='right' icon labeled primary size='small'>
+            <Button floated='right' icon labelPosition='left' primary size='small'>
               <Icon name='user' /> Add User
             </Button>
             <Button size='small'>Approve</Button>

--- a/docs/app/Examples/collections/Table/Variations/TableFullWidth.js
+++ b/docs/app/Examples/collections/Table/Variations/TableFullWidth.js
@@ -48,7 +48,7 @@ const TableFullWidth = () => {
       <Table.Row>
         <Table.HeaderCell />
         <Table.HeaderCell colSpan='4'>
-          <Button floated='right' icon labeled primary size='small'>
+          <Button floated='right' icon labelPosition='left' primary size='small'>
             <Icon name='user' /> Add User
           </Button>
           <Button size='small'>Approve</Button>

--- a/docs/app/Examples/modules/Modal/Variations/ModalCloseConfigExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalCloseConfigExample.js
@@ -32,7 +32,7 @@ class ModalCloseConfigExample extends Component {
           </Modal.Content>
           <Modal.Actions>
             <Button negative>No</Button>
-            <Button positive labeled='right' icon>
+            <Button positive labelPosition='right' icon>
               Yes <Icon name='checkmark' />
             </Button>
           </Modal.Actions>

--- a/docs/app/Examples/modules/Modal/Variations/ModalDimmerExample.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalDimmerExample.js
@@ -31,7 +31,7 @@ class ModalDimmerExample extends Component {
             <Button color='black' onClick={this.close}>
               Nope
             </Button>
-            <Button positive icon labeled='right' onClick={this.close}>
+            <Button positive icon labelPosition='right' onClick={this.close}>
               Yep, that's me <Icon name='checkmark' />
             </Button>
           </Modal.Actions>

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -121,7 +121,6 @@ export default class Label extends Component {
 
   static _meta = _meta
 
-  static create = createShorthandFactory(Label, value => ({ content: value }))
   static Detail = LabelDetail
   static Group = LabelGroup
 
@@ -203,3 +202,7 @@ export default class Label extends Component {
     )
   }
 }
+
+// Label is not yet defined inside the class
+// Do not use a static property initializer
+Label.create = createShorthandFactory(Label, value => ({ content: value }))

--- a/src/lib/factories.js
+++ b/src/lib/factories.js
@@ -34,6 +34,9 @@ const mergePropsAndClassName = (defaultProps, props) => {
  * @returns {function|null}
  */
 export function createShorthand(Component, mapValueToProps, val, defaultProps = {}) {
+  if (typeof Component !== 'function' && typeof Component !== 'string') {
+    throw new Error('createShorthandFactory() Component must be a string or function.')
+  }
   // short circuit for disabling shorthand
   if (val === null) return null
 
@@ -70,6 +73,9 @@ export function createShorthand(Component, mapValueToProps, val, defaultProps = 
 }
 
 export function createShorthandFactory(Component, mapValueToProps) {
+  if (typeof Component !== 'function' && typeof Component !== 'string') {
+    throw new Error('createShorthandFactory() Component must be a string or function.')
+  }
   return _.partial(createShorthand, Component, mapValueToProps)
 }
 

--- a/test/specs/collections/Table/TableCell-test.js
+++ b/test/specs/collections/Table/TableCell-test.js
@@ -7,6 +7,7 @@ describe('TableCell', () => {
   common.isConformant(TableCell)
   common.rendersChildren(TableCell)
 
+  common.implementsCreateMethod(TableCell)
   common.implementsTextAlignProp(TableCell)
   common.implementsVerticalAlignProp(TableCell)
   common.implementsWidthProp(TableCell, { propKey: 'width', widthClass: 'wide', canEqual: false })

--- a/test/specs/collections/Table/TableRow-test.js
+++ b/test/specs/collections/Table/TableRow-test.js
@@ -7,6 +7,7 @@ describe('TableRow', () => {
   common.isConformant(TableRow)
   common.rendersChildren(TableRow)
 
+  common.implementsCreateMethod(TableRow)
   common.implementsTextAlignProp(TableRow)
   common.implementsVerticalAlignProp(TableRow)
 

--- a/test/specs/commonTests.js
+++ b/test/specs/commonTests.js
@@ -1,7 +1,7 @@
 import faker from 'faker'
 import _ from 'lodash'
 import path from 'path'
-import React, { createElement } from 'react'
+import React, { createElement, isValidElement } from 'react'
 import ReactDOMServer from 'react-dom/server'
 
 import { createShorthand, META, numberToWord } from 'src/lib'
@@ -520,6 +520,58 @@ const _classNamePropValueBeforePropName = (Component, propKey, options = {}) => 
     it(`adds "${propVal} ${className}" to className`, () => {
       shallow(createElement(Component, { ...requiredProps, [propKey]: propVal }))
         .should.have.className(`${propVal} ${className}`)
+    })
+  })
+}
+/**
+ * Assert a Component correctly implements a shorthand create method.
+ * @param {React.Component|Function} Component The component to test.
+ */
+export const implementsCreateMethod = (Component) => {
+  const name = Component._meta.name
+
+  describe('create shorthand method (common)', () => {
+    it('is a static method', () => {
+      Component.should.have.any.keys('create')
+      Component.create.should.be.a('function')
+    })
+    it(`creates a ${name} from a string`, () => {
+      isValidElement(Component.create('foo'))
+        .should.equal(true)
+    })
+    it(`creates a ${name} from a number`, () => {
+      isValidElement(Component.create(123))
+        .should.equal(true)
+    })
+    it(`creates a ${name} from a props object`, () => {
+      isValidElement(Component.create({ 'data-foo': 'bar' }))
+        .should.equal(true)
+    })
+    it(`creates a ${name} from an array`, () => {
+      // not all components support array shorthand, suppress warnings
+      consoleUtil.disableOnce()
+      isValidElement(Component.create(['foo', 123, { 'data-foo': 'bar' }]))
+        .should.equal(true)
+    })
+    it(`creates a ${name} from an element`, () => {
+      isValidElement(Component.create(<div />))
+        .should.equal(true)
+    })
+    it('returns null when passed null', () => {
+      expect(Component.create(null))
+        .to.equal(null)
+    })
+    it('returns null when passed undefined', () => {
+      expect(Component.create(undefined))
+        .to.equal(null)
+    })
+    it('returns null when passed true', () => {
+      expect(Component.create(true))
+        .to.equal(null)
+    })
+    it('returns null when passed false', () => {
+      expect(Component.create(false))
+        .to.equal(null)
     })
   })
 }

--- a/test/specs/elements/Button/Button-test.js
+++ b/test/specs/elements/Button/Button-test.js
@@ -11,6 +11,7 @@ describe('Button', () => {
   common.isConformant(Button)
   common.hasUIClassName(Button)
   common.hasSubComponents(Button, [ButtonContent, ButtonGroup, ButtonOr])
+  common.implementsCreateMethod(Button)
   common.implementsIconProp(Button)
   common.implementsLabelProp(Button, {
     shorthandDefaultProps: {

--- a/test/specs/elements/Icon/Icon-test.js
+++ b/test/specs/elements/Icon/Icon-test.js
@@ -6,6 +6,7 @@ import * as common from 'test/specs/commonTests'
 describe('Icon', () => {
   common.isConformant(Icon)
   common.hasSubComponents(Icon, [IconGroup])
+  common.implementsCreateMethod(Icon)
 
   common.propKeyOnlyToClassName(Icon, 'bordered')
   common.propKeyOnlyToClassName(Icon, 'circular')

--- a/test/specs/elements/Image/Image-test.js
+++ b/test/specs/elements/Image/Image-test.js
@@ -26,6 +26,7 @@ describe('Image Component', () => {
 
   common.propKeyOrValueAndKeyToClassName(Image, 'spaced')
 
+  common.implementsCreateMethod(Image)
   common.implementsLabelProp(Image)
   common.implementsVerticalAlignProp(Image, 'verticalAlign')
 

--- a/test/specs/elements/Label/Label-test.js
+++ b/test/specs/elements/Label/Label-test.js
@@ -28,6 +28,7 @@ describe('Label', () => {
   common.propValueOnlyToClassName(Label, 'color')
   common.propValueOnlyToClassName(Label, 'size')
 
+  common.implementsCreateMethod(Label)
   common.implementsIconProp(Label)
   common.implementsImageProp(Label)
   common.implementsShorthandProp(Label, {
@@ -44,8 +45,8 @@ describe('Label', () => {
   describe('content', () => {
     it('has no content by default', () => {
       shallow(<Label />)
-      .text()
-      .should.be.empty()
+        .text()
+        .should.be.empty()
     })
 
     it('adds the value as children', () => {

--- a/test/specs/lib/factories-test.js
+++ b/test/specs/lib/factories-test.js
@@ -4,6 +4,7 @@ import React, { isValidElement } from 'react'
 import { sandbox } from 'test/utils'
 import {
   createShorthand,
+  createShorthandFactory,
 } from 'src/lib'
 
 // ----------------------------------------
@@ -109,9 +110,53 @@ const itOverridesDefaultPropsWithFalseyProps = (propsSource, shorthandConfig) =>
 // ----------------------------------------
 
 describe('factories', () => {
+  describe('createShorthandFactory', () => {
+    it('is a function', () => {
+      createShorthandFactory.should.be.a('function')
+    })
+    it('does not throw if passed a function Component', () => {
+      const goodUsage = () => createShorthandFactory(() => <div />, () => ({}))
+
+      expect(goodUsage).not.to.throw()
+    })
+    it('does not throw if passed a string Component', () => {
+      const goodUsage = () => createShorthandFactory('div', () => ({}))
+
+      expect(goodUsage).not.to.throw()
+    })
+    it('throw if passed Component that is not a string nor function', () => {
+      const badComponents = [undefined, null, true, false, [], {}, 123]
+
+      _.each(badComponents, badComponent => {
+        const badUsage = () => createShorthandFactory(badComponent, () => ({}))
+
+        expect(badUsage).to.throw()
+      })
+    })
+  })
+
   describe('createShorthand', () => {
     it('is a function', () => {
       createShorthand.should.be.a('function')
+    })
+    it('does not throw if passed a function Component', () => {
+      const goodUsage = () => createShorthand(() => <div />, () => ({}))
+
+      expect(goodUsage).not.to.throw()
+    })
+    it('does not throw if passed a string Component', () => {
+      const goodUsage = () => createShorthand('div', () => ({}))
+
+      expect(goodUsage).not.to.throw()
+    })
+    it('throw if passed Component that is not a string nor function', () => {
+      const badComponents = [undefined, null, true, false, [], {}, 123]
+
+      _.each(badComponents, badComponent => {
+        const badUsage = () => createShorthand(badComponent, () => ({}))
+
+        expect(badUsage).to.throw()
+      })
     })
 
     describe('defaultProps', () => {


### PR DESCRIPTION
This PR fixes 2 issues:
- left over deprecated `labeled` Button usages in the docs
- `Label.create` returned undefined

Heads up, we cannot put a `static create = createShorthandFactory()` call in a class, as was the Label.  The `Label` class is not yet defined, so the factory returns `undefined`.

I've updated the factories to throw if the Component is not a string or function.  I've also added tests for this.
