### PR TITLE
fix(package): revert define browser field (#702)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.56.6",
   "description": "The official Semantic-UI-React integration.",
   "main": "dist/commonjs/index.js",
-  "browser": "dist/umd/semantic-ui-react.min.js",
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
Fixes #703 

The recently merged `browser` field also instructs webpack (and other bundlers) to assume the `browser` field as the `main` when requiring the module.  This is unfortunate as there is then no way to define a true browser _bundle_ separate from a commonjs compatible _main_ entry point.

Reverting.
