### PR TITLE
fix(Dimmer): allow children to be clicked

### DIFF
--- a/src/modules/Dimmer/Dimmer.js
+++ b/src/modules/Dimmer/Dimmer.js
@@ -83,6 +83,7 @@ export default class Dimmer extends Component {
     const classes = cx(
       'ui',
       useKeyOnly(active, 'active'),
+      useKeyOnly(!active, 'disabled'),
       useKeyOnly(inverted, 'inverted'),
       useKeyOnly(page, 'page'),
       useKeyOnly(simple, 'simple'),

--- a/test/specs/modules/Dimmer/Dimmer-test.js
+++ b/test/specs/modules/Dimmer/Dimmer-test.js
@@ -27,11 +27,16 @@ describe('Dimmer', () => {
         .should.contain.text(text)
     })
 
-    it('renders clickable buttons', () => {
-      const spy = sandbox.spy()
-      const wrapper = mount(<Dimmer><a onClick={spy} href='#'>{faker.hacker.phrase()}</a></Dimmer>)
-      wrapper.find('a').simulate('click')
-      spy.should.have.been.callCount(1)
+  })
+
+  describe('active', () => {
+    it('removes the `disabled` className when true', () => {
+      shallow(<Dimmer active />)
+        .should.not.have.className('disabled')
+    })
+    it('adds the `disabled` className when false', () => {
+      shallow(<Dimmer active={false} />)
+        .should.have.className('disabled')
     })
   })
 

--- a/test/specs/modules/Dimmer/Dimmer-test.js
+++ b/test/specs/modules/Dimmer/Dimmer-test.js
@@ -26,7 +26,6 @@ describe('Dimmer', () => {
       shallow(<Dimmer content={text} />)
         .should.contain.text(text)
     })
-
   })
 
   describe('active', () => {

--- a/test/specs/modules/Dimmer/Dimmer-test.js
+++ b/test/specs/modules/Dimmer/Dimmer-test.js
@@ -26,6 +26,13 @@ describe('Dimmer', () => {
       shallow(<Dimmer content={text} />)
         .should.contain.text(text)
     })
+
+    it('renders clickable buttons', () => {
+      const spy = sandbox.spy()
+      const wrapper = mount(<Dimmer><a onClick={spy} href='#'>{faker.hacker.phrase()}</a></Dimmer>)
+      wrapper.find('a').simulate('click')
+      spy.should.have.been.callCount(1)
+    })
   })
 
   describe('onClickOutside', () => {


### PR DESCRIPTION
Fixes #780 by adding a disabled class when the Dimmer is not active. Also adds a test to ensure the fix isn't regressed.