### PR TITLE
chore(package): define browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.56.5",
   "description": "The official Semantic-UI-React integration.",
   "main": "dist/commonjs/index.js",
+  "browser": "dist/umd/semantic-ui-react.min.js",
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
This PR adds a `browser` field the `package.json` to point users and tools to the browser bundle.  This was specifically added for better [`unpkg`](https://unpkg.com/#/) support:

https://unpkg.com/semantic-ui-react will now resolve to the `latest` build browser bundle, instead having to specify https://unpkg.com/semantic-ui-react/dist/umd/semantic-ui-react.min.js.
