### PR TITLE
fix(AutoControlledComponent): replace startsWith call

### DIFF
--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -107,7 +107,7 @@ export default class AutoControlledComponent extends Component {
       //
       // Default props are automatically handled.
       // Listing defaults in autoControlledProps would result in allowing defaultDefaultValue props.
-      const illegalAutoControlled = _.filter(autoControlledProps, prop => prop.startsWith('default'))
+      const illegalAutoControlled = _.filter(autoControlledProps, prop => _.startsWith(prop, 'default'))
       if (!_.isEmpty(illegalAutoControlled)) {
         console.error([
           'Do not add default props to autoControlledProps.',


### PR DESCRIPTION
Fixes #733 

There was a `''.startsWith()` call in AutoControlledComponent.  We use `_.startsWith` instead for browser support.  This PR replaces the native string method with the lodash util.
