### PR TITLE
feat(Dropdown): Enable custom DropdownItem render

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleItemContent.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleItemContent.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Dropdown, Header } from 'semantic-ui-react'
+
+const options = [
+  { text: 'Mobile',
+    value: 1,
+    content: <Header icon='mobile' content='Mobile' subheader='The smallest size' /> },
+  { text: 'Tablet',
+    value: 2,
+    content: <Header icon='tablet' content='Tablet' subheader='The size in the middle' /> },
+  { text: 'Desktop',
+    value: 3,
+    content: <Header icon='desktop' content='Desktop' subheader='The largest size' /> },
+]
+
+const DropdownExampleItemContent = () => (
+  <Dropdown
+    selection
+    fluid
+    options={options}
+    placeholder='Choose an option'
+  />
+)
+
+export default DropdownExampleItemContent

--- a/docs/app/Examples/modules/Dropdown/Usage/index.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/index.js
@@ -44,6 +44,11 @@ const DropdownUsageExamples = () => (
       description='A "multiple" dropdown can render customized label for selected items.'
       examplePath='modules/Dropdown/Usage/DropdownExampleMultipleCustomLabel'
     />
+    <ComponentExample
+      title='Item Content'
+      description='A dropdown item can be rendered differently inside the menu.'
+      examplePath='modules/Dropdown/Usage/DropdownExampleItemContent'
+    />
 
   </ExampleSection>
 )

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -32,6 +32,9 @@ export default class DropdownItem extends Component {
     /** Additional classes. */
     className: PropTypes.string,
 
+    /** Shorthand for primary content. */
+    content: customPropTypes.contentShorthand,
+
     /** Additional text with less emphasis. */
     description: customPropTypes.itemShorthand,
 
@@ -86,6 +89,7 @@ export default class DropdownItem extends Component {
       active,
       children,
       className,
+      content,
       disabled,
       description,
       flag,
@@ -130,7 +134,7 @@ export default class DropdownItem extends Component {
           {flagElement}
           {labelElement}
           {descriptionElement}
-          {createShorthand('span', val => ({ className: 'text', children: val }), text)}
+          {createShorthand('span', val => ({ className: 'text', children: val }), content || text)}
         </ElementType>
       )
     }
@@ -141,7 +145,7 @@ export default class DropdownItem extends Component {
         {iconElement}
         {flagElement}
         {labelElement}
-        {text}
+        {content || text}
       </ElementType>
     )
   }

--- a/test/specs/modules/Dropdown/DropdownItem-test.js
+++ b/test/specs/modules/Dropdown/DropdownItem-test.js
@@ -48,6 +48,21 @@ describe('DropdownItem', () => {
     })
   })
 
+  describe('content', () => {
+    it('renders text if no content', () => {
+      const wrapper = shallow(<DropdownItem text='hey' />)
+
+      wrapper.text().should.include('hey')
+    })
+
+    it('renders content if present', () => {
+      const wrapper = shallow(<DropdownItem text='hey' content='you' />)
+
+      wrapper.text().should.not.include('hey')
+      wrapper.text().should.include('you')
+    })
+  })
+
   describe('onClick', () => {
     it('omitted when not defined', () => {
       const click = () => shallow(<DropdownItem />).simulate('click')
@@ -59,7 +74,7 @@ describe('DropdownItem', () => {
 
       const value = faker.hacker.phrase()
       const event = { target: null }
-      const props = { value, foo: 'bar' }
+      const props = { value, 'data-foo': 'bar' }
 
       shallow(<DropdownItem onClick={spy} {...props} />)
         .simulate('click', event)


### PR DESCRIPTION
Fixes #852

See the linked issue and also this comment for relevant discussion: https://github.com/Semantic-Org/Semantic-UI-React/pull/682#discussion_r84160476

In the SUI-core dropdown, you can pass both the `text` and `name` props for each option. 
- `text` - the text that gets rendered within the closed `Dropdown` when that option is selected
- `name` - the text that gets rendered for a given option within the dropdown menu.

If no `name` is provided, `text` is used for both. See the second example ("Trending Repos") for an example of the distinction: http://semantic-ui.com/modules/dropdown.html#inline. Notice how within the dropdown the options are title-cased whereas when you select an option it is rendered lowercased:
<img width="306" alt="screen shot 2016-11-14 at 2 21 20 pm" src="https://cloud.githubusercontent.com/assets/847027/20279213/a33f58e4-aa75-11e6-9f34-70022bada482.png">

This PR implements what essentially is the `name` prop, although I named it `content` to fit into the pattern established throughout the rest of the repo. It's shorthand that takes the place of `children` and is rendered alongside the other shorthand props (icon, flag, etc) if given.

This isn't a breaking change since the `text` prop is used if the `content` prop is missing.