### PR TITLE
docs(ComponentDoc): show props by default

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentDoc.js
+++ b/docs/app/Components/ComponentDoc/ComponentDoc.js
@@ -65,8 +65,10 @@ export default class ComponentDoc extends Component {
     _meta: PropTypes.object,
   }
 
-  state = {
-    showPropsFor: null,
+  componentWillMount() {
+    this.setState({
+      showPropsFor: this.props._meta.name,
+    })
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
The current docs hide the props behind a little gray toggle switch in the header of every component doc page.  The default state is to collapse the prop table.  We've had several users not know where to find props.  It seems it is too subdued.

This PR makes sets default prop table state to open.  As before, the prop table state (open/closed) persists across route changes.  If you do not want to see props and you toggle them closed, then they will remain closed for your entire browser session.
