### PR TITLE
feat(Rating): Rating now keyboard navigable and visually impaired accessible

### DIFF
--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -143,12 +143,15 @@ export default class Rating extends Component {
     const ElementType = getElementType(Rating, this.props)
 
     return (
-      <ElementType {...rest} className={classes} onMouseLeave={this.handleMouseLeave}>
+      <ElementType {...rest} className={classes} role='radiogroup' onMouseLeave={this.handleMouseLeave}>
         {_.times(maxRating, (i) => (
           <RatingIcon
             active={rating >= i + 1}
             index={i}
             key={i}
+            aria-checked={rating === i + 1}
+            aria-posinset={i + 1}
+            aria-setsize={maxRating}
             onClick={this.handleIconClick}
             onMouseEnter={this.handleIconMouseEnter}
             selected={selectedIndex >= i && isSelecting }

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -41,7 +41,7 @@ export default class RatingIcon extends Component {
     if (onClick) onClick(e, index)
   }
 
-  handleKeyPress = (e) => {
+  handleKeyUp = (e) => {
     const { onClick, index } = this.props
 
     if (onClick) {
@@ -76,7 +76,7 @@ export default class RatingIcon extends Component {
       <i role='radio' tabIndex={0}
         {...rest}
         className={classes}
-        onKeyPress={this.handleKeyPress}
+        onKeyUp={this.handleKeyUp}
         onClick={this.handleClick}
         onMouseEnter={this.handleMouseEnter}
       />

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -1,9 +1,11 @@
+import _ from 'lodash'
 import cx from 'classnames'
 import React, { Component, PropTypes } from 'react'
 
 import {
   META,
   useKeyOnly,
+  keyboardKey,
 } from '../../lib'
 
 /**
@@ -39,6 +41,22 @@ export default class RatingIcon extends Component {
     if (onClick) onClick(e, index)
   }
 
+  handleKeyPress = (e) => {
+    const { onClick, index } = this.props
+
+    if (onClick) {
+      switch (keyboardKey.getCode(e)) {
+        case keyboardKey.Enter:
+        case keyboardKey.Spacebar:
+          e.preventDefault()
+          onClick(e, index)
+          break
+        default:
+          return
+      }
+    }
+  }
+
   handleMouseEnter = () => {
     const { onMouseEnter, index } = this.props
 
@@ -52,7 +70,16 @@ export default class RatingIcon extends Component {
       useKeyOnly(selected, 'selected'),
       'icon'
     )
+    const rest = _.omit(this.props, _.keys(RatingIcon.propTypes))
 
-    return <i className={classes} onClick={this.handleClick} onMouseEnter={this.handleMouseEnter} />
+    return (
+      <i role='radio' tabIndex={0}
+        {...rest}
+        className={classes}
+        onKeyPress={this.handleKeyPress}
+        onClick={this.handleClick}
+        onMouseEnter={this.handleMouseEnter}
+      />
+    )
   }
 }

--- a/test/specs/modules/Rating/Rating-test.js
+++ b/test/specs/modules/Rating/Rating-test.js
@@ -26,6 +26,48 @@ describe('Rating', () => {
       icons.at(2).should.have.prop('active', false)
     })
 
+    it('if no rating selected no icon should have aria-checked', () => {
+      const wrapper = mount(<Rating maxRating={3} />)
+      const icons = wrapper.find('RatingIcon')
+
+      icons.at(0).should.have.prop('aria-checked', false)
+      icons.at(1).should.have.prop('aria-checked', false)
+      icons.at(2).should.have.prop('aria-checked', false)
+    })
+
+    it('makes the clicked icon aria-checked', () => {
+      const wrapper = mount(<Rating maxRating={3} />)
+      const icons = wrapper.find('RatingIcon')
+
+      icons.at(1).simulate('click')
+
+      icons.at(0).should.have.prop('aria-checked', false)
+      icons.at(1).should.have.prop('aria-checked', true)
+      icons.at(2).should.have.prop('aria-checked', false)
+    })
+
+    it('set aria-setsize on each rating icon', () => {
+      const wrapper = mount(<Rating maxRating={3} />)
+      const icons = wrapper.find('RatingIcon')
+
+      icons.at(1).simulate('click')
+
+      icons.at(0).should.have.prop('aria-setsize', 3)
+      icons.at(1).should.have.prop('aria-setsize', 3)
+      icons.at(2).should.have.prop('aria-setsize', 3)
+    })
+
+    it('sets aria-posinset on each rating icon', () => {
+      const wrapper = mount(<Rating maxRating={3} />)
+      const icons = wrapper.find('RatingIcon')
+
+      icons.at(1).simulate('click')
+
+      icons.at(0).should.have.prop('aria-posinset', 1)
+      icons.at(1).should.have.prop('aria-posinset', 2)
+      icons.at(2).should.have.prop('aria-posinset', 3)
+    })
+
     it('removes the "selected" prop', () => {
       const wrapper = mount(<Rating maxRating={3} />)
       const icons = wrapper.find('RatingIcon')

--- a/test/specs/modules/Rating/RatingIcon-test.js
+++ b/test/specs/modules/Rating/RatingIcon-test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import * as common from 'test/specs/commonTests'
 import { sandbox } from 'test/utils'
 import RatingIcon from 'src/modules/Rating/RatingIcon'
+import { keyboardKey } from 'src/lib'
 
 describe('RatingIcon', () => {
   common.propKeyOnlyToClassName(RatingIcon, 'active')
@@ -23,6 +24,51 @@ describe('RatingIcon', () => {
 
       spy.should.have.been.calledOnce()
       spy.should.have.been.calledWithMatch(event, 0)
+    })
+  })
+
+  describe('onKeyPress', () => {
+    it('omitted when not defined', () => {
+      const event = { keyCode: keyboardKey.Enter, preventDefault: sandbox.spy() }
+      const keypress = () => shallow(<RatingIcon />).simulate('keypress', event)
+
+      expect(keypress).to.not.throw()
+      event.preventDefault.should.not.have.been.called()
+    })
+
+    it('is called with (e, index) when space key is pressed', () => {
+      const spy = sandbox.spy()
+      const event = { keyCode: keyboardKey.Spacebar, preventDefault: sandbox.spy() }
+
+      mount(<RatingIcon index={0} onClick={spy} />)
+        .simulate('keypress', event)
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(event, 0)
+      event.preventDefault.should.have.been.calledOnce()
+    })
+
+    it('is called with (e, index) when enter key is pressed', () => {
+      const spy = sandbox.spy()
+      const event = { keyCode: keyboardKey.Enter, preventDefault: sandbox.spy() }
+
+      mount(<RatingIcon index={0} onClick={spy} />)
+        .simulate('keypress', event)
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(event, 0)
+      event.preventDefault.should.have.been.calledOnce()
+    })
+
+    it('omitted when non space/enter key is pressed', () => {
+      const spy = sandbox.spy()
+      const event = { keyCode: keyboardKey.A, preventDefault: sandbox.spy() }
+
+      const keypress = () => shallow(<RatingIcon onClick={spy} />).simulate('keypress', event)
+
+      expect(keypress).to.not.throw()
+      spy.should.not.have.been.called()
+      event.preventDefault.should.not.have.been.called()
     })
   })
 

--- a/test/specs/modules/Rating/RatingIcon-test.js
+++ b/test/specs/modules/Rating/RatingIcon-test.js
@@ -27,10 +27,10 @@ describe('RatingIcon', () => {
     })
   })
 
-  describe('onKeyPress', () => {
+  describe('onKeyUp', () => {
     it('omitted when not defined', () => {
       const event = { keyCode: keyboardKey.Enter, preventDefault: sandbox.spy() }
-      const keypress = () => shallow(<RatingIcon />).simulate('keypress', event)
+      const keypress = () => shallow(<RatingIcon />).simulate('keyup', event)
 
       expect(keypress).to.not.throw()
       event.preventDefault.should.not.have.been.called()
@@ -41,7 +41,7 @@ describe('RatingIcon', () => {
       const event = { keyCode: keyboardKey.Spacebar, preventDefault: sandbox.spy() }
 
       mount(<RatingIcon index={0} onClick={spy} />)
-        .simulate('keypress', event)
+        .simulate('keyup', event)
 
       spy.should.have.been.calledOnce()
       spy.should.have.been.calledWithMatch(event, 0)
@@ -53,7 +53,7 @@ describe('RatingIcon', () => {
       const event = { keyCode: keyboardKey.Enter, preventDefault: sandbox.spy() }
 
       mount(<RatingIcon index={0} onClick={spy} />)
-        .simulate('keypress', event)
+        .simulate('keyup', event)
 
       spy.should.have.been.calledOnce()
       spy.should.have.been.calledWithMatch(event, 0)
@@ -64,9 +64,9 @@ describe('RatingIcon', () => {
       const spy = sandbox.spy()
       const event = { keyCode: keyboardKey.A, preventDefault: sandbox.spy() }
 
-      const keypress = () => shallow(<RatingIcon onClick={spy} />).simulate('keypress', event)
+      const keyup = () => shallow(<RatingIcon onClick={spy} />).simulate('keyup', event)
 
-      expect(keypress).to.not.throw()
+      expect(keyup).to.not.throw()
       spy.should.not.have.been.called()
       event.preventDefault.should.not.have.been.called()
     })


### PR DESCRIPTION
Related to #885 

Accessibility issues addressed:
* Module is now keyboard accessible by adding tabIndex and keyPress handlers for space and enter activation
* added role=radio/radiogroup, aria-checked, aria-posinset, aria-setsize to properly indicate to visually impaired users the kind of module and what values they're selecting

W3C Documentation:
https://www.w3.org/TR/wai-aria-1.1/#radiogroup
https://www.w3.org/TR/wai-aria-1.1/#radio
