### PR TITLE
test(lint): Added eslint-plugin-jsx-a11y plugin in warning mode

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,9 @@
 {
+  "plugins": [
+    "jsx-a11y"
+  ],
   "extends": [
+    "plugin:jsx-a11y/recommended",
     "ta",
     "ta/frontend"
   ],
@@ -10,6 +14,12 @@
     "react/sort-comp": 0,
     "valid-jsdoc": 0,
     "react/jsx-curly-spacing": 0,
+    "jsx-a11y/click-events-have-key-events": 1,
+    "jsx-a11y/href-no-hash": 1,
+    "jsx-a11y/img-has-alt": 1,
+    "jsx-a11y/label-has-for": 1,
+    "jsx-a11y/onclick-has-focus": 1,
+    "jsx-a11y/onclick-has-role": 1,
     "padded-blocks": [2, {
       "blocks": "never",
       "switches": "never",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "empty": "^0.10.1",
     "enzyme": "^2.6.0",
     "eslint-config-ta": "^5.2.0",
+    "eslint-plugin-jsx-a11y": "^3.0.1",
     "express": "^4.13.4",
     "faker": "^3.0.1",
     "file-loader": "^0.9.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -7,6 +7,29 @@
     "mount": false
   },
   "rules": {
+    "jsx-a11y/anchor-has-content": 0,
+    "jsx-a11y/aria-props": 0,
+    "jsx-a11y/aria-proptypes": 0,
+    "jsx-a11y/aria-role": 0,
+    "jsx-a11y/aria-unsupported-elements": 0,
+    "jsx-a11y/click-events-have-key-events": 0,
+    "jsx-a11y/heading-has-content": 0,
+    "jsx-a11y/href-no-hash": 0,
+    "jsx-a11y/html-has-lang": 0,
+    "jsx-a11y/img-has-alt": 0,
+    "jsx-a11y/img-redundant-alt": 0,
+    "jsx-a11y/label-has-for": 0,
+    "jsx-a11y/mouse-events-have-key-events": 0,
+    "jsx-a11y/no-access-key": 0,
+    "jsx-a11y/no-marquee": 0,
+    "jsx-a11y/no-onchange": 0,
+    "jsx-a11y/no-static-element-interactions": 0,
+    "jsx-a11y/onclick-has-focus": 0,
+    "jsx-a11y/onclick-has-role": 0,
+    "jsx-a11y/role-has-required-aria-props": 0,
+    "jsx-a11y/role-supports-aria-props": 0,
+    "jsx-a11y/scope": 0,
+    "jsx-a11y/tabindex-no-positive": 0,
     "react/jsx-curly-spacing": 0
   }
 }


### PR DESCRIPTION
Based on feedback to #885 this adds the eslint-plugin-jsx-a11y in warning mode to showcase where it thinks we're failing. 

Currently have 93 warnings.