### PR TITLE
feat(Portal|Modal|Confirm): Better uncontrolled usage support

### DIFF
--- a/docs/app/Examples/addons/Confirm/Types/ConfirmExampleCallbacks.js
+++ b/docs/app/Examples/addons/Confirm/Types/ConfirmExampleCallbacks.js
@@ -2,22 +2,20 @@ import React, { Component } from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
 class ConfirmExampleCallbacks extends Component {
-  state = { open: false, result: 'show the modal to capture a result' }
+  state = { result: 'show the modal to capture a result' }
 
-  show = () => this.setState({ open: true })
-  handleConfirm = () => this.setState({ result: 'confirmed', open: false })
-  handleCancel = () => this.setState({ result: 'cancelled', open: false })
+  handleConfirm = () => this.setState({ result: 'confirmed' })
+  handleCancel = () => this.setState({ result: 'cancelled' })
 
   render() {
-    const { open, result } = this.state
+    const { result } = this.state
 
     return (
       <div>
         <p>Result: <em>{result}</em></p>
 
-        <Button onClick={this.show}>Show</Button>
         <Confirm
-          open={open}
+          trigger={<Button>Show</Button>}
           onCancel={this.handleCancel}
           onConfirm={this.handleConfirm}
         />

--- a/docs/app/Examples/addons/Confirm/Types/ConfirmExampleConfirm.js
+++ b/docs/app/Examples/addons/Confirm/Types/ConfirmExampleConfirm.js
@@ -1,25 +1,8 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
-class ConfirmExampleConfirm extends Component {
-  state = { open: false }
-
-  show = () => this.setState({ open: true })
-  handleConfirm = () => this.setState({ open: false })
-  handleCancel = () => this.setState({ open: false })
-
-  render() {
-    return (
-      <div>
-        <Button onClick={this.show}>Show</Button>
-        <Confirm
-          open={this.state.open}
-          onCancel={this.handleCancel}
-          onConfirm={this.handleConfirm}
-        />
-      </div>
-    )
-  }
-}
+const ConfirmExampleConfirm = () => (
+  <Confirm trigger={<Button>Show</Button>} />
+)
 
 export default ConfirmExampleConfirm

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleButtons.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleButtons.js
@@ -1,27 +1,12 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
-class ConfirmExampleHeader extends Component {
-  state = { open: false }
+const ConfirmExampleButtons = () => (
+  <Confirm
+    trigger={<Button>Show</Button>}
+    cancelButton='Never mind'
+    confirmButton="Let's do it"
+  />
+)
 
-  show = () => this.setState({ open: true })
-  handleConfirm = () => this.setState({ open: false })
-  handleCancel = () => this.setState({ open: false })
-
-  render() {
-    return (
-      <div>
-        <Button onClick={this.show}>Show</Button>
-        <Confirm
-          open={this.state.open}
-          cancelButton='Never mind'
-          confirmButton="Let's do it"
-          onCancel={this.handleCancel}
-          onConfirm={this.handleConfirm}
-        />
-      </div>
-    )
-  }
-}
-
-export default ConfirmExampleHeader
+export default ConfirmExampleButtons

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleContent.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleContent.js
@@ -1,26 +1,11 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
-class ConfirmExampleContent extends Component {
-  state = { open: false }
-
-  show = () => this.setState({ open: true })
-  handleConfirm = () => this.setState({ open: false })
-  handleCancel = () => this.setState({ open: false })
-
-  render() {
-    return (
-      <div>
-        <Button onClick={this.show}>Show</Button>
-        <Confirm
-          open={this.state.open}
-          content='This is a custom message'
-          onCancel={this.handleCancel}
-          onConfirm={this.handleConfirm}
-        />
-      </div>
-    )
-  }
-}
+const ConfirmExampleContent = () => (
+  <Confirm
+    trigger={<Button>Show</Button>}
+    content='This is a custom message'
+  />
+)
 
 export default ConfirmExampleContent

--- a/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleHeader.js
+++ b/docs/app/Examples/addons/Confirm/Variations/ConfirmExampleHeader.js
@@ -1,26 +1,11 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Button, Confirm } from 'semantic-ui-react'
 
-class ConfirmExampleHeader extends Component {
-  state = { open: false }
-
-  show = () => this.setState({ open: true })
-  handleConfirm = () => this.setState({ open: false })
-  handleCancel = () => this.setState({ open: false })
-
-  render() {
-    return (
-      <div>
-        <Button onClick={this.show}>Show</Button>
-        <Confirm
-          open={this.state.open}
-          header='This is a custom header'
-          onCancel={this.handleCancel}
-          onConfirm={this.handleConfirm}
-        />
-      </div>
-    )
-  }
-}
+const ConfirmExampleHeader = () => (
+  <Confirm
+    trigger={<Button>Show</Button>}
+    header='This is a custom header'
+  />
+)
 
 export default ConfirmExampleHeader

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -86,7 +86,7 @@ class Confirm extends Component {
     const rest = getUnhandledProps(Confirm, this.props)
 
     return (
-      <Modal open={open} size='small' onOpen={this.handleOpen} onClose={this.handleClose} closeOnCloseClick {...rest}>
+      <Modal open={open} size='small' onOpen={this.handleOpen} onClose={this.handleClose} {...rest}>
         {header && <Modal.Header>{header}</Modal.Header>}
         {content && <Modal.Content>{content}</Modal.Content>}
         <Modal.Actions>

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -1,68 +1,101 @@
-import _ from 'lodash'
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 
 import { getUnhandledProps, META } from '../../lib'
 import Button from '../../elements/Button'
 import Modal from '../../modules/Modal'
 
-/**
- * A Confirm modal gives the user a choice to confirm or cancel an action
- * @see Modal
- */
-function Confirm(props) {
-  const { open, cancelButton, confirmButton, header, content, onConfirm, onCancel } = props
-  const rest = getUnhandledProps(Confirm, props)
-
-  // `open` is auto controlled by the Modal
-  // It cannot be present (even undefined) with `defaultOpen`
-  // only apply it if the user provided an open prop
-  const openProp = {}
-  if (_.has(props, 'open')) openProp.open = open
-
-  return (
-    <Modal {...openProp} size='small' onClose={onCancel} {...rest}>
-      {header && <Modal.Header>{header}</Modal.Header>}
-      {content && <Modal.Content>{content}</Modal.Content>}
-      <Modal.Actions>
-        <Button onClick={onCancel}>{cancelButton}</Button>
-        <Button primary onClick={onConfirm}>{confirmButton}</Button>
-      </Modal.Actions>
-    </Modal>
-  )
-}
-
-Confirm._meta = {
+const _meta = {
   name: 'Confirm',
   type: META.TYPES.ADDON,
 }
 
-Confirm.propTypes = {
-  /** Whether or not the modal is visible */
-  open: PropTypes.bool,
+/**
+ * A Confirm modal gives the user a choice to confirm or cancel an action
+ * @see Modal
+ */
+class Confirm extends Component {
+  static propTypes = {
+    /** Whether or not the modal is visible */
+    open: PropTypes.bool,
 
-  /** The cancel button text */
-  cancelButton: PropTypes.string,
+    /** The cancel button text */
+    cancelButton: PropTypes.string,
 
-  /** The OK button text */
-  confirmButton: PropTypes.string,
+    /** The OK button text */
+    confirmButton: PropTypes.string,
 
-  /** The ModalHeader text */
-  header: PropTypes.string,
+    /** The ModalHeader text */
+    header: PropTypes.string,
 
-  /** The ModalContent text. */
-  content: PropTypes.string,
+    /** The ModalContent text. */
+    content: PropTypes.string,
 
-  /** Called when the OK button is clicked */
-  onConfirm: PropTypes.func,
+    /** Called when the Cancel button is clicked */
+    onCancel: PropTypes.func,
 
-  /** Called when the Cancel button is clicked */
-  onCancel: PropTypes.func,
-}
+    /** Called when a close event happens */
+    onClose: PropTypes.func,
 
-Confirm.defaultProps = {
-  cancelButton: 'Cancel',
-  confirmButton: 'OK',
-  content: 'Are you sure?',
+    /** Called when the OK button is clicked */
+    onConfirm: PropTypes.func,
+
+    /** Called when an open event happens */
+    onOpen: PropTypes.func,
+  }
+
+  static _meta = _meta
+
+  static defaultProps = {
+    cancelButton: 'Cancel',
+    confirmButton: 'OK',
+    content: 'Are you sure?',
+  }
+
+  handleCancel = (e) => {
+    this.clicked = true
+
+    const { onCancel } = this.props
+    if (onCancel) onCancel(e, this.props)
+  }
+
+  handleOpen = (e) => {
+    this.clicked = undefined
+
+    const { onOpen } = this.props
+    if (onOpen) onOpen(e, this.props)
+  }
+
+  handleClose = (e) => {
+    const { onCancel, onClose } = this.props
+    if (onClose) onClose(e, this.props)
+
+    // Only call onCancel if this was closed was some other way besides an
+    // explicit click of confirm/cancel (e.g. a click-away).
+    if (!this.clicked && onCancel) onCancel(e, this.props)
+  }
+
+  handleConfirm = (e) => {
+    this.clicked = true
+
+    const { onConfirm } = this.props
+    if (onConfirm) onConfirm(e, this.props)
+  }
+
+  render() {
+    const { open, cancelButton, confirmButton, header, content } = this.props
+    const rest = getUnhandledProps(Confirm, this.props)
+
+    return (
+      <Modal open={open} size='small' onOpen={this.handleOpen} onClose={this.handleClose} closeOnCloseClick {...rest}>
+        {header && <Modal.Header>{header}</Modal.Header>}
+        {content && <Modal.Content>{content}</Modal.Content>}
+        <Modal.Actions>
+          <Button data-close onClick={this.handleCancel}>{cancelButton}</Button>
+          <Button data-close primary onClick={this.handleConfirm}>{confirmButton}</Button>
+        </Modal.Actions>
+      </Modal>
+    )
+  }
 }
 
 export default Confirm

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -30,16 +30,36 @@ class Confirm extends Component {
     /** The ModalContent text. */
     content: PropTypes.string,
 
-    /** Called when the Cancel button is clicked */
+    /**
+     * Called when the cancel button is clicked.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onCancel: PropTypes.func,
 
-    /** Called when a close event happens */
+    /**
+     * Called when a close event happens.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClose: PropTypes.func,
 
-    /** Called when the OK button is clicked */
+    /**
+     * Called when the confirm button is clicked.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onConfirm: PropTypes.func,
 
-    /** Called when an open event happens */
+    /**
+     * Called when an open event happens.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onOpen: PropTypes.func,
   }
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom'
 import {
   AutoControlledComponent as Component,
   customPropTypes,
+  domUtils,
   keyboardKey,
   isBrowser,
   makeDebugger,
@@ -197,7 +198,7 @@ class Portal extends Component {
 
   handlePortalClick = (e) => {
     if (!this.props.closeOnCloseClick) return
-    if (!e.target || !e.target.hasAttribute('data-close')) return
+    if (!domUtils.closest(e.target, '[data-close]')) return
 
     debug('handlePortalClick()')
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -42,7 +42,10 @@ class Portal extends Component {
       PropTypes.bool,
     ]),
 
-    /** Controls whether or not the portal should close on click of the trigger. */
+    /**
+     * Controls whether or not the portal should close on click of an element
+     * with the [data-close] attribute.
+     */
     closeOnCloseClick: PropTypes.bool,
 
     /** Controls whether or not the portal should close on a click outside. */
@@ -116,6 +119,7 @@ class Portal extends Component {
   static defaultProps = {
     closeOnDocumentClick: true,
     closeOnEscape: true,
+    closeOnCloseClick: true,
     openOnTriggerClick: true,
     mountNode: isBrowser ? document.body : null,
   }

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -41,6 +41,9 @@ class Portal extends Component {
       PropTypes.bool,
     ]),
 
+    /** Controls whether or not the portal should close on click of the trigger. */
+    closeOnCloseClick: PropTypes.bool,
+
     /** Controls whether or not the portal should close on a click outside. */
     closeOnDocumentClick: customPropTypes.every([
       customPropTypes.disallow(['closeOnRootNodeClick']),
@@ -157,8 +160,18 @@ class Portal extends Component {
   handleDocumentClick = (e) => {
     const { closeOnDocumentClick, closeOnRootNodeClick } = this.props
 
-    // If not mounted, no portal, or event happened in the portal, ignore it
-    if (!this.node || !this.portal || this.portal.contains(e.target)) return
+    // If not mounted or no portal, ignore it
+    if (!this.node || !this.portal) return
+
+    // If event happened in the portal, ignore it
+    if (this.portal.contains(e.target)) {
+      // NOTE: Ideally we could attach `handlePortalClick` directly to
+      // this.portal. However, if it were to close the modal then the click
+      // event would never be fired on the target. Calling it here ensures
+      // the target receives the click event.
+      this.handlePortalClick(e)
+      return
+    }
 
     if (closeOnDocumentClick || (closeOnRootNodeClick && this.node.contains(e.target))) {
       debug('handleDocumentClick()')
@@ -181,6 +194,15 @@ class Portal extends Component {
   // ----------------------------------------
   // Component Event Handlers
   // ----------------------------------------
+
+  handlePortalClick = (e) => {
+    if (!this.props.closeOnCloseClick) return
+    if (!e.target || !e.target.hasAttribute('data-close')) return
+
+    debug('handlePortalClick()')
+
+    this.close(e)
+  }
 
   handlePortalMouseLeave = (e) => {
     const { closeOnPortalMouseLeave, mouseLeaveDelay } = this.props

--- a/src/lib/domUtils.js
+++ b/src/lib/domUtils.js
@@ -1,0 +1,36 @@
+/* eslint-disable */
+// Polyfill taken from:
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
+if (!Element.prototype.matches) {
+  Element.prototype.matches =
+    Element.prototype.matchesSelector ||
+    Element.prototype.mozMatchesSelector ||
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.oMatchesSelector ||
+    Element.prototype.webkitMatchesSelector ||
+    function(s) {
+      var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+          i = matches.length;
+      while (--i >= 0 && matches.item(i) !== this) {}
+      return i > -1;
+    };
+}
+/* eslint-enable */
+
+/**
+ * NOTE:
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element/closest doesn't
+ * have wide browser support so this is an implementation in vanilla js.
+ *
+ * Returns the closest ancestor of the current element (or the current element
+ * itself) which matches the selectors given in parameter.
+ *
+ * @param {Node} children The children prop of a component.
+ * @param {string} type An html tag name string or React component.
+ * @returns {Node|undefined}
+ */
+export const closest = (node, selector) => {
+  while (node && !node.matches(selector)) node = node.parentElement
+
+  return node
+}

--- a/src/lib/domUtils.js
+++ b/src/lib/domUtils.js
@@ -1,7 +1,9 @@
+import isBrowser from './isBrowser'
+
 /* eslint-disable */
 // Polyfill taken from:
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
-if (!Element.prototype.matches) {
+if (isBrowser && !Element.prototype.matches) {
   Element.prototype.matches =
     Element.prototype.matchesSelector ||
     Element.prototype.mozMatchesSelector ||

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,5 +1,6 @@
 export { default as AutoControlledComponent } from './AutoControlledComponent'
 export * as childrenUtils from './childrenUtils'
+export * as domUtils from './domUtils'
 
 export {
   useKeyOnly,

--- a/test/specs/addons/Confirm-test.js
+++ b/test/specs/addons/Confirm-test.js
@@ -17,6 +17,8 @@ let wrapper
 const wrapperMount = (...args) => (wrapper = mount(...args))
 const wrapperShallow = (...args) => (wrapper = shallow(...args))
 
+const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }
+
 describe('Confirm', () => {
   beforeEach(() => {
     wrapper = undefined
@@ -96,6 +98,17 @@ describe('Confirm', () => {
         .find('ModalContent')
         .shallow()
         .should.have.text('foo')
+    })
+  })
+
+  describe('opOpen', () => {
+    it('is called whtn the trigger is clicked', () => {
+      const spy = sandbox.spy()
+      wrapperMount(<Confirm trigger={<button />} onOpen={spy} />)
+        .find('button')
+        .simulate('click', nativeEvent)
+
+      spy.should.have.been.calledOnce()
     })
   })
 

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -272,10 +272,21 @@ describe('Portal', () => {
   })
 
   describe('closeOnCloseClick', () => {
-    it('should not close portal on click', () => {
+    it('should close portal on click by default', () => {
       const spy = sandbox.spy()
       const closeButton = <button onClick={spy} data-close>button</button>
       wrapperMount(<Portal defaultOpen>{closeButton}</Portal>)
+
+      domEvent.click('[data-close]')
+
+      document.body.childElementCount.should.equal(0)
+      spy.should.have.been.calledOnce()
+    })
+
+    it('should not close portal on click when false', () => {
+      const spy = sandbox.spy()
+      const closeButton = <button onClick={spy} data-close>button</button>
+      wrapperMount(<Portal defaultOpen closeOnCloseClick={false}>{closeButton}</Portal>)
 
       domEvent.click('[data-close]')
 

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -293,6 +293,17 @@ describe('Portal', () => {
       document.body.childElementCount.should.equal(0)
       spy.should.have.been.calledOnce()
     })
+
+    it('should close portal on click of child when set', () => {
+      const spy = sandbox.spy()
+      const closeButton = <button onClick={spy} data-close><i className='icon bullseye' /></button>
+      wrapperMount(<Portal defaultOpen closeOnCloseClick>{closeButton}</Portal>)
+
+      domEvent.click('.icon.bullseye')
+
+      document.body.childElementCount.should.equal(0)
+      spy.should.have.been.calledOnce()
+    })
   })
 
   describe('openOnTriggerMouseOver', () => {

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -271,6 +271,30 @@ describe('Portal', () => {
     })
   })
 
+  describe('closeOnCloseClick', () => {
+    it('should not close portal on click', () => {
+      const spy = sandbox.spy()
+      const closeButton = <button onClick={spy} data-close>button</button>
+      wrapperMount(<Portal defaultOpen>{closeButton}</Portal>)
+
+      domEvent.click('[data-close]')
+
+      document.body.lastElementChild.should.equal(wrapper.instance().node)
+      spy.should.have.been.calledOnce()
+    })
+
+    it('should close portal on click when set', () => {
+      const spy = sandbox.spy()
+      const closeButton = <button onClick={spy} data-close>button</button>
+      wrapperMount(<Portal defaultOpen closeOnCloseClick>{closeButton}</Portal>)
+
+      domEvent.click('[data-close]')
+
+      document.body.childElementCount.should.equal(0)
+      spy.should.have.been.calledOnce()
+    })
+  })
+
   describe('openOnTriggerMouseOver', () => {
     it('should not open portal on mouseover when not set', (done) => {
       const spy = sandbox.spy()


### PR DESCRIPTION
Fixes #891

A few updates that I think will have a big impact in terms of usability of these components:
- Adds a `closeOnCloseClick` to `Portal` which makes it so that if an element with the `data-close` attribute within the portal is clicked, it will close the portal.
- Update the `Confirm` component so clicking confirm/cancel will close the modal (makes use of `closeOnCloseClick`). This enables uncontrolled usage and I've updated all of the `Confirm` examples to make use of that where possible.
- Adds a `closeIcon` prop to `Modal` which renders an icon in the modal which, onClick, will trigger the modal to close (makes use of `closeOnCloseClick`). NOTE: With the default SUI styling, the icon appears outside of the modal. This is not an error on our side - the placement of the icon matches the [SUI-core example](http://semantic-ui.com/modules/modal.html#/usage) and there are SUI CSS rules for `.ui.modal > .close` which intentionally put it out there. This seemed weird to me so I just wanted to call attention to it not being a bug:
<img width="780" alt="screen shot 2016-11-18 at 12 32 14 am" src="https://cloud.githubusercontent.com/assets/847027/20419793/dad24588-ad26-11e6-9dde-e88a619151f1.png">
