### PR TITLE
fix(Dimmer): Fix "simple" usage, add disabled prop

### DIFF
--- a/src/modules/Dimmer/Dimmer.js
+++ b/src/modules/Dimmer/Dimmer.js
@@ -37,6 +37,9 @@ export default class Dimmer extends Component {
     /** Shorthand for primary content. */
     content: customPropTypes.contentShorthand,
 
+    /** A disabled dimmer cannot be activated */
+    disabled: PropTypes.bool,
+
     /** Called with (event, props) after user's click. */
     onClick: PropTypes.func,
 
@@ -75,6 +78,7 @@ export default class Dimmer extends Component {
       children,
       className,
       content,
+      disabled,
       inverted,
       page,
       simple,
@@ -82,24 +86,24 @@ export default class Dimmer extends Component {
 
     const classes = cx(
       'ui',
-      useKeyOnly(active, 'active'),
-      useKeyOnly(!active, 'disabled'),
+      useKeyOnly(active, 'active transition visible'),
+      useKeyOnly(disabled, 'disabled'),
       useKeyOnly(inverted, 'inverted'),
       useKeyOnly(page, 'page'),
       useKeyOnly(simple, 'simple'),
-      'dimmer transition visible',
+      'dimmer',
       className,
     )
     const rest = getUnhandledProps(Dimmer, this.props)
     const ElementType = getElementType(Dimmer, this.props)
 
     const childrenJSX = (children || content) && (
-        <div className='content'>
-          <div className='center' ref={center => (this.center = center)}>
-            { children || content }
-          </div>
+      <div className='content'>
+        <div className='center' ref={center => (this.center = center)}>
+          { children || content }
         </div>
-      )
+      </div>
+    )
 
     if (page) {
       return (

--- a/test/specs/modules/Dimmer/Dimmer-test.js
+++ b/test/specs/modules/Dimmer/Dimmer-test.js
@@ -13,7 +13,10 @@ describe('Dimmer', () => {
   common.hasUIClassName(Dimmer)
   common.rendersChildren(Dimmer)
 
-  common.propKeyOnlyToClassName(Dimmer, 'active')
+  common.propKeyOnlyToClassName(Dimmer, 'active', {
+    className: 'active transition visible',
+  })
+  common.propKeyOnlyToClassName(Dimmer, 'disabled')
   common.propKeyOnlyToClassName(Dimmer, 'inverted')
   common.propKeyOnlyToClassName(Dimmer, 'simple')
 
@@ -25,17 +28,6 @@ describe('Dimmer', () => {
 
       shallow(<Dimmer content={text} />)
         .should.contain.text(text)
-    })
-  })
-
-  describe('active', () => {
-    it('adds the `transition visible` className when true', () => {
-      shallow(<Dimmer active />)
-        .should.have.className('transition visible')
-    })
-    it('removes the `transition visible` className when false', () => {
-      shallow(<Dimmer active={false} />)
-        .should.not.have.className('transition visible')
     })
   })
 

--- a/test/specs/modules/Dimmer/Dimmer-test.js
+++ b/test/specs/modules/Dimmer/Dimmer-test.js
@@ -29,13 +29,13 @@ describe('Dimmer', () => {
   })
 
   describe('active', () => {
-    it('removes the `disabled` className when true', () => {
+    it('adds the `transition visible` className when true', () => {
       shallow(<Dimmer active />)
-        .should.not.have.className('disabled')
+        .should.have.className('transition visible')
     })
-    it('adds the `disabled` className when false', () => {
+    it('removes the `transition visible` className when false', () => {
       shallow(<Dimmer active={false} />)
-        .should.have.className('disabled')
+        .should.not.have.className('transition visible')
     })
   })
 


### PR DESCRIPTION
I realized that #782 breaks the "simple" example: http://react.semantic-ui.com/modules/dimmer#simple-dimmer. That should be enabled by virtue of having a parent with `ui dimmable dimmed`. See the SUI-core docs: http://semantic-ui.com/modules/dimmer.html#simple-dimmer

Digging into it further, two things stuck out to me:
- The reason the children were unclickable is because the dimmer always had the `visible` class, regardless of whether it was active. `active` controls the opacity, `visible` sets the `visibility`.
- `disabled` is a prop that overrides any active/visible state so we shouldn't be using it for that.

This fixes both issues.
- `visible` is only added when the dimmer is active, which removes the need to force `disabled`, which enables clicking on children and fixes the "simple" usage.
- We now expose `disabled` as a prop which conforms more to our API. A user can set that to override any active/visible state.