### PR TITLE
breaking(Dropdown|Label): Multi-select customization

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleMultipleCustomLabel.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleMultipleCustomLabel.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Dropdown, Icon, Label } from 'semantic-ui-react'
+
+const options = [
+  { text: 'One', value: 1 },
+  { text: 'Two', value: 2 },
+  { text: 'Three', value: 3 },
+]
+
+const renderLabel = (label, index, props) => ({
+  color: 'blue',
+  content: `Customized label - ${label.text}`,
+  icon: 'check',
+})
+
+const DropdownExampleMultipleCustomLabel = () => (
+  <Dropdown
+    multiple
+    selection
+    fluid
+    options={options}
+    placeholder='Choose an option'
+    renderLabel={renderLabel}
+  />
+)
+
+export default DropdownExampleMultipleCustomLabel

--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleMultipleCustomLabel.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleMultipleCustomLabel.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Dropdown, Icon, Label } from 'semantic-ui-react'
+import { Dropdown } from 'semantic-ui-react'
 
 const options = [
   { text: 'One', value: 1 },

--- a/docs/app/Examples/modules/Dropdown/Usage/index.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/index.js
@@ -39,6 +39,11 @@ const DropdownUsageExamples = () => (
     <ComponentExample
       examplePath='modules/Dropdown/Usage/DropdownExampleTriggerImage'
     />
+    <ComponentExample
+      title='Multiple Custom Label'
+      description='A "multiple" dropdown can render customized label for selected items.'
+      examplePath='modules/Dropdown/Usage/DropdownExampleMultipleCustomLabel'
+    />
 
   </ExampleSection>
 )

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -40,7 +40,7 @@ export default class Label extends Component {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
 
-    /** An active can be active. */
+    /** A label can be active. */
     active: PropTypes.bool,
 
     /** A label can attach to a content segment. */
@@ -106,8 +106,11 @@ export default class Label extends Component {
     /** Adds an "x" icon, called with (event, props) when "x" is clicked. */
     onRemove: PropTypes.func,
 
-    /** Props for remove icon. */
-    removeIcon: customPropTypes.itemShorthand,
+    /** Shorthand for Icon to appear as the last child and trigger onRemove. */
+    removeIcon: customPropTypes.every([
+      customPropTypes.demand(['onRemove']),
+      customPropTypes.itemShorthand,
+    ]),
 
     /** A label can appear as a ribbon attaching itself to an element. */
     ribbon: PropTypes.oneOfType([

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -106,8 +106,8 @@ export default class Label extends Component {
     /** Adds an "x" icon, called with (event, props) when "x" is clicked. */
     onRemove: PropTypes.func,
 
-    /** Add an "x" icon that calls onRemove when clicked. */
-    removable: PropTypes.bool,
+    /** Props for remove icon. */
+    removeIcon: customPropTypes.itemShorthand,
 
     /** A label can appear as a ribbon attaching itself to an element. */
     ribbon: PropTypes.oneOfType([
@@ -120,6 +120,10 @@ export default class Label extends Component {
 
     /** A label can appear as a tag. */
     tag: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    removeIcon: 'delete',
   }
 
   static _meta = _meta
@@ -158,7 +162,7 @@ export default class Label extends Component {
       image,
       onRemove,
       pointing,
-      removable,
+      removeIcon,
       ribbon,
       size,
       tag,
@@ -200,9 +204,7 @@ export default class Label extends Component {
         {typeof image !== 'boolean' && Image.create(image)}
         {content}
         {createShorthand(LabelDetail, val => ({ content: val }), detail)}
-        {(removable || onRemove) && (
-          <Icon name='delete' onClick={this.handleRemove} />
-        )}
+        {onRemove && Icon.create(removeIcon, { onClick: this.handleRemove })}
       </ElementType>
     )
   }

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -40,6 +40,9 @@ export default class Label extends Component {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
 
+    /** An active can be active. */
+    active: PropTypes.bool,
+
     /** A label can attach to a content segment. */
     attached: PropTypes.oneOf(_meta.props.attached),
 
@@ -138,6 +141,7 @@ export default class Label extends Component {
 
   render() {
     const {
+      active,
       attached,
       basic,
       children,
@@ -169,6 +173,7 @@ export default class Label extends Component {
       color,
       pointingClass,
       size,
+      useKeyOnly(active, 'active'),
       useKeyOnly(basic, 'basic'),
       useKeyOnly(circular, 'circular'),
       useKeyOnly(empty, 'empty'),

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -516,7 +516,8 @@ export default class Dropdown extends Component {
     debug('closeOnDocumentClick()')
     debug(e)
 
-    if (this._dropdown && this._dropdown.contains(e.target)) return
+    // If event happened in the dropdown, ignore it
+    if (this._dropdown && _.isFunction(this._dropdown.contains) && this._dropdown.contains(e.target)) return
 
     this.close()
   }

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -158,7 +158,7 @@ export default class Dropdown extends Component {
     /** Called when a close event happens. */
     onClose: PropTypes.func,
 
-    /** Called when a multi-select label is clicked.. */
+    /** Called when a multi-select label is clicked. */
     onLabelClick: PropTypes.func,
 
     /** Called when an open event happens. */
@@ -263,10 +263,11 @@ export default class Dropdown extends Component {
   }
 
   static defaultProps = {
-    icon: 'dropdown',
     additionLabel: 'Add ',
     additionPosition: 'top',
+    icon: 'dropdown',
     noResultsMessage: 'No results found.',
+    renderLabel: ({ text }) => text,
     selectOnBlur: true,
     tabIndex: '0',
   }
@@ -957,11 +958,10 @@ export default class Dropdown extends Component {
         value: item.value,
       }
 
-      const labelShorthand = renderLabel
-        ? renderLabel(item, index, defaultLabelProps)
-        : item.text
-
-      return Label.create(labelShorthand, defaultLabelProps)
+      return Label.create(
+        renderLabel(item, index, defaultLabelProps),
+        defaultLabelProps,
+      )
     })
   }
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -86,6 +86,15 @@ export default class Dropdown extends Component {
     /** Initial value of open. */
     defaultOpen: PropTypes.bool,
 
+    /** Currently selected label in multi-select. */
+    defaultSelectedLabel: customPropTypes.every([
+      customPropTypes.demand(['multiple']),
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+      ]),
+    ]),
+
     /** Initial value or value array if multiple. */
     defaultValue: PropTypes.oneOfType([
       PropTypes.string,
@@ -146,10 +155,13 @@ export default class Dropdown extends Component {
     /** Called with the React Synthetic Event and { name, value } on change. */
     onChange: PropTypes.func,
 
-    /** Called when a close event happens */
+    /** Called when a close event happens. */
     onClose: PropTypes.func,
 
-    /** Called when an open event happens */
+    /** Called when a multi-select label is clicked.. */
+    onLabelClick: PropTypes.func,
+
+    /** Called when an open event happens. */
     onOpen: PropTypes.func,
 
     /** Called with the React Synthetic Event and current value on search input change. */
@@ -182,6 +194,15 @@ export default class Dropdown extends Component {
       PropTypes.oneOf(_meta.props.pointing),
     ]),
 
+    /**
+     * A function that takes (data, index, defaultLabelProps) and returns
+     * shorthand for Label .
+     */
+    renderLabel: customPropTypes.every([
+      customPropTypes.demand(['multiple']),
+      PropTypes.func,
+    ]),
+
     /** A dropdown can have its menu scroll. */
     scrolling: PropTypes.bool,
 
@@ -195,6 +216,15 @@ export default class Dropdown extends Component {
     ]),
 
     // TODO 'searchInMenu' or 'search='in menu' or ???  How to handle this markup and functionality?
+
+    /** Currently selected label in multi-select. */
+    selectedLabel: customPropTypes.every([
+      customPropTypes.demand(['multiple']),
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+      ]),
+    ]),
 
     /** A dropdown can be used to select between choices in a form. */
     selection: customPropTypes.every([
@@ -244,6 +274,7 @@ export default class Dropdown extends Component {
   static autoControlledProps = [
     'open',
     'value',
+    'selectedLabel',
   ]
 
   static _meta = _meta
@@ -483,6 +514,9 @@ export default class Dropdown extends Component {
   closeOnDocumentClick = (e) => {
     debug('closeOnDocumentClick()')
     debug(e)
+
+    if (this._dropdown && this._dropdown.contains(e.target)) return
+
     this.close()
   }
 
@@ -714,6 +748,17 @@ export default class Dropdown extends Component {
     this.setState({ selectedIndex: newSelectedIndex })
   }
 
+  handleLabelClick = (e, labelProps) => {
+    debug('handleLabelClick()')
+    // prevent focusing search input on click
+    e.stopPropagation()
+
+    this.setState({ selectedLabel: labelProps.value })
+
+    const { onLabelClick } = this.props
+    if (onLabelClick) onLabelClick(e, labelProps)
+  }
+
   handleLabelRemove = (e, labelProps) => {
     debug('handleLabelRemove()')
     // prevent focusing search input on click
@@ -892,8 +937,8 @@ export default class Dropdown extends Component {
 
   renderLabels = () => {
     debug('renderLabels()')
-    const { multiple } = this.props
-    const { value } = this.state
+    const { multiple, renderLabel } = this.props
+    const { selectedLabel, value } = this.state
     if (!multiple || _.isEmpty(value)) {
       return
     }
@@ -902,16 +947,21 @@ export default class Dropdown extends Component {
 
     // if no item could be found for a given state value the selected item will be undefined
     // compact the selectedItems so we only have actual objects left
-    return _.map(_.compact(selectedItems), (item) => {
-      return (
-        <Label
-          key={item.value}
-          as={'a'}
-          content={item.text}
-          value={item.value}
-          onRemove={this.handleLabelRemove}
-        />
-      )
+    return _.map(_.compact(selectedItems), (item, index) => {
+      const defaultLabelProps = {
+        active: item.value === selectedLabel,
+        as: 'a',
+        key: item.value,
+        onClick: this.handleLabelClick,
+        onRemove: this.handleLabelRemove,
+        value: item.value,
+      }
+
+      const labelShorthand = renderLabel
+        ? renderLabel(item, index, defaultLabelProps)
+        : item.text
+
+      return Label.create(labelShorthand, defaultLabelProps)
     })
   }
 

--- a/test/specs/elements/Label/Label-test.js
+++ b/test/specs/elements/Label/Label-test.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import faker from 'faker'
 import React from 'react'
 
@@ -36,6 +37,11 @@ describe('Label', () => {
     propKey: 'detail',
     ShorthandComponent: LabelDetail,
     mapValueToProps: val => ({ content: val }),
+  })
+
+  common.implementsIconProp(Label, {
+    propKey: 'removeIcon',
+    requiredProps: { onRemove: _.noop },
   })
 
   it('is a div by default', () => {

--- a/test/specs/elements/Label/Label-test.js
+++ b/test/specs/elements/Label/Label-test.js
@@ -39,14 +39,34 @@ describe('Label', () => {
     mapValueToProps: val => ({ content: val }),
   })
 
-  common.implementsIconProp(Label, {
-    propKey: 'removeIcon',
-    requiredProps: { onRemove: _.noop },
-  })
-
   it('is a div by default', () => {
     shallow(<Label />)
       .should.have.tagName('div')
+  })
+
+  describe('removeIcon', () => {
+    it('has no icon without onRemove', () => {
+      shallow(<Label />)
+        .should.not.have.descendants('Icon')
+    })
+
+    it('has delete icon by default', () => {
+      shallow(<Label onRemove={_.noop} />)
+        .find('Icon')
+        .should.have.prop('name', 'delete')
+    })
+
+    it('uses passed removeIcon string', () => {
+      shallow(<Label onRemove={_.noop} removeIcon='foo' />)
+        .find('Icon')
+        .should.have.prop('name', 'foo')
+    })
+
+    it('uses passed removeIcon props', () => {
+      shallow(<Label onRemove={_.noop} removeIcon={{ 'data-foo': true }} />)
+        .find('Icon')
+        .should.have.prop('data-foo', true)
+    })
   })
 
   describe('content', () => {

--- a/test/specs/elements/Label/Label-test.js
+++ b/test/specs/elements/Label/Label-test.js
@@ -15,6 +15,7 @@ describe('Label', () => {
 
   common.propKeyAndValueToClassName(Label, 'attached')
 
+  common.propKeyOnlyToClassName(Label, 'active')
   common.propKeyOnlyToClassName(Label, 'basic')
   common.propKeyOnlyToClassName(Label, 'circular')
   common.propKeyOnlyToClassName(Label, 'empty')


### PR DESCRIPTION
# Breaking Change

Removes the `removable` prop from `Label`. This isn't in SUI-core and it didn't really make sense since it would show the icon without handling the click in some way.

### Upgrade Guide

- `removable ` is no longer a valid prop
- You must pass an `onRemove` for the remove icon to show up

**BEFORE**
```jsx
<Label removable />
```

**AFTER**
```jsx
<Label onRemove={handleRemove} />
```

----

Multiple improvements to `<Dropdown multiple />`
- Set label to "active" on click
- Allow custom rendering of labels
- Add handler for label click

**Active**
<img width="439" alt="screen shot 2016-11-08 at 12 01 20 pm" src="https://cloud.githubusercontent.com/assets/847027/20108751/1c1564ea-a5ab-11e6-86e2-0f983e7f6d2c.png">

**Custom Label**
<img width="463" alt="screen shot 2016-11-08 at 12 00 35 pm" src="https://cloud.githubusercontent.com/assets/847027/20108723/fcfc4f2e-a5aa-11e6-8970-ef7e0fe3e362.png">

Also adds an `active` prop to the `Label` element. This is actually a valid class name in SUI-core for `Label` outside of the context of a `Dropdown`:
<img width="136" alt="screen shot 2016-11-08 at 11 58 16 am" src="https://cloud.githubusercontent.com/assets/847027/20108618/a7d55202-a5aa-11e6-95ff-dd1b0a9d0c37.png">
The one on the right has the `active` class applied.

Also adds `removeIcon` prop to be able to customize the icon that triggers `onRemove`
