### PR TITLE
feat(Search|Dropdown): Improve arrow navigation

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -713,8 +713,10 @@ export default class Dropdown extends Component {
     const isOutOfUpperView = item.offsetTop < menu.scrollTop
     const isOutOfLowerView = (item.offsetTop + item.clientHeight) > menu.scrollTop + menu.clientHeight
 
-    if (isOutOfUpperView || isOutOfLowerView) {
+    if (isOutOfUpperView) {
       menu.scrollTop = item.offsetTop
+    } else if (isOutOfLowerView) {
+      menu.scrollTop = item.offsetTop + item.clientHeight - menu.clientHeight
     }
   }
 

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -438,8 +438,10 @@ export default class Search extends Component {
     const isOutOfUpperView = item.offsetTop < menu.scrollTop
     const isOutOfLowerView = (item.offsetTop + item.clientHeight) > menu.scrollTop + menu.clientHeight
 
-    if (isOutOfUpperView || isOutOfLowerView) {
+    if (isOutOfUpperView) {
       menu.scrollTop = item.offsetTop
+    } else if (isOutOfLowerView) {
+      menu.scrollTop = item.offsetTop + item.clientHeight - menu.clientHeight
     }
   }
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -432,6 +432,10 @@ describe('Dropdown Component', () => {
       dropdownMenuIsOpen()
       const menu = document.querySelector('.ui.dropdown .menu.visible')
 
+      // Limit the menu's height and set an overflow so it's scrollable
+      menu.style.height = '100px'
+      menu.style.overflow = 'auto'
+
       //
       // Scrolls to bottom
       //
@@ -467,8 +471,10 @@ describe('Dropdown Component', () => {
         .find('.selected')
         .should.contain.text(opts[0].text)
 
-      // menu should be completely scrolled to the bottom
-      const isMenuScrolledToTop = menu.scrollTop === 0
+      // Note: For some reason the first item's offsetTop is not 0 so we need
+      // to find the item's offsetTop and ensure it's at the top.
+      const selectedItem = document.querySelector('.ui.dropdown .menu.visible .item.selected')
+      const isMenuScrolledToTop = menu.scrollTop === selectedItem.offsetTop
       isMenuScrolledToTop.should.be.true(
         'When the first item in the list was selected, DropdownMenu did not scroll to top.'
       )

--- a/test/specs/modules/Search/Search-test.js
+++ b/test/specs/modules/Search/Search-test.js
@@ -16,7 +16,7 @@ let wrapper
 // ----------------------------------------
 // Wrapper
 // ----------------------------------------
-// we need to unmount the dropdown after every test to ensure all event listeners are cleaned up
+// we need to unmount the search after every test to ensure all event listeners are cleaned up
 // wrap the render methods to update a global wrapper that is unmounted after each test
 const wrapperMount = (node, opts) => {
   attachTo = document.createElement('div')
@@ -188,6 +188,10 @@ describe('Search Component', () => {
       searchResultsIsOpen()
       const menu = document.querySelector('.ui.search .results.visible')
 
+      // Limit the menu's height and set an overflow so it's scrollable
+      menu.style.height = '100px'
+      menu.style.overflow = 'auto'
+
       //
       // Scrolls to bottom
       //
@@ -223,8 +227,10 @@ describe('Search Component', () => {
         .find('.result.active')
         .should.contain.text(opts[0].title)
 
-      // menu should be completely scrolled to the bottom
-      const isMenuScrolledToTop = menu.scrollTop === 0
+      // Note: For some reason the first item's offsetTop is not 0 so we need
+      // to find the item's offsetTop and ensure it's at the top.
+      const selectedItem = document.querySelector('.ui.search .results.visible .result.active')
+      const isMenuScrolledToTop = menu.scrollTop === selectedItem.offsetTop
       isMenuScrolledToTop.should.be.true(
         'When the first item in the list was selected, SearchResults did not scroll to top.'
       )


### PR DESCRIPTION
This improves arrow navigation in both the dropdown and search menus.

**Previously**
When pressing "arrow-down" to move through results once an item was past the bottom the menu's scrollTop would move to that item's scrollTop, which was kinda jarring. It was almost as if you were moving to the next "page" of items, which is pretty non-standard:
![before](https://cloud.githubusercontent.com/assets/847027/19504395/ea08b2f0-9587-11e6-9b71-62b67cfb3923.gif)

**After**
When an item is past the bottom, the menu adjusts so that the bottom of the menu is at the item's bottom:
![after](https://cloud.githubusercontent.com/assets/847027/19504427/278243bc-9588-11e6-8f0d-55e7babec8c3.gif)

This also fixes the specs that were testing this functionality - they weren't actually testing anything 😐 
