### PR TITLE
feat(Dropdown): Prevent open when disabled

### DIFF
--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -726,6 +726,30 @@ describe('Dropdown Component', () => {
       dropdownMenuIsOpen()
     })
 
+    it('opens on arrow down when focused', () => {
+      wrapperMount(<Dropdown options={options} selection />)
+        // Note: This mousedown is necessary to get the Dropdown focused
+        // without it being open.
+        .simulate('mousedown')
+        .simulate('focus')
+
+      dropdownMenuIsClosed()
+      domEvent.keyDown(document, { key: 'ArrowDown' })
+      dropdownMenuIsOpen()
+    })
+
+    it('opens on space when focused', () => {
+      wrapperMount(<Dropdown options={options} selection />)
+        // Note: This mousedown is necessary to get the Dropdown focused
+        // without it being open.
+        .simulate('mousedown')
+        .simulate('focus')
+
+      dropdownMenuIsClosed()
+      domEvent.keyDown(document, { key: ' ' })
+      dropdownMenuIsOpen()
+    })
+
     it('does not open on arrow down when not focused', () => {
       wrapperMount(<Dropdown options={options} selection />)
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -309,6 +309,20 @@ describe('Dropdown Component', () => {
         .at(1)
         .should.have.prop('selected', true)
     })
+    it('defaults to selected item when options are initially empty', () => {
+      const randomIndex = 1 + _.random(options.length - 2)
+      const value = options[randomIndex].value
+
+      wrapperShallow(<Dropdown options={[]} selection value={value} />)
+
+      wrapper
+        .setProps({ options, value })
+
+      wrapper
+        .find('DropdownItem')
+        .at(randomIndex)
+        .should.have.prop('selected', true)
+    })
     it('is null when all options disabled', () => {
       const disabledOptions = options.map((o) => ({ ...o, disabled: true }))
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -129,6 +129,32 @@ describe('Dropdown Component', () => {
     dropdownMenuIsOpen()
   })
 
+  describe('disabled', () => {
+    it('does not open on click', () => {
+      wrapperMount(<Dropdown options={options} disabled />)
+
+      dropdownMenuIsClosed()
+      wrapper.simulate('click')
+      dropdownMenuIsClosed()
+    })
+
+    it('does not open on click with pointer events enabled', () => {
+      wrapperMount(<Dropdown options={options} disabled style={{ pointerEvents: 'all' }} />)
+
+      dropdownMenuIsClosed()
+      wrapper.simulate('click')
+      dropdownMenuIsClosed()
+    })
+
+    it('does not open on focus', () => {
+      wrapperMount(<Dropdown options={options} disabled />)
+
+      dropdownMenuIsClosed()
+      wrapper.simulate('focus')
+      dropdownMenuIsClosed()
+    })
+  })
+
   describe('handleBlur', () => {
     it('passes the event to the onBlur prop', () => {
       const spy = sandbox.spy()
@@ -769,6 +795,34 @@ describe('Dropdown Component', () => {
     })
   })
 
+  describe('onOpen', () => {
+    it('called when dropdown would open', () => {
+      const onOpen = sandbox.spy()
+      wrapperMount(<Dropdown options={options} selection onOpen={onOpen} />)
+
+      wrapper.simulate('click')
+      onOpen.should.have.been.calledOnce()
+    })
+
+    it('not called when dropdown would not open', () => {
+      const onOpen = sandbox.spy()
+      wrapperMount(<Dropdown options={options} selection onOpen={onOpen} />)
+
+      domEvent.keyDown(document, { key: 'ArrowDown' })
+      onOpen.should.not.have.been.calledOnce()
+    })
+  })
+
+  describe('onClose', () => {
+    it('called when dropdown would close', () => {
+      const onClose = sandbox.spy()
+      wrapperMount(<Dropdown options={options} selection defaultOpen onClose={onClose} />)
+
+      wrapper.simulate('click')
+      onClose.should.have.been.calledOnce()
+    })
+  })
+
   describe('open', () => {
     it('defaultOpen opens the menu when true', () => {
       wrapperShallow(<Dropdown options={options} selection defaultOpen />)
@@ -1209,6 +1263,12 @@ describe('Dropdown Component', () => {
       wrapperShallow(<Dropdown options={options} selection search />)
         .find('input.search')
         .should.have.prop('tabIndex', '0')
+    })
+
+    it('has a search input props-defined tabIndex', () => {
+      wrapperShallow(<Dropdown options={options} selection search tabIndex='123' />)
+        .find('input.search')
+        .should.have.prop('tabIndex', '123')
     })
 
     it('clears the search query when an item is selected', () => {


### PR DESCRIPTION
Fixes #791

This PR fixes a few issues with the Dropdown:
- Prevent the dropdown from opening/focused when disabled.
- Respect the user's `tabIndex` if passed. Previously there was no way to prevent the dropdown from being focusable
- Add onOpen/onClose props to fire when the dropdown would've been opened/closed
- Fix issue with selectedIndex. If your dropdown has options that load after the component is mounted (e.g. from a remote API) the selectedIndex would always be -1 instead of the selected value or the first item. This updates the Dropdown to recompute the selected index when the options change.