### PR TITLE
fix(Dropdown): unselected dropdown to have empty value

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -902,8 +902,10 @@ export default class Dropdown extends Component {
     debug(`value:     ${value}`)
     if (!selection) return null
 
+    // unselected dropdown will have an empty string value
     return (
       <select type='hidden' name={name} value={value} multiple={multiple}>
+        <option key='empty' value=''></option>
         {_.map(options, option => (
           <option key={option.value} value={option.value}>{option.text}</option>
         ))}

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -902,7 +902,7 @@ export default class Dropdown extends Component {
     debug(`value:     ${value}`)
     if (!selection) return null
 
-    // unselected dropdown will have an empty string value
+    // a dropdown without an active item will have an empty string value
     return (
       <select type='hidden' name={name} value={value} multiple={multiple}>
         <option key='empty' value=''></option>

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1313,10 +1313,11 @@ describe('Dropdown Component', () => {
     })
     it('adds options to the hidden select', () => {
       wrapperShallow(<Dropdown options={options} selection />)
-        .should.have.exactly(options.length).descendants('option')
+        .should.have.exactly(options.length + 1).descendants('option')
 
       options.forEach((opt, i) => {
-        const optionElement = wrapper.find('option').at(i)
+        // index is incremented to exclude the empty option value
+        const optionElement = wrapper.find('option').at(i + 1)
 
         optionElement.should.have.prop('value', opt.value)
         optionElement.should.have.text(opt.text)


### PR DESCRIPTION
Fixes #811

Changes:
- Adds a new empty option to the hidden select element in the Dropdown component so that unselected dropdown's will have an empty string value.
- Fixed one test to accommodate this change.
