### PR TITLE
feat(Item.Image): Add size prop

### DIFF
--- a/src/views/Item/ItemImage.js
+++ b/src/views/Item/ItemImage.js
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { PropTypes } from 'react'
 import {
   META,
+  getUnhandledProps,
 } from '../../lib'
 import Image from '../../elements/Image'
 
@@ -8,13 +9,21 @@ import Image from '../../elements/Image'
  * An item can contain an image
  **/
 function ItemImage(props) {
-  return <Image {...props} ui={false} wrapped />
+  const { size } = props
+  const rest = getUnhandledProps(ItemImage, props)
+
+  return <Image {...rest} size={size} ui={!!size} wrapped />
 }
 
 ItemImage._meta = {
   name: 'ItemImage',
   parent: 'Item',
   type: META.TYPES.VIEW,
+}
+
+ItemImage.propTypes = {
+  /** An image may appear at different sizes */
+  size: PropTypes.oneOf(Image._meta.props.size),
 }
 
 export default ItemImage

--- a/test/specs/views/Item/ItemImage-test.js
+++ b/test/specs/views/Item/ItemImage-test.js
@@ -13,4 +13,9 @@ describe('ItemImage', () => {
     wrapper.should.have.prop('wrapped', true)
     wrapper.should.have.prop('ui', false)
   })
+
+  it('has ui with size prop', () => {
+    shallow(<ItemImage size='small' />)
+      .should.have.prop('ui', true)
+  })
 })


### PR DESCRIPTION
- Resolves #746
- Reverses an explicit test for ui=false, so needs review.
- Renders similar to the example at http://semantic-ui.com/views/item.html#image
- Images now render left aligned and sized.
