### PR TITLE
fix(Accordion): respect defaultActiveIndex

### DIFF
--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -79,7 +79,13 @@ export default class Accordion extends Component {
 
   componentWillMount() {
     super.componentWillMount()
-    this.trySetState({ activeIndex: -1 })
+    // TODO AutoControlledComponent should consider default prop values when trySetState is called before mount.
+    // Otherwise, on first render we're allowed to set state for a prop that might have a default.
+    // The default prop should always win on first render.
+    // This default check should then be removed.
+    if (!this.props.defaultActiveIndex) {
+      this.trySetState({ activeIndex: -1 })
+    }
   }
 
   handleTitleClick = (e, index) => {

--- a/test/specs/modules/Accordion/Accordion-test.js
+++ b/test/specs/modules/Accordion/Accordion-test.js
@@ -17,6 +17,10 @@ describe('Accordion', () => {
   common.propKeyOnlyToClassName(Accordion, 'styled')
 
   describe('activeIndex', () => {
+    it('defaults to -1', () => {
+      shallow(<Accordion />)
+        .should.have.state('activeIndex', -1)
+    })
     it('can be overridden with "active" on Title/Content', () => {
       const wrapper = mount(
         <Accordion activeIndex={0}>
@@ -72,6 +76,13 @@ describe('Accordion', () => {
         .should.not.have.className('active')
       wrapper
         .should.have.state('activeIndex', -1)
+    })
+  })
+
+  describe('defaultActiveIndex', () => {
+    it('sets the initial activeIndex state', () => {
+      shallow(<Accordion defaultActiveIndex={123} />)
+        .should.have.state('activeIndex', 123)
     })
   })
 


### PR DESCRIPTION
Fixes #761 

The `defaultActiveIndex` is overridden in the Accordion on `componentWillMount`. This PR adds an inline manual check for the default prop and a TODO to resolve the bug.  I've also added 2 tests to assert the initial index of `-1` and the default prop works correctly.

This is an edge case, but we need to update the `AutoControlledComponent` to defer to default props when calling `trySetState` in `componentWillMount`.

The real solve here is likely adding `static defaultAutoControlledProps`.  Currently, the `AutoControlledComponent` tells devs to use `trySetState` in `componentWillMount` instead of setting defaults for auto controlled props.  This is to prevent the actual defaults from always winning, however, if we had our own auto controlled defaults then we could apply them correctly.
