### PR TITLE
feat(Popup): Enabled controlled usage

### DIFF
--- a/docs/app/Examples/modules/Popup/Types/PopupExampleHtml.js
+++ b/docs/app/Examples/modules/Popup/Types/PopupExampleHtml.js
@@ -17,7 +17,7 @@ const IndividualCard = (
   </Card>
 )
 
-const PopupHtmlExample = () => (
+const PopupExampleHtml = () => (
   <Popup trigger={IndividualCard}>
     <Popup.Header>User Rating</Popup.Header>
     <Popup.Content>
@@ -26,4 +26,4 @@ const PopupHtmlExample = () => (
   </Popup>
 )
 
-export default PopupHtmlExample
+export default PopupExampleHtml

--- a/docs/app/Examples/modules/Popup/Types/PopupExampleTitled.js
+++ b/docs/app/Examples/modules/Popup/Types/PopupExampleTitled.js
@@ -19,7 +19,7 @@ const users = [
   },
 ]
 
-export default function PopupTitledExample() {
+export default function PopupExampleTitled() {
   const avatars = users.map((user, index) =>
     <Popup
       key={user.name}

--- a/docs/app/Examples/modules/Popup/Types/index.js
+++ b/docs/app/Examples/modules/Popup/Types/index.js
@@ -6,17 +6,17 @@ const PopupTypesExamples = () => (
   <ExampleSection title='Types'>
     <ComponentExample
       title='Popup'
-      description='An element can specify popup content to appear'
+      description='An element can specify popup content to appear.'
       examplePath='modules/Popup/Types/PopupExample'
     />
     <ComponentExample
       title='Titled'
-      description='An element can specify popup content with a title'
+      description='An element can specify popup content with a title.'
       examplePath='modules/Popup/Types/PopupExampleTitled'
     />
     <ComponentExample
       title='HTML'
-      description='An element can specify HTML for a popup'
+      description='An element can specify HTML for a popup.'
       examplePath='modules/Popup/Types/PopupExampleHtml'
     />
   </ExampleSection>

--- a/docs/app/Examples/modules/Popup/Types/index.js
+++ b/docs/app/Examples/modules/Popup/Types/index.js
@@ -12,12 +12,12 @@ const PopupTypesExamples = () => (
     <ComponentExample
       title='Titled'
       description='An element can specify popup content with a title'
-      examplePath='modules/Popup/Types/PopupTitledExample'
+      examplePath='modules/Popup/Types/PopupExampleTitled'
     />
     <ComponentExample
       title='HTML'
       description='An element can specify HTML for a popup'
-      examplePath='modules/Popup/Types/PopupHtmlExample'
+      examplePath='modules/Popup/Types/PopupExampleHtml'
     />
   </ExampleSection>
 )

--- a/docs/app/Examples/modules/Popup/Usage/PopupExampleClick.js
+++ b/docs/app/Examples/modules/Popup/Usage/PopupExampleClick.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button, Popup } from 'semantic-ui-react'
 
-const PopupClickExample = () => (
+const PopupExampleClick = () => (
   <Popup
     trigger={<Button color='red' icon='flask' content='Activate doomsday device' />}
     content={<Button color='green' content='Confirm the launch' />}
@@ -10,4 +10,4 @@ const PopupClickExample = () => (
   />
 )
 
-export default PopupClickExample
+export default PopupExampleClick

--- a/docs/app/Examples/modules/Popup/Usage/PopupExampleControlled.js
+++ b/docs/app/Examples/modules/Popup/Usage/PopupExampleControlled.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Button, Grid, Header, Popup } from 'semantic-ui-react'
+
+const timeoutLength = 2500
+
+class PopupExampleControlled extends React.Component {
+  state = { isOpen: false }
+
+  handleOpen = () => {
+    this.setState({ isOpen: true })
+
+    this.timeout = setTimeout(() => {
+      this.setState({ isOpen: false })
+    }, timeoutLength)
+  }
+
+  handleClose = () => {
+    this.setState({ isOpen: false })
+    clearTimeout(this.timeout)
+  }
+
+  render() {
+    return (
+      <Grid>
+        <Grid.Column width={8}>
+          <Popup
+            trigger={<Button content='Open controlled popup' />}
+            content={`This message will self-destruct in ${timeoutLength / 1000} seconds!`}
+            on='click'
+            open={this.state.isOpen}
+            onClose={this.handleClose}
+            onOpen={this.handleOpen}
+            positioning='top right'
+          />
+        </Grid.Column>
+        <Grid.Column width={8}>
+          <Header>State</Header>
+          <pre>{JSON.stringify(this.state, null, 2)}</pre>
+        </Grid.Column>
+      </Grid>
+    )
+  }
+}
+
+export default PopupExampleControlled

--- a/docs/app/Examples/modules/Popup/Usage/PopupExampleFocus.js
+++ b/docs/app/Examples/modules/Popup/Usage/PopupExampleFocus.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Input, Popup } from 'semantic-ui-react'
 
-const PopupFocusExample = () => (
+const PopupExampleFocus = () => (
   <Popup
     trigger={<Input icon='search' placeholder='Search...' />}
     header='Movie Search'
@@ -10,4 +10,4 @@ const PopupFocusExample = () => (
   />
 )
 
-export default PopupFocusExample
+export default PopupExampleFocus

--- a/docs/app/Examples/modules/Popup/Usage/PopupExampleHover.js
+++ b/docs/app/Examples/modules/Popup/Usage/PopupExampleHover.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button, Popup } from 'semantic-ui-react'
 
-const PopupHoverExample = () => (
+const PopupExampleHover = () => (
   <Popup
     trigger={<Button icon='add' content='Add a friend' />}
     content='Sends an email invite to a friend.'
@@ -9,4 +9,4 @@ const PopupHoverExample = () => (
   />
 )
 
-export default PopupHoverExample
+export default PopupExampleHover

--- a/docs/app/Examples/modules/Popup/Usage/index.js
+++ b/docs/app/Examples/modules/Popup/Usage/index.js
@@ -6,17 +6,17 @@ const PopupUsageExamples = () => (
   <ExampleSection title='Usage'>
     <ComponentExample
       title='Hover'
-      description='A popup can be triggered on hover'
+      description='A popup can be triggered on hover.'
       examplePath='modules/Popup/Usage/PopupExampleHover'
     />
     <ComponentExample
       title='Click'
-      description='A popup can be triggered on click'
+      description='A popup can be triggered on click.'
       examplePath='modules/Popup/Usage/PopupExampleClick'
     />
     <ComponentExample
       title='Focus'
-      description='A popup can be triggered on focus'
+      description='A popup can be triggered on focus.'
       examplePath='modules/Popup/Usage/PopupExampleFocus'
     />
     <ComponentExample

--- a/docs/app/Examples/modules/Popup/Usage/index.js
+++ b/docs/app/Examples/modules/Popup/Usage/index.js
@@ -2,24 +2,29 @@ import React from 'react'
 import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
 import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
 
-const PopupTriggersExamples = () => (
-  <ExampleSection title='Triggers'>
+const PopupUsageExamples = () => (
+  <ExampleSection title='Usage'>
     <ComponentExample
       title='Hover'
       description='A popup can be triggered on hover'
-      examplePath='modules/Popup/Triggers/PopupHoverExample'
+      examplePath='modules/Popup/Usage/PopupExampleHover'
     />
     <ComponentExample
       title='Click'
       description='A popup can be triggered on click'
-      examplePath='modules/Popup/Triggers/PopupClickExample'
+      examplePath='modules/Popup/Usage/PopupExampleClick'
     />
     <ComponentExample
       title='Focus'
       description='A popup can be triggered on focus'
-      examplePath='modules/Popup/Triggers/PopupFocusExample'
+      examplePath='modules/Popup/Usage/PopupExampleFocus'
+    />
+    <ComponentExample
+      title='Controlled'
+      description='A popup can have its visibility controlled from outside.'
+      examplePath='modules/Popup/Usage/PopupExampleControlled'
     />
   </ExampleSection>
 )
 
-export default PopupTriggersExamples
+export default PopupUsageExamples

--- a/docs/app/Examples/modules/Popup/Variations/PopupExampleBasic.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupExampleBasic.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button, Popup } from 'semantic-ui-react'
 
-const PopupBasicExample = () => (
+const PopupExampleBasic = () => (
   <Popup
     trigger={<Button icon='add' />}
     content="The default theme's basic popup removes the pointing arrow."
@@ -9,4 +9,4 @@ const PopupBasicExample = () => (
   />
 )
 
-export default PopupBasicExample
+export default PopupExampleBasic

--- a/docs/app/Examples/modules/Popup/Variations/PopupExampleFlowing.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupExampleFlowing.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Header, Button, Popup, Grid } from 'semantic-ui-react'
 
-const PopupFlowingExample = () => (
+const PopupExampleFlowing = () => (
   <Popup
     trigger={<Button>Show flowing popup</Button>}
     flowing
@@ -27,4 +27,4 @@ const PopupFlowingExample = () => (
   </Popup>
 )
 
-export default PopupFlowingExample
+export default PopupExampleFlowing

--- a/docs/app/Examples/modules/Popup/Variations/PopupExampleHideOnScroll.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupExampleHideOnScroll.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button, Popup } from 'semantic-ui-react'
 
-const PopupHideOnScrollExample = () => (
+const PopupExampleHideOnScroll = () => (
   <div>
     <Popup
       trigger={<Button icon>Click me</Button>}
@@ -17,4 +17,4 @@ const PopupHideOnScrollExample = () => (
   </div>
 )
 
-export default PopupHideOnScrollExample
+export default PopupExampleHideOnScroll

--- a/docs/app/Examples/modules/Popup/Variations/PopupExampleInverted.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupExampleInverted.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button, Icon, Popup } from 'semantic-ui-react'
 
-const PopupInvertedExample = () => (
+const PopupExampleInverted = () => (
   <div>
     <Popup
       trigger={<Button icon='add' />}
@@ -16,4 +16,4 @@ const PopupInvertedExample = () => (
   </div>
 )
 
-export default PopupInvertedExample
+export default PopupExampleInverted

--- a/docs/app/Examples/modules/Popup/Variations/PopupExampleOffset.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupExampleOffset.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Icon, Popup } from 'semantic-ui-react'
 
-const PopupOffsetExample = () => (
+const PopupExampleOffset = () => (
   <div>
     <Popup
       trigger={<Icon size='large' name='heart' circular />}
@@ -18,4 +18,4 @@ const PopupOffsetExample = () => (
   </div>
 )
 
-export default PopupOffsetExample
+export default PopupExampleOffset

--- a/docs/app/Examples/modules/Popup/Variations/PopupExamplePosition.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupExamplePosition.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Icon, Popup, Grid } from 'semantic-ui-react'
 
-const PopupPositionExample = () => (
+const PopupExamplePosition = () => (
   <Grid columns={3} style={{ width: '600px' }}>
     <Grid.Row>
       <Grid.Column>
@@ -68,4 +68,4 @@ const PopupPositionExample = () => (
   </Grid>
 )
 
-export default PopupPositionExample
+export default PopupExamplePosition

--- a/docs/app/Examples/modules/Popup/Variations/PopupExampleSize.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupExampleSize.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Icon, Popup } from 'semantic-ui-react'
 
-const PopupSizeExample = () => (
+const PopupExampleSize = () => (
   <div>
     <Popup
       trigger={<Icon circular name='heart' />}
@@ -31,4 +31,4 @@ const PopupSizeExample = () => (
   </div>
 )
 
-export default PopupSizeExample
+export default PopupExampleSize

--- a/docs/app/Examples/modules/Popup/Variations/PopupExampleStyle.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupExampleStyle.js
@@ -7,7 +7,7 @@ const style = {
   padding: '2em',
 }
 
-const PopupStyleExample = () => (
+const PopupExampleStyle = () => (
   <Popup
     trigger={<Button icon='eye' />}
     content='Popup with a custom style prop'
@@ -16,4 +16,4 @@ const PopupStyleExample = () => (
   />
 )
 
-export default PopupStyleExample
+export default PopupExampleStyle

--- a/docs/app/Examples/modules/Popup/Variations/PopupExampleWide.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupExampleWide.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Icon, Popup } from 'semantic-ui-react'
 
-const PopupWideExample = () => (
+const PopupExampleWide = () => (
   <div>
     <Popup trigger={<Icon circular name='heart' />} >
       Hello. This is a regular pop-up which does not allow for lots
@@ -27,4 +27,4 @@ const PopupWideExample = () => (
   </div>
 )
 
-export default PopupWideExample
+export default PopupExampleWide

--- a/docs/app/Examples/modules/Popup/Variations/index.js
+++ b/docs/app/Examples/modules/Popup/Variations/index.js
@@ -6,47 +6,47 @@ const PopupVariationsExamples = () => (
   <ExampleSection title='Variations'>
     <ComponentExample
       title='Basic'
-      description='A popup can provide more basic formatting'
+      description='A popup can provide more basic formatting.'
       examplePath='modules/Popup/Variations/PopupExampleBasic'
     />
     <ComponentExample
       title='Wide'
-      description='A popup can be extra wide to allow for longer content'
+      description='A popup can be extra wide to allow for longer content.'
       examplePath='modules/Popup/Variations/PopupExampleWide'
     />
     <ComponentExample
       title='Size'
-      description='A popup can vary in size'
+      description='A popup can vary in size.'
       examplePath='modules/Popup/Variations/PopupExampleSize'
     />
     <ComponentExample
       title='Flowing'
-      description='A popup can have no maximum width and continue to flow to fit its content'
+      description='A popup can have no maximum width and continue to flow to fit its content.'
       examplePath='modules/Popup/Variations/PopupExampleFlowing'
     />
     <ComponentExample
       title='Inverted'
-      description='A popup can have its colors inverted'
+      description='A popup can have its colors inverted.'
       examplePath='modules/Popup/Variations/PopupExampleInverted'
     />
     <ComponentExample
       title='Position'
-      description='A popup can be position around its trigger'
+      description='A popup can be position around its trigger.'
       examplePath='modules/Popup/Variations/PopupExamplePosition'
     />
     <ComponentExample
       title='Offset'
-      description='A popup position can be adjusted manually by specifying an offset property'
+      description='A popup position can be adjusted manually by specifying an offset property.'
       examplePath='modules/Popup/Variations/PopupExampleOffset'
     />
     <ComponentExample
       title='Style'
-      description='A popup accepts custom styles'
+      description='A popup accepts custom styles.'
       examplePath='modules/Popup/Variations/PopupExampleStyle'
     />
     <ComponentExample
       title='Hide on scroll'
-      description='A popup can be hidden on a scroll event'
+      description='A popup can be hidden on a scroll event.'
       examplePath='modules/Popup/Variations/PopupExampleHideOnScroll'
     />
   </ExampleSection>

--- a/docs/app/Examples/modules/Popup/Variations/index.js
+++ b/docs/app/Examples/modules/Popup/Variations/index.js
@@ -7,47 +7,47 @@ const PopupVariationsExamples = () => (
     <ComponentExample
       title='Basic'
       description='A popup can provide more basic formatting'
-      examplePath='modules/Popup/Variations/PopupBasicExample'
+      examplePath='modules/Popup/Variations/PopupExampleBasic'
     />
     <ComponentExample
       title='Wide'
       description='A popup can be extra wide to allow for longer content'
-      examplePath='modules/Popup/Variations/PopupWideExample'
+      examplePath='modules/Popup/Variations/PopupExampleWide'
     />
     <ComponentExample
       title='Size'
       description='A popup can vary in size'
-      examplePath='modules/Popup/Variations/PopupSizeExample'
+      examplePath='modules/Popup/Variations/PopupExampleSize'
     />
     <ComponentExample
       title='Flowing'
       description='A popup can have no maximum width and continue to flow to fit its content'
-      examplePath='modules/Popup/Variations/PopupFlowingExample'
+      examplePath='modules/Popup/Variations/PopupExampleFlowing'
     />
     <ComponentExample
       title='Inverted'
       description='A popup can have its colors inverted'
-      examplePath='modules/Popup/Variations/PopupInvertedExample'
+      examplePath='modules/Popup/Variations/PopupExampleInverted'
     />
     <ComponentExample
       title='Position'
       description='A popup can be position around its trigger'
-      examplePath='modules/Popup/Variations/PopupPositionExample'
+      examplePath='modules/Popup/Variations/PopupExamplePosition'
     />
     <ComponentExample
       title='Offset'
       description='A popup position can be adjusted manually by specifying an offset property'
-      examplePath='modules/Popup/Variations/PopupOffsetExample'
+      examplePath='modules/Popup/Variations/PopupExampleOffset'
     />
     <ComponentExample
       title='Style'
       description='A popup accepts custom styles'
-      examplePath='modules/Popup/Variations/PopupStyleExample'
+      examplePath='modules/Popup/Variations/PopupExampleStyle'
     />
     <ComponentExample
       title='Hide on scroll'
       description='A popup can be hidden on a scroll event'
-      examplePath='modules/Popup/Variations/PopupHideOnScrollExample'
+      examplePath='modules/Popup/Variations/PopupExampleHideOnScroll'
     />
   </ExampleSection>
 )

--- a/docs/app/Examples/modules/Popup/index.js
+++ b/docs/app/Examples/modules/Popup/index.js
@@ -1,14 +1,14 @@
 import React from 'react'
 
 import Types from './Types'
+import Usage from './Usage'
 import Variations from './Variations'
-import Triggers from './Triggers'
 
 const PopupExamples = () => (
   <div>
     <Types />
     <Variations />
-    <Triggers />
+    <Usage />
   </div>
 )
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -355,7 +355,7 @@ class Portal extends Component {
     document.addEventListener('keydown', this.handleEscape)
 
     const { onMount } = this.props
-    if (onMount) onMount(undefined, this.props)
+    if (onMount) onMount(null, this.props)
   }
 
   unmountPortal = () => {
@@ -376,7 +376,7 @@ class Portal extends Component {
     document.removeEventListener('keydown', this.handleEscape)
 
     const { onUnmount } = this.props
-    if (onUnmount) onUnmount(undefined, this.props)
+    if (onUnmount) onUnmount(null, this.props)
   }
 
   render() {

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -287,7 +287,7 @@ class Portal extends Component {
     debug('open()')
 
     const { onOpen } = this.props
-    if (onOpen) onOpen(e)
+    if (onOpen) onOpen(e, this.props)
 
     this.trySetState({ open: true })
   }
@@ -304,7 +304,7 @@ class Portal extends Component {
     debug('close()')
 
     const { onClose } = this.props
-    if (onClose) onClose(e)
+    if (onClose) onClose(e, this.props)
 
     this.trySetState({ open: false })
   }
@@ -355,7 +355,7 @@ class Portal extends Component {
     document.addEventListener('keydown', this.handleEscape)
 
     const { onMount } = this.props
-    if (onMount) onMount()
+    if (onMount) onMount(undefined, this.props)
   }
 
   unmountPortal = () => {
@@ -376,7 +376,7 @@ class Portal extends Component {
     document.removeEventListener('keydown', this.handleEscape)
 
     const { onUnmount } = this.props
-    if (onUnmount) onUnmount()
+    if (onUnmount) onUnmount(undefined, this.props)
   }
 
   render() {

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -56,6 +56,18 @@ class Modal extends Component {
     /** The node where the modal should mount.. */
     mountNode: PropTypes.any,
 
+    /** Called when a close event happens */
+    onClose: PropTypes.func,
+
+    /** Called when the portal is mounted on the DOM */
+    onMount: PropTypes.func,
+
+    /** Called when an open event happens */
+    onOpen: PropTypes.func,
+
+    /** Called when the portal is unmounted from the DOM */
+    onUnmount: PropTypes.func,
+
     /** A modal can vary in size */
     size: PropTypes.oneOf(_meta.props.size),
 
@@ -82,7 +94,17 @@ class Modal extends Component {
     this.handlePortalUnmount()
   }
 
-  handlePortalMount = () => {
+  handleClose = (e) => {
+    const { onClose } = this.props
+    if (onClose) onClose(e, this.props)
+  }
+
+  handleOpen = (e) => {
+    const { onOpen } = this.props
+    if (onOpen) onOpen(e, this.props)
+  }
+
+  handlePortalMount = (e) => {
     debug('handlePortalMount()')
     const { dimmer } = this.props
     const mountNode = this.getMountNode()
@@ -98,19 +120,24 @@ class Modal extends Component {
     }
 
     this.setPosition()
+
+    const { onMount } = this.props
+    if (onMount) onMount(e, this.props)
   }
 
-  handlePortalUnmount = () => {
+  handlePortalUnmount = (e) => {
     debug('handlePortalUnmount()')
 
-    const mountNode = this.getMountNode()
-
     // Always remove all dimmer classes.
-    // If the dimmer value changes while the modal is open,
-    //   then removing its current value could leave cruft classes previously added.
+    // If the dimmer value changes while the modal is open, then removing its
+    // current value could leave cruft classes previously added.
+    const mountNode = this.getMountNode()
     mountNode.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
 
     cancelAnimationFrame(this.animationRequestId)
+
+    const { onUnmount } = this.props
+    if (onUnmount) onUnmount(e, this.props)
   }
 
   getMountNode = () => {
@@ -192,7 +219,9 @@ class Modal extends Component {
         {...portalProps}
         className={dimmerClasses}
         mountNode={this.getMountNode()}
+        onClose={this.handleClose}
         onMount={this.handlePortalMount}
+        onOpen={this.handleOpen}
         onUnmount={this.handlePortalUnmount}
       >
         {modalJSX}

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -79,8 +79,14 @@ export default class Popup extends Component {
     /** Called when a close event happens */
     onClose: PropTypes.func,
 
+    /** Called when the portal is mounted on the DOM */
+    onMount: PropTypes.func,
+
     /** Called when an open event happens */
     onOpen: PropTypes.func,
+
+    /** Called when the portal is unmounted from the DOM */
+    onUnmount: PropTypes.func,
 
     /** Positioning for the popover */
     positioning: PropTypes.oneOf(_meta.props.positioning),
@@ -246,24 +252,30 @@ export default class Popup extends Component {
     setTimeout(() => this.setState({ closed: false }), 50)
   }
 
-  handlePortalMount = (e) => {
-    if (this.props.hideOnScroll) {
-      window.addEventListener('scroll', this.hideOnScroll)
-    }
-  }
-
-  // Note: We can just pass this through but since we need a custom onOpen
-  // handler it's more clear to define the onClose handler in the same way
   handleClose = (e) => {
     const { onClose } = this.props
-    if (onClose) onClose(e)
+    if (onClose) onClose(e, this.props)
   }
 
   handleOpen = (e) => {
     this.coords = e.currentTarget.getBoundingClientRect()
 
     const { onOpen } = this.props
-    if (onOpen) onOpen(e)
+    if (onOpen) onOpen(e, this.props)
+  }
+
+  handlePortalMount = (e) => {
+    if (this.props.hideOnScroll) {
+      window.addEventListener('scroll', this.hideOnScroll)
+    }
+
+    const { onMount } = this.props
+    if (onMount) onMount(e, this.props)
+  }
+
+  handlePortalUnmount = (e) => {
+    const { onUnmount } = this.props
+    if (onUnmount) onUnmount(e, this.props)
   }
 
   popupMounted = (ref) => {
@@ -324,6 +336,7 @@ export default class Popup extends Component {
         onClose={this.handleClose}
         onMount={this.handlePortalMount}
         onOpen={this.handleOpen}
+        onUnmount={this.handlePortalUnmount}
       >
         {popupJSX}
       </Portal>

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -76,6 +76,12 @@ export default class Popup extends Component {
     /** Event triggering the popup */
     on: PropTypes.oneOf(_meta.props.on),
 
+    /** Called when a close event happens */
+    onClose: PropTypes.func,
+
+    /** Called when an open event happens */
+    onOpen: PropTypes.func,
+
     /** Positioning for the popover */
     positioning: PropTypes.oneOf(_meta.props.positioning),
 
@@ -201,7 +207,8 @@ export default class Popup extends Component {
   }
 
   getPortalProps() {
-    const portalProps = { onOpen: this.onOpen }
+    const portalProps = {}
+
     const { on, hoverable } = this.props
 
     switch (on) {
@@ -233,17 +240,30 @@ export default class Popup extends Component {
     return portalProps
   }
 
-  hideOnScroll = (event) => {
+  hideOnScroll = (e) => {
     this.setState({ closed: true })
     window.removeEventListener('scroll', this.hideOnScroll)
     setTimeout(() => this.setState({ closed: false }), 50)
   }
 
-  onOpen = (event) => {
-    this.coords = event.currentTarget.getBoundingClientRect()
+  handlePortalMount = (e) => {
     if (this.props.hideOnScroll) {
       window.addEventListener('scroll', this.hideOnScroll)
     }
+  }
+
+  // Note: We can just pass this through but since we need a custom onOpen
+  // handler it's more clear to define the onClose handler in the same way
+  handleClose = (e) => {
+    const { onClose } = this.props
+    if (onClose) onClose(e)
+  }
+
+  handleOpen = (e) => {
+    this.coords = e.currentTarget.getBoundingClientRect()
+
+    const { onOpen } = this.props
+    if (onOpen) onOpen(e)
   }
 
   popupMounted = (ref) => {
@@ -281,9 +301,12 @@ export default class Popup extends Component {
 
     if (closed) return trigger
 
-    const rest = getUnhandledProps(Popup, this.props)
+    const unhandled = getUnhandledProps(Popup, this.props)
+    const portalPropNames = _.keys(Portal.propTypes)
+
+    const rest = _.omit(unhandled, portalPropNames)
+    const portalProps = _.pick(unhandled, portalPropNames)
     const ElementType = getElementType(Popup, this.props)
-    const portalProps = _.pick(rest, _.keys(Portal.propTypes))
 
     const popupJSX = (
       <ElementType {...rest} className={classes} style={style} ref={this.popupMounted}>
@@ -295,9 +318,12 @@ export default class Popup extends Component {
 
     return (
       <Portal
+        {...this.getPortalProps()}
         {...portalProps}
         trigger={trigger}
-        {...this.getPortalProps()}
+        onClose={this.handleClose}
+        onMount={this.handlePortalMount}
+        onOpen={this.handleOpen}
       >
         {popupJSX}
       </Portal>

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -36,6 +36,8 @@ const assertBodyClasses = (...rest) => {
   })
 }
 
+const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }
+
 describe('Modal', () => {
   beforeEach(() => {
     wrapper = undefined
@@ -235,6 +237,25 @@ describe('Modal', () => {
         wrapperMount(<Modal open dimmer='inverted' />)
         assertBodyContains('.ui.inverted.page.modals.dimmer.transition.visible.active')
       })
+    })
+  })
+
+  describe('onOpen', () => {
+    let spy
+
+    beforeEach(() => {
+      spy = sandbox.spy()
+      wrapperMount(<Modal onOpen={spy} trigger={<div id='trigger' />} />)
+    })
+
+    it('is called on trigger click', () => {
+      wrapper.find('#trigger').simulate('click', nativeEvent)
+      spy.should.have.been.calledOnce()
+    })
+
+    it('is not called on body click', () => {
+      domEvent.click('body')
+      spy.should.not.have.been.calledOnce()
     })
   })
 


### PR DESCRIPTION
Fixes #727 

Previously the popup was swallowing the `onOpen` event so you couldn't control the `open` prop from outside. This enables that and adds an example in the "Usage" section.

This also:
- Cleans up the order of props passed to the portal to enable more user control. Previously any props derived from the "on" prop would win, now you can override those.
- Rename the popup examples to the new naming scheme.
- Move "Triggers" section of examples to "Usage"
