### PR TITLE
fix(Header): add `sub header` className to subheader shorthand

### DIFF
--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -2,7 +2,6 @@ import _ from 'lodash'
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 import {
-  createShorthand,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -54,15 +53,16 @@ function Header(props) {
 
   const iconElement = Icon.create(icon)
   const imageElement = Image.create(image)
+  const subheaderElement = HeaderSubheader.create(subheader, { className: 'sub header' })
 
   if (iconElement || imageElement) {
     return (
       <ElementType {...rest} className={classes}>
         {iconElement || imageElement}
-        {(content || subheader) && (
+        {(content || subheaderElement) && (
           <HeaderContent>
             {content}
-            {createShorthand(HeaderSubheader, val => ({ content: val }), subheader)}
+            {subheaderElement}
           </HeaderContent>
         )}
       </ElementType>
@@ -72,7 +72,7 @@ function Header(props) {
   return (
     <ElementType {...rest} className={classes}>
       {content}
-      {createShorthand(HeaderSubheader, val => ({ content: val }), subheader)}
+      {subheaderElement}
     </ElementType>
   )
 }

--- a/src/elements/Header/HeaderSubheader.js
+++ b/src/elements/Header/HeaderSubheader.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -36,5 +37,7 @@ HeaderSubheader.propTypes = {
   /** Shorthand for primary content. */
   content: customPropTypes.contentShorthand,
 }
+
+HeaderSubheader.create = createShorthandFactory(HeaderSubheader, content => ({ content }))
 
 export default HeaderSubheader

--- a/test/specs/elements/Header/Header-test.js
+++ b/test/specs/elements/Header/Header-test.js
@@ -29,6 +29,7 @@ describe('Header', () => {
   common.implementsShorthandProp(Header, {
     propKey: 'subheader',
     ShorthandComponent: HeaderSubheader,
+    shorthandDefaultProps: { className: 'sub header' },
     mapValueToProps: val => ({ content: val }),
   })
 


### PR DESCRIPTION
Fixes #902 

This PR adds the `sub header` className to the `subheader` when an element is used for shorthand.

```jsx
<Header subheader={<span>My sub header</span>} />

//=> <span class="sub header">My sub header</span>
```