### PR TITLE
fix(Modal): Only set position when modal is open

### DIFF
--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -77,18 +77,13 @@ class Modal extends Component {
 
   state = {}
 
-  componentDidMount() {
-    debug('componentDidMount()')
-    this.setPosition()
-  }
-
   componentWillUnmount() {
     debug('componentWillUnmount()')
-    this.handleUnmount()
+    this.handlePortalUnmount()
   }
 
-  handleMount = () => {
-    debug('handleOpen()')
+  handlePortalMount = () => {
+    debug('handlePortalMount()')
     const { dimmer } = this.props
     const mountNode = this.getMountNode()
 
@@ -101,10 +96,12 @@ class Modal extends Component {
         mountNode.classList.add('blurring')
       }
     }
+
+    this.setPosition()
   }
 
-  handleUnmount = () => {
-    debug('handleUnmount()')
+  handlePortalUnmount = () => {
+    debug('handlePortalUnmount()')
 
     const mountNode = this.getMountNode()
 
@@ -112,6 +109,8 @@ class Modal extends Component {
     // If the dimmer value changes while the modal is open,
     //   then removing its current value could leave cruft classes previously added.
     mountNode.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
+
+    cancelAnimationFrame(this.animationRequestId)
   }
 
   getMountNode = () => {
@@ -141,7 +140,7 @@ class Modal extends Component {
       }
     }
 
-    requestAnimationFrame(this.setPosition)
+    this.animationRequestId = requestAnimationFrame(this.setPosition)
   }
 
   render() {
@@ -193,8 +192,8 @@ class Modal extends Component {
         {...portalProps}
         className={dimmerClasses}
         mountNode={this.getMountNode()}
-        onMount={this.handleMount}
-        onUnmount={this.handleUnmount}
+        onMount={this.handlePortalMount}
+        onUnmount={this.handlePortalUnmount}
       >
         {modalJSX}
       </Portal>


### PR DESCRIPTION
Fixes #712 

The modal has code that continuously calculates its position to:
- ensure it's centered vertically.
- add the scrolling class to the body if need be.

This was being called on component mount, which doesn't make sense since the modal itself may not actually be visible. This updates the the `setPosition` to start when the `Portal` gets mounted (the modal becomes visible) and stop when the `Portal` unmounts (the modal is hidden).

This should:
- reduce the workload being done by modals rendered onto a page. 
- make it so the component doesn't touch the `mountNode` until the page has been fully rendered. This (I think) should fix #712 since the `mountNode` defaults to `document.body` which isn't present server-side.
