### PR TITLE
fix(Input): use e.target.value in onChange data.value

### DIFF
--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -116,7 +116,7 @@ class Input extends Component {
     /** An Icon Input field can show that it is currently loading data */
     loading: PropTypes.bool,
 
-    /** Called with (e, props) on change. */
+    /** Called with (e, data) on change. */
     onChange: PropTypes.func,
 
     /** An Input can vary in size */
@@ -137,7 +137,12 @@ class Input extends Component {
 
   handleChange = (e) => {
     const { onChange } = this.props
-    if (onChange) onChange(e, this.props)
+    if (onChange) {
+      onChange(e, {
+        ...this.props,
+        value: _.get(e, 'target.value'),
+      })
+    }
   }
 
   render() {

--- a/test/specs/elements/Input/Input-test.js
+++ b/test/specs/elements/Input/Input-test.js
@@ -73,17 +73,17 @@ describe('Input', () => {
   })
 
   describe('onChange', () => {
-    it('is called with (event, props) on change', () => {
+    it('is called with (e, data) on change', () => {
       const spy = sandbox.spy()
-      const event = { fake: 'event' }
+      const e = { target: { value: 'name' } }
       const props = { 'data-foo': 'bar', onChange: spy }
 
       const wrapper = shallow(<Input {...props} />)
 
-      wrapper.find('input').simulate('change', event)
+      wrapper.find('input').simulate('change', e)
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(event, props)
+      spy.should.have.been.calledWithMatch(e, { ...props, value: e.target.value })
     })
   })
 })


### PR DESCRIPTION
#846 added `props` as the second callback param to Input `onChange`, however, the `value` in the second param should be usable in a controlled component pattern.  This means the `value` in the second parameter should be the event target value and not the prop value, otherwise, when used in a controlled component pattern, the value would never update.

This PR updates the `value` in the second param to an Input's `onChange` to reflect the event target value.