### PR TITLE
breaking(AutoControlledProps): Ignore undefined

### DIFF
--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -121,8 +121,13 @@ export default class AutoControlledComponent extends Component {
   componentWillReceiveProps(nextProps) {
     if (super.componentWillReceiveProps) super.componentWillReceiveProps(nextProps)
 
-    // props always win, update state with all auto controlled prop
-    const newState = _.pick(nextProps, this.constructor.autoControlledProps)
+    // Props always win, update state with all auto controlled prop that were
+    // defined by the parent.
+    const newState = _.pick(
+      _.omitBy(nextProps, _.isUndefined),
+      this.constructor.autoControlledProps
+    )
+
     if (!_.isEmpty(newState)) this.setState(newState)
   }
 
@@ -147,9 +152,10 @@ export default class AutoControlledComponent extends Component {
       }
     }
 
-    // pick auto controlled props
-    // omit props from parent
-    let newState = _.omit(_.pick(maybeState, autoControlledProps), _.keys(this.props))
+    const parentDefinedProps = _.omitBy(this.props, _.isUndefined)
+
+    // Pick auto controlled props, omitting props defined by the parent.
+    let newState = _.omit(_.pick(maybeState, autoControlledProps), _.keys(parentDefinedProps))
 
     if (state) newState = { ...newState, ...state }
 

--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -148,12 +148,9 @@ export default class AutoControlledComponent extends Component {
 
       // reinitialize state for props just removed / set undefined
       else if (propWasRemoved) acc[prop] = getAutoControlledStateValue(nextProps, prop)
-
-      // otherwise, continue persisting the auto controlled state value
-      else acc[prop] = this.state[prop]
     }, {})
 
-    this.setState(newState)
+    if (Object.keys(newState).length > 0) this.setState(newState)
   }
 
   /**
@@ -177,13 +174,19 @@ export default class AutoControlledComponent extends Component {
       }
     }
 
-    const parentDefinedProps = _.omitBy(this.props, _.isUndefined)
+    let newState = Object.keys(maybeState).reduce((acc, prop) => {
+      // ignore props defined by the parent
+      if (this.props[prop] !== undefined) return acc
 
-    // Pick auto controlled props, omitting props defined by the parent.
-    let newState = _.omit(_.pick(maybeState, autoControlledProps), _.keys(parentDefinedProps))
+      // ignore props not listed in auto controlled props
+      if (autoControlledProps.indexOf(prop) === -1) return acc
+
+      acc[prop] = maybeState[prop]
+      return acc
+    }, {})
 
     if (state) newState = { ...newState, ...state }
 
-    if (!_.isEmpty(newState)) this.setState(newState)
+    if (Object.keys(newState).length > 0) this.setState(newState)
   }
 }

--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -42,10 +42,15 @@ const getDefaultPropName = (prop) => `default${prop[0].toUpperCase() + prop.slic
  */
 export const getAutoControlledStateValue = (props, propName, includeDefaultProps = false) => {
   const defaultPropName = getDefaultPropName(propName)
+  const prop = props[propName]
+  const defaultProp = props[defaultPropName]
+
+  const hasProp = prop !== undefined
+  const hasDefaultProp = defaultProp !== undefined
 
   // defaultProps & props
-  if (includeDefaultProps && _.has(props, defaultPropName)) return props[defaultPropName]
-  if (props[propName] !== undefined) return props[propName]
+  if (includeDefaultProps && !hasProp && hasDefaultProp) return defaultProp
+  if (hasProp) return prop
 
   // React doesn't allow changing from uncontrolled to controlled components,
   // default checked/value if they were not present.
@@ -136,7 +141,7 @@ export default class AutoControlledComponent extends Component {
     // Solve the next state for autoControlledProps
     const newState = _.transform(autoControlledProps, (acc, prop) => {
       const isNextUndefined = _.isUndefined(nextProps[prop])
-      const propWasRemoved = _.has(this.props, prop) && isNextUndefined
+      const propWasRemoved = !_.isUndefined(this.props[prop]) && isNextUndefined
 
       // if next is defined then use its value
       if (!isNextUndefined) acc[prop] = nextProps[prop]

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -225,33 +225,24 @@ export default class Popup extends Component {
 
     const { on, hoverable } = this.props
 
-    switch (on) {
-      case 'click':
-        portalProps.openOnTriggerClick = true
-        portalProps.closeOnTriggerClick = true
-        portalProps.closeOnDocumentClick = true
-        break
-
-      case 'focus':
-        portalProps.openOnTriggerFocus = true
-        portalProps.closeOnTriggerBlur = true
-        break
-
-      case 'hover':
-        portalProps.openOnTriggerMouseOver = true
-        portalProps.closeOnTriggerMouseLeave = true
-        // Taken from SUI: https://git.io/vPmCm
-        portalProps.mouseLeaveDelay = 70
-        portalProps.mouseOverDelay = 50
-        break
-
-      default:
-        break
-    }
-
     if (hoverable) {
       portalProps.closeOnPortalMouseLeave = true
       portalProps.mouseLeaveDelay = 300
+    }
+
+    if (on === 'click') {
+      portalProps.openOnTriggerClick = true
+      portalProps.closeOnTriggerClick = true
+      portalProps.closeOnDocumentClick = true
+    } else if (on === 'focus') {
+      portalProps.openOnTriggerFocus = true
+      portalProps.closeOnTriggerBlur = true
+    } else if (on === 'hover') {
+      portalProps.openOnTriggerMouseOver = true
+      portalProps.closeOnTriggerMouseLeave = true
+      // Taken from SUI: https://git.io/vPmCm
+      portalProps.mouseLeaveDelay = 70
+      portalProps.mouseOverDelay = 50
     }
 
     return portalProps

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -5,6 +5,7 @@ import {
   getElementType,
   getUnhandledProps,
   isBrowser,
+  makeDebugger,
   META,
   SUI,
   useKeyOnly,
@@ -13,6 +14,8 @@ import {
 import Portal from '../../addons/Portal'
 import PopupContent from './PopupContent'
 import PopupHeader from './PopupHeader'
+
+const debug = makeDebugger('popup')
 
 const _meta = {
   name: 'Popup',
@@ -234,12 +237,15 @@ export default class Popup extends Component {
         portalProps.closeOnTriggerBlur = true
         break
 
-      default:  // default to hover
+      case 'hover':
         portalProps.openOnTriggerMouseOver = true
         portalProps.closeOnTriggerMouseLeave = true
         // Taken from SUI: https://git.io/vPmCm
         portalProps.mouseLeaveDelay = 70
         portalProps.mouseOverDelay = 50
+        break
+
+      default:
         break
     }
 
@@ -258,11 +264,13 @@ export default class Popup extends Component {
   }
 
   handleClose = (e) => {
+    debug('handleClose()')
     const { onClose } = this.props
     if (onClose) onClose(e, this.props)
   }
 
   handleOpen = (e) => {
+    debug('handleOpen()')
     this.coords = e.currentTarget.getBoundingClientRect()
 
     const { onOpen } = this.props
@@ -270,6 +278,7 @@ export default class Popup extends Component {
   }
 
   handlePortalMount = (e) => {
+    debug('handlePortalMount()')
     if (this.props.hideOnScroll) {
       window.addEventListener('scroll', this.hideOnScroll)
     }
@@ -279,11 +288,13 @@ export default class Popup extends Component {
   }
 
   handlePortalUnmount = (e) => {
+    debug('handlePortalUnmount()')
     const { onUnmount } = this.props
     if (onUnmount) onUnmount(e, this.props)
   }
 
   popupMounted = (ref) => {
+    debug('popupMounted()')
     this.popupCoords = ref ? ref.getBoundingClientRect() : null
     this.setPopupStyle()
   }
@@ -333,10 +344,12 @@ export default class Popup extends Component {
       </ElementType>
     )
 
+    const mergedPortalProps = { ...this.getPortalProps(), ...portalProps }
+    debug('portal props:', mergedPortalProps)
+
     return (
       <Portal
-        {...this.getPortalProps()}
-        {...portalProps}
+        {...mergedPortalProps}
         trigger={trigger}
         onClose={this.handleClose}
         onMount={this.handlePortalMount}

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -95,6 +95,56 @@ describe('extending AutoControlledComponent', () => {
       wrapper
         .should.have.state(randomProp, props[randomProp])
     })
+
+    it('sets state for props passed as undefined by the parent', () => {
+      consoleUtil.disableOnce()
+
+      const props = makeProps()
+      const autoControlledProps = _.keys(props)
+
+      const randomProp = _.sample(autoControlledProps)
+      const randomValue = faker.hacker.phrase()
+
+      props[randomProp] = undefined
+
+      TestClass = createTestClass({ autoControlledProps, state: {} })
+      const wrapper = shallow(<TestClass {...props } />)
+
+      wrapper
+        .instance()
+        .trySetState({ [randomProp]: randomValue })
+
+      // not updated
+      wrapper
+        .should.have.state(randomProp, randomValue)
+    })
+
+    it('does not set state for props passed as null by the parent', () => {
+      consoleUtil.disableOnce()
+
+      const props = makeProps()
+      const autoControlledProps = _.keys(props)
+
+      const randomProp = _.sample(autoControlledProps)
+      const randomValue = faker.hacker.phrase()
+
+      props[randomProp] = null
+
+      TestClass = createTestClass({ autoControlledProps, state: {} })
+      const wrapper = shallow(<TestClass {...props } />)
+
+      wrapper
+        .instance()
+        .trySetState({ [randomProp]: randomValue })
+
+      // not updated
+      wrapper
+        .should.not.have.state(randomProp, randomValue)
+
+      // is original value
+      wrapper
+        .should.have.state(randomProp, props[randomProp])
+    })
   })
 
   describe('initial state', () => {
@@ -243,6 +293,42 @@ describe('extending AutoControlledComponent', () => {
 
       wrapper
         .should.not.have.state(randomDefaultProp, randomValue)
+    })
+
+    it('sets state for props passed as undefined by the parent', () => {
+      consoleUtil.disableOnce()
+
+      const props = makeProps()
+      const autoControlledProps = _.keys(props)
+
+      const randomProp = _.sample(autoControlledProps)
+
+      TestClass = createTestClass({ autoControlledProps, state: {} })
+      const wrapper = shallow(<TestClass {...props} />)
+
+      wrapper
+        .setProps({ [randomProp]: undefined })
+
+      wrapper
+        .should.have.state(randomProp, props[randomProp])
+    })
+
+    it('does not set state for props passed as null by the parent', () => {
+      consoleUtil.disableOnce()
+
+      const props = makeProps()
+      const autoControlledProps = _.keys(props)
+
+      const randomProp = _.sample(autoControlledProps)
+
+      TestClass = createTestClass({ autoControlledProps, state: {} })
+      const wrapper = shallow(<TestClass {...props} />)
+
+      wrapper
+        .setProps({ [randomProp]: null })
+
+      wrapper
+        .should.have.state(randomProp, null)
     })
   })
 })

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -11,6 +11,7 @@ let TestClass
 /* eslint-disable */
 const createTestClass = (options = {}) => class Test extends AutoControlledComponent {
   static autoControlledProps = options.autoControlledProps
+  static defaultProps = options.defaultProps
   state = options.state
   render = () => <div />
 }
@@ -166,6 +167,30 @@ describe('extending AutoControlledComponent', () => {
       _.each(props, (val, key) => wrapper.should.not.have.state(key, val))
     })
 
+    it('uses the default prop is the regular prop is undefined', () => {
+      consoleUtil.disableOnce()
+
+      const defaultProps = { defaultFoo: 'default' }
+      const autoControlledProps = ['foo']
+
+      TestClass = createTestClass({ autoControlledProps, defaultProps, state: {} })
+
+      shallow(<TestClass foo={undefined} />)
+        .should.have.state('foo', 'default')
+    })
+
+    it('uses the regular prop when a default is also defined', () => {
+      consoleUtil.disableOnce()
+
+      const defaultProps = { defaultFoo: 'default' }
+      const autoControlledProps = ['foo']
+
+      TestClass = createTestClass({ autoControlledProps, defaultProps, state: {} })
+
+      shallow(<TestClass foo='initial' />)
+        .should.have.state('foo', 'initial')
+    })
+
     it('defaults "checked" to false if not present', () => {
       consoleUtil.disableOnce()
       TestClass.autoControlledProps.push('checked')
@@ -280,8 +305,7 @@ describe('extending AutoControlledComponent', () => {
       const autoControlledProps = _.keys(props)
       const defaultProps = makeDefaultProps(props)
 
-      const randomPropIndex = _.random(0, autoControlledProps.length)
-      const randomDefaultProp = _.keys(defaultProps)[randomPropIndex]
+      const randomDefaultProp = _.sample(defaultProps)
       const randomValue = faker.hacker.phrase()
 
       TestClass = createTestClass({ autoControlledProps, state: {} })
@@ -292,6 +316,26 @@ describe('extending AutoControlledComponent', () => {
 
       wrapper
         .should.not.have.state(randomDefaultProp, randomValue)
+    })
+
+    it('does not return state to default props when setting props undefined', () => {
+      consoleUtil.disableOnce()
+
+      const autoControlledProps = ['foo']
+      const defaultProps = { defaultFoo: 'default' }
+
+      TestClass = createTestClass({ autoControlledProps, defaultProps, state: {} })
+      const wrapper = shallow(<TestClass foo='initial' />)
+
+      // default value
+      wrapper
+        .should.have.state('foo', 'initial')
+
+      wrapper
+        .setProps({ foo: undefined })
+
+      wrapper
+        .should.not.have.state('foo', 'foo')
     })
 
     it('sets state to undefined for props passed as undefined by the parent', () => {

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -288,7 +288,7 @@ describe('extending AutoControlledComponent', () => {
       const randomProp = _.sample(_.keys(props))
       const randomValue = faker.hacker.phrase()
 
-      TestClass = createTestClass({ state: {} })
+      TestClass = createTestClass({ autoControlledProps: [], state: {} })
       const wrapper = shallow(<TestClass {...props} />)
 
       wrapper

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -60,7 +60,7 @@ describe('extending AutoControlledComponent', () => {
     it('does not set state for non autoControlledProps', () => {
       consoleUtil.disableOnce()
 
-      TestClass = createTestClass({ state: {} })
+      TestClass = createTestClass({ autoControlledProps: [], state: {} })
       const wrapper = shallow(<TestClass />)
 
       wrapper

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -114,7 +114,6 @@ describe('extending AutoControlledComponent', () => {
         .instance()
         .trySetState({ [randomProp]: randomValue })
 
-      // not updated
       wrapper
         .should.have.state(randomProp, randomValue)
     })
@@ -295,9 +294,8 @@ describe('extending AutoControlledComponent', () => {
         .should.not.have.state(randomDefaultProp, randomValue)
     })
 
-    it('sets state for props passed as undefined by the parent', () => {
+    it('sets state to undefined for props passed as undefined by the parent', () => {
       consoleUtil.disableOnce()
-
       const props = makeProps()
       const autoControlledProps = _.keys(props)
 
@@ -306,11 +304,16 @@ describe('extending AutoControlledComponent', () => {
       TestClass = createTestClass({ autoControlledProps, state: {} })
       const wrapper = shallow(<TestClass {...props} />)
 
+      // state exists initially
+      wrapper
+        .should.have.state(randomProp)
+
       wrapper
         .setProps({ [randomProp]: undefined })
 
+      // use "should not have" to assert undefined state
       wrapper
-        .should.have.state(randomProp, props[randomProp])
+        .should.not.have.state(randomProp)
     })
 
     it('does not set state for props passed as null by the parent', () => {


### PR DESCRIPTION
# Breaking Change

This PR changes the way components auto control their state and how they release control.  Previously, when a prop was removed or set to `undefined`, the component would not resume control.  Now, when an auto controlled prop is removed or set to `undefined`, it will resume auto control.

#### _This applies to all auto controlled prop for all components.  The Dropdown `open` prop and state is used for illustration._

### Before

Previously, passing `undefined` to a Component's auto controlled `open` prop would control the `open` state and prevent the Dropdown from auto controlling its `open` state:

```jsx
<Dropdown open={undefined} />
````
### After

Now, `undefined` props are treated as non-existent so you must explicitly pass a value if you wish you prevent the Dropdown from auto controlling the `open` prop.

```jsx
<Dropdown open={false} />
<Dropdown open={null} />
```

***

Fixes an issue raised in #769

@levithomason - this is somewhat of an RFC as I'm not sure if this is the way we want this to work.

`AutoControlledComponent` (ACC) will control props that weren't passed by the parent, and defer to the parent-defined props if passed. However, in the case of that issue with the `Modal` there was no way to pass the `open` prop through to the `Portal` without forcing "controlled" usage. This PR updates the ACC to control props that are either missing entirely (existing behavior) or that are passed as `undefined` from the parent.

This seems sane to me because it follows the convention of:
- undefined - same as if I didn't pass it
- null - I explicitly passed an empty/null value
- anyValue - I explicitly passed a non-nil value

One weird thing is that if you initially set a prop to any value, and then later on set it to undefined, it won't unset the value. IMHO this could seem unexpected because doing something like `{ ...props, x: undefined }` would yield an object with `x === undefined`.

Again, I opened this more just to start a discussion so if you don't think this makes sense I'm fine closing this. I kinda think we should support the usage suggested in #769, which this does, so if not this we'll need to figure out a different way.