### PR TITLE
feat(TextArea): add onChange(e, data) callback signature

### DIFF
--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Component, PropTypes } from 'react'
 import {
   customPropTypes,
   getElementType,
@@ -11,25 +11,41 @@ import {
  * We may add more features to the TextArea in the future.
  * @see Form
  */
-function TextArea(props) {
-  const rest = getUnhandledProps(TextArea, props)
-  const ElementType = getElementType(TextArea, props)
+class TextArea extends Component {
+  static _meta = {
+    name: 'TextArea',
+    type: META.TYPES.ADDON,
+  }
 
-  return <ElementType {...rest} />
-}
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-TextArea._meta = {
-  name: 'TextArea',
-  type: META.TYPES.ADDON,
-}
+    /**
+     * Called on change.
+     * @param {SyntheticEvent} event - The React SyntheticEvent object
+     * @param {object} data - All props and the event value.
+     */
+    onChange: PropTypes.func,
+  }
 
-TextArea.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
-}
+  static defaultProps = {
+    as: 'textarea',
+  }
 
-TextArea.defaultProps = {
-  as: 'textarea',
+  handleChange = (e) => {
+    const { onChange } = this.props
+    if (onChange) {
+      onChange(e, { ...this.props, value: e.target && e.target.value })
+    }
+  }
+
+  render() {
+    const rest = getUnhandledProps(TextArea, this.props)
+    const ElementType = getElementType(TextArea, this.props)
+
+    return <ElementType {...rest} onChange={this.handleChange} />
+  }
 }
 
 export default TextArea

--- a/test/specs/addons/TextArea-test.js
+++ b/test/specs/addons/TextArea-test.js
@@ -1,29 +1,28 @@
 import React from 'react'
 
 import TextArea from 'src/addons/TextArea/TextArea'
+import { sandbox } from 'test/utils'
 import * as common from '../commonTests'
 
 describe('TextArea', () => {
-  common.isConformant(TextArea)
-
-  it('accepts a default value', () => {
-    const wrapper = mount(<TextArea defaultValue='Hello World' />)
-
-    wrapper
-      .should.have.have.exactly(1).descendants('textarea')
-
-    wrapper
-      .should.have.value('Hello World')
+  common.isConformant(TextArea, {
+    eventTargets: {
+      onChange: 'textarea',
+    },
   })
 
-  it('has a name assigned', () => {
-    shallow(<TextArea name='sample-post' />)
-      .should.have.prop('name', 'sample-post')
-  })
+  describe('onChange', () => {
+    it('is called with (e, data) on change', () => {
+      const spy = sandbox.spy()
+      const e = { target: { value: 'name' } }
+      const props = { 'data-foo': 'bar', onChange: spy }
 
-  it('has assigned amount of rows', () => {
-    shallow(<TextArea rows='6' />)
-      .should.have.tagName('textarea')
-      .with.attr('rows', '6')
+      const wrapper = shallow(<TextArea {...props} />)
+
+      wrapper.find('textarea').simulate('change', e)
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(e, { ...props, value: e.target.value })
+    })
   })
 })


### PR DESCRIPTION
Fixes #907 

This PR adds the `onChange(e, data)` signature to the TextArea.  This component is now a class to house the `handleClick` state.  Old tests were also removed (covered by common) and `onChange` tests were added.