### PR TITLE
docs(usage): Add usage section to docs

### DIFF
--- a/docs/app/Components/Sidebar/Sidebar.js
+++ b/docs/app/Components/Sidebar/Sidebar.js
@@ -190,6 +190,9 @@ export default class Sidebar extends Component {
             <Menu.Item as={Link} to='/introduction' activeClassName='active'>
               Introduction
             </Menu.Item>
+            <Menu.Item as={Link} to='/usage'>
+              Usage
+            </Menu.Item>
             <Menu.Item as='a' href={repoURL}>
               <Icon name='github' /> GitHub
             </Menu.Item>

--- a/docs/app/Views/Introduction.js
+++ b/docs/app/Views/Introduction.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react'
+import { Link } from 'react-router'
 import Editor from 'docs/app/Components/Editor/Editor'
 import pkg from 'package.json'
 import {
@@ -12,7 +13,7 @@ import {
   Segment,
 } from 'src'
 import Logo from '../Components/Logo/Logo'
-import { repoURL } from 'docs/app/utils'
+import { semanticUIDocsURL, repoURL } from 'docs/app/utils'
 
 const AccordionJSX = `const panels = [{
   title: 'What is a dog?',
@@ -150,10 +151,10 @@ const Introduction = () => (
     </Segment>
 
     <Segment basic padded>
-      <Header as='h2' dividing>Install</Header>
-      <Segment>
-        <pre>$ npm install {pkg.name}</pre>
-      </Segment>
+      <Header as='h2' dividing>Introduction</Header>
+      <p>
+        Semantic-UI-React is the official React integration for <a href={semanticUIDocsURL}>Semantic UI</a> .
+      </p>
       <List>
         <List.Item icon='check mark' content='jQuery Free' />
         <List.Item icon='check mark' content='Declarative API' />
@@ -162,6 +163,9 @@ const Introduction = () => (
         <List.Item icon='check mark' content='Sub Components' />
         <List.Item icon='check mark' content='Auto Controlled State' />
       </List>
+      <p>
+        Installation instructions are provided in the <Link to='/usage'>Usage</Link> section.
+      </p>
     </Segment>
 
     {/* ----------------------------------------

--- a/docs/app/Views/Usage.js
+++ b/docs/app/Views/Usage.js
@@ -1,0 +1,118 @@
+import React from 'react'
+import pkg from 'package.json'
+import {
+  Container,
+  Header,
+  Segment,
+} from 'src'
+import Logo from '../Components/Logo/Logo'
+import { semanticUIDocsURL, semanticUIRepoURL, semanticUICSSRepoURL } from 'docs/app/utils'
+
+const suiCSSVersion = pkg.devDependencies['semantic-ui-css'].replace(/[~^]/, '')
+
+const Usage = () => (
+  <Container id='usage-page'>
+    <Segment basic textAlign='center'>
+      <Logo centered size='small' />
+      <Header as='h1' textAlign='center'>
+        Semantic-UI-React
+        <Header.Subheader>
+          {pkg.description}
+        </Header.Subheader>
+      </Header>
+    </Segment>
+
+    <Segment basic padded>
+      <Header as='h2' dividing>JavaScript</Header>
+      <p>
+        The Semantic UI React package can be installed via NPM:
+      </p>
+      <Segment>
+        <pre>$ npm install {pkg.name} --save</pre>
+      </Segment>
+      <p>
+        Installing Semantic UI React provides the JavaScript for your components.
+        You'll also need to include a stylesheet to provide the styling for your components.
+        This is the typical pattern for component frameworks, such as Semantic UI or Bootstrap.
+      </p>
+      <p>
+        The method you choose to include the stylesheet in your project will depend on the level
+        of customisation you require.
+      </p>
+    </Segment>
+
+    <Segment basic padded>
+      <Header as='h2' dividing>CSS</Header>
+
+      {/* ----------------------------------------
+       *  Content Delivery Network (CDN)
+       * -------------------------------------- */}
+      <Header as='h3'>Content Delivery Network (CDN)</Header>
+      <p>
+        You can use the default Semantic UI stylesheet by including a Semantic UI CDN link in your
+        <em>index.html</em> file.
+      </p>
+      <p>
+        This is the quickest way to get started with Semantic UI React. You won't be able to use
+        custom themes with this method.
+      </p>
+      <Segment>
+        <pre>
+          {'<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/'}
+          {suiCSSVersion}
+          {'/semantic.min.css"></link>'}
+        </pre>
+      </Segment>
+
+      {/* ----------------------------------------
+       *  Semantic-UI-CSS package
+       * -------------------------------------- */}
+      <Header as='h3'>Semantic UI CSS package</Header>
+      <p>
+        The <a href={semanticUICSSRepoURL}>Semantic UI CSS package</a> is automatically synced with the
+        main Semantic UI repository to provide a lightweight CSS only version of Semantic UI.
+      </p>
+      <p>
+        Semantic UI CSS can be installed as a package in your project using NPM. You won't be able to
+        use custom themes with this method.
+      </p>
+      <Segment>
+        <pre>
+          $ npm install semantic-ui-css --save
+        </pre>
+      </Segment>
+
+      {/* ----------------------------------------
+       *  Semantic-UI package
+       * -------------------------------------- */}
+      <Header as='h3'>Semantic UI package</Header>
+      <p>
+        Install the full <a href={semanticUIRepoURL}>Semantic UI package</a>.
+      </p>
+      <p>
+        Semantic UI includes Gulp build tools so your project can preserve its own theme changes,
+        allowing you to customise the style variables.
+      </p>
+      <p>
+        Detailed documentation on theming in Semantic UI is
+        provided <a href={`${semanticUIDocsURL}usage/theming.html`}>here</a>.
+      </p>
+      <Segment>
+        <pre>
+          $ npm install semantic-ui --save-dev
+        </pre>
+      </Segment>
+      <p>
+        After building the project with Gulp, you'll need to include the minified CSS file
+        in your <em>index.js</em> file:
+      </p>
+      <Segment>
+        <pre>
+          import '.../semantic/dist/semantic.min.css';
+        </pre>
+      </Segment>
+    </Segment>
+  </Container>
+)
+
+export default Usage

--- a/docs/app/routes.js
+++ b/docs/app/routes.js
@@ -4,6 +4,7 @@ import { Route, IndexRedirect } from 'react-router'
 import Root from './Components/Root'
 import Layout from './Components/Layout'
 import Introduction from './Views/Introduction'
+import Usage from './Views/Usage'
 import PageNotFound from './Views/PageNotFound'
 
 const routes = (
@@ -11,6 +12,7 @@ const routes = (
     <IndexRedirect to='introduction' />
 
     <Route path='introduction' component={Introduction} />
+    <Route path='usage' component={Usage} />
     <Route path=':type/:name' component={Root} />
     <Route path='*' component={PageNotFound} />
   </Route>

--- a/docs/app/utils.js
+++ b/docs/app/utils.js
@@ -21,3 +21,6 @@ export const parentComponents = _.flow(
 export const exampleContext = require.context('docs/app/Examples/', true, /\.js$/)
 
 export const repoURL = 'https://github.com/Semantic-Org/Semantic-UI-React'
+export const semanticUIDocsURL = 'http://semantic-ui.com/'
+export const semanticUIRepoURL = 'https://github.com/Semantic-Org/Semantic-UI'
+export const semanticUICSSRepoURL = 'https://github.com/Semantic-Org/Semantic-UI-CSS'


### PR DESCRIPTION
This PR includes a 'Usage' section in the documentation, detailing the installation steps for Semantic UI React and the necessary stylesheet to use the project.

For those unfamiliar with component frameworks such as Semantic UI, it would be handy to have this information upfront in the docs. It would allow new users to get started with the React integration as quickly as possible.

I recently joined the Gitter chat to ask a question around this, and saw that a similar question had already been asked a few hours earlier. @levithomason provided some really useful info, which has formed the basis of this page. He also mentioned PRs for new docs were welcome.

Apologies if I've missed anything around contributing - let me know and I'll fix up.
