### PR TITLE
breaking(BreadcrumbSection): change `text` prop to `content`

### DIFF
--- a/docs/app/Examples/collections/Breadcrumb/Content/BreadcrumbExampleDividerProps.js
+++ b/docs/app/Examples/collections/Breadcrumb/Content/BreadcrumbExampleDividerProps.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { Breadcrumb } from 'semantic-ui-react'
 
 const sections = [
-  { text: 'Home', link: true },
-  { text: 'Registration', link: true },
-  { text: 'Personal Information', active: true },
+  { content: 'Home', link: true },
+  { content: 'Registration', link: true },
+  { content: 'Personal Information', active: true },
 ]
 
 const BreadcrumbExampleDividerProps = () => (

--- a/docs/app/Examples/collections/Breadcrumb/Content/BreadcrumbExampleIconDividerProps.js
+++ b/docs/app/Examples/collections/Breadcrumb/Content/BreadcrumbExampleIconDividerProps.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { Breadcrumb } from 'semantic-ui-react'
 
 const sections = [
-  { text: 'Home', link: true },
-  { text: 'Registration', link: true },
-  { text: 'Personal Information', active: true },
+  { content: 'Home', link: true },
+  { content: 'Registration', link: true },
+  { content: 'Personal Information', active: true },
 ]
 
 const BreadcrumbExampleIconDividerProps = () => (

--- a/docs/app/Examples/collections/Breadcrumb/Content/BreadcrumbExampleSectionProps.js
+++ b/docs/app/Examples/collections/Breadcrumb/Content/BreadcrumbExampleSectionProps.js
@@ -2,8 +2,8 @@ import React from 'react'
 import { Breadcrumb } from 'semantic-ui-react'
 
 const sections = [
-  { text: 'Home', link: true },
-  { text: 'Search', active: true },
+  { content: 'Home', link: true },
+  { content: 'Search', active: true },
 ]
 
 const BreadcrumbExampleSectionProps = () => (

--- a/docs/app/Examples/collections/Breadcrumb/Types/BreadcrumbExampleProps.js
+++ b/docs/app/Examples/collections/Breadcrumb/Types/BreadcrumbExampleProps.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { Breadcrumb } from 'semantic-ui-react'
 
 const sections = [
-  { text: 'Home', link: true },
-  { text: 'Store', link: true },
-  { text: 'T-Shirt', active: true },
+  { content: 'Home', link: true },
+  { content: 'Store', link: true },
+  { content: 'T-Shirt', active: true },
 ]
 
 const BreadcrumbExampleProps = () => (

--- a/src/collections/Breadcrumb/Breadcrumb.js
+++ b/src/collections/Breadcrumb/Breadcrumb.js
@@ -25,24 +25,35 @@ function Breadcrumb(props) {
     return <ElementType {...rest} className={classes}>{children}</ElementType>
   }
 
-  const dividerJSX = <BreadcrumbDivider icon={icon}>{divider}</BreadcrumbDivider>
-  const sectionsJSX = []
+  const childElements = []
 
-  _.each(sections, ({ text, key, ...restSection }, index) => {
-    const finalKey = key || text
-    const dividerKey = `${finalKey}-divider`
+  _.each(sections, (section, index) => {
+    // section
+    const breadcrumbSection = BreadcrumbSection.create(section)
+    childElements.push(breadcrumbSection)
 
-    sectionsJSX.push(
-      <BreadcrumbSection {...restSection} key={finalKey}>{text}</BreadcrumbSection>
-    )
-
+    // divider
     if (index !== sections.length - 1) {
-      sectionsJSX.push(React.cloneElement(dividerJSX, { key: dividerKey }))
+      // TODO generate a key from breadcrumbSection.props once this is merged:
+      // https://github.com/Semantic-Org/Semantic-UI-React/pull/645
+      //
+      // Stringify the props of the section as the divider key.
+      //
+      // Section:     { content: 'Home', link: true, onClick: handleClick }
+      // Divider key: content=Home|link=true|onClick=handleClick
+      let key
+      if (section.key) {
+        key = `${section.key}_divider`
+      } else {
+        key = _.map(breadcrumbSection.props, (v, k) => {
+          return `${k}=${typeof v === 'function' ? v.name || 'func' : v}`
+        }).join('|')
+      }
+      childElements.push(BreadcrumbDivider.create({ content: divider, icon, key }))
     }
   })
 
-
-  return <ElementType {...rest} className={classes}>{sectionsJSX}</ElementType>
+  return <ElementType {...rest} className={classes}>{childElements}</ElementType>
 }
 
 Breadcrumb._meta = {

--- a/src/collections/Breadcrumb/BreadcrumbDivider.js
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.js
@@ -13,14 +13,14 @@ import Icon from '../../elements/Icon'
  * A divider sub-component for Breadcrumb component.
  */
 function BreadcrumbDivider(props) {
-  const { children, icon, className } = props
+  const { children, content, icon, className } = props
   const classes = cx(className, 'divider')
   const rest = getUnhandledProps(BreadcrumbDivider, props)
   const ElementType = getElementType(BreadcrumbDivider, props)
 
   if (icon) return Icon.create(icon, { ...rest, className: classes })
 
-  return <ElementType {...rest} className={classes}>{children || '/'}</ElementType>
+  return <ElementType {...rest} className={classes}>{content || children || '/'}</ElementType>
 }
 
 BreadcrumbDivider._meta = {
@@ -38,6 +38,9 @@ BreadcrumbDivider.propTypes = {
 
   /** Additional classes. */
   className: PropTypes.string,
+
+  /** Shorthand for primary content. */
+  content: customPropTypes.contentShorthand,
 
   /** Render as an `Icon` component with `divider` class instead of a `div`. */
   icon: customPropTypes.itemShorthand,

--- a/src/collections/Breadcrumb/BreadcrumbDivider.js
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getUnhandledProps,
   getElementType,
@@ -45,5 +46,7 @@ BreadcrumbDivider.propTypes = {
   /** Render as an `Icon` component with `divider` class instead of a `div`. */
   icon: customPropTypes.itemShorthand,
 }
+
+BreadcrumbDivider.create = createShorthandFactory(BreadcrumbDivider, icon => ({ icon }))
 
 export default BreadcrumbDivider

--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { Component, PropTypes } from 'react'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getUnhandledProps,
   getElementType,
@@ -85,3 +86,5 @@ export default class BreadcrumbSection extends Component {
     )
   }
 }
+
+BreadcrumbSection.create = createShorthandFactory(BreadcrumbSection, content => ({ content, link: true }))

--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -26,6 +26,9 @@ export default class BreadcrumbSection extends Component {
     /** Additional classes. */
     className: PropTypes.string,
 
+    /** Shorthand for primary content. */
+    content: customPropTypes.contentShorthand,
+
     /** Render as an `a` tag instead of a `div`. */
     link: customPropTypes.every([
       customPropTypes.disallow(['href']),
@@ -59,6 +62,7 @@ export default class BreadcrumbSection extends Component {
       active,
       children,
       className,
+      content,
       href,
       link,
       onClick,
@@ -74,6 +78,10 @@ export default class BreadcrumbSection extends Component {
       if (link || onClick) return 'a'
     })
 
-    return <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>{children}</ElementType>
+    return (
+      <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>
+        {children || content}
+      </ElementType>
+    )
   }
 }

--- a/test/specs/collections/Breadcrumb/Breadcrumb-test.js
+++ b/test/specs/collections/Breadcrumb/Breadcrumb-test.js
@@ -13,8 +13,8 @@ describe('Breadcrumb', () => {
   })
 
   const sections = [
-    { text: 'Home', link: true },
-    { text: 'T-Shirt', href: 'google.com' },
+    { content: 'Home', link: true },
+    { content: 'T-Shirt', href: 'google.com' },
   ]
 
   it('renders children with `sections` prop', () => {

--- a/test/specs/collections/Breadcrumb/Breadcrumb-test.js
+++ b/test/specs/collections/Breadcrumb/Breadcrumb-test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Breadcrumb from 'src/collections/Breadcrumb/Breadcrumb'
 import * as common from 'test/specs/commonTests'
+import { sandbox } from 'test/utils'
 
 describe('Breadcrumb', () => {
   common.isConformant(Breadcrumb)
@@ -29,5 +30,31 @@ describe('Breadcrumb', () => {
     const divider = wrapper.find('BreadcrumbDivider').first()
 
     divider.should.contain.text('>')
+  })
+
+  it('generates a divider key from section props', () => {
+    sandbox.spy(Breadcrumb.Divider, 'create')
+    shallow(<Breadcrumb sections={sections} />)
+
+    Breadcrumb.Divider.create.should.have.been.calledWithMatch({
+      content: undefined,
+      icon: undefined,
+      key: 'content=Home|link=true',
+    })
+
+    Breadcrumb.Divider.create.restore()
+  })
+
+  it('generates a divider key from section key', () => {
+    sandbox.spy(Breadcrumb.Divider, 'create')
+    shallow(<Breadcrumb sections={[{ key: 'sectionA' }, { key: 'sectionB' }]} />)
+
+    Breadcrumb.Divider.create.should.have.been.calledWithMatch({
+      content: undefined,
+      icon: undefined,
+      key: 'sectionA_divider',
+    })
+
+    Breadcrumb.Divider.create.restore()
   })
 })


### PR DESCRIPTION
## Breaking Changes
### `Breadcrumb.Section` prop `text` => `content`

`<Breadcrumb />` allows defining children via the `sections` shorthand prop.  The `sections` value is an array of objects where each item in the array is a `Breadcrumb.Section` props object.

The `Breadcrumb.Section` currently accepts primary content via the `text` prop.  The standardized prop name for passing primary content is `content`.  This PR changes the `text` prop to `content` to maintain standards.

You should update your code as follows:

``` diff
-<Breadcrumb.Section text='Home' />
+<Breadcrumb.Section content='Home' />
```

``` diff
const sections = [
- { text: 'Home', link: true },
+ { content: 'Home', link: true },
]

<Breadcrumb sections={sections} />
```
## Features

The `sections` prop previously only accepted a `Breadcrumb.Section` props object.  It now accepts any shorthand value: string, number, props object, or an element.

``` jsx
<Breadcrumb sections={['Home', 'Store', 'T-Shirt']} />
```

``` jsx
const sections = [
  <Breadcrumb.Section content='Home' link />,
  <Breadcrumb.Section content='Store' link />,
  <Breadcrumb.Section content='T-Shirt' active />,
]

<Breadcrumb sections={sections} />
```
