### PR TITLE
chore(scripts): setup auto release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,7 @@ deployment:
     commands:
       - git config --global user.email "devteam+deweybot@technologyadvice.com"
       - git config --global user.name "deweybot"
+      - node scripts/auto-release.js
       # changelog generator is crashing, skipping for manual updates for now
       # - $(npm bin)/ta-script circle_ci/create_changelog
       - NODE_ENV=production npm run deploy:docs

--- a/scripts/auto-release.js
+++ b/scripts/auto-release.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+const childProcess = require('child_process')
+const log = (...msgs) => {
+  console.log('AUTO RELEASE:', ...msgs) // eslint-disable-line no-console
+}
+
+// ----------------------------------------
+// Gather info
+// ----------------------------------------
+const pkg = require('../package')
+const isPreVersion1 = /^0/.test(pkg.version)
+
+const versionBumpMap = {
+  breaking: isPreVersion1 ? 'minor' : 'major',
+  feat: isPreVersion1 ? 'patch' : 'minor',
+  fix: 'patch',
+  docs: 'patch',
+  style: 'patch',
+  refactor: 'patch',
+  perf: 'patch',
+  test: 'patch',
+  chore: 'patch',
+}
+
+const lastCommitMessage = childProcess.execSync('git log -1 --pretty=%B').toString().replace(/\n/g, '')
+const commitType = /\w+/.exec(lastCommitMessage)
+const bumpVersion = versionBumpMap[commitType]
+
+// ----------------------------------------
+// Safety Checks
+// ----------------------------------------
+if (!bumpVersion) {
+  log(`
+
+Could not determine version to bump from the last commit message:
+  Current Version : ${pkg.version}
+  Is pre v1       : ${isPreVersion1}
+  Commit Message  : ${lastCommitMessage}
+  Commit Type     : ${commitType}
+  Bump Version    : ${bumpVersion}
+
+Version bump map: ${JSON.stringify(versionBumpMap, null, 2)}`)
+  process.exit(1)
+}
+
+// ----------------------------------------
+// Release
+// ----------------------------------------
+const command = `npm run release:${bumpVersion}`
+log(`
+  Current Version : ${pkg.version}
+  Is pre v1       : ${isPreVersion1}
+  Commit Message  : ${lastCommitMessage}
+  Commit Type     : ${commitType}
+  Bump Version    : ${bumpVersion}
+  Command         : ${command}`)
+
+childProcess.execSync(command)


### PR DESCRIPTION
@jcarbo @layershifter Hey, this is pretty important:

This PR  adds a script to automatically release commits on the `master` branch.  Version bumps are determined by the commit message `type` (ie chore, feat, etc).  This accounts for pre v1 bumps vs v1 bumps as promised in our README.md.

**Before merging PRs, the titles _must_ follow our commit guidelines**.  This is on me so I'll work to ensure they are correct.

I've added `breaking(scope): message` as a type to signify breaking changes. **All PRs must follow this convention moving forward.**

If anything goes wrong, the script will fail and CI will not release.
