### PR TITLE
fix(package): build before release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,6 @@ deployment:
     commands:
       - git config --global user.email "devteam+deweybot@technologyadvice.com"
       - git config --global user.name "deweybot"
-      - $(npm bin)/ta-script npm/auto-release
+      - npm run auto-release
       - $(npm bin)/ta-script circle_ci/create_changelog
       - NODE_ENV=production npm run deploy:docs

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   ],
   "scripts": {
     "docs": "gulp docs",
+    "preauto-release": "npm run build",
+    "auto-release": "ta-script npm/auto-release",
     "build": "npm run build:commonjs && npm run build:umd && npm run build:docs",
     "prebuild:commonjs": "rimraf dist/commonjs && npm run build:dll",
     "build:commonjs": "babel src -d dist/commonjs",


### PR DESCRIPTION
This PR fixes #724.  CircleCI is not building in the same container that is releasing.  So, the module is published with no `/dist` folder.  This PR adds an additional `npm run build` prior to the release.
