### PR TITLE
fix(Accordion) fix wrong indexes when using Accordion.Title and Accordion.Content

### DIFF
--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -101,24 +101,28 @@ export default class Accordion extends Component {
   renderChildren = () => {
     const { children } = this.props
     const { activeIndex } = this.state
+    let titleIndex = 0
+    let contentIndex = 0
 
-    return Children.map(children, (child, i) => {
+    return Children.map(children, (child) => {
       const isTitle = child.type === AccordionTitle
       const isContent = child.type === AccordionContent
 
       if (isTitle) {
-        const isActive = _.has(child, 'props.active') ? child.props.active : activeIndex === i
+        const currentIndex = titleIndex
+        const isActive = _.has(child, 'props.active') ? child.props.active : activeIndex === currentIndex
         const onClick = (e) => {
-          this.handleTitleClick(e, i)
-          if (child.props.onClick) child.props.onClick(e, i)
+          this.handleTitleClick(e, currentIndex)
+          if (child.props.onClick) child.props.onClick(e, currentIndex)
         }
+        titleIndex++
         return cloneElement(child, { ...child.props, active: isActive, onClick })
       }
 
       if (isContent) {
-        // content must be the a sibling too title
-        // it is active if the active title index that precedes it is active
-        const isActive = _.has(child, 'props.active') ? child.props.active : activeIndex === i - 1
+        const currentIndex = contentIndex
+        const isActive = _.has(child, 'props.active') ? child.props.active : activeIndex === currentIndex
+        contentIndex++
         return cloneElement(child, { ...child.props, active: isActive })
       }
 

--- a/test/specs/modules/Accordion/Accordion-test.js
+++ b/test/specs/modules/Accordion/Accordion-test.js
@@ -77,6 +77,29 @@ describe('Accordion', () => {
       wrapper
         .should.have.state('activeIndex', -1)
     })
+    it('is called with (event, index) on AccordionTitle click', () => {
+      const spy = sandbox.spy()
+      const titles = mount(
+        <Accordion>
+          <Accordion.Title onClick={spy} />
+          <Accordion.Content />
+          <Accordion.Title onClick={spy} />
+          <Accordion.Content />
+          <Accordion.Title onClick={spy} />
+          <Accordion.Content />
+        </Accordion>
+      )
+        .find('AccordionTitle')
+
+      titles.at(0).simulate('click')
+      spy.should.have.been.calledWithMatch({}, 0)
+
+      titles.at(1).simulate('click')
+      spy.should.have.been.calledWithMatch({}, 1)
+
+      titles.at(2).simulate('click')
+      spy.should.have.been.calledWithMatch({}, 2)
+    })
   })
 
   describe('defaultActiveIndex', () => {

--- a/test/specs/modules/Accordion/Accordion-test.js
+++ b/test/specs/modules/Accordion/Accordion-test.js
@@ -77,28 +77,28 @@ describe('Accordion', () => {
       wrapper
         .should.have.state('activeIndex', -1)
     })
-    it('is called with (event, index) on AccordionTitle click', () => {
-      const spy = sandbox.spy()
-      const titles = mount(
+    it('sets the correct pair of title/content active', () => {
+      const wrapper = shallow(
         <Accordion>
-          <Accordion.Title onClick={spy} />
+          <Accordion.Title />
           <Accordion.Content />
-          <Accordion.Title onClick={spy} />
+          <Accordion.Title />
           <Accordion.Content />
-          <Accordion.Title onClick={spy} />
+          <Accordion.Title />
           <Accordion.Content />
         </Accordion>
       )
-        .find('AccordionTitle')
+      wrapper.setProps({ activeIndex: 0 })
+      wrapper.childAt(0).should.have.prop('active', true)
+      wrapper.childAt(1).should.have.prop('active', true)
 
-      titles.at(0).simulate('click')
-      spy.should.have.been.calledWithMatch({}, 0)
+      wrapper.setProps({ activeIndex: 1 })
+      wrapper.childAt(2).should.have.prop('active', true)
+      wrapper.childAt(3).should.have.prop('active', true)
 
-      titles.at(1).simulate('click')
-      spy.should.have.been.calledWithMatch({}, 1)
-
-      titles.at(2).simulate('click')
-      spy.should.have.been.calledWithMatch({}, 2)
+      wrapper.setProps({ activeIndex: 2 })
+      wrapper.childAt(4).should.have.prop('active', true)
+      wrapper.childAt(5).should.have.prop('active', true)
     })
   })
 
@@ -112,6 +112,7 @@ describe('Accordion', () => {
   describe('onTitleClick', () => {
     it('is called with (event, index)', () => {
       const spy = sandbox.spy()
+      const event = { foo: 'bar' }
       const titles = mount(
         <Accordion onTitleClick={spy}>
           <Accordion.Title />
@@ -120,11 +121,11 @@ describe('Accordion', () => {
       )
         .find('AccordionTitle')
 
-      titles.at(0).simulate('click')
-      spy.should.have.been.calledWithMatch({}, 0)
+      titles.at(0).simulate('click', event)
+      spy.should.have.been.calledWithMatch(event, 0)
 
-      titles.at(1).simulate('click')
-      spy.should.have.been.calledWithMatch({}, 1)
+      titles.at(1).simulate('click', event)
+      spy.should.have.been.calledWithMatch(event, 1)
     })
   })
 
@@ -207,6 +208,7 @@ describe('Accordion', () => {
 
       it('is called with (event, index) on AccordionTitle click', () => {
         const spy = sandbox.spy()
+        const event = { foo: 'bar' }
         const panels = [{
           onClick: spy,
           title: 'First panel',
@@ -215,15 +217,22 @@ describe('Accordion', () => {
           onClick: spy,
           title: 'Second panel',
           content: 'second panel content',
+        }, {
+          onClick: spy,
+          title: 'Third panel',
+          content: 'third panel content',
         }]
         const titles = mount(<Accordion panels={panels} />)
           .find('AccordionTitle')
 
-        titles.at(0).simulate('click')
-        spy.should.have.been.calledWithMatch({}, 0)
+        titles.at(0).simulate('click', event)
+        spy.should.have.been.calledWithMatch(event, 0)
 
-        titles.at(1).simulate('click')
-        spy.should.have.been.calledWithMatch({}, 1)
+        titles.at(1).simulate('click', event)
+        spy.should.have.been.calledWithMatch(event, 1)
+
+        titles.at(2).simulate('click', event)
+        spy.should.have.been.calledWithMatch(event, 2)
       })
     })
   })


### PR DESCRIPTION
RFC

fixes #773 

I fix wrong indexes but I find the code kinda ugly. It would be better if we don't need to copy index into local variable, but without it its buggy, i'm not sure why.

Another way: still use `child.index` but divide it by two like this
```
return Children.map(children, (child, i) => {
  const currentIndex = i / 2 
  // 0 / 2 = 0
  // 1 / 2 = 1
  // 2 / 2 = 1
  // 3 / 2 = 1
  // etc.
  ...
})
```
But its hard to read