### PR TITLE
feat(Confirm): switch from active prop to open

### DIFF
--- a/docs/app/Examples/addons/Confirm/Types/ConfirmExampleCallbacks.js
+++ b/docs/app/Examples/addons/Confirm/Types/ConfirmExampleCallbacks.js
@@ -2,14 +2,14 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleCallbacks extends Component {
-  state = { active: false, result: 'show the modal to capture a result' }
+  state = { open: false, result: 'show the modal to capture a result' }
 
-  show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ result: 'confirmed', active: false })
-  handleCancel = () => this.setState({ result: 'cancelled', active: false })
+  show = () => this.setState({ open: true })
+  handleConfirm = () => this.setState({ result: 'confirmed', open: false })
+  handleCancel = () => this.setState({ result: 'cancelled', open: false })
 
   render() {
-    const { active, result } = this.state
+    const { open, result } = this.state
 
     return (
       <div>
@@ -17,7 +17,7 @@ class ConfirmExampleCallbacks extends Component {
 
         <Button onClick={this.show}>Show</Button>
         <Confirm
-          active={active}
+          open={open}
           onCancel={this.handleCancel}
           onConfirm={this.handleConfirm}
         />

--- a/docs/app/Examples/addons/Confirm/Types/ConfirmExampleConfirm.js
+++ b/docs/app/Examples/addons/Confirm/Types/ConfirmExampleConfirm.js
@@ -2,18 +2,18 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleConfirm extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ active: false })
-  handleCancel = () => this.setState({ active: false })
+  show = () => this.setState({ open: true })
+  handleConfirm = () => this.setState({ open: false })
+  handleCancel = () => this.setState({ open: false })
 
   render() {
     return (
       <div>
         <Button onClick={this.show}>Show</Button>
         <Confirm
-          active={this.state.active}
+          open={this.state.open}
           onCancel={this.handleCancel}
           onConfirm={this.handleConfirm}
         />

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleButtons.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleButtons.js
@@ -2,18 +2,18 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleHeader extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ active: false })
-  handleCancel = () => this.setState({ active: false })
+  show = () => this.setState({ open: true })
+  handleConfirm = () => this.setState({ open: false })
+  handleCancel = () => this.setState({ open: false })
 
   render() {
     return (
       <div>
         <Button onClick={this.show}>Show</Button>
         <Confirm
-          active={this.state.active}
+          open={this.state.open}
           cancelButton='Never mind'
           confirmButton="Let's do it"
           onCancel={this.handleCancel}

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleContent.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleContent.js
@@ -2,18 +2,18 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleContent extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ active: false })
-  handleCancel = () => this.setState({ active: false })
+  show = () => this.setState({ open: true })
+  handleConfirm = () => this.setState({ open: false })
+  handleCancel = () => this.setState({ open: false })
 
   render() {
     return (
       <div>
         <Button onClick={this.show}>Show</Button>
         <Confirm
-          active={this.state.active}
+          open={this.state.open}
           content='This is a custom message'
           onCancel={this.handleCancel}
           onConfirm={this.handleConfirm}

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleHeader.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleHeader.js
@@ -2,18 +2,18 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleHeader extends Component {
-  state = { active: false }
+  state = { open: false }
 
-  show = () => this.setState({ active: true })
-  handleConfirm = () => this.setState({ active: false })
-  handleCancel = () => this.setState({ active: false })
+  show = () => this.setState({ open: true })
+  handleConfirm = () => this.setState({ open: false })
+  handleCancel = () => this.setState({ open: false })
 
   render() {
     return (
       <div>
         <Button onClick={this.show}>Show</Button>
         <Confirm
-          active={this.state.active}
+          open={this.state.open}
           header='This is a custom header'
           onCancel={this.handleCancel}
           onConfirm={this.handleConfirm}

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react'
 
-import { getUnhandledProps, META } from '../../lib'
+import { getUnhandledProps, META, customPropTypes } from '../../lib'
 import Button from '../../elements/Button'
 import Modal from '../../modules/Modal'
 
@@ -9,13 +9,14 @@ import Modal from '../../modules/Modal'
  * @see Modal
  */
 function Confirm(props) {
-  const { active, cancelButton, confirmButton, header, content, onConfirm, onCancel } = props
+  const { cancelButton, children, confirmButton, header, content, onConfirm, onCancel } = props
   const rest = getUnhandledProps(Confirm, props)
 
   return (
-    <Modal active={active} size='small' onHide={onCancel} {...rest}>
-      {header && <Modal.Header>{header}</Modal.Header>}
-      {content && <Modal.Content>{content}</Modal.Content>}
+    <Modal size='small' onClose={onCancel} {...rest}>
+      {children}
+      {!children && Modal.Header.create(header)}
+      {!children && Modal.Content.create(content)}
       <Modal.Actions>
         <Button onClick={onCancel}>{cancelButton}</Button>
         <Button primary onClick={onConfirm}>{confirmButton}</Button>
@@ -30,11 +31,11 @@ Confirm._meta = {
 }
 
 Confirm.propTypes = {
-  /** Whether or not the modal is visible */
-  active: PropTypes.bool,
-
   /** The cancel button text */
   cancelButton: PropTypes.string,
+
+  /** You may pass a content as children */
+  children: PropTypes.node,
 
   /** The OK button text */
   confirmButton: PropTypes.string,

--- a/src/modules/Modal/ModalActions.js
+++ b/src/modules/Modal/ModalActions.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -16,6 +17,8 @@ function ModalActions(props) {
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
+
+ModalActions.create = createShorthandFactory(ModalActions, value => ({ children: value }))
 
 ModalActions._meta = {
   name: 'ModalActions',

--- a/src/modules/Modal/ModalContent.js
+++ b/src/modules/Modal/ModalContent.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -21,6 +22,8 @@ function ModalContent(props) {
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
+
+ModalContent.create = createShorthandFactory(ModalContent, value => ({ children: value }))
 
 ModalContent._meta = {
   name: 'ModalContent',

--- a/src/modules/Modal/ModalDescription.js
+++ b/src/modules/Modal/ModalDescription.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -16,6 +17,8 @@ function ModalDescription(props) {
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
+
+ModalDescription.create = createShorthandFactory(ModalDescription, value => ({ children: value }))
 
 ModalDescription._meta = {
   name: 'ModalDescription',

--- a/src/modules/Modal/ModalHeader.js
+++ b/src/modules/Modal/ModalHeader.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import cx from 'classnames'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -16,6 +17,8 @@ function ModalHeader(props) {
 
   return <ElementType {...rest} className={classes}>{children}</ElementType>
 }
+
+ModalHeader.create = createShorthandFactory(ModalHeader, value => ({ children: value }))
 
 ModalHeader._meta = {
   name: 'ModalHeader',

--- a/test/specs/addons/Confirm-test.js
+++ b/test/specs/addons/Confirm-test.js
@@ -110,5 +110,19 @@ describe('Confirm', () => {
 
       spy.should.have.been.calledOnce()
     })
+
+    // Ensures that modal onClose is not triggered
+    // when open prop is controlled.
+    it('only calls confirm on Confirm', () => {
+      const cancelSpy = sandbox.spy()
+      const confirmSpy = sandbox.spy()
+
+      shallow(<Confirm onCancel={cancelSpy} onConfirm={confirmSpy} />)
+        .find('Button[primary]')
+        .simulate('click')
+
+      confirmSpy.should.have.been.calledOnce()
+      cancelSpy.should.not.have.been.called()
+    })
   })
 })


### PR DESCRIPTION
- Switch from `Confirm.props.active` to `Confirm.props.open`
- Use `createShorthandFactory` on Modal shorthands
- Use the shortHand create method for Confirm content
- Use children as modal content **or** props shorthands
