### PR TITLE
fix(Accordion): Fixed incorrect defaultActiveIndex check

### DIFF
--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -83,7 +83,7 @@ export default class Accordion extends Component {
     // Otherwise, on first render we're allowed to set state for a prop that might have a default.
     // The default prop should always win on first render.
     // This default check should then be removed.
-    if (!this.props.defaultActiveIndex) {
+    if (typeof this.props.defaultActiveIndex === 'undefined' || this.props.defaultActiveIndex === -1) {
       this.trySetState({ activeIndex: -1 })
     }
   }

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -83,9 +83,10 @@ export default class Accordion extends Component {
     // Otherwise, on first render we're allowed to set state for a prop that might have a default.
     // The default prop should always win on first render.
     // This default check should then be removed.
-    if (typeof this.props.defaultActiveIndex === 'undefined' || this.props.defaultActiveIndex === -1) {
+    if (typeof this.props.defaultActiveIndex === 'undefined') {
       this.trySetState({ activeIndex: -1 })
     }
+
   }
 
   handleTitleClick = (e, index) => {

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -86,7 +86,6 @@ export default class Accordion extends Component {
     if (typeof this.props.defaultActiveIndex === 'undefined') {
       this.trySetState({ activeIndex: -1 })
     }
-
   }
 
   handleTitleClick = (e, index) => {


### PR DESCRIPTION
Fixes #772

This PR fixes the incorrect check of the props defaultActiveIndex in the componentWillMount hook. Instead of using the ! operator, which evaluates falsy values like 0 to true, the new condition checks for an undeclared variable or the number -1.