### PR TITLE
breaking(DropdownItem): callback with (e, props) onClick

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -149,7 +149,7 @@ export default class Dropdown extends Component {
     /** Called when a close event happens */
     onClose: PropTypes.func,
 
-     /** Called when an open event happens */
+    /** Called when an open event happens */
     onOpen: PropTypes.func,
 
     /** Called with the React Synthetic Event and current value on search input change. */
@@ -513,7 +513,7 @@ export default class Dropdown extends Component {
     this.toggle(e)
   }
 
-  handleItemClick = (e, value) => {
+  handleItemClick = (e, { value }) => {
     debug('handleItemClick()')
     debug(value)
     const { multiple, name, onAddItem, options } = this.props

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -65,7 +65,7 @@ export default class DropdownItem extends Component {
       PropTypes.string,
     ]),
 
-    /** Called on click with (event, value, text). */
+    /** Called on click with (event, props). */
     onClick: PropTypes.func,
   }
 
@@ -76,9 +76,9 @@ export default class DropdownItem extends Component {
   }
 
   handleClick = (e) => {
-    const { onClick, value } = this.props
+    const { onClick } = this.props
 
-    if (onClick) onClick(e, value)
+    if (onClick) onClick(e, this.props)
   }
 
   render() {

--- a/test/specs/modules/Dropdown/DropdownItem-test.js
+++ b/test/specs/modules/Dropdown/DropdownItem-test.js
@@ -54,18 +54,18 @@ describe('DropdownItem', () => {
       expect(click).to.not.throw()
     })
 
-    it('is called with (e, value) when clicked', () => {
+    it('is called with (e, props) when clicked', () => {
       const spy = sandbox.spy()
 
       const value = faker.hacker.phrase()
       const event = { target: null }
-      const props = { value }
+      const props = { value, foo: 'bar' }
 
       shallow(<DropdownItem onClick={spy} {...props} />)
         .simulate('click', event)
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(event, value)
+      spy.should.have.been.calledWithMatch(event, props)
     })
   })
 })


### PR DESCRIPTION
# Breaking Change
Fixes #804.

This PR updates DropdownItem onClick to callback with the event and all props.  Previously it called back with the event and value, but the docs stated it also called back with the text.

### Upgrade Guide

The second DropdownItem onClick parameter is now the full props object.

**BEFORE**
```jsx
const handleItemClick = (e, value) => {
  console.log('You clicked:', value)
}

<DropdownItem onClick={handleClick} />
```

**AFTER**
```jsx
const handleItemClick = (e, props) => {
  console.log('You clicked:', props.value)
}

<DropdownItem onClick={handleClick} />
```