### PR TITLE
feat(Dropdown): support additionLabel components

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleAdditionLabelComponent.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleAdditionLabelComponent.js
@@ -9,7 +9,7 @@ const options = [
   { text: 'Chinese', value: 'Chinese' },
 ]
 
-class DropdownExampleAllowAdditions extends Component {
+class DropdownExampleAdditionLabelComponent extends Component {
   state = { options }
 
   handleAddition = (e, { value }) => {
@@ -18,21 +18,21 @@ class DropdownExampleAllowAdditions extends Component {
     })
   }
 
-  handleChange = (e, { value }) => this.setState({ currentValues: value })
+  handleChange = (e, { value }) => this.setState({ currentValue: value })
 
   render() {
-    const { currentValues } = this.state
+    const { currentValue } = this.state
 
     return (
       <Dropdown
         options={this.state.options}
-        placeholder='Choose Languages'
+        placeholder='Choose Language'
         search
         selection
         fluid
-        multiple
         allowAdditions
-        value={currentValues}
+        additionLabel={<i style={{ color: 'red' }}>Custom Language: </i>}
+        value={currentValue}
         onAddItem={this.handleAddition}
         onChange={this.handleChange}
       />
@@ -40,4 +40,4 @@ class DropdownExampleAllowAdditions extends Component {
   }
 }
 
-export default DropdownExampleAllowAdditions
+export default DropdownExampleAdditionLabelComponent

--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleAdditionLabelString.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleAdditionLabelString.js
@@ -9,7 +9,7 @@ const options = [
   { text: 'Chinese', value: 'Chinese' },
 ]
 
-class DropdownExampleAllowAdditions extends Component {
+class DropdownExampleAdditionLabelString extends Component {
   state = { options }
 
   handleAddition = (e, { value }) => {
@@ -18,21 +18,21 @@ class DropdownExampleAllowAdditions extends Component {
     })
   }
 
-  handleChange = (e, { value }) => this.setState({ currentValues: value })
+  handleChange = (e, { value }) => this.setState({ currentValue: value })
 
   render() {
-    const { currentValues } = this.state
+    const { currentValue } = this.state
 
     return (
       <Dropdown
         options={this.state.options}
-        placeholder='Choose Languages'
+        placeholder='Choose Language'
         search
         selection
         fluid
-        multiple
         allowAdditions
-        value={currentValues}
+        additionLabel='Custom Language: '
+        value={currentValue}
         onAddItem={this.handleAddition}
         onChange={this.handleChange}
       />
@@ -40,4 +40,4 @@ class DropdownExampleAllowAdditions extends Component {
   }
 }
 
-export default DropdownExampleAllowAdditions
+export default DropdownExampleAdditionLabelString

--- a/docs/app/Examples/modules/Dropdown/Usage/index.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/index.js
@@ -24,6 +24,14 @@ const DropdownUsageExamples = () => (
       examplePath='modules/Dropdown/Usage/DropdownExampleMultipleAllowAdditions'
     />
     <ComponentExample
+      description='You can provide a custom additionLabel as a string.'
+      examplePath='modules/Dropdown/Usage/DropdownExampleAdditionLabelString'
+    />
+    <ComponentExample
+      description='Or provide additionLabel as a component.'
+      examplePath='modules/Dropdown/Usage/DropdownExampleAdditionLabelComponent'
+    />
+    <ComponentExample
       title='Trigger'
       description='A dropdown can render a node in place of the text.'
       examplePath='modules/Dropdown/Usage/DropdownExampleTrigger'

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -54,7 +54,10 @@ export default class Dropdown extends Component {
     additionPosition: PropTypes.oneOf(_meta.props.additionPosition),
 
     /** Label prefixed to an option added by a user. */
-    additionLabel: PropTypes.string,
+    additionLabel: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.string,
+    ]),
 
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
@@ -222,7 +225,8 @@ export default class Dropdown extends Component {
 
   static defaultProps = {
     icon: 'dropdown',
-    additionLabel: 'Add:',
+    additionLabel: 'Add ',
+    additionPosition: 'top',
     noResultsMessage: 'No results found.',
     selectOnBlur: true,
   }
@@ -587,9 +591,19 @@ export default class Dropdown extends Component {
 
     // insert the "add" item
     if (allowAdditions && search && searchQuery && !_.some(filteredOptions, { text: searchQuery })) {
+      const additionLabelElement = React.isValidElement(additionLabel)
+        ? React.cloneElement(additionLabel, { key: 'label' })
+        : additionLabel || ''
+
       const addItem = {
-        text: additionLabel ? `${additionLabel} ${searchQuery}` : searchQuery,
+        // by using an array, we can pass multiple elements, but when doing so
+        // we must specify a `key` for React to know which one is which
+        text: [
+          additionLabelElement,
+          <b key='addition'>{searchQuery}</b>,
+        ],
         value: searchQuery,
+        className: 'addition',
       }
       if (additionPosition === 'top') filteredOptions.unshift(addItem)
       else filteredOptions.push(addItem)

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1511,7 +1511,7 @@ describe('Dropdown Component', () => {
 
       wrapper
         .find('DropdownItem')
-        .last()
+        .first()
         .should.have.prop('value', 'a')
     })
 
@@ -1527,12 +1527,20 @@ describe('Dropdown Component', () => {
 
       wrapper
         .find('DropdownItem')
-        .should.have.prop('text', 'Add: boo')
+        .last()
+        .should.have.prop('className', 'addition')
+
+      const text = wrapper
+        .find('DropdownItem')
+        .prop('text')
+
+      expect(text[0]).to.equal('Add ')
+      shallow(text[1]).equals(<b key='addition'>boo</b>)
     })
 
-    it('uses custom additionLabel', () => {
+    it('uses custom additionLabel string', () => {
       const search = wrapperMount(
-        <Dropdown options={customOptions} selection search allowAdditions additionLabel='New:' />
+        <Dropdown options={customOptions} selection search allowAdditions additionLabel='New: ' />
       )
         .find('input.search')
 
@@ -1544,7 +1552,40 @@ describe('Dropdown Component', () => {
 
       wrapper
         .find('DropdownItem')
-        .should.have.prop('text', 'New: boo')
+        .last()
+        .should.have.prop('className', 'addition')
+
+      const text = wrapper
+        .find('DropdownItem')
+        .prop('text')
+
+      expect(text[0]).to.equal('New: ')
+      shallow(text[1]).equals(<b key='addition'>boo</b>)
+    })
+
+    it('uses custom additionLabel element', () => {
+      const search = wrapperMount(
+        <Dropdown options={customOptions} selection search allowAdditions additionLabel={<i>New: </i>} />
+      )
+        .find('input.search')
+
+      search.simulate('change', { target: { value: 'boo' } })
+
+      wrapper
+        .find('DropdownItem')
+        .should.have.lengthOf(1)
+
+      wrapper
+        .find('DropdownItem')
+        .last()
+        .should.have.prop('className', 'addition')
+
+      const text = wrapper
+        .find('DropdownItem')
+        .prop('text')
+
+      shallow(text[0]).equals(<i key='label'>New: </i>)
+      shallow(text[1]).equals(<b key='addition'>boo</b>)
     })
 
     it('uses no additionLabel', () => {
@@ -1561,11 +1602,21 @@ describe('Dropdown Component', () => {
 
       wrapper
         .find('DropdownItem')
-        .should.have.prop('text', 'boo')
+        .last()
+        .should.have.prop('className', 'addition')
+
+      const text = wrapper
+        .find('DropdownItem')
+        .prop('text')
+
+      expect(text[0]).to.equal('')
+      shallow(text[1]).equals(<b key='addition'>boo</b>)
     })
 
     it('keeps custom value option (bottom) when options change', () => {
-      const search = wrapperMount(<Dropdown options={customOptions} selection search allowAdditions />)
+      const search = wrapperMount(
+        <Dropdown options={customOptions} selection search allowAdditions additionPosition='bottom' />
+      )
         .find('input.search')
 
       search.simulate('change', { target: { value: 'a' } })
@@ -1593,7 +1644,7 @@ describe('Dropdown Component', () => {
 
     it('keeps custom value option (top) when options change', () => {
       const search = wrapperMount(
-        <Dropdown options={customOptions} selection search allowAdditions additionPosition='top' />
+        <Dropdown options={customOptions} selection search allowAdditions />
       )
         .find('input.search')
 


### PR DESCRIPTION
Dropdown now wraps additions in `<b>` tags and uses `additionPosition="top"` by default, just like the jQuery semantic-ui plugin.

![image](https://cloud.githubusercontent.com/assets/762949/19794337/48fb2cac-9c86-11e6-9e27-e8fb40a9eb9c.png)

There is also some more subtle changes to align with the jQuery version:
- default additionLabel is now "Add" without the semicolon, and includes the space between the label and the addition. This allows users to use labels which do not wish to have space between the two. 
  - this overall API differs from the jQuery version which uses unsafe templates: `addResult     : 'Add <b>{term}</b>'`. We could instead use callbacks, if even more alignment was preferred. `addResult={term => <span>Add <b>{term}</b></span>`
  - or of course, we could use templates too and use `dangerouslySetInnerHTML` 😨 
- The addition item now has the `addition` className added to it--this can be important for themes

You will notice that, because of a React limitation/design I am passing `text` as an array of elements. Because of the current way the React diffing algorithm works, even though these elements will always be in the same order we must define a `key` for them. This isn't pretty--but at least for me, having the same styling behavior of the wrapped `<b>` is critical to UX.

---

This was my first experience with enzyme/chai-enzyme so lmk if there is a better way to write the prop tests that contain the array of elements. It's not ideal 😞 
