### PR TITLE
perf(getUnhandledProps): replace lodash with vanilla js

### DIFF
--- a/src/lib/getUnhandledProps.js
+++ b/src/lib/getUnhandledProps.js
@@ -1,4 +1,16 @@
-import _ from 'lodash'
+const handledPropsCache = {}
+
+/**
+ * Push all `source` array elements to the `target` array if they don't already exist in `target`.
+ *
+ * @param {Array} source - An array of elements to add to the `target`
+ * @param {Array} target - An array to receive unique elements from the `source`
+ * @returns {Array} Mutated `target` array
+ */
+const pushUnique = (source, target) => source.forEach(x => {
+  if (target.indexOf(x) === -1) target.push(x)
+})
+
 /**
  * Returns an object consisting of props beyond the scope of the Component.
  * Useful for getting and spreading unknown props from the user.
@@ -7,13 +19,27 @@ import _ from 'lodash'
  * @returns {{}} A shallow copy of the prop object
  */
 const getUnhandledProps = (Component, props) => {
-  const handledProps = _.union(
-    Component.autoControlledProps,
-    _.keys(Component.defaultProps),
-    _.keys(Component.propTypes),
-  )
+  const { _meta: { name }, autoControlledProps, defaultProps, propTypes } = Component
 
-  return _.omit(props, handledProps)
+  let handledProps = handledPropsCache[name]
+
+  // ----------------------------------------
+  // Calculate handledProps once and cache
+  // ----------------------------------------
+  if (!handledProps) {
+    handledProps = []
+
+    if (autoControlledProps) pushUnique(autoControlledProps, handledProps)
+    if (defaultProps) pushUnique(Object.keys(defaultProps), handledProps)
+    if (propTypes) pushUnique(Object.keys(propTypes), handledProps)
+
+    handledPropsCache[name] = handledProps
+  }
+
+  return Object.keys(props).reduce((acc, prop) => {
+    if (handledProps.indexOf(prop) === -1) acc[prop] = props[prop]
+    return acc
+  }, {})
 }
 
 export default getUnhandledProps

--- a/test/specs/lib/getUnhandledProps-test.js
+++ b/test/specs/lib/getUnhandledProps-test.js
@@ -8,6 +8,7 @@ import { getUnhandledProps } from 'src/lib'
 function TestComponent(props) {
   return <div {...getUnhandledProps(TestComponent, props)} />
 }
+TestComponent._meta = { name: 'TestComponent' }
 
 beforeEach(() => {
   delete TestComponent.propTypes


### PR DESCRIPTION
Fixes #859 

**TL;DR** Conclusion at the bottom.

As with the linked issue, I've also noticed some severe performance issues, mostly in Grid and Grid column.  It appears there is a memory leak somewhere in getUnhandledProps due to lodash.

Calculating unhandled props can be expensive due to the several nested object references it has to traverse to first calculate the _handled_ props: `autoControlledProps`, `defaultProps` keys, `props` keys.  It then needs to loop the props again to omit all those keys.  This can be done several times per render, per element.  This alone should not be responsible for the results we're seeing below, however.

This PR replaces lodash with vanilla JS, **resulting in >12,000 times performance improvement** .

It also caches _handledProps_ so they are only calculated once per component (handled props never change).  This will be fixed permanently once #731 is merged as we'll have a static array of handled props baked into every component.

# Rough Perf Analysis

## No cache, lodash (baseline)

After lots of testing, I notice that the Grid and Grid column render times seem increase every render for the particular view I am testing against.  Note the instance count and render count remains constant, but the time required is growing rapidly.

### First Render - `1s`

![image](https://cloud.githubusercontent.com/assets/5067638/20317341/7e30acce-ab1a-11e6-900c-ff765bb7b1aa.png)

### Second Render - `3s`

![image](https://cloud.githubusercontent.com/assets/5067638/20317350/88d1bdd0-ab1a-11e6-897a-63f2f9363d9c.png)

### Third Render - `27s`

![image](https://cloud.githubusercontent.com/assets/5067638/20317360/951ce880-ab1a-11e6-90b4-65898ed7fb38.png)

## With cache, lodash

### First Render - `1.5s`

![image](https://cloud.githubusercontent.com/assets/5067638/20318995/658ba398-ab21-11e6-99c0-719f442393d8.png)

### Second Render - `21s`

![image](https://cloud.githubusercontent.com/assets/5067638/20319045/8b612a48-ab21-11e6-8a1c-ffae18f690d5.png)

### Third Render - `1.3s`

![image](https://cloud.githubusercontent.com/assets/5067638/20319075/a7fac402-ab21-11e6-8a8d-6f402796e813.png)

### Additional tests...

I found the `21s` odd here, so I ran renders 4 and 5 with results of `3.6s` and `2.8s`.  This seems odd.

## No cache, vanilla JS

**All three runs completed in <=2ms (approx.)** 😮.  This certainly means, lodash is at fault here.

![image](https://cloud.githubusercontent.com/assets/5067638/20319622/bd3c2020-ab23-11e6-9b7c-565db2eaba2e.png)

## Cache and vanilla JS

Using vanilla JS is obviously sufficient, however, I tested vanilla with cache for completeness.  The results were not significantly different from vanilla JS without cache.

# Conclusion

Something in lodash is _extremely_ non-performant given the usage in our `getUnhandledProps()` lib method.  Using vanilla JS increases performance by up to >12,000 times.  Caching makes no difference and is not necessary.