### PR TITLE
fix(Dropdown): over zealous propType warnings

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -56,7 +56,6 @@ export default class Dropdown extends Component {
     /** Array of Dropdown.Item props e.g. `{ text: '', value: '' }` */
     options: customPropTypes.every([
       customPropTypes.disallow(['children']),
-      customPropTypes.demand(['selection']),
       PropTypes.arrayOf(PropTypes.shape(DropdownItem.propTypes)),
     ]),
 
@@ -69,7 +68,6 @@ export default class Dropdown extends Component {
     /** Primary content. */
     children: customPropTypes.every([
       customPropTypes.disallow(['options', 'selection']),
-      customPropTypes.demand(['text']),
       customPropTypes.givenProps(
         { children: PropTypes.any.isRequired },
         React.PropTypes.element.isRequired,


### PR DESCRIPTION
This PR fixes over zealous propType warnings from the Dropdown.  Both of these are valid usages:

A Dropdown menu only that currently throws warnings demanding `selection`.

``` jsx
<Dropdown options={[...]} />
```

A Dropdown with a menu child that currently throws warnings demaing `text`.  This is also a doc site example.

``` jsx
<Dropdown trigger={<span>Click Me</span>}>
  <Dropdown.Menu>
    ...
  </Dropdown.Menu>
</Dropdown>
```
