### PR TITLE
test(isBrowser): add tests

### DIFF
--- a/src/lib/isBrowser.js
+++ b/src/lib/isBrowser.js
@@ -1,4 +1,4 @@
-const hasDocument = typeof document === 'object'
-const hasWindow = typeof window === 'object' && window.self === window
+const hasDocument = typeof document === 'object' && document !== null
+const hasWindow = typeof window === 'object' && window !== null && window.self === window
 
 export default hasDocument && hasWindow

--- a/test/specs/lib/isBrowser-test.js
+++ b/test/specs/lib/isBrowser-test.js
@@ -1,0 +1,18 @@
+import isBrowser from 'src/lib/isBrowser'
+
+describe('isBrowser', () => {
+  it('should return true in a browser', () => {
+    // tests are run in a browser, this should be true
+    isBrowser.should.be.true()
+  })
+
+  it('should return false when there is no document', () => {
+    require('imports?document=>undefined!src/lib/isBrowser').default.should.be.false()
+    require('imports?document=>null!src/lib/isBrowser').default.should.be.false()
+  })
+
+  it('should return false when there is no window', () => {
+    require('imports?window=>undefined!src/lib/isBrowser').default.should.be.false()
+    require('imports?window=>null!src/lib/isBrowser').default.should.be.false()
+  })
+})


### PR DESCRIPTION
Per #824, this PR adds some tests for the isBrowser util.  It also fixes the `typeof` check which forgot to account for `null` objects.

Tests are run in karma, so we can assert the positive case.  We're utilizing the `imports` loader to load the module as if both the `document` and `window` are each either `undefined` and `null` to assert the negative case.