### PR TITLE
feat(customPropTypes): add suggest prop type checker

### DIFF
--- a/docs/app/index.ejs
+++ b/docs/app/index.ejs
@@ -63,7 +63,8 @@
   ></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/Faker/<%= htmlWebpackPlugin.options.versions.faker %>/faker.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/js-beautify/<%= htmlWebpackPlugin.options.versions.jsBeautify %>/beautify-html.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/react/<%= htmlWebpackPlugin.options.versions.react %>/react.min.js"></script>
+  <!-- Use unminified React when not in production so we get errors and warnings -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/react/<%= htmlWebpackPlugin.options.versions.react %>/react<%= __PROD__ ? '.min' : '' %>.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/react/<%= htmlWebpackPlugin.options.versions.reactDOM %>/react-dom.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/react/<%= htmlWebpackPlugin.options.versions.reactDOM %>/react-dom-server.min.js"></script>
   <style>

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -78,7 +78,7 @@ Flag.propTypes = {
   className: PropTypes.string,
 
   /** Flag name, can use the two digit country code, the full name, or a common alias */
-  name: PropTypes.oneOf(Flag._meta.props.name).isRequired,
+  name: customPropTypes.suggest(Flag._meta.props.name),
 }
 
 Flag.defaultProps = {

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -94,7 +94,7 @@ Icon.propTypes = {
   inverted: PropTypes.bool,
 
   /** Name of the icon */
-  name: PropTypes.oneOf(Icon._meta.props.name),
+  name: customPropTypes.suggest(Icon._meta.props.name),
 
   /** Icon can be formatted as a link */
   link: PropTypes.bool,

--- a/src/lib/SUI.js
+++ b/src/lib/SUI.js
@@ -27,138 +27,173 @@ export const WIDTHS = [
   ..._.values(numberToWordMap),
 ]
 
+// Generated from:
+// https://github.com/Semantic-Org/Semantic-UI/blob/master/dist/components/icon.css
 export const ICONS = [
-  // Web Content Icons
-  'add to calendar', 'alarm outline', 'alarm mute outline', 'alarm mute', 'alarm', 'at', 'browser', 'bug',
-  'calendar outline', 'calendar', 'checked calendar', 'cloud', 'code', 'comment outline', 'comment', 'comments outline',
-  'comments', 'copyright', 'creative commons', 'dashboard', 'delete calendar', 'external square', 'external',
-  'eyedropper', 'feed', 'find', 'hand pointer', 'hashtag', 'heartbeat', 'history', 'home', 'hourglass empty',
-  'hourglass end', 'hourglass full', 'hourglass half', 'hourglass start', 'idea', 'image', 'inbox', 'industry', 'lab',
-  'mail outline', 'mail square', 'mail', 'mouse pointer', 'options', 'paint brush', 'payment', 'percent', 'privacy',
-  'protect', 'registered', 'remove from calendar', 'search', 'setting', 'settings', 'shop', 'shopping bag',
-  'shopping basket', 'signal', 'sitemap', 'tag', 'tags', 'tasks', 'terminal', 'text telephone', 'ticket', 'trademark',
-  'trophy', 'wifi',
+  // Web Content
+  'search', 'mail outline', 'signal', 'setting', 'home', 'inbox', 'browser', 'tag', 'tags', 'image', 'calendar',
+  'comment', 'shop', 'comments', 'external', 'privacy', 'settings', 'comments', 'external', 'trophy', 'payment', 'feed',
+  'alarm outline', 'tasks', 'cloud', 'lab', 'mail', 'dashboard', 'comment outline', 'comments outline', 'sitemap',
+  'idea', 'alarm', 'terminal', 'code', 'protect', 'calendar outline', 'ticket', 'external square', 'bug', 'mail square',
+  'history', 'options', 'text telephone', 'find', 'wifi', 'alarm mute', 'alarm mute outline', 'copyright', 'at',
+  'eyedropper', 'paint brush', 'heartbeat', 'mouse pointer', 'hourglass empty', 'hourglass start', 'hourglass half',
+  'hourglass end', 'hourglass full', 'hand pointer', 'trademark', 'registered', 'creative commons', 'add to calendar',
+  'remove from calendar', 'delete calendar', 'checked calendar', 'industry', 'shopping bag', 'shopping basket',
+  'hashtag', 'percent',
 
-  // User Actions Icons
-  'add to cart', 'add user', 'adjust', 'archive', 'ban', 'bookmark', 'call', 'call square', 'clone', 'cloud download',
-  'cloud upload', 'talk', 'talk outline', 'compress', 'configure', 'download', 'edit', 'erase', 'exchange', 'expand',
-  'external share', 'filter', 'hide', 'in cart', 'lock', 'mail forward', 'object group', 'object ungroup', 'pin',
-  'print', 'random', 'recycle', 'refresh', 'remove bookmark', 'remove user', 'repeat', 'reply all', 'reply', 'retweet',
-  'send', 'send outline', 'share alternate', 'share alternate square', 'share', 'share square', 'sign in', 'sign out',
-  'theme', 'translate', 'undo', 'unhide', 'unlock alternate', 'unlock', 'upload', 'wait', 'wizard', 'write',
-  'write square',
+  // User Actions
+  'wait', 'download', 'repeat', 'refresh', 'lock', 'bookmark', 'print', 'write', 'adjust', 'theme', 'edit',
+  'external share', 'ban', 'mail forward', 'share', 'expand', 'compress', 'unhide', 'hide', 'random', 'retweet',
+  'sign out', 'pin', 'sign in', 'upload', 'call', 'remove bookmark', 'call square', 'unlock', 'configure', 'filter',
+  'wizard', 'undo', 'exchange', 'cloud download', 'cloud upload', 'reply', 'reply all', 'erase', 'unlock alternate',
+  'write square', 'share square', 'archive', 'translate', 'recycle', 'send', 'send outline', 'share alternate',
+  'share alternate square', 'add to cart', 'in cart', 'add user', 'remove user', 'object group', 'object ungroup',
+  'clone', 'talk', 'talk outline',
 
-  // Message Icons
-  'announcement', 'birthday', 'help circle', 'help', 'info circle', 'info', 'warning circle', 'warning', 'warning sign',
+  // Messages
+  'help circle', 'info circle', 'warning circle', 'warning sign', 'announcement', 'help', 'info', 'warning', 'birthday',
+  'help circle outline',
 
-  // User Types Icons
-  'child', 'doctor', 'handicap', 'spy', 'student', 'user', 'users',
+  // Users
+  'user', 'users', 'doctor', 'handicap', 'student', 'child', 'spy',
 
-  // Gender And Sexuality Icons
-  'female', 'gay', 'genderless', 'heterosexual', 'intergender', 'lesbian', 'male', 'man', 'neuter',
-  'non binary transgender', 'other gender horizontal', 'other gender', 'other gender vertical', 'transgender', 'woman',
+  // Gender & Sexuality
+  'female', 'male', 'woman', 'man', 'non binary transgender', 'intergender', 'transgender', 'lesbian', 'gay',
+  'heterosexual', 'other gender', 'other gender vertical', 'other gender horizontal', 'neuter', 'genderless',
 
-  // Layout Adjustment Icons
-  'block layout', 'crop', 'grid layout', 'list layout', 'maximize', 'resize horizontal', 'resize vertical', 'zoom',
-  'zoom out',
+  // Accessibility
+  'universal access', 'wheelchair', 'blind', 'audio description', 'volume control phone', 'braille', 'asl',
+  'assistive listening systems', 'deafness', 'sign language', 'low vision',
 
-  // Objects Icons
-  'anchor', 'bar', 'bomb', 'book', 'bullseye', 'calculator', 'cocktail', 'diamond', 'fax', 'fire extinguisher', 'fire',
-  'flag checkered', 'flag', 'flag outline', 'gift', 'hand lizard', 'hand peace', 'hand paper', 'hand rock',
-  'hand scissors', 'hand spock', 'law', 'leaf', 'legal', 'lemon', 'life ring', 'lightning', 'magnet', 'money', 'moon',
-  'plane', 'puzzle', 'road', 'rocket', 'shipping', 'soccer', 'sticky note', 'sticky note outline', 'suitcase', 'sun',
-  'travel', 'treatment', 'umbrella', 'world',
+  // View Adjustment
+  'block layout', 'grid layout', 'list layout', 'zoom', 'zoom out', 'resize vertical', 'resize horizontal', 'maximize',
+  'crop',
 
-  // Shapes Icons
-  'asterisk', 'certificate', 'circle', 'circle notched', 'circle thin', 'crosshairs', 'cube', 'cubes',
-  'ellipsis horizontal', 'ellipsis vertical', 'quote left', 'quote right', 'spinner', 'square', 'square outline',
+  // Literal Objects
+  'cocktail', 'road', 'flag', 'book', 'gift', 'leaf', 'fire', 'plane', 'magnet', 'lemon', 'world', 'travel', 'shipping',
+  'money', 'legal', 'lightning', 'umbrella', 'treatment', 'suitcase', 'bar', 'flag outline', 'flag checkered', 'puzzle',
+  'fire extinguisher', 'rocket', 'anchor', 'bullseye', 'sun', 'moon', 'fax', 'life ring', 'bomb', 'soccer',
+  'calculator', 'diamond', 'sticky note', 'sticky note outline', 'law', 'hand peace', 'hand rock', 'hand paper',
+  'hand scissors', 'hand lizard', 'hand spock', 'tv',
 
-  // Item Selection Icons
-  'add circle', 'add square', 'check circle', 'check circle outline', 'check square', 'checkmark box', 'checkmark',
-  'minus circle', 'minus', 'minus square', 'minus square outline', 'move', 'plus', 'plus square outline', 'radio',
-  'remove circle', 'remove circle outline', 'remove', 'selected radio', 'toggle off', 'toggle on',
+  // Shapes
+  'crosshairs', 'asterisk', 'square outline', 'certificate', 'square', 'quote left', 'quote right', 'spinner', 'circle',
+  'ellipsis horizontal', 'ellipsis vertical', 'cube', 'cubes', 'circle notched', 'circle thin',
 
-  // Media Icons
-  'area chart', 'bar chart', 'camera retro', 'film', 'line chart', 'newspaper', 'photo', 'pie chart', 'sound',
+  // Item Selection
+  'checkmark', 'remove', 'checkmark box', 'move', 'add circle', 'minus circle', 'remove circle', 'check circle',
+  'remove circle outline', 'check circle outline', 'plus', 'minus', 'add square', 'radio', 'minus square', 'minus square outline',
+  'check square', 'selected radio', 'plus square outline', 'toggle off', 'toggle on',
 
-  // Pointers Icons
-  'angle double down', 'angle double left', 'angle double right', 'angle double up', 'angle down', 'angle left',
-  'angle right', 'angle up', 'arrow circle down', 'arrow circle left', 'arrow circle outline down',
-  'arrow circle outline left', 'arrow circle outline right', 'arrow circle outline up', 'arrow circle right',
-  'arrow circle up', 'arrow down', 'arrow left', 'arrow right', 'arrow up', 'caret down', 'caret left', 'caret right',
-  'caret up', 'chevron circle down', 'chevron circle left', 'chevron circle right', 'chevron circle up', 'chevron down',
-  'chevron left', 'chevron right', 'chevron up', 'dropdown', 'long arrow down', 'long arrow left', 'long arrow right',
-  'long arrow up', 'pointing down', 'pointing left', 'pointing right', 'pointing up', 'toggle down', 'toggle left',
-  'toggle right', 'toggle up',
+  // Media
+  'film', 'sound', 'photo', 'bar chart', 'camera retro', 'newspaper', 'area chart', 'pie chart', 'line chart',
 
-  // Mobile Icons
-  'mobile', 'tablet', 'battery empty', 'battery full', 'battery low', 'battery medium',
+  // Pointers
+  'arrow circle outline down', 'arrow circle outline up', 'chevron left', 'chevron right', 'arrow left', 'arrow right',
+  'arrow up', 'arrow down', 'chevron up', 'chevron down', 'pointing right', 'pointing left', 'pointing up',
+  'pointing down', 'arrow circle left', 'arrow circle right', 'arrow circle up', 'arrow circle down', 'caret down',
+  'caret up', 'caret left', 'caret right', 'angle double left', 'angle double right', 'angle double up',
+  'angle double down', 'angle left', 'angle right', 'angle up', 'angle down', 'chevron circle left',
+  'chevron circle right', 'chevron circle up', 'chevron circle down', 'toggle down', 'toggle up', 'toggle right',
+  'long arrow down', 'long arrow up', 'long arrow left', 'long arrow right', 'arrow circle outline right',
+  'arrow circle outline left', 'toggle left',
 
-  // Computer Icons
-  'desktop', 'disk outline', 'game', 'high battery', 'keyboard', 'laptop', 'plug', 'power',
+  // Mobile
+  'tablet', 'mobile', 'battery full', 'battery high', 'battery medium', 'battery low', 'battery empty',
 
-  // Computer And File System Icons
-  'file archive outline', 'file audio outline', 'file code outline', 'file excel outline', 'file', 'file image outline',
-  'file outline', 'file pdf outline', 'file powerpoint outline', 'file text', 'file text outline', 'file video outline',
-  'file word outline', 'folder', 'folder open', 'folder open outline', 'folder outline', 'level down', 'level up',
-  'trash', 'trash outline',
+  // Computer
+  'power', 'trash outline', 'disk outline', 'desktop', 'laptop', 'game', 'keyboard', 'plug',
 
-  // Technologies Icons
-  'barcode', 'bluetooth alternative', 'bluetooth', 'css3', 'database', 'fork', 'html5', 'openid', 'qrcode', 'rss',
-  'rss square', 'server', 'usb',
+  // File System
+  'trash', 'file outline', 'folder', 'folder open', 'file text outline', 'folder outline', 'folder open outline',
+  'level up', 'level down', 'file', 'file text', 'file pdf outline', 'file word outline', 'file excel outline',
+  'file powerpoint outline', 'file image outline', 'file archive outline', 'file audio outline', 'file video outline',
+  'file code outline',
 
-  // Rating Icons
-  'empty heart', 'empty star', 'frown', 'heart', 'meh', 'smile', 'star half empty', 'star half', 'star', 'thumbs down',
-  'thumbs outline down', 'thumbs outline up', 'thumbs up',
+  // Technologies
+  'qrcode', 'barcode', 'rss', 'fork', 'html5', 'css3', 'rss square', 'openid', 'database', 'server', 'usb', 'bluetooth',
+  'bluetooth alternative',
 
-  // Audio Icons
-  'backward', 'closed captioning', 'eject', 'fast backward', 'fast forward', 'forward', 'music', 'mute', 'pause circle',
-  'pause circle outline', 'pause', 'play', 'record', 'step backward', 'step forward', 'stop circle',
-  'stop circle outline', 'stop', 'unmute', 'video play', 'video play outline', 'volume down', 'volume off', 'volume up',
+  // Rating
+  'heart', 'star', 'empty star', 'thumbs outline up', 'thumbs outline down', 'star half', 'empty heart', 'smile',
+  'frown', 'meh', 'star half empty', 'thumbs up', 'thumbs down',
 
-  // Map Icons
-  'bicycle', 'building', 'building outline', 'bus', 'car', 'coffee', 'compass', 'emergency', 'first aid', 'food', 'h',
-  'hospital', 'hotel', 'location arrow', 'map', 'map outline', 'map pin', 'map signs', 'marker', 'military',
-  'motorcycle', 'paw', 'ship', 'space shuttle', 'spoon', 'street view', 'subway', 'taxi', 'train', 'television', 'tree',
-  'university',
+  // Audio
+  'music', 'video play outline', 'volume off', 'volume down', 'volume up', 'record', 'step backward', 'fast backward',
+  'backward', 'play', 'pause', 'stop', 'forward', 'fast forward', 'step forward', 'eject', 'unmute', 'mute',
+  'video play', 'closed captioning', 'pause circle', 'pause circle outline', 'stop circle', 'stop circle outline',
 
-  // Tables Icons
-  'columns', 'sort alphabet ascending', 'sort alphabet descending', 'sort ascending', 'sort content ascending',
-  'sort content descending', 'sort descending', 'sort', 'sort numeric ascending', 'sort numeric descending', 'table',
+  // Map, Locations, & Transportation
+  'marker', 'coffee', 'food', 'building outline', 'hospital', 'emergency', 'first aid', 'military', 'h',
+  'location arrow', 'compass', 'space shuttle', 'university', 'building', 'paw', 'spoon', 'car', 'taxi', 'tree',
+  'bicycle', 'bus', 'ship', 'motorcycle', 'street view', 'hotel', 'train', 'subway', 'map pin', 'map signs',
+  'map outline', 'map',
 
-  // Text Editor Icons
-  'align center', 'align justify', 'align left', 'align right', 'attach', 'bold', 'content', 'copy', 'cut', 'font',
-  'header', 'indent', 'italic', 'linkify', 'list', 'ordered list', 'outdent', 'paragraph', 'paste', 'save',
-  'strikethrough', 'subscript', 'superscript', 'text cursor', 'text height', 'text width', 'underline', 'unlinkify',
-  'unordered list',
+  // Tables
+  'table', 'columns', 'sort', 'sort descending', 'sort ascending', 'sort alphabet ascending',
+  'sort alphabet descending', 'sort content ascending', 'sort content descending', 'sort numeric ascending',
+  'sort numeric descending',
 
-  // Currency Icons
-  'bitcoin', 'dollar', 'euro', 'lira', 'pound', 'ruble', 'rupee', 'shekel', 'won', 'yen',
+  // Text Editor
+  'font', 'bold', 'italic', 'text height', 'text width', 'align left', 'align center', 'align right', 'align justify',
+  'list', 'outdent', 'indent', 'linkify', 'cut', 'copy', 'attach', 'save', 'content', 'unordered list', 'ordered list',
+  'strikethrough', 'underline', 'paste', 'unlinkify', 'superscript', 'subscript', 'header', 'paragraph', 'text cursor',
 
-  // Payment Options Icons
-  'american express', 'credit card alternative', 'diners club', 'discover', 'google wallet', 'japan credit bureau',
-  'mastercard', 'paypal card', 'paypal', 'stripe', 'visa',
+  // Currency
+  'euro', 'pound', 'dollar', 'rupee', 'yen', 'ruble', 'won', 'bitcoin', 'lira', 'shekel',
 
-  // Accessibility Icons
-  'wheelchair', 'asl interpreting', 'assistive listening systems', 'audio description', 'blind', 'braille', 'deafness',
-  'low vision', 'sign language', 'universal access', 'volume control phone',
+  // Payment Options
+  'paypal', 'google wallet', 'visa', 'mastercard', 'discover', 'american express', 'paypal card', 'stripe',
+  'japan credit bureau', 'diners club', 'credit card alternative',
 
-  // Brands Icons
-  '500px', 'adn', 'amazon', 'android', 'angellist', 'apple', 'behance', 'behance square', 'bitbucket',
-  'bitbucket square', 'black tie', 'buysellads', 'chrome', 'codepen', 'codiepie', 'connectdevelop', 'contao',
-  'dashcube', 'delicious', 'deviantart', 'digg', 'dribbble', 'dropbox', 'drupal', 'empire', 'envira gallery',
-  'expeditedssl', 'facebook', 'facebook f', 'facebook square', 'firefox', 'first order', 'flickr', 'font awesome',
-  'fonticons', 'fort awesome', 'forumbee', 'foursquare', 'gg', 'gg circle', 'git', 'git square', 'github',
-  'github alternate', 'github square', 'gitlab', 'gittip', 'glide', 'glide g', 'google', 'google plus',
-  'google plus circle', 'google plus square', 'hacker news', 'houzz', 'instagram', 'internet explorer', 'ioxhost',
-  'joomla', 'jsfiddle', 'lastfm', 'lastfm square', 'leanpub', 'linkedin', 'linkedin square', 'linux', 'maxcdn',
-  'meanpath', 'medium', 'microsoft edge', 'mixcloud', 'modx', 'odnoklassniki', 'odnoklassniki square', 'opencart',
-  'opera', 'optinmonster', 'pagelines', 'pied piper', 'pied piper alternate', 'pied piper hat', 'pinterest',
-  'pinterest square', 'pocket', 'product hunt', 'qq', 'rebel', 'reddit', 'reddit alien', 'reddit square', 'renren',
-  'safari', 'scribd', 'sellsy', 'shirtsinbulk', 'simplybuilt', 'skyatlas', 'skype', 'slack', 'slideshare', 'snapchat',
-  'snapchat ghost', 'snapchat square', 'soundcloud', 'spotify', 'stack exchange', 'stack overflow', 'steam',
-  'steam square', 'stumbleupon', 'stumbleupon circle', 'tencent weibo', 'themeisle', 'trello', 'tripadvisor', 'tumblr',
-  'tumblr square', 'twitch', 'twitter', 'twitter square', 'viacoin', 'viadeo', 'viadeo square', 'vimeo', 'vimeo square',
-  'vine', 'vk', 'wechat', 'weibo', 'whatsapp', 'wikipedia', 'windows', 'wordpress', 'wpbeginner', 'wpforms', 'xing',
-  'xing square', 'y combinator', 'yahoo', 'yelp', 'yoast', 'youtube', 'youtube play', 'youtube square',
+  // Networks and Website
+  'twitter square', 'facebook square', 'linkedin square', 'github square', 'twitter', 'facebook f', 'github',
+  'pinterest', 'pinterest square', 'google plus square', 'google plus', 'linkedin', 'github alternate', 'maxcdn',
+  'youtube square', 'youtube', 'xing', 'xing square', 'youtube play', 'dropbox', 'stack overflow', 'instagram',
+  'flickr', 'adn', 'bitbucket', 'bitbucket square', 'tumblr', 'tumblr square', 'apple', 'windows', 'android', 'linux',
+  'dribble', 'skype', 'foursquare', 'trello', 'gittip', 'vk', 'weibo', 'renren', 'pagelines', 'stack exchange',
+  'vimeo square', 'slack', 'wordpress', 'yahoo', 'google', 'reddit', 'reddit square', 'stumbleupon circle',
+  'stumbleupon', 'delicious', 'digg', 'pied piper', 'pied piper alternate', 'drupal', 'joomla', 'behance',
+  'behance square', 'steam', 'steam square', 'spotify', 'deviantart', 'soundcloud', 'vine', 'codepen', 'jsfiddle',
+  'rebel', 'empire', 'git square', 'git', 'hacker news', 'tencent weibo', 'qq', 'wechat', 'slideshare', 'twitch',
+  'yelp', 'lastfm', 'lastfm square', 'ioxhost', 'angellist', 'meanpath', 'buysellads', 'connectdevelop', 'dashcube',
+  'forumbee', 'leanpub', 'sellsy', 'shirtsinbulk', 'simplybuilt', 'skyatlas', 'facebook', 'pinterest', 'whatsapp',
+  'viacoin', 'medium', 'y combinator', 'optinmonster', 'opencart', 'expeditedssl', 'gg', 'gg circle', 'tripadvisor',
+  'odnoklassniki', 'odnoklassniki square', 'pocket', 'wikipedia', 'safari', 'chrome', 'firefox', 'opera',
+  'internet explorer', 'contao', '500px', 'amazon', 'houzz', 'vimeo', 'black tie', 'fonticons', 'reddit alien',
+  'microsoft edge', 'codiepie', 'modx', 'fort awesome', 'product hunt', 'mixcloud', 'scribd', 'gitlab', 'wpbeginner',
+  'wpforms', 'envira gallery', 'glide', 'glide g', 'viadeo', 'viadeo square', 'snapchat', 'snapchat ghost',
+  'snapchat square', 'pied piper hat', 'first order', 'yoast', 'themeisle', 'google plus circle', 'font awesome',
+
+  // ----------------------------------------
+  // Aliases
+  // ----------------------------------------
+
+  'like', 'favorite', 'video', 'check', 'close', 'cancel', 'delete', 'x', 'zoom in', 'magnify', 'shutdown', 'clock',
+  'time', 'play circle outline', 'headphone', 'camera', 'video camera', 'picture', 'pencil', 'compose', 'point', 'tint',
+  'signup', 'plus circle', 'question circle', 'dont', 'minimize', 'add', 'exclamation circle', 'attention', 'eye',
+  'exclamation triangle', 'shuffle', 'chat', 'cart', 'shopping cart', 'bar graph', 'key', 'cogs', 'discussions',
+  'like outline', 'dislike outline', 'heart outline', 'log out', 'thumb tack', 'winner', 'phone', 'bookmark outline',
+  'phone square', 'credit card', 'hdd outline', 'bullhorn', 'bell outline', 'hand outline right', 'hand outline left',
+  'hand outline up', 'hand outline down', 'globe', 'wrench', 'briefcase', 'group', 'linkify', 'chain', 'flask',
+  'sidebar', 'bars', 'list ul', 'list ol', 'numbered list', 'magic', 'truck', 'currency', 'triangle down', 'dropdown',
+  'triangle up', 'triangle left', 'triangle right', 'envelope', 'conversation', 'rain', 'clipboard', 'lightbulb',
+  'bell', 'ambulance', 'medkit', 'fighter jet', 'beer', 'plus square', 'computer', 'circle outline', 'gamepad',
+  'star half full', 'broken chain', 'question', 'exclamation', 'eraser', 'microphone', 'microphone slash', 'shield',
+  'target', 'play circle', 'pencil square', 'eur', 'gbp', 'usd', 'inr', 'cny', 'rmb', 'jpy', 'rouble', 'rub', 'krw',
+  'btc', 'gratipay', 'zip', 'dot circle outline', 'try', 'graduation', 'circle outline', 'sliders', 'weixin', 'tty',
+  'teletype', 'binoculars', 'power cord', 'wifi', 'visa card', 'mastercard card', 'discover card', 'amex',
+  'american express card', 'stripe card', 'bell slash', 'bell slash outline', 'area graph', 'pie graph', 'line graph',
+  'cc', 'sheqel', 'ils', 'plus cart', 'arrow down cart', 'detective', 'venus', 'mars', 'mercury', 'intersex',
+  'venus double', 'female homosexual', 'mars double', 'male homosexual', 'venus mars', 'mars stroke', 'mars alternate',
+  'mars vertical', 'mars stroke vertical', 'mars horizontal', 'mars stroke horizontal', 'asexual', 'facebook official',
+  'user plus', 'user times', 'user close', 'user cancel', 'user delete', 'user x', 'bed', 'yc', 'ycombinator',
+  'battery four', 'battery three', 'battery three quarters', 'battery two', 'battery half', 'battery one',
+  'battery quarter', 'battery zero', 'i cursor', 'jcb', 'japan credit bureau card', 'diners club card', 'balance',
+  'hourglass outline', 'hourglass zero', 'hourglass one', 'hourglass two', 'hourglass three', 'hourglass four', 'grab',
+  'hand victory', 'tm', 'r circle', 'television', 'five hundred pixels', 'calendar plus', 'calendar minus',
+  'calendar times', 'calendar check', 'factory', 'commenting', 'commenting outline', 'edge', 'ms edge',
+  'wordpress beginner', 'wordpress forms', 'envira', 'question circle outline', 'assistive listening devices', 'als',
+  'ald', 'asl interpreting', 'deaf', 'american sign language interpreting', 'hard of hearing', 'signing',
+  'new pied piper', 'theme isle', 'google plus official', 'fa',
 ]

--- a/src/lib/SUI.js
+++ b/src/lib/SUI.js
@@ -82,8 +82,8 @@ export const ICONS = [
 
   // Item Selection
   'checkmark', 'remove', 'checkmark box', 'move', 'add circle', 'minus circle', 'remove circle', 'check circle',
-  'remove circle outline', 'check circle outline', 'plus', 'minus', 'add square', 'radio', 'minus square', 'minus square outline',
-  'check square', 'selected radio', 'plus square outline', 'toggle off', 'toggle on',
+  'remove circle outline', 'check circle outline', 'plus', 'minus', 'add square', 'radio', 'minus square',
+  'minus square outline', 'check square', 'selected radio', 'plus square outline', 'toggle off', 'toggle on',
 
   // Media
   'film', 'sound', 'photo', 'bar chart', 'camera retro', 'newspaper', 'area chart', 'pie chart', 'line chart',

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -19,8 +19,8 @@ export const disallow = disallowedProps => {
   return (props, propName, componentName) => {
     if (!Array.isArray(disallowedProps)) {
       throw new Error([
-        'Invalid argument supplied to disallow, expected an instance of array.'
-          ` See \`${propName}\` prop in \`${componentName}\`.`,
+        'Invalid argument supplied to disallow, expected an instance of array.',
+        ` See \`${propName}\` prop in \`${componentName}\`.`,
       ].join(''))
     }
 
@@ -34,7 +34,6 @@ export const disallow = disallowedProps => {
       }
       return acc
     }, [])
-
 
     if (disallowed.length > 0) {
       return new Error([
@@ -61,9 +60,7 @@ export const every = (validators) => {
     const errors = _.flow(
       _.map(validator => {
         if (typeof validator !== 'function') {
-          throw new Error(
-            `every() argument "validators" should contain functions, found: ${typeOf(validator)}.`
-          )
+          throw new Error(`every() argument "validators" should contain functions, found: ${typeOf(validator)}.`)
         }
         return validator(props, propName, componentName, ...rest)
       }),
@@ -90,9 +87,7 @@ export const some = (validators) => {
 
     const errors = _.compact(_.map(validators, validator => {
       if (!_.isFunction(validator)) {
-        throw new Error(
-          `some() argument "validators" should contain functions, found: ${typeOf(validator)}.`
-        )
+        throw new Error(`some() argument "validators" should contain functions, found: ${typeOf(validator)}.`)
       }
       return validator(props, propName, componentName, ...rest)
     }))
@@ -163,8 +158,8 @@ export const demand = (requiredProps) => {
   return (props, propName, componentName) => {
     if (!Array.isArray(requiredProps)) {
       throw new Error([
-        'Invalid `requiredProps` argument supplied to require, expected an instance of array.'
-          ` See \`${propName}\` prop in \`${componentName}\`.`,
+        'Invalid `requiredProps` argument supplied to require, expected an instance of array.',
+        ` See \`${propName}\` prop in \`${componentName}\`.`,
       ].join(''))
     }
 
@@ -174,7 +169,7 @@ export const demand = (requiredProps) => {
     const missingRequired = requiredProps.filter(requiredProp => props[requiredProp] === undefined)
     if (missingRequired.length > 0) {
       return new Error(
-        `\`${propName}\` prop in \`${componentName}\` requires props: \`${missingRequired.join('`, `')}\`.`,
+        `\`${propName}\` prop in \`${componentName}\` requires props: \`${missingRequired.join('`, `')}\`.`
       )
     }
   }

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -29,10 +29,7 @@ export const suggest = suggestions => {
     const propValue = props[propName]
 
     // skip if prop is undefined or is included in the suggestions
-    const nil = _.isNil(propValue)
-    const fal = propValue === false
-    const includes = _.includes(propValue, suggestions)
-    if (nil || fal || includes) return
+    if (_.isNil(propValue) || propValue === false || _.includes(propValue, suggestions)) return
 
     // find best suggestions
     const propValueWords = propValue.split(' ')

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -37,6 +37,7 @@ export const suggest = suggestions => {
     // find best suggestions
     const propValueWords = propValue.split(' ')
 
+    /* eslint-disable max-nested-callbacks */
     const bestMatches = _.flow(
       _.map(suggestion => {
         const suggestionWords = suggestion.split(' ')
@@ -58,6 +59,7 @@ export const suggest = suggestions => {
       _.sortBy(['score', 'suggestion']),
       _.take(3)
     )(suggestions)
+    /* eslint-enable max-nested-callbacks */
 
     // skip if a match scored 0
     // since we're matching on words (classNames) this allows any word order to pass validation

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -16,7 +16,7 @@ export const as = (...args) => PropTypes.oneOfType([
  * Similar to PropTypes.oneOf but shows closest matches.
  * Word order is ignored allowing `left chevron` to match `chevron left`.
  * Useful for very large lists of options (e.g. Icon name, Flag name, etc.)
- * @param {string[]} suggestions An array of props that cannot be used with this prop.
+ * @param {string[]} suggestions An array of allowed values.
  */
 export const suggest = suggestions => {
   return (props, propName, componentName) => {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -21,6 +21,7 @@ export * from './factories'
 export { default as getUnhandledProps } from './getUnhandledProps'
 export { default as getElementType } from './getElementType'
 export { default as isBrowser } from './isBrowser'
+export { default as leven } from './leven'
 export * as META from './META'
 export * as SUI from './SUI'
 

--- a/src/lib/leven.js
+++ b/src/lib/leven.js
@@ -1,0 +1,48 @@
+// Copy of sindre's leven, wrapped in dead code elimination for production
+// https://github.com/sindresorhus/leven/blob/master/index.js
+
+let leven = () => 0
+
+if (process.env.NODE_ENV !== 'production') {
+  /* eslint-disable complexity, no-nested-ternary */
+  const arr = []
+  const charCodeCache = []
+
+  leven = (a, b) => {
+    if (a === b) return 0
+
+    const aLen = a.length
+    const bLen = b.length
+
+    if (aLen === 0) return bLen
+    if (bLen === 0) return aLen
+
+    let bCharCode
+    let ret
+    let tmp
+    let tmp2
+    let i = 0
+    let j = 0
+
+    while (i < aLen) {
+      charCodeCache[i] = a.charCodeAt(i)
+      arr[i] = ++i
+    }
+
+    while (j < bLen) {
+      bCharCode = b.charCodeAt(j)
+      tmp = j++
+      ret = j
+
+      for (i = 0; i < aLen; i++) {
+        tmp2 = bCharCode === charCodeCache[i] ? tmp : tmp + 1
+        tmp = arr[i]
+        ret = arr[i] = tmp > ret ? tmp2 > ret ? ret + 1 : tmp2 : tmp2 > tmp ? tmp + 1 : tmp2
+      }
+    }
+
+    return ret
+  }
+}
+
+export default leven


### PR DESCRIPTION
Fixes #936 and several other issues.

This PR:
- updates Icon names, including all aliases
- adds a `suggest` prop type checker for large lists of options (see below)
- uses unminified React in dev (fixes missing React errors/warnings)
- fixes several broken customPropType error messages

### Suggest best match

We now show the top 3 matches for Icon and Flag names.  The `suggest` prop type checker can be used on any large list of options.

![image](https://cloud.githubusercontent.com/assets/5067638/20651919/00049db8-b4a4-11e6-855f-3c2d727c9d57.png)

### Forgiving className order

The `suggest` checker allows `right chevron` to be considered valid against the value `chevron right`.  As long as all the words match every word in one of the options, the prop is considered valid.