### PR TITLE
fix(ItemImage): wrap image to prevent vertical strech

### DIFF
--- a/src/views/Item/ItemImage.js
+++ b/src/views/Item/ItemImage.js
@@ -8,7 +8,7 @@ import Image from '../../elements/Image'
  * An item can contain an image
  **/
 function ItemImage(props) {
-  return <Image {...props} ui={false} />
+  return <Image {...props} ui={false} wrapped />
 }
 
 ItemImage._meta = {

--- a/test/specs/views/Item/ItemImage-test.js
+++ b/test/specs/views/Item/ItemImage-test.js
@@ -6,4 +6,11 @@ describe('ItemImage', () => {
     shallow(<ItemImage />)
       .should.have.descendants('Image')
   })
+
+  it('is wrapped without ui', () => {
+    const wrapper = shallow(<ItemImage />)
+
+    wrapper.should.have.prop('wrapped', true)
+    wrapper.should.have.prop('ui', false)
+  })
 })


### PR DESCRIPTION
Address vertical stretch of images within item view

![screen shot 2016-10-08 at 7 44 48 am](https://cloud.githubusercontent.com/assets/56964/19213886/2c3130ae-8d2b-11e6-8b5d-c467d02e055e.jpg)
