### PR TITLE
feat(Button): Prevent click on disabled button

### DIFF
--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 
 import {
   customPropTypes,
@@ -22,103 +22,7 @@ import ButtonOr from './ButtonOr'
 
 const debug = makeDebugger('button')
 
-/**
- * A Button indicates a possible user action
- * @see Form
- * @see Icon
- * @see Label
- */
-function Button(props) {
-  const {
-    active, animated, attached, basic, children, circular, className, color, compact, content, disabled, floated, fluid,
-    icon, inverted, label, labelPosition, loading, negative, positive, primary, secondary, size, toggle,
-  } = props
-
-  const labeledClasses = cx(
-    useKeyOrValueAndKey(labelPosition || !!label, 'labeled'),
-  )
-
-  const baseClasses = cx(
-    color,
-    size,
-    useKeyOnly(active, 'active'),
-    useKeyOrValueAndKey(animated, 'animated'),
-    useKeyOrValueAndKey(attached, 'attached'),
-    useKeyOnly(basic, 'basic'),
-    useKeyOnly(circular, 'circular'),
-    useKeyOnly(compact, 'compact'),
-    useKeyOnly(disabled, 'disabled'),
-    useValueAndKey(floated, 'floated'),
-    useKeyOnly(fluid, 'fluid'),
-    useKeyOnly(icon === true || icon && (labelPosition || !children && !content), 'icon'),
-    useKeyOnly(inverted, 'inverted'),
-    useKeyOnly(loading, 'loading'),
-    useKeyOnly(negative, 'negative'),
-    useKeyOnly(positive, 'positive'),
-    useKeyOnly(primary, 'primary'),
-    useKeyOnly(secondary, 'secondary'),
-    useKeyOnly(toggle, 'toggle'),
-  )
-  const rest = getUnhandledProps(Button, props)
-  const ElementType = getElementType(Button, props, () => {
-    if (label || attached) return 'div'
-  })
-  const tabIndex = ElementType === 'div' ? 0 : undefined
-
-  if (children) {
-    const classes = cx('ui', baseClasses, labeledClasses, 'button', className)
-    debug('render children:', { classes })
-    return (
-      <ElementType {...rest} className={classes} tabIndex={tabIndex}>
-        {children}
-      </ElementType>
-    )
-  }
-
-  if (label) {
-    const classes = cx('ui', baseClasses, 'button', className)
-    const containerClasses = cx('ui', labeledClasses, 'button', className)
-    debug('render label:', { classes, containerClasses }, props)
-    const labelElement = Label.create(label, {
-      basic: true,
-      pointing: labelPosition === 'left' ? 'right' : 'left',
-    })
-    return (
-      <ElementType {...rest} className={containerClasses}>
-        {labelPosition === 'left' && labelElement}
-        <button className={classes}>
-          {Icon.create(icon)} {content}
-        </button>
-        {(labelPosition === 'right' || !labelPosition) && labelElement}
-      </ElementType>
-    )
-  }
-
-  if (icon && !label) {
-    const classes = cx('ui', labeledClasses, baseClasses, 'button', className)
-    debug('render icon && !label:', { classes })
-    return (
-      <ElementType {...rest} className={classes} tabIndex={tabIndex}>
-        {Icon.create(icon)} {content}
-      </ElementType>
-    )
-  }
-
-  const classes = cx('ui', labeledClasses, baseClasses, 'button', className)
-  debug('render default:', { classes })
-
-  return (
-    <ElementType {...rest} className={classes} tabIndex={tabIndex}>
-      {content}
-    </ElementType>
-  )
-}
-
-Button.Content = ButtonContent
-Button.Group = ButtonGroup
-Button.Or = ButtonOr
-
-Button._meta = {
+const _meta = {
   name: 'Button',
   type: META.TYPES.ELEMENT,
   props: {
@@ -140,110 +44,249 @@ Button._meta = {
   },
 }
 
-Button.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+/**
+ * A Button indicates a possible user action
+ * @see Form
+ * @see Icon
+ * @see Label
+ */
+class Button extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-  /** A button can show it is currently the active user selection */
-  active: PropTypes.bool,
+    /** A button can show it is currently the active user selection */
+    active: PropTypes.bool,
 
-  /** A button can animate to show hidden content */
-  animated: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.oneOf(Button._meta.props.animated),
-  ]),
+    /** A button can animate to show hidden content */
+    animated: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(_meta.props.animated),
+    ]),
 
-  /** A button can be attached to the top or bottom of other content */
-  attached: PropTypes.oneOf(Button._meta.props.attached),
+    /** A button can be attached to the top or bottom of other content */
+    attached: PropTypes.oneOf(_meta.props.attached),
 
-  /** A basic button is less pronounced */
-  basic: PropTypes.bool,
+    /** A basic button is less pronounced */
+    basic: PropTypes.bool,
 
-  /** Primary content. */
-  children: customPropTypes.every([
-    PropTypes.node,
-    customPropTypes.disallow(['label']),
-    customPropTypes.givenProps(
-      {
-        icon: PropTypes.oneOfType([
-          PropTypes.string.isRequired,
-          PropTypes.object.isRequired,
-          PropTypes.element.isRequired,
-        ]),
-      },
-      customPropTypes.disallow(['icon']),
-    ),
-  ]),
+    /** Primary content. */
+    children: customPropTypes.every([
+      PropTypes.node,
+      customPropTypes.disallow(['label']),
+      customPropTypes.givenProps(
+        {
+          icon: PropTypes.oneOfType([
+            PropTypes.string.isRequired,
+            PropTypes.object.isRequired,
+            PropTypes.element.isRequired,
+          ]),
+        },
+        customPropTypes.disallow(['icon']),
+      ),
+    ]),
 
-  /** A button can be circular */
-  circular: PropTypes.bool,
+    /** A button can be circular */
+    circular: PropTypes.bool,
 
-  /** Additional classes. */
-  className: PropTypes.string,
+    /** Additional classes. */
+    className: PropTypes.string,
 
-  /** Shorthand for primary content. */
-  content: customPropTypes.contentShorthand,
+    /** Shorthand for primary content. */
+    content: customPropTypes.contentShorthand,
 
-  /** A button can have different colors */
-  color: PropTypes.oneOf(Button._meta.props.color),
+    /** A button can have different colors */
+    color: PropTypes.oneOf(_meta.props.color),
 
-  /** A button can reduce its padding to fit into tighter spaces */
-  compact: PropTypes.bool,
+    /** A button can reduce its padding to fit into tighter spaces */
+    compact: PropTypes.bool,
 
-  /** A button can show it is currently unable to be interacted with */
-  disabled: PropTypes.bool,
+    /** A button can show it is currently unable to be interacted with */
+    disabled: PropTypes.bool,
 
-  /** A button can be aligned to the left or right of its container */
-  floated: PropTypes.oneOf(Button._meta.props.floated),
+    /** A button can be aligned to the left or right of its container */
+    floated: PropTypes.oneOf(_meta.props.floated),
 
-  /** A button can take the width of its container */
-  fluid: PropTypes.bool,
+    /** A button can take the width of its container */
+    fluid: PropTypes.bool,
 
-  /** Add an Icon by name, props object, or pass an <Icon /> */
-  icon: customPropTypes.some([
-    PropTypes.bool,
-    PropTypes.string,
-    PropTypes.object,
-    PropTypes.element,
-  ]),
+    /** Add an Icon by name, props object, or pass an <Icon /> */
+    icon: customPropTypes.some([
+      PropTypes.bool,
+      PropTypes.string,
+      PropTypes.object,
+      PropTypes.element,
+    ]),
 
-  /** A button can be formatted to appear on dark backgrounds */
-  inverted: PropTypes.bool,
+    /** A button can be formatted to appear on dark backgrounds */
+    inverted: PropTypes.bool,
 
-  /** A labeled button can format a Label or Icon to appear on the left or right */
-  labelPosition: PropTypes.oneOf(Button._meta.props.labelPosition),
+    /** A labeled button can format a Label or Icon to appear on the left or right */
+    labelPosition: PropTypes.oneOf(_meta.props.labelPosition),
 
-  /** Add a Label by text, props object, or pass a <Label /> */
-  label: customPropTypes.some([
-    PropTypes.string,
-    PropTypes.object,
-    PropTypes.element,
-  ]),
+    /** Add a Label by text, props object, or pass a <Label /> */
+    label: customPropTypes.some([
+      PropTypes.string,
+      PropTypes.object,
+      PropTypes.element,
+    ]),
 
-  /** A button can show a loading indicator */
-  loading: PropTypes.bool,
+    /** A button can show a loading indicator */
+    loading: PropTypes.bool,
 
-  /** A button can hint towards a negative consequence */
-  negative: PropTypes.bool,
+    /** A button can hint towards a negative consequence */
+    negative: PropTypes.bool,
 
-  /** A button can hint towards a positive consequence */
-  positive: PropTypes.bool,
+    /**
+     * Called after user's click.
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - Relevant data.
+     */
+    onClick: PropTypes.func,
 
-  /** A button can be formatted to show different levels of emphasis */
-  primary: PropTypes.bool,
+    /** A button can hint towards a positive consequence */
+    positive: PropTypes.bool,
 
-  /** A button can be formatted to show different levels of emphasis */
-  secondary: PropTypes.bool,
+    /** A button can be formatted to show different levels of emphasis */
+    primary: PropTypes.bool,
 
-  /** A button can be formatted to toggle on and off */
-  toggle: PropTypes.bool,
+    /** A button can be formatted to show different levels of emphasis */
+    secondary: PropTypes.bool,
 
-  /** A button can have different sizes */
-  size: PropTypes.oneOf(Button._meta.props.size),
-}
+    /** A button can be formatted to toggle on and off */
+    toggle: PropTypes.bool,
 
-Button.defaultProps = {
-  as: 'button',
+    /** A button can have different sizes */
+    size: PropTypes.oneOf(_meta.props.size),
+  }
+
+  static defaultProps = {
+    as: 'button',
+  }
+
+  static _meta = _meta
+  static Content = ButtonContent
+  static Group = ButtonGroup
+  static Or = ButtonOr
+
+  handleClick = (e) => {
+    const { disabled, onClick } = this.props
+
+    if (disabled) {
+      e.preventDefault()
+      return
+    }
+
+    if (onClick) onClick(e, this.props)
+  }
+
+  render() {
+    const {
+      active,
+      animated,
+      attached,
+      basic,
+      children,
+      circular,
+      className,
+      color,
+      compact,
+      content,
+      disabled,
+      floated,
+      fluid,
+      icon,
+      inverted,
+      label,
+      labelPosition,
+      loading,
+      negative,
+      positive,
+      primary,
+      secondary,
+      size,
+      toggle,
+    } = this.props
+
+    const labeledClasses = cx(
+      useKeyOrValueAndKey(labelPosition || !!label, 'labeled'),
+    )
+
+    const baseClasses = cx(
+      color,
+      size,
+      useKeyOnly(active, 'active'),
+      useKeyOrValueAndKey(animated, 'animated'),
+      useKeyOrValueAndKey(attached, 'attached'),
+      useKeyOnly(basic, 'basic'),
+      useKeyOnly(circular, 'circular'),
+      useKeyOnly(compact, 'compact'),
+      useKeyOnly(disabled, 'disabled'),
+      useValueAndKey(floated, 'floated'),
+      useKeyOnly(fluid, 'fluid'),
+      useKeyOnly(icon === true || icon && (labelPosition || !children && !content), 'icon'),
+      useKeyOnly(inverted, 'inverted'),
+      useKeyOnly(loading, 'loading'),
+      useKeyOnly(negative, 'negative'),
+      useKeyOnly(positive, 'positive'),
+      useKeyOnly(primary, 'primary'),
+      useKeyOnly(secondary, 'secondary'),
+      useKeyOnly(toggle, 'toggle'),
+    )
+    const rest = getUnhandledProps(Button, this.props)
+    const ElementType = getElementType(Button, this.props, () => {
+      if (label || attached) return 'div'
+    })
+    const tabIndex = ElementType === 'div' ? 0 : undefined
+
+    if (children) {
+      const classes = cx('ui', baseClasses, labeledClasses, 'button', className)
+      debug('render children:', { classes })
+      return (
+        <ElementType {...rest} className={classes} tabIndex={tabIndex} onClick={this.handleClick}>
+          {children}
+        </ElementType>
+      )
+    }
+
+    if (label) {
+      const classes = cx('ui', baseClasses, 'button', className)
+      const containerClasses = cx('ui', labeledClasses, 'button', className)
+      debug('render label:', { classes, containerClasses }, this.props)
+      const labelElement = Label.create(label, {
+        basic: true,
+        pointing: labelPosition === 'left' ? 'right' : 'left',
+      })
+      return (
+        <ElementType {...rest} className={containerClasses} onClick={this.handleClick}>
+          {labelPosition === 'left' && labelElement}
+          <button className={classes}>
+            {Icon.create(icon)} {content}
+          </button>
+          {(labelPosition === 'right' || !labelPosition) && labelElement}
+        </ElementType>
+      )
+    }
+
+    if (icon && !label) {
+      const classes = cx('ui', labeledClasses, baseClasses, 'button', className)
+      debug('render icon && !label:', { classes })
+      return (
+        <ElementType {...rest} className={classes} tabIndex={tabIndex} onClick={this.handleClick}>
+          {Icon.create(icon)} {content}
+        </ElementType>
+      )
+    }
+
+    const classes = cx('ui', labeledClasses, baseClasses, 'button', className)
+    debug('render default:', { classes })
+
+    return (
+      <ElementType {...rest} className={classes} tabIndex={tabIndex} onClick={this.handleClick}>
+        {content}
+      </ElementType>
+    )
+  }
 }
 
 Button.create = createShorthandFactory(Button, value => ({ content: value }))

--- a/test/specs/elements/Button/Button-test.js
+++ b/test/specs/elements/Button/Button-test.js
@@ -7,6 +7,8 @@ import ButtonOr from 'src/elements/Button/ButtonOr'
 import * as common from 'test/specs/commonTests'
 import { sandbox } from 'test/utils'
 
+const syntheticEvent = { preventDefault: () => undefined }
+
 describe('Button', () => {
   common.isConformant(Button)
   common.hasUIClassName(Button)
@@ -58,10 +60,24 @@ describe('Button', () => {
     it('is called when clicked', () => {
       const handleClick = sandbox.spy()
 
-      shallow(<Button type='submit' onClick={handleClick} />)
-        .simulate('click')
+      shallow(<Button type='submit' data-foo='bar' onClick={handleClick} />)
+        .simulate('click', syntheticEvent)
 
       handleClick.should.have.been.calledOnce()
+      handleClick.should.have.been.calledWith(
+        sandbox.match.any,
+        // Ensure the second argument includes arbitrary button props
+        sandbox.match({ 'data-foo': 'bar' })
+      )
+    })
+
+    it('is not called when button is disabled', () => {
+      const handleClick = sandbox.spy()
+
+      shallow(<Button type='submit' disabled onClick={handleClick} />)
+        .simulate('click', syntheticEvent)
+
+      handleClick.should.not.have.been.calledOnce()
     })
   })
 


### PR DESCRIPTION
Fixes #929 

- Prevent clicks on a disabled button (both mouse clicks and "clicks" via focus + pressing enter). Also called `preventDefault` on the click event when the button is disabled to prevent form submission (if within a form) or link following (if an `a`).
- Pass back props to the `onClick` and documented the `onClick` prop as spec'd in https://github.com/Semantic-Org/Semantic-UI-React/issues/623#issuecomment-261018287