### PR TITLE
docs(Icon): correct `link` propType description typo

### DIFF
--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -96,7 +96,7 @@ Icon.propTypes = {
   /** Name of the icon */
   name: PropTypes.string,
 
-  /** Icon can be formatter as a link */
+  /** Icon can be formatted as a link */
   link: PropTypes.bool,
 
   /** Icon can be used as a simple loader */


### PR DESCRIPTION
/** Icon can be formatter as a link */ => /** Icon can be formatted as a link */