### PR TITLE
chore(build): simplify and fix hmr

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,27 +8,6 @@
     "lodash"
   ],
   "env": {
-    "development": {
-      "plugins": [
-        ["react-transform", {
-          "transforms": [{
-              "transform": "react-transform-hmr",
-              "imports": [
-                "react"
-              ],
-              "locals": [
-                "module"
-              ]
-            }, {
-              "transform": "react-transform-catch-errors",
-              "imports": [
-                "react",
-                "redbox-react"
-              ]
-            }]
-        }]
-      ]
-    },
     "test": {
       "plugins": [
         ["__coverage__", { "ignore": "test/" }]

--- a/docs/app/index.js
+++ b/docs/app/index.js
@@ -1,8 +1,41 @@
 import React from 'react'
-import { render } from 'react-dom'
+import ReactDOM from 'react-dom'
 import App from './App'
+
+// ----------------------------------------
+// Rendering
+// ----------------------------------------
 
 const mountNode = document.createElement('div')
 document.body.appendChild(mountNode)
 
-render(<App />, mountNode)
+const render = (NewApp) => ReactDOM.render(<NewApp />, mountNode)
+
+// ----------------------------------------
+// HMR
+// ----------------------------------------
+
+if (__DEV__) {
+  // When the application source code changes, re-render the whole thing.
+  if (module.hot) {
+    module.hot.accept('./App', () => {
+      // restore scroll
+      const { scrollLeft, scrollTop } = document.scrollingElement
+      ReactDOM.unmountComponentAtNode(mountNode)
+
+      try {
+        render(require('./App').default)
+        document.scrollingElement.scrollTop = scrollTop
+        document.scrollingElement.scrollLeft = scrollLeft
+      } catch (e) {
+        console.error(e) // eslint-disable-line no-console
+      }
+    })
+  }
+}
+
+// ----------------------------------------
+// Start the app
+// ----------------------------------------
+
+render(App)

--- a/gulp/tasks/dll.js
+++ b/gulp/tasks/dll.js
@@ -1,9 +1,9 @@
-import del from 'del'
-import { task, series } from 'gulp'
-import loadPlugins from 'gulp-load-plugins'
-import webpack from 'webpack'
+const del = require('del')
+const { task, series } = require('gulp')
+const loadPlugins = require('gulp-load-plugins')
+const webpack = require('webpack')
 
-import config from '../../config'
+const config = require('../../config')
 
 const g = loadPlugins()
 const { log, PluginError } = g.util
@@ -52,5 +52,5 @@ task('build:dll', (cb) => {
 
 task('dll', series(
   'clean:dll',
-  'build:dll',
+  'build:dll'
 ))

--- a/gulp/tasks/docs.js
+++ b/gulp/tasks/docs.js
@@ -1,13 +1,13 @@
-import historyApiFallback from 'connect-history-api-fallback'
-import del from 'del'
-import express from 'express'
-import { task, src, dest, parallel, series, watch } from 'gulp'
-import loadPlugins from 'gulp-load-plugins'
-import webpack from 'webpack'
-import WebpackDevMiddleware from 'webpack-dev-middleware'
-import WebpackHotMiddleware from 'webpack-hot-middleware'
+const historyApiFallback = require('connect-history-api-fallback')
+const del = require('del')
+const express = require('express')
+const { task, src, dest, parallel, series, watch } = require('gulp')
+const loadPlugins = require('gulp-load-plugins')
+const webpack = require('webpack')
+const WebpackDevMiddleware = require('webpack-dev-middleware')
+const WebpackHotMiddleware = require('webpack-hot-middleware')
 
-import config from '../../config'
+const config = require('../../config')
 
 const g = loadPlugins()
 const { colors, log, PluginError } = g.util
@@ -95,7 +95,7 @@ task('build:docs', series(
       )
     )
   ),
-  'build:docs:webpack',
+  'build:docs:webpack'
 ))
 
 // ----------------------------------------

--- a/gulp/tasks/umd.js
+++ b/gulp/tasks/umd.js
@@ -1,9 +1,9 @@
-import del from 'del'
-import { task, parallel, series } from 'gulp'
-import loadPlugins from 'gulp-load-plugins'
-import webpack from 'webpack'
+const del = require('del')
+const { task, parallel, series } = require('gulp')
+const loadPlugins = require('gulp-load-plugins')
+const webpack = require('webpack')
 
-import config from '../../config'
+const config = require('../../config')
 
 const g = loadPlugins()
 const { log, PluginError } = g.util

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,8 +2,8 @@
  * Tasks live in the tasks directory.
  * This file just loads all the gulp tasks.
  */
-import { task, parallel } from 'gulp'
-import requireDir from 'require-dir'
+const { task, parallel } = require('gulp')
+const requireDir = require('require-dir')
 
 requireDir('./gulp/tasks')
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
-    "babel-register": "^6.18.0",
     "babel-standalone": "^6.18.1",
     "brace": "^0.9.0",
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -49,13 +49,11 @@
     "lodash": "^4.6.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.18.0",
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.0.0",
     "babel-loader": "^6.2.0",
     "babel-plugin-__coverage__": "^11.0.0",
     "babel-plugin-lodash": "^3.1.4",
-    "babel-plugin-react-transform": "^2.0.2",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
@@ -107,9 +105,6 @@
     "react-dom": "^15.3.1",
     "react-hot-loader": "^1.3.0",
     "react-router": "^3.0.0",
-    "react-transform-catch-errors": "^1.0.2",
-    "react-transform-hmr": "^1.0.4",
-    "redbox-react": "^1.2.2",
     "require-dir": "^0.3.0",
     "rimraf": "^2.5.2",
     "sass-loader": "^4.0.2",


### PR DESCRIPTION
I'm beginning to address some of the build issues.  This PR:

- **Fixes hot module reloading**, the doc site actually reloads properly in dev now 🎉 
- trims the install footprint by removing unnecessary react and babel plugins
- rewrites the gulpfile and tasks to plain node, no babel-register precompile
