### PR TITLE
feat(Dropdown): Refactor dropdown

### DIFF
--- a/docs/app/Examples/modules/Dropdown/index.js
+++ b/docs/app/Examples/modules/Dropdown/index.js
@@ -4,6 +4,75 @@ import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
 
 import { Message } from 'semantic-ui-react'
 
+// const DropdownExamples = () => (
+//   <div>
+//     <ExampleSection title='Types'>
+//       <ComponentExample
+//         title='Dropdown'
+//         description='A dropdown menu'
+//         examplePath='modules/Dropdown/Types/Dropdown'
+//       />
+//       <ComponentExample
+//         title='Custom Trigger'
+//         description='A dropdown can use a custom trigger element'
+//         examplePath='modules/Dropdown/Types/Trigger'
+//       />
+//       <ComponentExample
+//         examplePath='modules/Dropdown/Types/ImageTrigger'
+//       />
+//       <ComponentExample
+//         title='Uncontrolled'
+//         description='A dropdown works as an uncontrolled component'
+//         examplePath='modules/Dropdown/Types/Uncontrolled'
+//       >
+//         <Message>
+//           See React form docs for an explanation of
+//           <a href='https://facebook.github.io/react/docs/forms.html' target='_blank'>
+//             &nbsp;controlled and uncontrolled&nbsp;
+//           </a>
+//           component patterns.
+//         </Message>
+//       </ComponentExample>
+//       <ComponentExample
+//         title='Selection'
+//         description='A dropdown can be used to select between choices in a form'
+//         examplePath='modules/Dropdown/Types/Selection'
+//       >
+//         <Message info>
+//           Selection dropdowns must use the <code>options</code> prop, instead of sub component markup.
+//         </Message>
+//       </ComponentExample>
+//       <ComponentExample
+//         title='Allow Additions'
+//         description='A dropdown that allows user additions'
+//         examplePath='modules/Dropdown/Types/AllowAdditions'
+//       >
+//         <Message className='info'>
+//           The <code>allowAdditions</code> prop requires you to handle updating the options list
+//           with the new value via the <code>onAddItem</code> prop.
+//         </Message>
+//       </ComponentExample>
+//     </ExampleSection>
+//     <ExampleSection title='Content'>
+//       <ComponentExample
+//         title='Header'
+//         description='A dropdown menu can contain a header'
+//         examplePath='modules/Dropdown/Content/Header'
+//       />
+//     </ExampleSection>
+//     <ExampleSection title='States'>
+//       <ComponentExample
+//         title='Disabled'
+//         description='A disabled dropdown menu or item does not allow user interaction'
+//         examplePath='modules/Dropdown/States/Disabled'
+//       />
+//       <ComponentExample
+//         examplePath='modules/Dropdown/States/DisabledItem'
+//       />
+//     </ExampleSection>
+//   </div>
+// )
+
 const DropdownExamples = () => (
   <div>
     <ExampleSection title='Types'>
@@ -11,63 +80,6 @@ const DropdownExamples = () => (
         title='Dropdown'
         description='A dropdown menu'
         examplePath='modules/Dropdown/Types/Dropdown'
-      />
-      <ComponentExample
-        title='Custom Trigger'
-        description='A dropdown can use a custom trigger element'
-        examplePath='modules/Dropdown/Types/Trigger'
-      />
-      <ComponentExample
-        examplePath='modules/Dropdown/Types/ImageTrigger'
-      />
-      <ComponentExample
-        title='Uncontrolled'
-        description='A dropdown works as an uncontrolled component'
-        examplePath='modules/Dropdown/Types/Uncontrolled'
-      >
-        <Message>
-          See React form docs for an explanation of
-          <a href='https://facebook.github.io/react/docs/forms.html' target='_blank'>
-            &nbsp;controlled and uncontrolled&nbsp;
-          </a>
-          component patterns.
-        </Message>
-      </ComponentExample>
-      <ComponentExample
-        title='Selection'
-        description='A dropdown can be used to select between choices in a form'
-        examplePath='modules/Dropdown/Types/Selection'
-      >
-        <Message info>
-          Selection dropdowns must use the <code>options</code> prop, instead of sub component markup.
-        </Message>
-      </ComponentExample>
-      <ComponentExample
-        title='Allow Additions'
-        description='A dropdown that allows user additions'
-        examplePath='modules/Dropdown/Types/AllowAdditions'
-      >
-        <Message className='info'>
-          The <code>allowAdditions</code> prop requires you to handle updating the options list
-          with the new value via the <code>onAddItem</code> prop.
-        </Message>
-      </ComponentExample>
-    </ExampleSection>
-    <ExampleSection title='Content'>
-      <ComponentExample
-        title='Header'
-        description='A dropdown menu can contain a header'
-        examplePath='modules/Dropdown/Content/Header'
-      />
-    </ExampleSection>
-    <ExampleSection title='States'>
-      <ComponentExample
-        title='Disabled'
-        description='A disabled dropdown menu or item does not allow user interaction'
-        examplePath='modules/Dropdown/States/Disabled'
-      />
-      <ComponentExample
-        examplePath='modules/Dropdown/States/DisabledItem'
       />
     </ExampleSection>
   </div>

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -4,24 +4,20 @@ import React, { Children, cloneElement, PropTypes } from 'react'
 
 import {
   AutoControlledComponent as Component,
-  createShorthand,
   customPropTypes,
-  getElementType,
   getUnhandledProps,
-  keyboardKey,
   makeDebugger,
   META,
-  objectDiff,
   useKeyOnly,
   useKeyOrValueAndKey,
 } from '../../lib'
-import Icon from '../../elements/Icon'
-import Label from '../../elements/Label'
+import Portal from '../../addons/Portal'
 
 import DropdownDivider from './DropdownDivider'
 import DropdownItem from './DropdownItem'
 import DropdownHeader from './DropdownHeader'
 import DropdownMenu from './DropdownMenu'
+import DropdownText from './DropdownText'
 
 const debug = makeDebugger('dropdown')
 
@@ -44,190 +40,94 @@ export default class Dropdown extends Component {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
 
-    // ------------------------------------
-    // Behavior
-    // ------------------------------------
-    /** Add an icon by name or as a component. */
-    icon: PropTypes.oneOfType([
-      PropTypes.element,
-      PropTypes.string,
-    ]),
-
-    /** Array of Dropdown.Item props e.g. `{ text: '', value: '' }` */
-    options: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      customPropTypes.demand(['selection']),
-      PropTypes.arrayOf(PropTypes.shape(DropdownItem.propTypes)),
-    ]),
-
-    /** Controls whether or not the dropdown menu is displayed. */
-    open: PropTypes.bool,
-
-    /** Initial value of open. */
-    defaultOpen: PropTypes.bool,
-
-    /** Primary content. */
-    children: customPropTypes.every([
-      customPropTypes.disallow(['options', 'selection']),
-      customPropTypes.demand(['text']),
-      customPropTypes.givenProps(
-        { children: PropTypes.any.isRequired },
-        React.PropTypes.element.isRequired,
-      ),
-    ]),
-
-    /** Current value or value array if multiple. Creates a controlled component. */
-    value: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.arrayOf(PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-      ])),
-    ]),
-
-    /** Initial value or value array if multiple. */
-    defaultValue: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.arrayOf(PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-      ])),
-    ]),
-
-    /** Placeholder text. */
-    placeholder: PropTypes.string,
-
-    /** Name of the hidden input which holds the value. */
-    name: PropTypes.string,
-
-    /** Custom element to trigger the menu to become visible. Takes place of 'text'. */
-    trigger: customPropTypes.every([
-      customPropTypes.disallow(['selection', 'text']),
-      PropTypes.node,
-    ]),
-
-    /**
-     * Allow user additions to the list of options (boolean).
-     * Requires the use of `selection`, `options` and `search`.
-     */
-    allowAdditions: customPropTypes.every([
-      customPropTypes.demand(['options', 'selection', 'search']),
-      PropTypes.bool,
-    ]),
-
-    /** Position of the `Add: ...` option in the dropdown list ('top' or 'bottom'). */
-    additionPosition: PropTypes.oneOf(_meta.props.additionPosition),
-
-    /** Label prefixed to an option added by a user. */
-    additionLabel: PropTypes.string,
-
-    /** Message to display when there are no results. */
-    noResultsMessage: PropTypes.string,
-
-    /** Define whether the highlighted item should be selected on blur. */
-    selectOnBlur: PropTypes.bool,
-
-    /** Make the dropdown options searchable by substring matching (default) or with a custom search function. */
-    search: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.func,
-    ]),
-
-    // ------------------------------------
-    // Callbacks
-    // ------------------------------------
-
-    /** Called with the name and new value added by the user. Use this to update the options list. */
-    onAddItem: PropTypes.func,
-
-    /** Called with the React Synthetic Event on Dropdown blur. */
-    onBlur: PropTypes.func,
-
-    /** Called with the React Synthetic Event and { name, value } on change. */
-    onChange: PropTypes.func,
-
-    /** Called with the React Synthetic Event and current value on search input change. */
-    onSearchChange: PropTypes.func,
-
-    /** Called with the React Synthetic Event on Dropdown click. */
-    onClick: PropTypes.func,
-
-    /** Called with the React Synthetic Event on Dropdown focus. */
-    onFocus: PropTypes.func,
-
-    /** Called with the React Synthetic Event on Dropdown mouse down. */
-    onMouseDown: PropTypes.func,
-
-    // ------------------------------------
-    // Style
-    // ------------------------------------
-
-    /** A Dropdown can reduce its complexity */
+    /** A Dropdown can reduce its complexity. */
     basic: PropTypes.bool,
 
     /** Format the Dropdown to appear as a button. */
     button: PropTypes.bool,
 
+    /** Primary content. */
+    children: React.PropTypes.node,
+
     /** Additional classes. */
     className: PropTypes.string,
 
-    /** Format the dropdown to only take up as much width as needed. */
+    /** A compact dropdown has no minimum width. */
     compact: PropTypes.bool,
 
-    /** Format the dropdown to only take up as much width as possible. */
-    fluid: PropTypes.bool,
+    /** Initial value of open. */
+    defaultOpen: PropTypes.bool,
 
-    /** Display the menu as detached from the Dropdown. */
+    /** A disabled dropdown menu or item does not allow user interaction. */
+    disabled: PropTypes.bool,
+
+    /** An errored dropdown can alert a user to a problem. */
+    error: PropTypes.bool,
+
+    /** A dropdown menu can contain floated content. */
     floating: PropTypes.bool,
 
-    /** A dropdown menu can contain a header. */
-    header: PropTypes.node,
+    /** A dropdown can take the full width of its parent */
+    fluid: PropTypes.bool,
 
+    /** Shorthand for Icon. */
+    icon: customPropTypes.itemShorthand,
+
+    /** A dropdown can be formatted to appear inline in other content. */
     inline: PropTypes.bool,
-    labeled: PropTypes.bool,
-    // linkItem: PropTypes.bool,
 
-    /** Allow selecting multiple options. */
+    /** A dropdown can be labeled. */
+    labeled: PropTypes.bool,
+
+    /** A dropdown can show that it is currently loading data. */
+    loading: PropTypes.bool,
+
+    /** A selection dropdown can allow multiple selections. */
     multiple: PropTypes.bool,
 
-    /** Use a detached menu that is pointing to the Dropdown. */
+    /** Called when a close event happens */
+    onClose: PropTypes.func,
+
+    /** Called when an open event happens */
+    onOpen: PropTypes.func,
+
+    /** Controls whether the dropdown menu is displayed. */
+    open: PropTypes.bool,
+
+    /** A dropdown can be formatted so that its menu is pointing. */
     pointing: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.oneOf(_meta.props.pointing),
     ]),
 
-    /** The text displayed in the dropdown, usually for the active item. */
-    text: PropTypes.string,
+    /** A dropdown can have its menu scroll. */
+    scrolling: PropTypes.bool,
 
-    // TODO 'searchInMenu' or 'search='in menu' or ???  How to handle this markup and functionality?
+    /** A selection dropdown can allow a user to search through a large list of choices. */
+    search: PropTypes.bool,
 
-    /** Behave as an html select. */
-    selection: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      customPropTypes.demand(['options']),
-      PropTypes.bool,
-    ]),
+    /** A dropdown can be used to select between choices in a form. */
+    selection: PropTypes.bool,
+
+    /** A simple dropdown can open without Javascript. */
     simple: PropTypes.bool,
 
-    loading: PropTypes.bool,
-    error: PropTypes.bool,
-    disabled: PropTypes.bool,
+    /** Shorthand for DropdownText. */
+    text: customPropTypes.every([
+      customPropTypes.disallow(['trigger']),
+      PropTypes.node,
+    ]),
 
-    scrolling: PropTypes.bool,
+    /** Element to be rendered in-place where the dropdown is defined. */
+    trigger: PropTypes.node,
   }
 
   static defaultProps = {
     icon: 'dropdown',
-    additionLabel: 'Add:',
-    noResultsMessage: 'No results found.',
-    selectOnBlur: true,
   }
 
   static autoControlledProps = [
     'open',
-    'value',
   ]
 
   static _meta = _meta
@@ -236,683 +136,64 @@ export default class Dropdown extends Component {
   static Item = DropdownItem
   static Menu = DropdownMenu
 
-  componentWillMount() {
-    if (super.componentWillMount) super.componentWillMount()
-    debug('componentWillMount()')
-    const { open, value } = this.state
-
-    this.setValue(value)
-    if (open) this.open()
-  }
-
   shouldComponentUpdate(nextProps, nextState) {
     return !_.isEqual(nextProps, this.props) || !_.isEqual(nextState, this.state)
   }
 
-  componentWillReceiveProps(nextProps) {
-    super.componentWillReceiveProps(nextProps)
-    debug('componentWillReceiveProps()')
-    // TODO objectDiff still runs in prod, stop it
-    debug('to props:', objectDiff(this.props, nextProps))
-
-    /* eslint-disable no-console */
-    if (process.env.NODE_ENV !== 'production') {
-      // in development, validate value type matches dropdown type
-      const isNextValueArray = Array.isArray(nextProps.value)
-      const hasValue = _.has(nextProps, 'value')
-
-      if (hasValue && nextProps.multiple && !isNextValueArray) {
-        console.error(
-          'Dropdown `value` must be an array when `multiple` is set.' +
-          ` Received type: \`${Object.prototype.toString.call(nextProps.value)}\`.`,
-        )
-      } else if (hasValue && !nextProps.multiple && isNextValueArray) {
-        console.error(
-          'Dropdown `value` must not be an array when `multiple` is not set.' +
-          ' Either set `multiple={true}` or use a string or number value.'
-        )
-      }
+  componentDidMount() {
+    if (this.state.open) {
+      this.open()
     }
-    /* eslint-enable no-console */
-
-    if (!_.isEqual(nextProps.value, this.props.value)) {
-      debug('value changed, setting', nextProps.value)
-      this.setValue(nextProps.value)
-    }
-  }
-
-  componentDidUpdate(prevProps, prevState) { // eslint-disable-line complexity
-    debug('componentDidUpdate()')
-    // TODO objectDiff still runs in prod, stop it
-    debug('to state:', objectDiff(prevState, this.state))
-
-    // focused / blurred
-    if (!prevState.focus && this.state.focus) {
-      debug('dropdown focused')
-      if (!this.isMouseDown) {
-        debug('mouse is not down, opening')
-        this.open()
-      }
-      if (!this.state.open) {
-        document.addEventListener('keydown', this.openOnArrow)
-        document.addEventListener('keydown', this.openOnSpace)
-      } else {
-        document.addEventListener('keydown', this.moveSelectionOnKeyDown)
-        document.addEventListener('keydown', this.selectItemOnEnter)
-        document.addEventListener('keydown', this.removeItemOnBackspace)
-      }
-    } else if (prevState.focus && !this.state.focus) {
-      debug('dropdown blurred')
-      if (!this.isMouseDown) {
-        debug('mouse is not down, closing')
-        this.close()
-      }
-      document.removeEventListener('keydown', this.openOnArrow)
-      document.removeEventListener('keydown', this.openOnSpace)
-      document.removeEventListener('keydown', this.moveSelectionOnKeyDown)
-      document.removeEventListener('keydown', this.selectItemOnEnter)
-      document.removeEventListener('keydown', this.removeItemOnBackspace)
-    }
-
-    // opened / closed
-    if (!prevState.open && this.state.open) {
-      debug('dropdown opened')
-      document.addEventListener('keydown', this.closeOnEscape)
-      document.addEventListener('keydown', this.moveSelectionOnKeyDown)
-      document.addEventListener('keydown', this.selectItemOnEnter)
-      document.addEventListener('keydown', this.removeItemOnBackspace)
-      document.addEventListener('click', this.closeOnDocumentClick)
-      document.removeEventListener('keydown', this.openOnArrow)
-      document.removeEventListener('keydown', this.openOnSpace)
-    } else if (prevState.open && !this.state.open) {
-      debug('dropdown closed')
-      this.handleClose()
-      document.removeEventListener('keydown', this.closeOnEscape)
-      document.removeEventListener('keydown', this.moveSelectionOnKeyDown)
-      document.removeEventListener('keydown', this.selectItemOnEnter)
-      document.removeEventListener('keydown', this.removeItemOnBackspace)
-      document.removeEventListener('click', this.closeOnDocumentClick)
-      if (prevState.focus && this.state.focus) {
-        document.addEventListener('keydown', this.openOnArrow)
-        document.addEventListener('keydown', this.openOnSpace)
-      }
-    }
-  }
-
-  componentWillUnmount() {
-    debug('componentWillUnmount()')
-    document.removeEventListener('keydown', this.openOnArrow)
-    document.removeEventListener('keydown', this.openOnSpace)
-    document.removeEventListener('keydown', this.moveSelectionOnKeyDown)
-    document.removeEventListener('keydown', this.selectItemOnEnter)
-    document.removeEventListener('keydown', this.removeItemOnBackspace)
-    document.removeEventListener('keydown', this.closeOnEscape)
-    document.removeEventListener('click', this.closeOnDocumentClick)
-  }
-
-  // ----------------------------------------
-  // Document Event Handlers
-  // ----------------------------------------
-
-  // onChange needs to receive a value
-  // can't rely on props.value if we are controlled
-  handleChange = (e, value) => {
-    debug('handleChange()')
-    debug(value)
-    const { name, onChange } = this.props
-    if (onChange) onChange(e, { name, value })
-  }
-
-  closeOnEscape = (e) => {
-    if (keyboardKey.getCode(e) !== keyboardKey.Escape) return
-    e.preventDefault()
-    this.close()
-  }
-
-  moveSelectionOnKeyDown = (e) => {
-    debug('moveSelectionOnKeyDown()')
-    debug(keyboardKey.getName(e))
-    switch (keyboardKey.getCode(e)) {
-      case keyboardKey.ArrowDown:
-        e.preventDefault()
-        this.moveSelectionBy(1)
-        break
-      case keyboardKey.ArrowUp:
-        e.preventDefault()
-        this.moveSelectionBy(-1)
-        break
-      default:
-        break
-    }
-  }
-
-  openOnSpace = (e) => {
-    debug('openOnSpace()')
-    if (keyboardKey.getCode(e) !== keyboardKey.Spacebar) return
-    if (this.state.open) return
-    e.preventDefault()
-    this.trySetState({ open: true })
-  }
-
-  openOnArrow = (e) => {
-    const code = keyboardKey.getCode(e)
-    debug('openOnArrow()')
-    if (!_.includes([keyboardKey.ArrowDown, keyboardKey.ArrowUp], code)) return
-    if (this.state.open) return
-    e.preventDefault()
-    this.trySetState({ open: true })
-  }
-
-  selectHighlightedItem = (e) => {
-    const { open } = this.state
-    const { multiple, name, onAddItem, options } = this.props
-    const value = _.get(this.getSelectedItem(), 'value')
-
-    // prevent selecting null if there was no selected item value
-    // prevent selecting duplicate items when the dropdown is closed
-    if (!value || !open) return
-
-    // notify the onAddItem prop if this is a new value
-    if (onAddItem && !_.some(options, { text: value })) {
-      onAddItem(e, { name, value })
-    }
-
-    // notify the onChange prop that the user is trying to change value
-    if (multiple) {
-      // state value may be undefined
-      const newValue = _.union(this.state.value, [value])
-      this.setValue(newValue)
-      this.handleChange(e, newValue)
-    } else {
-      this.setValue(value)
-      this.handleChange(e, value)
-      this.close()
-    }
-  }
-
-  selectItemOnEnter = (e) => {
-    debug('selectItemOnEnter()')
-    debug(keyboardKey.getName(e))
-    if (keyboardKey.getCode(e) !== keyboardKey.Enter) return
-    e.preventDefault()
-
-    this.selectHighlightedItem(e)
-  }
-
-  removeItemOnBackspace = (e) => {
-    debug('removeItemOnBackspace()')
-    debug(keyboardKey.getName(e))
-    if (keyboardKey.getCode(e) !== keyboardKey.Backspace) return
-
-    const { multiple, search } = this.props
-    const { searchQuery, value } = this.state
-
-    if (searchQuery || !search || !multiple || _.isEmpty(value)) return
-
-    e.preventDefault()
-
-    // remove most recent value
-    const newValue = _.dropRight(value)
-
-    this.setValue(newValue)
-    this.handleChange(e, newValue)
-  }
-
-  closeOnDocumentClick = (e) => {
-    debug('closeOnDocumentClick()')
-    debug(e)
-    this.close()
   }
 
   // ----------------------------------------
   // Component Event Handlers
   // ----------------------------------------
 
-  handleMouseDown = (e) => {
-    debug('handleMouseDown()')
-    const { onMouseDown } = this.props
-    if (onMouseDown) onMouseDown(e)
-    this.isMouseDown = true
-    document.addEventListener('mouseup', this.handleDocumentMouseUp)
+  handleClose = (e) => {
+    debug('handleClose()')
+    this.close(e)
   }
 
-  handleDocumentMouseUp = () => {
-    debug('handleDocumentMouseUp()')
-    this.isMouseDown = false
-    document.removeEventListener('mouseup', this.handleDocumentMouseUp)
-  }
-
-  handleClick = (e) => {
-    debug('handleClick()', e)
-    const { onClick } = this.props
-    if (onClick) onClick(e)
-    // prevent closeOnDocumentClick()
-    e.stopPropagation()
-    this.toggle()
-  }
-
-  handleItemClick = (e, value) => {
-    debug('handleItemClick()')
-    debug(value)
-    const { multiple, name, onAddItem, options } = this.props
-    const item = this.getItemByValue(value) || {}
-
-    // prevent toggle() in handleClick()
-    e.stopPropagation()
-    // prevent closeOnDocumentClick() if multiple or item is disabled
-    if (multiple || item.disabled) {
-      e.nativeEvent.stopImmediatePropagation()
-    }
-
-    if (item.disabled) return
-
-    // notify the onAddItem prop if this is a new value
-    if (onAddItem && !_.some(options, { text: value })) {
-      onAddItem(e, { name, value })
-    }
-
-    // notify the onChange prop that the user is trying to change value
-    if (multiple) {
-      const newValue = _.union(this.state.value, [value])
-      this.setValue(newValue)
-      this.handleChange(e, newValue)
-    } else {
-      this.setValue(value)
-      this.handleChange(e, value)
-      this.close()
-    }
-  }
-
-  handleFocus = (e) => {
-    debug('handleFocus()')
-    const { onFocus } = this.props
-    if (onFocus) onFocus(e)
-    this.setState({ focus: true })
-  }
-
-  handleBlur = (e) => {
-    debug('handleBlur()')
-    const { multiple, onBlur, selectOnBlur } = this.props
-    // do not "blur" when the mouse is down inside of the Dropdown
-    if (this.isMouseDown) return
-    if (onBlur) onBlur(e)
-    if (selectOnBlur && !multiple) this.selectHighlightedItem(e)
-    this.setState({ focus: false })
-  }
-
-  handleSearchChange = (e) => {
-    debug('handleSearchChange()')
-    debug(e.target.value)
-    // prevent propagating to this.props.onChange()
-    e.stopPropagation()
-    const { search, onSearchChange } = this.props
-    const { open } = this.state
-    const newQuery = e.target.value
-
-    if (onSearchChange) onSearchChange(e, newQuery)
-
-    // open search dropdown on search query
-    if (search && newQuery && !open) this.open()
-
-    this.setState({
-      selectedIndex: this.getEnabledIndices()[0],
-      searchQuery: newQuery,
-    })
-  }
-
-  // ----------------------------------------
-  // Getters
-  // ----------------------------------------
-
-  // There are times when we need to calculate the options based on a value
-  // that hasn't yet been persisted to state.
-  getMenuOptions = (value = this.state.value) => {
-    const { multiple, search, allowAdditions, additionPosition, additionLabel, options } = this.props
-    const { searchQuery } = this.state
-
-    let filteredOptions = options
-
-    // filter out active options
-    if (multiple) {
-      filteredOptions = _.filter(filteredOptions, opt => !_.includes(value, opt.value))
-    }
-
-    // filter by search query
-    if (search && searchQuery) {
-      if (_.isFunction(search)) {
-        filteredOptions = search(filteredOptions, searchQuery)
-      } else {
-        const re = new RegExp(_.escapeRegExp(searchQuery), 'i')
-        filteredOptions = _.filter(filteredOptions, (opt) => re.test(opt.text))
-      }
-    }
-
-    // insert the "add" item
-    if (allowAdditions && search && searchQuery && !_.some(filteredOptions, { text: searchQuery })) {
-      const addItem = {
-        text: additionLabel ? `${additionLabel} ${searchQuery}` : searchQuery,
-        value: searchQuery,
-      }
-      if (additionPosition === 'top') filteredOptions.unshift(addItem)
-      else filteredOptions.push(addItem)
-    }
-
-    return filteredOptions
-  }
-
-  getSelectedItem = () => {
-    const { selectedIndex } = this.state
-    const options = this.getMenuOptions()
-
-    return _.get(options, `[${selectedIndex}]`)
-  }
-
-  getEnabledIndices = (givenOptions) => {
-    const options = givenOptions || this.getMenuOptions()
-
-    return _.reduce(options, (memo, item, index) => {
-      if (!item.disabled) memo.push(index)
-      return memo
-    }, [])
-  }
-
-  getItemByValue = (value) => {
-    const { options } = this.props
-    return _.find(options, { value })
-  }
-
-  getMenuItemIndexByValue = (value) => {
-    const options = this.getMenuOptions()
-
-    return _.findIndex(options, ['value', value])
-  }
-
-  // ----------------------------------------
-  // Setters
-  // ----------------------------------------
-
-  setValue = (value) => {
-    debug('setValue()')
-    debug('value', value)
-    const { multiple } = this.props
-    const { selectedIndex } = this.state
-    const options = this.getMenuOptions(value)
-    const enabledIndicies = this.getEnabledIndices(options)
-    const newState = {
-      searchQuery: '',
-    }
-
-    // update the selected index
-    if (!selectedIndex) {
-      const firstIndex = enabledIndicies[0]
-
-      // Select the currently active item, if none, use the first item.
-      // Multiple selects remove active items from the list,
-      // their initial selected index should be 0.
-      newState.selectedIndex = multiple
-        ? firstIndex
-        : this.getMenuItemIndexByValue(value || _.get(options, `[${firstIndex}].value`))
-    } else if (multiple) {
-      // multiple selects remove options from the menu as they are made active
-      // keep the selected index within range of the remaining items
-      if (selectedIndex >= options.length - 1) {
-        newState.selectedIndex = enabledIndicies[enabledIndicies.length - 1]
-      }
-    } else {
-      const activeIndex = this.getMenuItemIndexByValue(value)
-
-      // regular selects can only have one active item
-      // set the selected index to the currently active item
-      newState.selectedIndex = _.includes(enabledIndicies, activeIndex) ? activeIndex : undefined
-    }
-
-    this.trySetState({ value }, newState)
-  }
-
-  handleLabelRemove = (e, labelProps) => {
-    debug('handleLabelRemove()')
-    // prevent focusing search input on click
-    e.stopPropagation()
-    const { value } = this.state
-    const newValue = _.without(value, labelProps.value)
-    debug('label props:', labelProps)
-    debug('current value:', value)
-    debug('remove value:', labelProps.value)
-    debug('new value:', newValue)
-
-    this.setValue(newValue)
-    this.handleChange(e, newValue)
-  }
-
-  moveSelectionBy = (offset, startIndex = this.state.selectedIndex) => {
-    debug('moveSelectionBy()')
-    debug(`offset: ${offset}`)
-
-    const options = this.getMenuOptions()
-    const lastIndex = options.length - 1
-
-    // Prevent infinite loop
-    if (_.every(options, 'disabled')) return
-
-    // next is after last, wrap to beginning
-    // next is before first, wrap to end
-    let nextIndex = startIndex + offset
-    if (nextIndex > lastIndex) nextIndex = 0
-    else if (nextIndex < 0) nextIndex = lastIndex
-
-    if (options[nextIndex].disabled) return this.moveSelectionBy(offset, nextIndex)
-
-    this.setState({ selectedIndex: nextIndex })
-    this.scrollSelectedItemIntoView()
+  handleOpen = (e) => {
+    debug('handleOpen()')
+    this.open(e)
   }
 
   // ----------------------------------------
   // Behavior
   // ----------------------------------------
 
-  scrollSelectedItemIntoView = () => {
-    debug('scrollSelectedItemIntoView()')
-    const menu = document.querySelector('.ui.dropdown.active.visible .menu.visible')
-    const item = menu.querySelector('.item.selected')
-    debug(`menu: ${menu}`)
-    debug(`item: ${item}`)
-    const isOutOfUpperView = item.offsetTop < menu.scrollTop
-    const isOutOfLowerView = (item.offsetTop + item.clientHeight) > menu.scrollTop + menu.clientHeight
-
-    if (isOutOfUpperView || isOutOfLowerView) {
-      menu.scrollTop = item.offsetTop
-    }
-  }
-
-  open = () => {
+  open = (e) => {
     debug('open()')
-    const { search } = this.props
-    if (search) this._search.focus()
+
+    const { onOpen } = this.props
+    if (onOpen) onOpen(e)
 
     this.trySetState({ open: true })
   }
 
-  close = () => {
+  close = (e) => {
     debug('close()')
+
+    const { onClose } = this.props
+    if (onClose) onClose(e)
+
     this.trySetState({ open: false })
   }
 
-  handleClose = () => {
-    debug('handleClose()')
-    this._dropdown.blur()
-  }
-
-  toggle = () => this.state.open ? this.close() : this.open()
-
-  // ----------------------------------------
-  // Render
-  // ----------------------------------------
-
-  renderText = () => {
-    const { multiple, placeholder, search, text } = this.props
-    const { searchQuery, value, open } = this.state
-    const hasValue = multiple ? !_.isEmpty(value) : !!value
-
-    const classes = cx(
-      placeholder && !hasValue && 'default',
-      'text',
-      search && searchQuery && 'filtered'
-    )
-    let _text = placeholder
-    if (searchQuery) {
-      _text = null
-    } else if (text) {
-      _text = text
-    } else if (open && !multiple) {
-      _text = _.get(this.getSelectedItem(), 'text')
-    } else if (hasValue) {
-      _text = _.get(this.getItemByValue(value), 'text')
-    }
-
-    return <div className={classes}>{_text}</div>
-  }
-
-  renderHiddenInput = () => {
-    debug('renderHiddenInput()')
-    const { value } = this.state
-    const { multiple, name, options, selection } = this.props
-    debug(`name:      ${name}`)
-    debug(`selection: ${selection}`)
-    debug(`value:     ${value}`)
-    if (!selection) return null
-
-    return (
-      <select type='hidden' name={name} value={value} multiple={multiple}>
-        {_.map(options, option => (
-          <option key={option.value} value={option.value}>{option.text}</option>
-        ))}
-      </select>
-    )
-  }
-
-  renderSearchInput = () => {
-    const { search, name } = this.props
-    const { searchQuery } = this.state
-
-    if (!search) return null
-
-    // resize the search input, temporarily show the sizer so we can measure it
-    let searchWidth
-    if (this._sizer && searchQuery) {
-      this._sizer.style.display = 'inline'
-      this._sizer.textContent = searchQuery
-      searchWidth = Math.ceil(this._sizer.getBoundingClientRect().width)
-      this._sizer.style.removeProperty('display')
-    }
-
-    return (
-      <input
-        value={searchQuery}
-        onChange={this.handleSearchChange}
-        className='search'
-        name={[name, 'search'].join('-')}
-        autoComplete='off'
-        tabIndex='0'
-        style={{ width: searchWidth }}
-        ref={c => (this._search = c)}
-      />
-    )
-  }
-
-  renderSearchSizer = () => {
-    const { search, multiple } = this.props
-
-    if (!(search && multiple)) return null
-
-    return <span className='sizer' ref={c => (this._sizer = c)} />
-  }
-
-  renderLabels = () => {
-    debug('renderLabels()')
-    const { multiple } = this.props
-    const { value } = this.state
-    if (!multiple || _.isEmpty(value)) {
-      return
-    }
-    const selectedItems = _.map(value, this.getItemByValue)
-    debug('selectedItems', selectedItems)
-
-    // if no item could be found for a given state value the selected item will be undefined
-    // compact the selectedItems so we only have actual objects left
-    return _.map(_.compact(selectedItems), (item) => {
-      return (
-        <Label
-          key={item.value}
-          as={'a'}
-          content={item.text}
-          value={item.value}
-          onRemove={this.handleLabelRemove}
-        />
-      )
-    })
-  }
-
-  renderOptions = () => {
-    const { multiple, search, noResultsMessage } = this.props
-    const { selectedIndex, value } = this.state
-    const options = this.getMenuOptions()
-
-    if (search && _.isEmpty(options)) {
-      return <div className='message'>{noResultsMessage}</div>
-    }
-
-    const isActive = multiple
-      ? optValue => _.includes(value, optValue)
-      : optValue => optValue === value
-
-    return _.map(options, (opt, i) => (
-      <DropdownItem
-        key={`${opt.value}-${i}`}
-        active={isActive(opt.value)}
-        onClick={this.handleItemClick}
-        selected={selectedIndex === i}
-        {...opt}
-        // Needed for handling click events on disabled items
-        style={{ ...opt.style, pointerEvents: 'all' }}
-      />
-    ))
-  }
-
-  renderMenu = () => {
-    const { children, header } = this.props
-    const { open } = this.state
-    const menuClasses = open ? 'visible' : ''
-
-    // single menu child
-    if (children) {
-      const menuChild = Children.only(children)
-      const className = cx(menuClasses, menuChild.props.className)
-
-      return cloneElement(menuChild, { className })
-    }
-
-    return (
-      <DropdownMenu className={menuClasses}>
-        {createShorthand(DropdownHeader, val => ({ content: val }), header)}
-        {this.renderOptions()}
-      </DropdownMenu>
-    )
-  }
-
   render() {
-    debug('render()')
-    debug('props', this.props)
-    debug('state', this.state)
     const { open } = this.state
 
     const {
       basic,
       button,
+      children,
       className,
       compact,
       fluid,
       floating,
-      icon,
+      // icon,
       inline,
       labeled,
       // linkItem,
@@ -925,63 +206,58 @@ export default class Dropdown extends Component {
       error,
       disabled,
       scrolling,
+      text,
       trigger,
     } = this.props
 
     // Classes
     const classes = cx(
       'ui',
-      useKeyOnly(open, 'active visible'),
-      useKeyOnly(disabled, 'disabled'),
-      useKeyOnly(error, 'error'),
-      useKeyOnly(loading, 'loading'),
-
       useKeyOnly(basic, 'basic'),
       useKeyOnly(button, 'button'),
       useKeyOnly(compact, 'compact'),
-      useKeyOnly(fluid, 'fluid'),
+      useKeyOnly(disabled, 'disabled'),
+      useKeyOnly(error, 'error'),
       useKeyOnly(floating, 'floating'),
-      useKeyOnly(inline, 'inline'),
-      // TODO: consider augmentation to render Dropdowns as Button/Menu, solves icon/link item issues
-      // https://github.com/Semantic-Org/Semantic-UI-React/issues/401#issuecomment-240487229
+      useKeyOnly(fluid, 'fluid'),
       // TODO: the icon class is only required when a dropdown is a button
       // useKeyOnly(icon, 'icon'),
+      useKeyOnly(inline, 'inline'),
       useKeyOnly(labeled, 'labeled'),
       // TODO: linkItem is required only when Menu child, add dynamically
       // useKeyOnly(linkItem, 'link item'),
+      useKeyOnly(loading, 'loading'),
       useKeyOnly(multiple, 'multiple'),
+      useKeyOnly(open, 'active visible'),
+      useKeyOnly(scrolling, 'scrolling'),
       useKeyOnly(search, 'search'),
       useKeyOnly(selection, 'selection'),
       useKeyOnly(simple, 'simple'),
-      useKeyOnly(scrolling, 'scrolling'),
-
       useKeyOrValueAndKey(pointing, 'pointing'),
       className,
       'dropdown',
     )
     const rest = getUnhandledProps(Dropdown, this.props)
-    const ElementType = getElementType(Dropdown, this.props)
+
+    const menuChild = Children.only(children)
+    const menuClassName = cx(
+      useKeyOnly(open, 'visible'),
+      menuChild.props.className,
+    )
+
+    const triggerElement = trigger || DropdownText.create(text)
 
     return (
-      <ElementType
-        {...rest}
+      <Portal {...rest}
         className={classes}
-        onBlur={this.handleBlur}
-        onClick={this.handleClick}
-        onMouseDown={this.handleMouseDown}
-        onFocus={this.handleFocus}
-        onChange={this.handleChange}
-        tabIndex={search ? undefined : 0}
-        ref={c => (this._dropdown = c)}
+        inline
+        onOpen={this.handleOpen}
+        onClose={this.handleClose}
+        open={open}
+        trigger={triggerElement}
       >
-        {this.renderHiddenInput()}
-        {this.renderLabels()}
-        {this.renderSearchInput()}
-        {this.renderSearchSizer()}
-        {trigger || this.renderText()}
-        {Icon.create(icon)}
-        {this.renderMenu()}
-      </ElementType>
+        {cloneElement(menuChild, { className: menuClassName })}
+      </Portal>
     )
   }
 }

--- a/src/modules/Dropdown/DropdownText.js
+++ b/src/modules/Dropdown/DropdownText.js
@@ -1,0 +1,47 @@
+import cx from 'classnames'
+import React, { PropTypes } from 'react'
+
+import {
+  createShorthandFactory,
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
+
+/**
+ * Header content wraps the main content when there is an adjacent Icon or Image.
+ */
+function DropdownText(props) {
+  const { children, className, content } = props
+  const classes = cx(className, 'text')
+  const rest = getUnhandledProps(DropdownText, props)
+  const ElementType = getElementType(DropdownText, props)
+
+  return <ElementType {...rest} className={classes}>{children || content}</ElementType>
+}
+
+DropdownText._meta = {
+  name: 'DropdownText',
+  parent: 'Dropdown',
+  type: META.TYPES.MODULE,
+}
+
+DropdownText.propTypes = {
+  /** An element type to render as (string or function). */
+  as: customPropTypes.as,
+
+  /** Primary content. */
+  children: PropTypes.node,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+
+  /** Shorthand for primary content. */
+  content: customPropTypes.contentShorthand,
+}
+
+DropdownText.create = createShorthandFactory(DropdownText, content => ({ content }))
+
+
+export default DropdownText

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -88,7 +88,7 @@ class Modal extends Component {
   }
 
   handleMount = () => {
-    debug('handleOpen()')
+    debug('handleMount()')
     const { dimmer } = this.props
     const mountNode = this.getMountNode()
 


### PR DESCRIPTION
⚠️ **NOTE: This was closed in favor of #672**

---

This PR intends to clean up the `Dropdown` component and address some open issues (e.g. #517 and #509.

The rough goals:
- Separate `Dropdown` and `Select` functionality:
  - `Dropdown` is renders a `.ui.dropdown` with a "trigger" and "menu". Meant to be used for static-ish dropdown menus.
  - `Select` will render a dropdown under the hood, but will maintain a value and add search functionality. Meant to be used in place of an html `select`.
- Defer the show/hide functionality to `Portal` (or some other shared component).

The plan is to break out the `Dropdown` to the simplest form, then add back functionality/shorthand as it makes sense.

TODO:
- [x] Use portal for dropdown show/hide
- [x] Remove select-related functionality
- [ ] Add select-related functionality via the `Select` component

Open questions:
- I'm reusing the `Portal` class and adding an `inline` class which renders the "portal" as a wrapping element (e.g. `<div class='ui dropdown' />`). The main reason is that there's already a bunch of open/close configuration. However, in this case it's no longer really a "portal" and the rendering is pretty different which leads to some `if (inline)` flow control. I'm on the fence about making this a different component with a similar interface. Thoughts?
