### PR TITLE
feat(FormField): pass `required` to the control

### DIFF
--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -56,7 +56,7 @@ function FormField(props) {
   // ----------------------------------------
   // Checkbox/Radio Control
   // ----------------------------------------
-  const controlProps = { ...rest, children, type }
+  const controlProps = { ...rest, children, required, type }
 
   // wrap HTML checkboxes/radios in the label
   if (control === 'input' && (type === 'checkbox' || type === 'radio')) {

--- a/test/specs/collections/Form/FormField-test.js
+++ b/test/specs/collections/Form/FormField-test.js
@@ -27,6 +27,18 @@ describe('FormField', () => {
     })
   })
 
+  describe('required', () => {
+    it('is passed to the control', () => {
+      const wrapper = shallow(<FormField control='input' required />)
+
+      wrapper.should.have.exactly(1).descendants('input')
+
+      wrapper
+        .find('input')
+        .should.have.prop('required', true)
+    })
+  })
+
   describe('label', () => {
     it('is not added as a child by default', () => {
       shallow(<FormField />)


### PR DESCRIPTION
Fixes #911 

This PR updates the FormField to pass the `required` prop to the `control` component.

```jsx
<Form.Field control='input' required />
//=> has child: <input required>

<Form.Input required />
//=> has child: <Input required />
//=> has child: <input required />
```
