### PR TITLE
fix(Portal): ignore document click if no node or portal

### DIFF
--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -157,8 +157,8 @@ class Portal extends Component {
   handleDocumentClick = (e) => {
     const { closeOnDocumentClick, closeOnRootNodeClick } = this.props
 
-    // If event happened in the portal, ignore it
-    if (this.portal.contains(e.target)) return
+    // If not mounted, no portal, or event happened in the portal, ignore it
+    if (!this.node || !this.portal || this.portal.contains(e.target)) return
 
     if (closeOnDocumentClick || (closeOnRootNodeClick && this.node.contains(e.target))) {
       debug('handleDocumentClick()')

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -330,6 +330,12 @@ class Portal extends Component {
 
     this.node.className = className || ''
 
+    // when re-rendering, first remove listeners before re-adding them to the new node
+    if (this.portal) {
+      this.portal.removeEventListener('mouseleave', this.handlePortalMouseLeave)
+      this.portal.removeEventListener('mouseover', this.handlePortalMouseOver)
+    }
+
     ReactDOM.unstable_renderSubtreeIntoContainer(
       this,
       Children.only(children),

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -122,10 +122,10 @@ class Portal extends Component {
 
   static _meta = _meta
 
+  state = {}
+
   componentDidMount() {
-    if (this.state.open) {
-      this.renderPortal()
-    }
+    this.renderPortal()
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -134,9 +134,7 @@ class Portal extends Component {
     // within this method.
 
     // If the portal is open, render (or re-render) the portal and child.
-    if (this.state.open) {
-      this.renderPortal()
-    }
+    this.renderPortal()
 
     if (prevState.open && !this.state.open) {
       debug('portal closed')
@@ -320,6 +318,9 @@ class Portal extends Component {
   }
 
   renderPortal() {
+    if (!this.state.open) return
+    debug('renderPortal()')
+
     const { children, className } = this.props
 
     this.mountPortal()


### PR DESCRIPTION
This PR makes a few fixes to the Portal, including one that should fix the IE Modal issue:

1. ignore document click if not mounted and open, fixes #750 
1. consolidates `if (this.state.open)` checks to the `renderPortal()` method, instead of checking every time `renderPortal()` is called.
1. remove `portal` event handlers before adding duplicates in `renderPortal()`, this should fix a memory leak