### PR TITLE
fix(dropdown): render text when option.value = 0

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -758,7 +758,9 @@ export default class Dropdown extends Component {
   renderText = () => {
     const { multiple, placeholder, search, text } = this.props
     const { searchQuery, value, open } = this.state
-    const hasValue = multiple ? !_.isEmpty(value) : !!value
+    const hasValue = multiple
+      ? !_.isEmpty(value)
+      : !_.isNil(value) && value !== ''
 
     const classes = cx(
       placeholder && !hasValue && 'default',

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -603,6 +603,60 @@ describe('Dropdown Component', () => {
         .find('.text')
         .should.contain.text(item.text())
     })
+    it('displays if value is 0', () => {
+      const text = faker.hacker.noun()
+
+      wrapperMount(<Dropdown options={[{ value: 0, text }]} selection />)
+
+      // open
+      wrapper.simulate('click')
+
+      // click item
+      const item = wrapper
+        .find('DropdownItem')
+        .simulate('click')
+
+      // text updated
+      wrapper
+        .find('.text')
+        .should.contain.text(item.text())
+    })
+    it('does not display if value is \'\'', () => {
+      const text = faker.hacker.noun()
+
+      wrapperMount(<Dropdown options={[{ value: '', text }]} selection />)
+        .simulate('click')
+        .find('DropdownItem')
+        .simulate('click')
+
+      wrapper
+        .find('.text')
+        .should.contain.text('')
+    })
+    it('does not display if value is null', () => {
+      const text = faker.hacker.noun()
+
+      wrapperMount(<Dropdown options={[{ value: null, text }]} selection />)
+        .simulate('click')
+        .find('DropdownItem')
+        .simulate('click')
+
+      wrapper
+        .find('.text')
+        .should.contain.text('')
+    })
+    it('does not display if value is undefined', () => {
+      const text = faker.hacker.noun()
+
+      wrapperMount(<Dropdown options={[{ value: undefined, text }]} selection />)
+        .simulate('click')
+        .find('DropdownItem')
+        .simulate('click')
+
+      wrapper
+        .find('.text')
+        .should.contain.text('')
+    })
   })
 
   describe('trigger', () => {


### PR DESCRIPTION
!!0 equals false so the text for a option object with value 0 never rendered after it was selected.
