### PR TITLE
fix(Dropdown): blur virtual DOM with real DOM

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -739,7 +739,14 @@ export default class Dropdown extends Component {
 
   handleClose = () => {
     debug('handleClose()')
+    // https://github.com/Semantic-Org/Semantic-UI-React/issues/627
+    // Blur the Dropdown on close so it is blurred after selecting an item.
+    // This is to prevent it from re-opening when switching tabs after selecting an item.
     this._dropdown.blur()
+
+    // We need to keep the virtual model in sync with the browser focus change
+    // https://github.com/Semantic-Org/Semantic-UI-React/issues/692
+    this.setState({ focus: false })
   }
 
   toggle = () => this.state.open ? this.close() : this.open()

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -332,10 +332,6 @@ export default class Dropdown extends Component {
       document.removeEventListener('keydown', this.selectItemOnEnter)
       document.removeEventListener('keydown', this.removeItemOnBackspace)
       document.removeEventListener('click', this.closeOnDocumentClick)
-      if (prevState.focus && this.state.focus) {
-        document.addEventListener('keydown', this.openOnArrow)
-        document.addEventListener('keydown', this.openOnSpace)
-      }
     }
   }
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -194,6 +194,48 @@ describe('Dropdown Component', () => {
     })
   })
 
+  describe('handleClose', () => {
+    it('is called when open changes to false', () => {
+      wrapperMount(<Dropdown options={options} selection />)
+      wrapper.simulate('click')
+      dropdownMenuIsOpen()
+
+      const instance = wrapper.instance()
+      sandbox.spy(instance, 'handleClose')
+
+      wrapper.simulate('click')
+      dropdownMenuIsClosed()
+
+      instance
+        .handleClose
+        .should.have.been.calledOnce()
+    })
+
+    it('prevents Space from opening a search Dropdown after selecting an item', () => {
+      // Prevent a bug where pressing space in another control opens the Dropdown
+      // https://github.com/Semantic-Org/Semantic-UI-React/issues/692
+      wrapperMount(<Dropdown options={options} search selection />)
+
+      // open, click an item, assert it is active and in the value
+      wrapper.simulate('click')
+      dropdownMenuIsOpen()
+
+      wrapper
+        .find('DropdownItem')
+        .first()
+        .simulate('click')
+        .should.have.prop('active', true)
+
+      wrapper.should.have.state('value', options[0].value)
+
+      dropdownMenuIsClosed()
+
+      // doesn't open on space
+      domEvent.keyDown(document, { key: ' ' })
+      dropdownMenuIsClosed()
+    })
+  })
+
   describe('isMouseDown', () => {
     it('tracks when the mouse is down', () => {
       wrapperShallow(<Dropdown />)

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -626,38 +626,6 @@ describe('Dropdown Component', () => {
       dropdownMenuIsOpen()
     })
 
-    it('opens on arrow down when focused and closed', () => {
-      wrapperMount(<Dropdown options={options} selection />)
-
-      wrapper.simulate('focus')
-      domEvent.keyDown(document, { key: 'Escape' })
-      dropdownMenuIsClosed()
-
-      domEvent.keyDown(document, { key: 'ArrowDown' })
-      dropdownMenuIsOpen()
-    })
-
-    it('opens on arrow up when focused and closed', () => {
-      wrapperMount(<Dropdown options={options} selection />)
-
-      wrapper.simulate('focus')
-      domEvent.keyDown(document, { key: 'Escape' })
-      dropdownMenuIsClosed()
-
-      domEvent.keyDown(document, { key: 'ArrowUp' })
-      dropdownMenuIsOpen()
-    })
-
-    it('opens on space when focused and closed', () => {
-      wrapperMount(<Dropdown options={options} selection />)
-
-      dropdownMenuIsClosed()
-      wrapper.simulate('focus')
-      domEvent.keyDown(document, { key: 'Escape' })
-      domEvent.keyDown(document, { key: ' ' })
-      dropdownMenuIsOpen()
-    })
-
     it('does not open on arrow down when not focused', () => {
       wrapperMount(<Dropdown options={options} selection />)
 


### PR DESCRIPTION
Fixes #692 

All event handlers are added/removed based on the virtual DOM events.  A recent PR blurred the Dropdown node on close (#628) to prevent a re-opening bug on switching browser tabs.  It did not also blur the virtual DOM. This circumvented the Dropdown's virtual DOM onBlur event which removes the `openOnSpace` listener.  This created a bug where a Dropdown without focus opens when pressing space anywhere on the page.

This PR blurs the virtual DOM along side blurring the real DOM.  It also adds missing tests for these areas.

Lastly, this PR removes logic and tests for the now unreachable state of "closed and focused".  The Dropdown is now blurred on close so it is impossible to enter this state and those tests were failing.
