### PR TITLE
fix(customPropTypes): ignore nil and false in disallow()

### DIFF
--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -25,11 +25,11 @@ export const disallow = disallowedProps => {
     }
 
     // skip if prop is undefined
-    if (props[propName] === undefined) return
+    if (_.isNil(props[propName]) || props[propName] === false) return
 
     // find disallowed props with values
     const disallowed = disallowedProps.reduce((acc, disallowedProp) => {
-      if (props[disallowedProp] !== undefined) {
+      if (!_.isNil(props[disallowedProp]) && props[disallowedProp] !== false) {
         return [...acc, disallowedProp]
       }
       return acc


### PR DESCRIPTION
Fixes #699 

The Portal defaults `closeOnDocumentClick: true` but also `disallow()`s this prop with `closeOnRootNodeClick`.  The Modal uses the Portal like so:

``` jsx
<Portal
  closeOnRootNodeClick
  closeOnDocumentClick={false}
  ...
/>
```

The current `disallow()` logic throws a warning because both props are present.  This PR updates the disallow logic to ignore not only `undefined` props but any `_.isNil` and or `false` props as well. This makes sense as any nil or false prop is not in conflict since it is not "on" if you will.
