### PR TITLE
breaking(Form|RatingIcon|Search|SearchResult): Pass data to event handlers

### DIFF
--- a/docs/app/Examples/collections/Form/Types/FormExampleOnSubmit.js
+++ b/docs/app/Examples/collections/Form/Types/FormExampleOnSubmit.js
@@ -21,17 +21,17 @@ const products = [
 ]
 
 class FormExampleOnSubmit extends Component {
-  state = { serializedForm: {} }
+  state = { formData: {} }
 
   handleChange = (e, { value }) => this.setState({ value })
 
-  handleSubmit = (e, serializedForm) => {
+  handleSubmit = (e, { formData }) => {
     e.preventDefault()
-    this.setState({ serializedForm })
+    this.setState({ formData })
   }
 
   render() {
-    const { serializedForm, value } = this.state
+    const { formData, value } = this.state
     return (
       <Form onSubmit={this.handleSubmit}>
         <Form.Group widths='equal'>
@@ -62,7 +62,7 @@ class FormExampleOnSubmit extends Component {
         <Button primary type='submit'>Submit</Button>
 
         <Message>
-          <pre>serializedForm: {JSON.stringify(serializedForm, null, 2)}</pre>
+          <pre>formData: {JSON.stringify(formData, null, 2)}</pre>
         </Message>
       </Form>
     )

--- a/docs/app/Examples/modules/Search/Types/SearchExampleCategory.js
+++ b/docs/app/Examples/modules/Search/Types/SearchExampleCategory.js
@@ -28,7 +28,7 @@ export default class SearchExampleCategory extends Component {
 
   resetComponent = () => this.setState({ isLoading: false, results: [], value: '' })
 
-  handleChange = (e, result) => this.setState({ value: result.title })
+  handleResultSelect = (e, result) => this.setState({ value: result.title })
 
   handleSearchChange = (e, value) => {
     this.setState({ isLoading: true, value })
@@ -65,7 +65,7 @@ export default class SearchExampleCategory extends Component {
           <Search
             category
             loading={isLoading}
-            onChange={this.handleChange}
+            onResultSelect={this.handleResultSelect}
             onSearchChange={this.handleSearchChange}
             results={results}
             value={value}

--- a/docs/app/Examples/modules/Search/Types/SearchExampleStandard.js
+++ b/docs/app/Examples/modules/Search/Types/SearchExampleStandard.js
@@ -17,7 +17,7 @@ export default class SearchExampleStandard extends Component {
 
   resetComponent = () => this.setState({ isLoading: false, results: [], value: '' })
 
-  handleChange = (e, result) => this.setState({ value: result.title })
+  handleResultSelect = (e, result) => this.setState({ value: result.title })
 
   handleSearchChange = (e, value) => {
     this.setState({ isLoading: true, value })
@@ -43,7 +43,7 @@ export default class SearchExampleStandard extends Component {
         <Grid.Column width={8}>
           <Search
             loading={isLoading}
-            onChange={this.handleChange}
+            onResultSelect={this.handleResultSelect}
             onSearchChange={this.handleSearchChange}
             results={results}
             value={value}

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -78,16 +78,36 @@ class Portal extends Component {
     /** Milliseconds to wait before opening on mouse over */
     mouseOverDelay: PropTypes.number,
 
-    /** Called when a close event happens */
+    /**
+     * Called when a close event happens
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClose: PropTypes.func,
 
-    /** Called when the portal is mounted on the DOM */
+    /**
+     * Called when the portal is mounted on the DOM
+     *
+     * @param {null}
+     * @param {object} data - All props.
+     */
     onMount: PropTypes.func,
 
-    /** Called when an open event happens */
+    /**
+     * Called when an open event happens
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onOpen: PropTypes.func,
 
-    /** Called when the portal is unmounted from the DOM */
+    /**
+     * Called when the portal is unmounted from the DOM
+     *
+     * @param {null}
+     * @param {object} data - All props.
+     */
     onUnmount: PropTypes.func,
 
     /** Controls whether or not the portal is displayed. */

--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -42,7 +42,13 @@ export default class BreadcrumbSection extends Component {
       PropTypes.string,
     ]),
 
-    /** Render as an `a` tag instead of a `div` and called with event on Section click. */
+    /**
+     * Called on click. When passed, the component render as an `a`
+     * tag by default instead of a `div`.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClick: PropTypes.func,
   }
 
@@ -55,7 +61,7 @@ export default class BreadcrumbSection extends Component {
   handleClick = (e) => {
     const { onClick } = this.props
 
-    if (onClick) onClick(e)
+    if (onClick) onClick(e, this.props)
   }
 
   render() {

--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -43,7 +43,7 @@ export default class BreadcrumbSection extends Component {
     ]),
 
     /**
-     * Called on click. When passed, the component render as an `a`
+     * Called on click. When passed, the component will render as an `a`
      * tag by default instead of a `div`.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -244,7 +244,7 @@ export default class Form extends Component {
   handleSubmit = (e) => {
     const { onSubmit, serializer } = this.props
 
-    if (onSubmit) onSubmit(e, { ...this.props, value: serializer(this._form) })
+    if (onSubmit) onSubmit(e, { ...this.props, formData: serializer(this._form) })
   }
 
   render() {

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -198,7 +198,12 @@ export default class Form extends Component {
     /** Automatically show a loading indicator */
     loading: PropTypes.bool,
 
-    /** Called with (event, jsonSerializedForm) on submit */
+    /**
+     * Called with (event, jsonSerializedForm) on submit
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props and the form's serialized values.
+     */
     onSubmit: PropTypes.func,
 
     /** A comment can contain a form to reply to a comment. This may have arbitrary content. */
@@ -239,7 +244,7 @@ export default class Form extends Component {
   handleSubmit = (e) => {
     const { onSubmit, serializer } = this.props
 
-    if (onSubmit) onSubmit(e, serializer(this._form))
+    if (onSubmit) onSubmit(e, { ...this.props, value: serializer(this._form) })
   }
 
   render() {

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -199,7 +199,7 @@ export default class Form extends Component {
     loading: PropTypes.bool,
 
     /**
-     * Called with (event, jsonSerializedForm) on submit
+     * Called on submit
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
      * @param {object} data - All props and the form's serialized values.

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -93,7 +93,12 @@ class Menu extends Component {
     /** Shorthand array of props for Menu. */
     items: customPropTypes.collectionShorthand,
 
-    /** onClick handler for MenuItem. Mutually exclusive with children. */
+    /**
+     * onClick handler for MenuItem. Mutually exclusive with children.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All item props.
+     */
     onItemClick: customPropTypes.every([
       customPropTypes.disallow(['children']),
       PropTypes.func,
@@ -140,12 +145,14 @@ class Menu extends Component {
   static Item = MenuItem
   static Menu = MenuMenu
 
-  handleItemClick = (e, { name, index }) => {
+  handleItemClick = (e, itemProps) => {
+    const { index } = itemProps
+
     this.trySetState({ activeIndex: index })
     const { items, onItemClick } = this.props
 
-    if (_.get(items[index], 'onClick')) items[index].onClick(e, { name, index })
-    if (onItemClick) onItemClick(e, { name, index })
+    if (_.get(items[index], 'onClick')) items[index].onClick(e, itemProps)
+    if (onItemClick) onItemClick(e, itemProps)
   }
 
   renderItems() {

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -68,7 +68,13 @@ export default class MenuItem extends Component {
     /** Internal name of the MenuItem. */
     name: PropTypes.string,
 
-    /** Render as an `a` tag instead of a `div` and called with event on MenuItem click. */
+    /**
+     * Called on click. When passed, the component render as an `a`
+     * tag by default instead of a `div`.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClick: PropTypes.func,
 
     /** A menu item can take right position. */
@@ -78,9 +84,9 @@ export default class MenuItem extends Component {
   static _meta = _meta
 
   handleClick = (e) => {
-    const { index, name, onClick } = this.props
+    const { onClick } = this.props
 
-    if (onClick) onClick(e, { name, index })
+    if (onClick) onClick(e, this.props)
   }
 
   render() {

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -69,7 +69,7 @@ export default class MenuItem extends Component {
     name: PropTypes.string,
 
     /**
-     * Called on click. When passed, the component render as an `a`
+     * Called on click. When passed, the component will render as an `a`
      * tag by default instead of a `div`.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -140,7 +140,7 @@ class Button extends Component {
     /**
      * Called after user's click.
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - Button props.
+     * @param {object} data - All props.
      */
     onClick: PropTypes.func,
 

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -124,7 +124,12 @@ class Input extends Component {
     /** An Icon Input field can show that it is currently loading data */
     loading: PropTypes.bool,
 
-    /** Called with (e, data) on change. */
+    /**
+     * Called on change.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props and proposed value.
+     */
     onChange: PropTypes.func,
 
     /** An Input can vary in size */
@@ -144,13 +149,10 @@ class Input extends Component {
   static _meta = _meta
 
   handleChange = (e) => {
+    const value = _.get(e, 'target.value')
+
     const { onChange } = this.props
-    if (onChange) {
-      onChange(e, {
-        ...this.props,
-        value: _.get(e, 'target.value'),
-      })
-    }
+    if (onChange) onChange(e, { ...this.props, value })
   }
 
   render() {

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -101,10 +101,20 @@ export default class Label extends Component {
       PropTypes.oneOf(_meta.props.pointing),
     ]),
 
-    /** Adds the link style when present, called with (event, props). */
+    /**
+     * Adds the link style when present, called with (event, props).
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClick: PropTypes.func,
 
-    /** Adds an "x" icon, called with (event, props) when "x" is clicked. */
+    /**
+     * Adds an "x" icon, called with (event, props) when "x" is clicked.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onRemove: PropTypes.func,
 
     /** Shorthand for Icon to appear as the last child and trigger onRemove. */

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -102,7 +102,7 @@ export default class Label extends Component {
     ]),
 
     /**
-     * Adds the link style when present, called with (event, props).
+     * Called on click.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
      * @param {object} data - All props.
@@ -110,7 +110,7 @@ export default class Label extends Component {
     onClick: PropTypes.func,
 
     /**
-     * Adds an "x" icon, called with (event, props) when "x" is clicked.
+     * Adds an "x" icon, called when "x" is clicked.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
      * @param {object} data - All props.

--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -50,7 +50,13 @@ export default class Step extends Component {
     /** Render as an `a` tag instead of a `div` and adds the href attribute. */
     href: PropTypes.string,
 
-    /** Render as an `a` tag instead of a `div` and called with event on Step click. */
+    /**
+     * Called on click. When passed, the component render as an `a`
+     * tag by default instead of a `div`.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClick: PropTypes.func,
 
     /** A step can show a ordered sequence of steps. Passed from StepGroup. */
@@ -73,7 +79,7 @@ export default class Step extends Component {
   handleClick = (e) => {
     const { onClick } = this.props
 
-    if (onClick) onClick(e)
+    if (onClick) onClick(e, this.props)
   }
 
   render() {

--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -51,7 +51,7 @@ export default class Step extends Component {
     href: PropTypes.string,
 
     /**
-     * Called on click. When passed, the component render as an `a`
+     * Called on click. When passed, the component will render as an `a`
      * tag by default instead of a `div`.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,7 @@ export { default as PopupHeader } from './modules/Popup/PopupHeader'
 export { default as Progress } from './modules/Progress'
 
 export { default as Rating } from './modules/Rating'
+export { default as RatingIcon } from './modules/Rating/RatingIcon'
 
 export { default as Search } from './modules/Search'
 export { default as SearchCategory } from './modules/Search/SearchCategory'

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -28,7 +28,12 @@ export default class AccordionTitle extends Component {
     /** Additional classes. */
     className: PropTypes.string,
 
-    /** Called with (event, index) on title click. */
+    /**
+     * Called on blur.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClick: PropTypes.func,
   }
 
@@ -41,7 +46,7 @@ export default class AccordionTitle extends Component {
   handleClick = (e) => {
     const { onClick } = this.props
 
-    if (onClick) onClick(e)
+    if (onClick) onClick(e, this.props)
   }
 
   render() {

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -56,10 +56,20 @@ export default class Checkbox extends Component {
     /** The HTML input name. */
     name: PropTypes.string,
 
-    /** Called with (event, { name, value, checked }) when the user attempts to change the value. */
+    /**
+     * Called when the user attempts to change the checked state.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props and proposed checked state.
+     */
     onChange: PropTypes.func,
 
-    /** Called with (event, { name, value, checked }) when the checkbox or label is clicked. */
+    /**
+     * Called when the checkbox or label is clicked.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props and current checked state.
+     */
     onClick: PropTypes.func,
 
     /** Format as a radio element. This means it is an exclusive option.*/
@@ -111,15 +121,12 @@ export default class Checkbox extends Component {
 
   handleClick = (e) => {
     debug('handleClick()')
-    const { name, onChange, onClick, value } = this.props
+    const { onChange, onClick } = this.props
     const { checked } = this.state
-    debug(`  name:       ${name}`)
-    debug(`  value:      ${value}`)
-    debug(`  checked:    ${checked}`)
 
     if (this.canToggle()) {
-      if (onClick) onClick(e, { name, value, checked: !!checked })
-      if (onChange) onChange(e, { name, value, checked: !checked })
+      if (onClick) onClick(e, { ...this.props, checked: !!checked })
+      if (onChange) onChange(e, { ...this.props, checked: !checked })
 
       this.trySetState({ checked: !checked })
     }

--- a/src/modules/Dimmer/Dimmer.js
+++ b/src/modules/Dimmer/Dimmer.js
@@ -41,10 +41,20 @@ export default class Dimmer extends Component {
     /** A disabled dimmer cannot be activated */
     disabled: PropTypes.bool,
 
-    /** Called with (event, props) after user's click. */
+    /**
+     * Called with (event, props) after user's click.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClick: PropTypes.func,
 
-    /** Handles click outside Dimmer's content, but inside Dimmer area. */
+    /**
+     * Handles click outside Dimmer's content, but inside Dimmer area.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClickOutside: PropTypes.func,
 
     /** A dimmer can be formatted to have its colors inverted. */

--- a/src/modules/Dimmer/Dimmer.js
+++ b/src/modules/Dimmer/Dimmer.js
@@ -42,7 +42,7 @@ export default class Dimmer extends Component {
     disabled: PropTypes.bool,
 
     /**
-     * Called with (event, props) after user's click.
+     * Called on click.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
      * @param {object} data - All props.

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -147,34 +147,84 @@ export default class Dropdown extends Component {
     /** Message to display when there are no results. */
     noResultsMessage: PropTypes.string,
 
-    /** Called with the name and new value added by the user. Use this to update the options list. */
+    /**
+     * Called with the name and new value added by the user. Use this to update the options list.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onAddItem: PropTypes.func,
 
-    /** Called with the React Synthetic Event on Dropdown blur. */
+    /**
+     * Called on blur.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onBlur: PropTypes.func,
 
-    /** Called with the React Synthetic Event and { name, value } on change. */
+    /**
+     * Called when the user attempts to change the value.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props and proposed value.
+     */
     onChange: PropTypes.func,
 
-    /** Called when a close event happens. */
+    /**
+     * Called when a close event happens.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClose: PropTypes.func,
 
-    /** Called when a multi-select label is clicked. */
+    /**
+     * Called when a multi-select label is clicked.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All label props.
+     */
     onLabelClick: PropTypes.func,
 
-    /** Called when an open event happens. */
+    /**
+     * Called when an open event happens.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onOpen: PropTypes.func,
 
-    /** Called with the React Synthetic Event and current value on search input change. */
+    /**
+     * Called with the React Synthetic Event and current value on search input change.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onSearchChange: PropTypes.func,
 
-    /** Called with the React Synthetic Event on Dropdown click. */
+    /**
+     * Called on click.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClick: PropTypes.func,
 
-    /** Called with the React Synthetic Event on Dropdown focus. */
+    /**
+     * Called on focus.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onFocus: PropTypes.func,
 
-    /** Called with the React Synthetic Event on Dropdown mouse down. */
+    /**
+     * Called on mousedown.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onMouseDown: PropTypes.func,
 
     /** Controls whether or not the dropdown menu is displayed. */
@@ -412,8 +462,8 @@ export default class Dropdown extends Component {
   handleChange = (e, value) => {
     debug('handleChange()')
     debug(value)
-    const { name, onChange } = this.props
-    if (onChange) onChange(e, { name, value })
+    const { onChange } = this.props
+    if (onChange) onChange(e, { ...this.props, value })
   }
 
   closeOnEscape = (e) => {
@@ -534,7 +584,7 @@ export default class Dropdown extends Component {
   handleMouseDown = (e) => {
     debug('handleMouseDown()')
     const { onMouseDown } = this.props
-    if (onMouseDown) onMouseDown(e)
+    if (onMouseDown) onMouseDown(e, this.props)
     this.isMouseDown = true
     // Do not access document when server side rendering
     if (!isBrowser) return
@@ -552,7 +602,7 @@ export default class Dropdown extends Component {
   handleClick = (e) => {
     debug('handleClick()', e)
     const { onClick } = this.props
-    if (onClick) onClick(e)
+    if (onClick) onClick(e, this.props)
     // prevent closeOnDocumentClick()
     e.stopPropagation()
     this.toggle(e)
@@ -593,7 +643,7 @@ export default class Dropdown extends Component {
   handleFocus = (e) => {
     debug('handleFocus()')
     const { onFocus } = this.props
-    if (onFocus) onFocus(e)
+    if (onFocus) onFocus(e, this.props)
     this.setState({ focus: true })
   }
 
@@ -602,7 +652,7 @@ export default class Dropdown extends Component {
     const { multiple, onBlur, selectOnBlur } = this.props
     // do not "blur" when the mouse is down inside of the Dropdown
     if (this.isMouseDown) return
-    if (onBlur) onBlur(e)
+    if (onBlur) onBlur(e, this.props)
     if (selectOnBlur && !multiple) this.selectHighlightedItem(e)
     this.setState({ focus: false })
   }

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -151,7 +151,7 @@ export default class Dropdown extends Component {
      * Called with the name and new value added by the user. Use this to update the options list.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All props.
+     * @param {object} data - All item props.
      */
     onAddItem: PropTypes.func,
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -148,10 +148,10 @@ export default class Dropdown extends Component {
     noResultsMessage: PropTypes.string,
 
     /**
-     * Called with the name and new value added by the user. Use this to update the options list.
+     * Called when a user adds a new item. Use this to update the options list.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All item props.
+     * @param {object} data - All props and the new item's value.
      */
     onAddItem: PropTypes.func,
 
@@ -196,10 +196,10 @@ export default class Dropdown extends Component {
     onOpen: PropTypes.func,
 
     /**
-     * Called with the React Synthetic Event and current value on search input change.
+     * Called on search input change.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All props.
+     * @param {string} value - Current value of search input.
      */
     onSearchChange: PropTypes.func,
 
@@ -514,7 +514,7 @@ export default class Dropdown extends Component {
 
   selectHighlightedItem = (e) => {
     const { open } = this.state
-    const { multiple, name, onAddItem, options } = this.props
+    const { multiple, onAddItem, options } = this.props
     const value = _.get(this.getSelectedItem(), 'value')
 
     // prevent selecting null if there was no selected item value
@@ -523,7 +523,7 @@ export default class Dropdown extends Component {
 
     // notify the onAddItem prop if this is a new value
     if (onAddItem && !_.some(options, { text: value })) {
-      onAddItem(e, { name, value })
+      onAddItem(e, { ...this.props, value })
     }
 
     // notify the onChange prop that the user is trying to change value
@@ -608,11 +608,11 @@ export default class Dropdown extends Component {
     this.toggle(e)
   }
 
-  handleItemClick = (e, { value }) => {
+  handleItemClick = (e, item) => {
     debug('handleItemClick()')
-    debug(value)
-    const { multiple, name, onAddItem, options } = this.props
-    const item = this.getItemByValue(value) || {}
+    debug(item)
+    const { multiple, onAddItem, options } = this.props
+    const { value } = item
 
     // prevent toggle() in handleClick()
     e.stopPropagation()
@@ -625,7 +625,7 @@ export default class Dropdown extends Component {
 
     // notify the onAddItem prop if this is a new value
     if (onAddItem && !_.some(options, { text: value })) {
-      onAddItem(e, { name, value })
+      onAddItem(e, { ...this.props, value })
     }
 
     // notify the onChange prop that the user is trying to change value

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -68,7 +68,12 @@ export default class DropdownItem extends Component {
       PropTypes.string,
     ]),
 
-    /** Called on click with (event, props). */
+    /**
+     * Called on click.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClick: PropTypes.func,
   }
 

--- a/src/modules/Embed/Embed.js
+++ b/src/modules/Embed/Embed.js
@@ -86,7 +86,12 @@ export default class Embed extends Component {
     /** Specifies an icon to use with placeholder content. */
     icon: customPropTypes.itemShorthand,
 
-    /** Сalled with event on Embed click with (event, props). */
+    /**
+     * Сalled with event on Embed click with (event, props).
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props and proposed value.
+     */
     onClick: PropTypes.func,
 
     /** A placeholder image for embed. */
@@ -149,7 +154,7 @@ export default class Embed extends Component {
     const { onClick } = this.props
     const { active } = this.state
 
-    if (onClick) onClick(e, this.props)
+    if (onClick) onClick(e, { ...this.props, active: true })
     if (!active) this.trySetState({ active: true })
   }
 

--- a/src/modules/Embed/Embed.js
+++ b/src/modules/Embed/Embed.js
@@ -87,7 +87,7 @@ export default class Embed extends Component {
     icon: customPropTypes.itemShorthand,
 
     /**
-     * Сalled with event on Embed click with (event, props).
+     * Сalled on click.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
      * @param {object} data - All props and proposed value.

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -69,16 +69,36 @@ class Modal extends Component {
     /** The node where the modal should mount.. */
     mountNode: PropTypes.any,
 
-    /** Called when a close event happens */
+    /**
+     * Called when a close event happens
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClose: PropTypes.func,
 
-    /** Called when the portal is mounted on the DOM */
+    /**
+     * Called when the portal is mounted on the DOM
+     *
+     * @param {null}
+     * @param {object} data - All props.
+     */
     onMount: PropTypes.func,
 
-    /** Called when an open event happens */
+    /**
+     * Called when an open event happens
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onOpen: PropTypes.func,
 
-    /** Called when the portal is unmounted from the DOM */
+    /**
+     * Called when the portal is unmounted from the DOM
+     *
+     * @param {null}
+     * @param {object} data - All props.
+     */
     onUnmount: PropTypes.func,
 
     /** Controls whether or not the Modal is displayed. */

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -80,16 +80,36 @@ export default class Popup extends Component {
     /** Event triggering the popup */
     on: PropTypes.oneOf(_meta.props.on),
 
-    /** Called when a close event happens */
+    /**
+     * Called when a close event happens
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClose: PropTypes.func,
 
-    /** Called when the portal is mounted on the DOM */
+    /**
+     * Called when the portal is mounted on the DOM
+     *
+     * @param {null}
+     * @param {object} data - All props.
+     */
     onMount: PropTypes.func,
 
-    /** Called when an open event happens */
+    /**
+     * Called when an open event happens
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onOpen: PropTypes.func,
 
-    /** Called when the portal is unmounted from the DOM */
+    /**
+     * Called when the portal is unmounted from the DOM
+     *
+     * @param {null}
+     * @param {object} data - All props.
+     */
     onUnmount: PropTypes.func,
 
     /** Positioning for the popover */

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -71,7 +71,12 @@ export default class Rating extends Component {
       PropTypes.number,
     ]),
 
-    /** Called with (event, { rating, maxRating }) after user selects a new rating. */
+    /**
+     * Called with (event, { rating, maxRating }) after user selects a new rating.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props and proposed rating.
+     */
     onRate: PropTypes.func,
 
     /** The current number of active icons. */
@@ -86,7 +91,7 @@ export default class Rating extends Component {
 
   static _meta = _meta
 
-  handleIconClick = (e, index) => {
+  handleIconClick = (e, { index }) => {
     const { clearable, disabled, maxRating, onRate } = this.props
     const { rating } = this.state
     if (disabled) return
@@ -103,10 +108,10 @@ export default class Rating extends Component {
 
     // set rating
     this.trySetState({ rating: newRating }, { isSelecting: false })
-    if (onRate) onRate(e, { rating: newRating, maxRating })
+    if (onRate) onRate(e, { ...this.props, rating: newRating })
   }
 
-  handleIconMouseEnter = (index) => {
+  handleIconMouseEnter = (e, { index }) => {
     if (this.props.disabled) return
 
     this.setState({ selectedIndex: index, isSelecting: true })

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -90,6 +90,7 @@ export default class Rating extends Component {
   }
 
   static _meta = _meta
+  static Icon = RatingIcon
 
   handleIconClick = (e, { index }) => {
     const { clearable, disabled, maxRating, onRate } = this.props

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -72,7 +72,7 @@ export default class Rating extends Component {
     ]),
 
     /**
-     * Called with (event, { rating, maxRating }) after user selects a new rating.
+     * Called after user selects a new rating.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
      * @param {object} data - All props and proposed rating.

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -19,10 +19,20 @@ export default class RatingIcon extends Component {
     /** An index of icon inside Rating. */
     index: PropTypes.number,
 
-    /** Called with (event, index) after user clicked on an icon. */
+    /**
+     * Called with (event, index) after user clicked on an icon.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClick: PropTypes.func,
 
-    /** Called with (index) after user move cursor to an icon. */
+    /**
+     * Called with (index) after user move cursor to an icon.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onMouseEnter: PropTypes.func,
 
     /** Indicates selection of an icon. */
@@ -36,20 +46,20 @@ export default class RatingIcon extends Component {
   }
 
   handleClick = (e) => {
-    const { onClick, index } = this.props
+    const { onClick } = this.props
 
-    if (onClick) onClick(e, index)
+    if (onClick) onClick(e, this.props)
   }
 
   handleKeyUp = (e) => {
-    const { onClick, index } = this.props
+    const { onClick } = this.props
 
     if (onClick) {
       switch (keyboardKey.getCode(e)) {
         case keyboardKey.Enter:
         case keyboardKey.Spacebar:
           e.preventDefault()
-          onClick(e, index)
+          onClick(e, this.props)
           break
         default:
           return
@@ -57,10 +67,10 @@ export default class RatingIcon extends Component {
     }
   }
 
-  handleMouseEnter = () => {
-    const { onMouseEnter, index } = this.props
+  handleMouseEnter = (e) => {
+    const { onMouseEnter } = this.props
 
-    if (onMouseEnter) onMouseEnter(index)
+    if (onMouseEnter) onMouseEnter(e, this.props)
   }
 
   render() {

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -1,8 +1,10 @@
-import _ from 'lodash'
 import cx from 'classnames'
 import React, { Component, PropTypes } from 'react'
 
 import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
   META,
   useKeyOnly,
   keyboardKey,
@@ -16,11 +18,17 @@ export default class RatingIcon extends Component {
     /** Indicates activity of an icon. */
     active: PropTypes.bool,
 
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
+
+    /** Additional classes. */
+    className: PropTypes.string,
+
     /** An index of icon inside Rating. */
     index: PropTypes.number,
 
     /**
-     * Called with (event, index) after user clicked on an icon.
+     * Called on click.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
      * @param {object} data - All props.
@@ -28,7 +36,15 @@ export default class RatingIcon extends Component {
     onClick: PropTypes.func,
 
     /**
-     * Called with (index) after user move cursor to an icon.
+     * Called on keyup.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onKeyUp: PropTypes.func,
+
+    /**
+     * Called on mouseenter.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
      * @param {object} data - All props.
@@ -37,6 +53,10 @@ export default class RatingIcon extends Component {
 
     /** Indicates selection of an icon. */
     selected: PropTypes.bool,
+  }
+
+  defaultProps = {
+    as: 'i',
   }
 
   static _meta = {
@@ -52,7 +72,9 @@ export default class RatingIcon extends Component {
   }
 
   handleKeyUp = (e) => {
-    const { onClick } = this.props
+    const { onClick, onKeyUp } = this.props
+
+    if (onKeyUp) onKeyUp(e, this.props)
 
     if (onClick) {
       switch (keyboardKey.getCode(e)) {
@@ -74,16 +96,20 @@ export default class RatingIcon extends Component {
   }
 
   render() {
-    const { active, selected } = this.props
+    const { active, className, selected } = this.props
     const classes = cx(
       useKeyOnly(active, 'active'),
       useKeyOnly(selected, 'selected'),
-      'icon'
+      'icon',
+      className,
     )
-    const rest = _.omit(this.props, _.keys(RatingIcon.propTypes))
+    const rest = getUnhandledProps(RatingIcon, this.props)
+    const ElementType = getElementType(RatingIcon, this.props)
 
     return (
-      <i role='radio' tabIndex={0}
+      <ElementType
+        role='radio'
+        tabIndex={0}
         {...rest}
         className={classes}
         onKeyUp={this.handleKeyUp}

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -110,19 +110,44 @@ export default class Search extends Component {
     // Callbacks
     // ------------------------------------
 
-    /** Called with the React Synthetic Event on Search blur. */
+    /**
+     * Called on blur.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onBlur: PropTypes.func,
 
-    /** Called with the React Synthetic Event, the selected result. */
-    onChange: PropTypes.func,
+    /**
+     * Called when a result is selected.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onResultSelect: PropTypes.func,
 
-    /** Called with the React Synthetic Event and current value on search input change. */
+    /**
+     * Called with the React Synthetic Event and current value on search input change.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onSearchChange: PropTypes.func,
 
-    /** Called with the React Synthetic Event on Search focus. */
+    /**
+     * Called on focus.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onFocus: PropTypes.func,
 
-    /** Called with the React Synthetic Event on Dropdown mouse down. */
+    /**
+     * Called on mousedown.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onMouseDown: PropTypes.func,
 
     // ------------------------------------
@@ -251,13 +276,11 @@ export default class Search extends Component {
   // Document Event Handlers
   // ----------------------------------------
 
-  // onChange needs to receive a value
-  // can't rely on props.value if we are controlled
-  handleChange = (e, result) => {
-    debug('handleChange()')
+  handleResultSelect = (e, result) => {
+    debug('handleResultSelect()')
     debug(result)
-    const { onChange } = this.props
-    if (onChange) onChange(e, result)
+    const { onResultSelect } = this.props
+    if (onResultSelect) onResultSelect(e, result)
   }
 
   closeOnEscape = (e) => {
@@ -294,9 +317,9 @@ export default class Search extends Component {
     // prevent selecting null if there was no selected item value
     if (!result) return
 
-    // notify the onChange prop that the user is trying to change value
+    // notify the onResultSelect prop that the user is trying to change value
     this.setValue(result.title)
-    this.handleChange(e, result)
+    this.handleResultSelect(e, result)
     this.close()
   }
 
@@ -313,7 +336,7 @@ export default class Search extends Component {
   handleMouseDown = (e) => {
     debug('handleMouseDown()')
     const { onMouseDown } = this.props
-    if (onMouseDown) onMouseDown(e)
+    if (onMouseDown) onMouseDown(e, this.props)
     this.isMouseDown = true
     // Do not access document when server side rendering
     if (!isBrowser) return
@@ -337,7 +360,7 @@ export default class Search extends Component {
     this.tryOpen()
   }
 
-  handleItemClick = (e, id) => {
+  handleItemClick = (e, { id }) => {
     debug('handleItemClick()')
     debug(id)
     const result = this.getSelectedResult(id)
@@ -345,23 +368,23 @@ export default class Search extends Component {
     // prevent closeOnDocumentClick()
     e.nativeEvent.stopImmediatePropagation()
 
-    // notify the onChange prop that the user is trying to change value
+    // notify the onResultSelect prop that the user is trying to change value
     this.setValue(result.title)
-    this.handleChange(e, result)
+    this.handleResultSelect(e, result)
     this.close()
   }
 
   handleFocus = (e) => {
     debug('handleFocus()')
     const { onFocus } = this.props
-    if (onFocus) onFocus(e)
+    if (onFocus) onFocus(e, this.props)
     this.setState({ focus: true })
   }
 
   handleBlur = (e) => {
     debug('handleBlur()')
     const { onBlur } = this.props
-    if (onBlur) onBlur(e)
+    if (onBlur) onBlur(e, this.props)
     this.setState({ focus: false })
   }
 
@@ -530,7 +553,6 @@ export default class Search extends Component {
         key={childKey || result.title}
         active={selectedIndex === offsetIndex}
         onClick={this.handleItemClick}
-        onMouseDown={e => e.preventDefault()} // prevent default to allow item select without closing on blur
         renderer={resultRenderer}
         {...result}
         id={offsetIndex} // Used to lookup the result on item click
@@ -633,7 +655,6 @@ export default class Search extends Component {
         className={classes}
         onBlur={this.handleBlur}
         onFocus={this.handleFocus}
-        onChange={this.handleChange}
         onMouseDown={this.handleMouseDown}
       >
         {this.renderSearchInput()}

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -127,10 +127,10 @@ export default class Search extends Component {
     onResultSelect: PropTypes.func,
 
     /**
-     * Called with the React Synthetic Event and current value on search input change.
+     * Called on search input change.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All props.
+     * @param {string} value - Current value of search input.
      */
     onSearchChange: PropTypes.func,
 

--- a/src/modules/Search/SearchResult.js
+++ b/src/modules/Search/SearchResult.js
@@ -46,7 +46,12 @@ export default class SearchResult extends Component {
     /** Add an image to the item. */
     image: PropTypes.string,
 
-    /** Called on click with (event, value, text). */
+    /**
+     * Called on click.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
     onClick: PropTypes.func,
 
     /** Customized text for price. */
@@ -63,9 +68,9 @@ export default class SearchResult extends Component {
   }
 
   handleClick = (e) => {
-    const { id, onClick } = this.props
+    const { onClick } = this.props
 
-    if (onClick) onClick(e, id)
+    if (onClick) onClick(e, this.props)
   }
 
   static _meta = {

--- a/src/views/Card/Card.js
+++ b/src/views/Card/Card.js
@@ -67,11 +67,11 @@ export default class Card extends Component {
     meta: customPropTypes.itemShorthand,
 
     /**
-     * Called after user's click. When passed, the component render as an `a`
+     * Called on click. When passed, the component renders as an `a`
      * tag by default instead of a `div`.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - Card props.
+     * @param {object} data - All props.
      */
     onClick: PropTypes.func,
 

--- a/test/specs/collections/Breadcrumb/BreadcrumbSection-test.js
+++ b/test/specs/collections/Breadcrumb/BreadcrumbSection-test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import BreadcrumbSection from 'src/collections/Breadcrumb/BreadcrumbSection'
 import * as common from 'test/specs/commonTests'
-import { sandbox } from 'test/utils'
 
 describe('BreadcrumbSection', () => {
   common.isConformant(BreadcrumbSection)
@@ -31,24 +30,6 @@ describe('BreadcrumbSection', () => {
 
       section.should.have.tagName('a')
       section.should.have.attr('href').and.equal('http://google.com')
-    })
-  })
-
-  describe('onClick', () => {
-    it('omitted when not defined', () => {
-      const click = () => shallow(<BreadcrumbSection />).simulate('click')
-      expect(click).to.not.throw()
-    })
-
-    it('is called with (event) on click', () => {
-      const handleClick = sandbox.spy()
-      const section = mount(<BreadcrumbSection onClick={handleClick} />)
-
-      section.should.have.tagName('a')
-      section.simulate('click')
-
-      handleClick.should.have.been.calledOnce()
-      handleClick.should.have.been.calledWithMatch({})
     })
   })
 })

--- a/test/specs/collections/Form/Form-test.js
+++ b/test/specs/collections/Form/Form-test.js
@@ -162,6 +162,7 @@ describe('Form', () => {
       it('an empty object by default', () => {
         spyFormSubmit()
           .firstCall.args[1]
+          .value
           .should.be.deep.equal({})
       })
 
@@ -170,10 +171,10 @@ describe('Form', () => {
       //
       it('text inputs as { name: value }', () => {
         spyFormSubmit(<input type='text' name='foo' defaultValue='bar' />)
-          .should.have.been.calledWithMatch({}, { foo: 'bar' })
+          .should.have.been.calledWithMatch({}, { value: { foo: 'bar' } })
 
         spyFormSubmit(<input type='text' name='foo' />)
-          .should.have.been.calledWithMatch({}, { foo: '' })
+          .should.have.been.calledWithMatch({}, { value: { foo: '' } })
       })
 
       //
@@ -181,18 +182,18 @@ describe('Form', () => {
       //
       it('single checkboxes without a value as { name: checked }', () => {
         spyFormSubmit(<input type='checkbox' name='foo' defaultChecked />)
-          .should.have.been.calledWithMatch({}, { foo: true })
+          .should.have.been.calledWithMatch({}, { value: { foo: true } })
 
         spyFormSubmit(<input type='checkbox' name='foo' />)
-          .should.have.been.calledWithMatch({}, { foo: false })
+          .should.have.been.calledWithMatch({}, { value: { foo: false } })
       })
 
       it('single checkboxes with a value as { name: (value|false) }', () => {
         spyFormSubmit(<input type='checkbox' name='foo' value='bar' defaultChecked />)
-          .should.have.been.calledWithMatch({}, { foo: 'bar' })
+          .should.have.been.calledWithMatch({}, { value: { foo: 'bar' } })
 
         spyFormSubmit(<input type='checkbox' name='foo' value='bar' />)
-          .should.have.been.calledWithMatch({}, { foo: false })
+          .should.have.been.calledWithMatch({}, { value: { foo: false } })
       })
 
       it('multiple checkboxes with some checked as { name: [value, ...] }', () => {
@@ -203,7 +204,7 @@ describe('Form', () => {
             <input type='checkbox' name='foo' value='qux' defaultChecked />
           </Form.Field>
         )
-          .should.have.been.calledWithMatch({}, { foo: ['bar', 'qux'] })
+          .should.have.been.calledWithMatch({}, { value: { foo: ['bar', 'qux'] } })
       })
 
       it('multiple checkboxes with none checked as { name: [] }', () => {
@@ -214,7 +215,7 @@ describe('Form', () => {
             <input type='checkbox' name='foo' value='qux' />
           </Form.Field>
         )
-          .should.have.been.calledWithMatch({}, { foo: [] })
+          .should.have.been.calledWithMatch({}, { value: { foo: [] } })
       })
 
       //
@@ -228,7 +229,7 @@ describe('Form', () => {
             <input type='radio' name='foo' value='qux' />
           </Form.Field>
         )
-          .should.have.been.calledWithMatch({}, { foo: 'bar' })
+          .should.have.been.calledWithMatch({}, { value: { foo: 'bar' } })
       })
 
       it('radios with none checked as { name: null }', () => {
@@ -239,7 +240,7 @@ describe('Form', () => {
             <input type='radio' name='foo' value='qux' />
           </Form.Field>
         )
-          .should.have.been.calledWithMatch({}, { foo: null })
+          .should.have.been.calledWithMatch({}, { value: { foo: null } })
       })
 
       //
@@ -247,10 +248,10 @@ describe('Form', () => {
       //
       it('text areas as { name: value }', () => {
         spyFormSubmit(<textarea name='foo' defaultValue='bar' />)
-          .should.have.been.calledWithMatch({}, { foo: 'bar' })
+          .should.have.been.calledWithMatch({}, { value: { foo: 'bar' } })
 
         spyFormSubmit(<textarea name='foo' />)
-          .should.have.been.calledWithMatch({}, { foo: '' })
+          .should.have.been.calledWithMatch({}, { value: { foo: '' } })
       })
 
       //
@@ -263,7 +264,7 @@ describe('Form', () => {
             <option value='2'>Two</option>
           </select>
         )
-          .should.have.been.calledWithMatch({}, { foo: '2' })
+          .should.have.been.calledWithMatch({}, { value: { foo: '2' } })
 
         spyFormSubmit(
           <select name='foo'>
@@ -272,7 +273,7 @@ describe('Form', () => {
             <option value='2'>Two</option>
           </select>
         )
-          .should.have.been.calledWithMatch({}, { foo: '' })
+          .should.have.been.calledWithMatch({}, { value: { foo: '' } })
       })
 
       it('multiple selects with some selected as { name: [value, ...] }', () => {
@@ -283,7 +284,7 @@ describe('Form', () => {
             <option value='3'>Three</option>
           </select>
         )
-          .should.have.been.calledWithMatch({}, { foo: ['1', '3'] })
+          .should.have.been.calledWithMatch({}, { value: { foo: ['1', '3'] } })
       })
 
       it('multiple selects with none selected as { name: [] }', () => {
@@ -294,7 +295,7 @@ describe('Form', () => {
             <option value='3'>Three</option>
           </select>
         )
-          .should.have.been.calledWithMatch({}, { foo: [] })
+          .should.have.been.calledWithMatch({}, { value: { foo: [] } })
       })
     })
   })

--- a/test/specs/collections/Form/Form-test.js
+++ b/test/specs/collections/Form/Form-test.js
@@ -162,7 +162,7 @@ describe('Form', () => {
       it('an empty object by default', () => {
         spyFormSubmit()
           .firstCall.args[1]
-          .value
+          .formData
           .should.be.deep.equal({})
       })
 
@@ -171,10 +171,10 @@ describe('Form', () => {
       //
       it('text inputs as { name: value }', () => {
         spyFormSubmit(<input type='text' name='foo' defaultValue='bar' />)
-          .should.have.been.calledWithMatch({}, { value: { foo: 'bar' } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: 'bar' } })
 
         spyFormSubmit(<input type='text' name='foo' />)
-          .should.have.been.calledWithMatch({}, { value: { foo: '' } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: '' } })
       })
 
       //
@@ -182,18 +182,18 @@ describe('Form', () => {
       //
       it('single checkboxes without a value as { name: checked }', () => {
         spyFormSubmit(<input type='checkbox' name='foo' defaultChecked />)
-          .should.have.been.calledWithMatch({}, { value: { foo: true } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: true } })
 
         spyFormSubmit(<input type='checkbox' name='foo' />)
-          .should.have.been.calledWithMatch({}, { value: { foo: false } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: false } })
       })
 
       it('single checkboxes with a value as { name: (value|false) }', () => {
         spyFormSubmit(<input type='checkbox' name='foo' value='bar' defaultChecked />)
-          .should.have.been.calledWithMatch({}, { value: { foo: 'bar' } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: 'bar' } })
 
         spyFormSubmit(<input type='checkbox' name='foo' value='bar' />)
-          .should.have.been.calledWithMatch({}, { value: { foo: false } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: false } })
       })
 
       it('multiple checkboxes with some checked as { name: [value, ...] }', () => {
@@ -204,7 +204,7 @@ describe('Form', () => {
             <input type='checkbox' name='foo' value='qux' defaultChecked />
           </Form.Field>
         )
-          .should.have.been.calledWithMatch({}, { value: { foo: ['bar', 'qux'] } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: ['bar', 'qux'] } })
       })
 
       it('multiple checkboxes with none checked as { name: [] }', () => {
@@ -215,7 +215,7 @@ describe('Form', () => {
             <input type='checkbox' name='foo' value='qux' />
           </Form.Field>
         )
-          .should.have.been.calledWithMatch({}, { value: { foo: [] } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: [] } })
       })
 
       //
@@ -229,7 +229,7 @@ describe('Form', () => {
             <input type='radio' name='foo' value='qux' />
           </Form.Field>
         )
-          .should.have.been.calledWithMatch({}, { value: { foo: 'bar' } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: 'bar' } })
       })
 
       it('radios with none checked as { name: null }', () => {
@@ -240,7 +240,7 @@ describe('Form', () => {
             <input type='radio' name='foo' value='qux' />
           </Form.Field>
         )
-          .should.have.been.calledWithMatch({}, { value: { foo: null } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: null } })
       })
 
       //
@@ -248,10 +248,10 @@ describe('Form', () => {
       //
       it('text areas as { name: value }', () => {
         spyFormSubmit(<textarea name='foo' defaultValue='bar' />)
-          .should.have.been.calledWithMatch({}, { value: { foo: 'bar' } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: 'bar' } })
 
         spyFormSubmit(<textarea name='foo' />)
-          .should.have.been.calledWithMatch({}, { value: { foo: '' } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: '' } })
       })
 
       //
@@ -264,7 +264,7 @@ describe('Form', () => {
             <option value='2'>Two</option>
           </select>
         )
-          .should.have.been.calledWithMatch({}, { value: { foo: '2' } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: '2' } })
 
         spyFormSubmit(
           <select name='foo'>
@@ -273,7 +273,7 @@ describe('Form', () => {
             <option value='2'>Two</option>
           </select>
         )
-          .should.have.been.calledWithMatch({}, { value: { foo: '' } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: '' } })
       })
 
       it('multiple selects with some selected as { name: [value, ...] }', () => {
@@ -284,7 +284,7 @@ describe('Form', () => {
             <option value='3'>Three</option>
           </select>
         )
-          .should.have.been.calledWithMatch({}, { value: { foo: ['1', '3'] } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: ['1', '3'] } })
       })
 
       it('multiple selects with none selected as { name: [] }', () => {
@@ -295,7 +295,7 @@ describe('Form', () => {
             <option value='3'>Three</option>
           </select>
         )
-          .should.have.been.calledWithMatch({}, { value: { foo: [] } })
+          .should.have.been.calledWithMatch({}, { formData: { foo: [] } })
       })
     })
   })

--- a/test/specs/commonTests.js
+++ b/test/specs/commonTests.js
@@ -304,10 +304,18 @@ export const isConformant = (Component, options = {}) => {
           'You may need to hoist your event handlers up to the root element.\n'
         )
 
+        let expectedArgs = [eventShape]
+        let errorMessage = 'was not called with (event)'
+
+        if (_.has(Component.propTypes, listenerName)) {
+          expectedArgs = [eventShape, props]
+          errorMessage = 'was not called with (event, data)'
+        }
+
         // Components should return the event first, then any data
-        handlerSpy.calledWithMatch(eventShape).should.equal(true,
+        handlerSpy.calledWithMatch(...expectedArgs).should.equal(true,
           `<${constructorName} ${listenerName}={${handlerName}} />\n` +
-          `${leftPad} ^ was not called with an "${listenerName}" event\n` +
+          `${leftPad} ^ ${errorMessage}\n` +
           'It was called with args:\n' +
           JSON.stringify(handlerSpy.args, null, 2)
         )

--- a/test/specs/elements/Button/Button-test.js
+++ b/test/specs/elements/Button/Button-test.js
@@ -60,15 +60,10 @@ describe('Button', () => {
     it('is called when clicked', () => {
       const handleClick = sandbox.spy()
 
-      shallow(<Button type='submit' data-foo='bar' onClick={handleClick} />)
+      shallow(<Button type='submit' onClick={handleClick} />)
         .simulate('click', syntheticEvent)
 
       handleClick.should.have.been.calledOnce()
-      handleClick.should.have.been.calledWith(
-        sandbox.match.any,
-        // Ensure the second argument includes arbitrary props
-        sandbox.match({ 'data-foo': 'bar' })
-      )
     })
 
     it('is not called when button is disabled', () => {

--- a/test/specs/modules/Accordion/AccordionTitle-test.js
+++ b/test/specs/modules/Accordion/AccordionTitle-test.js
@@ -1,43 +1,9 @@
-import React from 'react'
 import * as common from 'test/specs/commonTests'
-import { sandbox } from 'test/utils'
 
-import Accordion from 'src/modules/Accordion/Accordion'
 import AccordionTitle from 'src/modules/Accordion/AccordionTitle'
 
 describe('AccordionTitle', () => {
   common.isConformant(AccordionTitle)
   common.rendersChildren(AccordionTitle)
   common.propKeyOnlyToClassName(AccordionTitle, 'active')
-
-  describe('onClick', () => {
-    it('omitted when not defined', () => {
-      const click = () => shallow(<AccordionTitle />).simulate('click')
-      expect(click).to.not.throw()
-    })
-    it('is called with (event, undefined) when not a child of Accordion', () => {
-      const spy = sandbox.spy()
-      shallow(<AccordionTitle onClick={spy} />)
-        .simulate('click')
-
-      spy.should.have.been.calledOnce()
-
-      const arg2 = spy.firstCall.args[1]
-      expect(arg2).to.equal(undefined, `The second argument was not undefined, got: ${typeof arg2}`)
-    })
-    it('is called with (event, index) when a child of Accordion', () => {
-      const spy = sandbox.spy()
-      shallow(
-        <Accordion>
-          <AccordionTitle onClick={spy} />
-        </Accordion>
-      )
-        .find('AccordionTitle')
-        .simulate('click')
-
-      const arg2 = spy.firstCall.args[1]
-      spy.should.have.been.calledOnce()
-      expect(arg2).to.equal(0, `The second argument was not the index, got: ${typeof arg2}`)
-    })
-  })
 })

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -75,7 +75,10 @@ describe('Checkbox', () => {
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, expectProps)
+      spy.should.have.been.calledWithMatch({}, {
+        ...expectProps,
+        checked: !expectProps.checked,
+      })
     })
     it('is not called when the checkbox has the disabled prop set', () => {
       const spy = sandbox.spy()
@@ -92,7 +95,10 @@ describe('Checkbox', () => {
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, { ...expectProps, checked: true })
+      spy.should.have.been.calledWithMatch({}, {
+        ...expectProps,
+        checked: expectProps.checked,
+      })
     })
     it('is not called when the checkbox has the disabled prop set', () => {
       const spy = sandbox.spy()

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -75,9 +75,7 @@ describe('Checkbox', () => {
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, {})
-      spy.firstCall.args[1]
-        .should.deep.equal({ ...expectProps, checked: true })
+      spy.should.have.been.calledWithMatch({}, expectProps)
     })
     it('is not called when the checkbox has the disabled prop set', () => {
       const spy = sandbox.spy()
@@ -94,9 +92,7 @@ describe('Checkbox', () => {
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, {})
-      spy.firstCall.args[1]
-        .should.deep.equal(expectProps)
+      spy.should.have.been.calledWithMatch({}, { ...expectProps, checked: true })
     })
     it('is not called when the checkbox has the disabled prop set', () => {
       const spy = sandbox.spy()

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1026,7 +1026,7 @@ describe('Dropdown Component', () => {
           .at(randomIndex)
           .simulate('click', nativeEvent)
 
-        spy.should.have.been.calledWith(sandbox.match.any, sandbox.match({ value: randomValue }))
+        spy.should.have.been.calledWithMatch({}, { value: randomValue })
       })
     })
     describe('removing items', () => {
@@ -1045,7 +1045,7 @@ describe('Dropdown Component', () => {
           .simulate('click')
 
         spy.should.have.been.calledOnce()
-        spy.should.have.been.calledWith(sandbox.match.any, { name, value: expected })
+        spy.should.have.been.calledWithMatch({}, { name, value: expected })
       })
     })
   })
@@ -1078,7 +1078,7 @@ describe('Dropdown Component', () => {
       domEvent.keyDown(document, { key: 'Backspace' })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWith(sandbox.match.any, { name, value: expected })
+      spy.should.have.been.calledWithMatch({}, { name, value: expected })
     })
     it('removes the last item when there is no search query when uncontrolled', () => {
       const name = 'my-dropdown'
@@ -1094,7 +1094,7 @@ describe('Dropdown Component', () => {
       domEvent.keyDown(document, { key: 'Backspace' })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWith(sandbox.match.any, { name, value: expected })
+      spy.should.have.been.calledWithMatch({}, { name, value: expected })
 
       wrapper
         .state('value')
@@ -1145,7 +1145,7 @@ describe('Dropdown Component', () => {
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWith(sandbox.match.any, { name, value: randomValue })
+      spy.should.have.been.calledWithMatch({}, { name, value: randomValue })
     })
     it('is called with event and value when pressing enter on a selected item', () => {
       const name = 'my-dropdown'
@@ -1156,7 +1156,7 @@ describe('Dropdown Component', () => {
       domEvent.keyDown(document, { key: 'Enter' })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWith(sandbox.match.any, { name, value: firstValue })
+      spy.should.have.been.calledWithMatch({}, { name, value: firstValue })
     })
     it('is called with event and value when blurring', () => {
       const name = 'my-dropdown'
@@ -1166,7 +1166,7 @@ describe('Dropdown Component', () => {
         .simulate('blur')   // blur should activate selected item
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWith(sandbox.match.any, { name, value: firstValue })
+      spy.should.have.been.calledWithMatch({}, { name, value: firstValue })
     })
     it('is not called on blur when closed', () => {
       wrapperMount(<Dropdown options={options} selection open={false} onChange={spy} />)
@@ -1901,7 +1901,7 @@ describe('Dropdown Component', () => {
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWith(sandbox.match.any, { name, value: 'boo' })
+      spy.should.have.been.calledWithMatch({}, { name, value: 'boo' })
     })
 
     it('calls onAddItem prop when pressing enter on new value', () => {
@@ -1916,7 +1916,7 @@ describe('Dropdown Component', () => {
       domEvent.keyDown(document, { key: 'Enter' })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWith(sandbox.match.any, { name, value: 'boo' })
+      spy.should.have.been.calledWithMatch({}, { name, value: 'boo' })
     })
   })
 

--- a/test/specs/modules/Embed/Embed-test.js
+++ b/test/specs/modules/Embed/Embed-test.js
@@ -3,7 +3,6 @@ import React from 'react'
 
 import Embed from 'src/modules/Embed/Embed'
 import * as common from 'test/specs/commonTests'
-import { sandbox } from 'test/utils'
 
 const assertIframeSrc = (props, srcPart) => {
   const {
@@ -105,18 +104,6 @@ describe('Embed', () => {
     it('omitted when not defined', () => {
       const click = () => shallow(<Embed />).simulate('click')
       expect(click).to.not.throw()
-    })
-
-    it('is called with (event, props) on click', () => {
-      const spy = sandbox.spy()
-      const event = { target: null }
-      const props = { active: faker.random.boolean() }
-
-      mount(<Embed onClick={spy} {...props} />)
-        .simulate('click', event)
-
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(event, props)
     })
 
     it('updates state', () => {

--- a/test/specs/modules/Rating/RatingIcon-test.js
+++ b/test/specs/modules/Rating/RatingIcon-test.js
@@ -2,9 +2,12 @@ import React from 'react'
 
 import * as common from 'test/specs/commonTests'
 import RatingIcon from 'src/modules/Rating/RatingIcon'
-import { keyboardKey, sandbox } from 'src/lib'
+import { keyboardKey } from 'src/lib'
+import { sandbox } from 'test/utils'
 
 describe('RatingIcon', () => {
+  common.isConformant(RatingIcon)
+
   common.propKeyOnlyToClassName(RatingIcon, 'active')
   common.propKeyOnlyToClassName(RatingIcon, 'selected')
 
@@ -25,7 +28,7 @@ describe('RatingIcon', () => {
         .simulate('keyup', event)
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(event, 0)
+      spy.should.have.been.calledWithMatch(event, { index: 0 })
       event.preventDefault.should.have.been.calledOnce()
     })
 
@@ -37,7 +40,7 @@ describe('RatingIcon', () => {
         .simulate('keyup', event)
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(event, 0)
+      spy.should.have.been.calledWithMatch(event, { index: 0 })
       event.preventDefault.should.have.been.calledOnce()
     })
 

--- a/test/specs/modules/Rating/RatingIcon-test.js
+++ b/test/specs/modules/Rating/RatingIcon-test.js
@@ -1,31 +1,12 @@
 import React from 'react'
 
 import * as common from 'test/specs/commonTests'
-import { sandbox } from 'test/utils'
 import RatingIcon from 'src/modules/Rating/RatingIcon'
-import { keyboardKey } from 'src/lib'
+import { keyboardKey, sandbox } from 'src/lib'
 
 describe('RatingIcon', () => {
   common.propKeyOnlyToClassName(RatingIcon, 'active')
   common.propKeyOnlyToClassName(RatingIcon, 'selected')
-
-  describe('onClick', () => {
-    it('omitted when not defined', () => {
-      const click = () => shallow(<RatingIcon />).simulate('click')
-      expect(click).to.not.throw()
-    })
-
-    it('is called with (e, index) when clicked', () => {
-      const spy = sandbox.spy()
-      const event = { target: null }
-
-      shallow(<RatingIcon index={0} onClick={spy} />)
-        .simulate('click', event)
-
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(event, 0)
-    })
-  })
 
   describe('onKeyUp', () => {
     it('omitted when not defined', () => {
@@ -36,7 +17,7 @@ describe('RatingIcon', () => {
       event.preventDefault.should.not.have.been.called()
     })
 
-    it('is called with (e, index) when space key is pressed', () => {
+    it('calls onClick with (e, index) when space key is pressed', () => {
       const spy = sandbox.spy()
       const event = { keyCode: keyboardKey.Spacebar, preventDefault: sandbox.spy() }
 
@@ -48,7 +29,7 @@ describe('RatingIcon', () => {
       event.preventDefault.should.have.been.calledOnce()
     })
 
-    it('is called with (e, index) when enter key is pressed', () => {
+    it('calls onClick with (e, index) when enter key is pressed', () => {
       const spy = sandbox.spy()
       const event = { keyCode: keyboardKey.Enter, preventDefault: sandbox.spy() }
 
@@ -60,7 +41,7 @@ describe('RatingIcon', () => {
       event.preventDefault.should.have.been.calledOnce()
     })
 
-    it('omitted when non space/enter key is pressed', () => {
+    it('does not call onClick when non space/enter key is pressed', () => {
       const spy = sandbox.spy()
       const event = { keyCode: keyboardKey.A, preventDefault: sandbox.spy() }
 
@@ -69,23 +50,6 @@ describe('RatingIcon', () => {
       expect(keyup).to.not.throw()
       spy.should.not.have.been.called()
       event.preventDefault.should.not.have.been.called()
-    })
-  })
-
-  describe('onMouseEnter', () => {
-    it('omitted when not defined', () => {
-      const click = () => shallow(<RatingIcon />).simulate('mouseEnter')
-      expect(click).to.not.throw()
-    })
-
-    it('is called with (index) when clicked', () => {
-      const spy = sandbox.spy()
-
-      shallow(<RatingIcon index={0} onMouseEnter={spy} />)
-        .simulate('mouseEnter')
-
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(0)
     })
   })
 })

--- a/test/specs/modules/Search/Search-test.js
+++ b/test/specs/modules/Search/Search-test.js
@@ -523,7 +523,7 @@ describe('Search Component', () => {
     })
   })
 
-  describe('onChange', () => {
+  describe('onResultSelect', () => {
     let spy
     beforeEach(() => {
       spy = sandbox.spy()
@@ -532,7 +532,7 @@ describe('Search Component', () => {
     it('is called with event and value on item click', () => {
       const randomIndex = _.random(options.length - 1)
       const randomResult = options[randomIndex]
-      wrapperMount(<Search results={options} minCharacters={0} onChange={spy} />)
+      wrapperMount(<Search results={options} minCharacters={0} onResultSelect={spy} />)
 
       // open
       openSearchResults()
@@ -544,11 +544,11 @@ describe('Search Component', () => {
         .simulate('click', nativeEvent)
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWith(sandbox.match.any, randomResult)
+      spy.should.have.been.calledWithMatch({}, randomResult)
     })
     it('is called with event and value when pressing enter on a selected item', () => {
       const firstResult = options[0]
-      wrapperMount(<Search results={options} minCharacters={0} onChange={spy} selectFirstResult />)
+      wrapperMount(<Search results={options} minCharacters={0} onResultSelect={spy} selectFirstResult />)
 
       // open
       openSearchResults()
@@ -557,27 +557,27 @@ describe('Search Component', () => {
       domEvent.keyDown(document, { key: 'Enter' })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWith(sandbox.match.any, firstResult)
+      spy.should.have.been.calledWithMatch({}, firstResult)
     })
     it('is not called when updating the value prop', () => {
       const value = _.sample(options).title
       const next = _.sample(_.without(options, value)).title
 
-      wrapperMount(<Search results={options} minCharacters={0} value={value} onChange={spy} />)
+      wrapperMount(<Search results={options} minCharacters={0} value={value} onResultSelect={spy} />)
         .setProps({ value: next })
 
       spy.should.not.have.been.called()
     })
-    it('does not call onChange on query change', () => {
-      const onChangeSpy = sandbox.spy()
-      wrapperMount(<Search results={options} minCharacters={0} onChange={onChangeSpy} />)
+    it('does not call onResultSelect on query change', () => {
+      const onResultSelectSpy = sandbox.spy()
+      wrapperMount(<Search results={options} minCharacters={0} onResultSelect={onResultSelectSpy} />)
 
       // simulate search
       wrapper
         .find('input.prompt')
         .simulate('change', { target: { value: faker.hacker.noun() } })
 
-      onChangeSpy.should.not.have.been.called()
+      onResultSelectSpy.should.not.have.been.called()
     })
   })
 

--- a/test/specs/modules/Search/SearchResult-test.js
+++ b/test/specs/modules/Search/SearchResult-test.js
@@ -1,32 +1,7 @@
-import facker from 'faker'
-import React from 'react'
-
 import SearchResult from 'src/modules/Search/SearchResult'
 import * as common from 'test/specs/commonTests'
-import { sandbox } from 'test/utils'
 
 describe('SearchResult', () => {
   common.isConformant(SearchResult)
   common.propKeyOnlyToClassName(SearchResult, 'active')
-
-  describe('onClick', () => {
-    it('omitted when not defined', () => {
-      const click = () => shallow(<SearchResult />).simulate('click')
-      expect(click).to.not.throw()
-    })
-
-    it('is called with (e, id) when clicked', () => {
-      const spy = sandbox.spy()
-
-      const id = facker.random.number()
-      const event = { target: null }
-      const props = { id }
-
-      shallow(<SearchResult onClick={spy} {...props} />)
-        .simulate('click', event)
-
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(event, id)
-    })
-  })
 })

--- a/test/specs/views/Card/Card-test.js
+++ b/test/specs/views/Card/Card-test.js
@@ -34,30 +34,11 @@ describe('Card', () => {
   })
 
   describe('onClick', () => {
-    it('omitted when not defined', () => {
-      const click = () => shallow(<Card />).simulate('click')
-      expect(click).to.not.throw()
-    })
-
     it('renders <a> instead of <div>', () => {
       const handleClick = sandbox.spy()
       const wrapper = shallow(<Card onClick={handleClick} />)
 
       wrapper.should.have.tagName('a')
-    })
-
-    it('is called with (event, props) on click', () => {
-      const handleClick = sandbox.spy()
-      const event = { fake: 'event' }
-      const data = { 'data-foo': 'bar' }
-
-      const wrapper = mount(<Card onClick={handleClick} {...data} />)
-
-      wrapper.simulate('click', event)
-
-      handleClick.should.have.been.calledOnce()
-      // Ensure the second argument includes arbitrary props
-      handleClick.should.have.been.calledWithMatch(event, data)
     })
   })
 


### PR DESCRIPTION
Breaking Changes!
-------------------

The following components have breaking changes in their event handler props.

### Form

Handler | Previous Signature | Current Signature
------- | ------------------ | -----------------
onClick | (e, formData) | (e, { ...props, formData })

### RatingIcon

Handler | Previous Signature | Current Signature
------- | ------------------ | -----------------
onClick | (e, index) | (e, { ...props, index })
onKeyUp | (e, index) | (e, { ...props, index })
onMouseEnter | (e, index) | (e, { ...props, index })

### Search

NOTE: The handler name changed from `onChange` to `onResultSelect`. The change was made because:
- onChange doesn't really make sense in this context since nothing is really changing.
- given the result is being returned, onChange made even less sense.
- it maps closer to the SUI-core event (`onSelect`). The reason to not use `onSelect` is because that's a built-in html event type for when a user selects text.

Handler | New Name | Previous Signature | Current Signature
------- | -------- | ------------------ | -----------------
onChange | onResultSelect | (e, result) | (e, result) _no change_

### SearchResult

Handler | Previous Signature | Current Signature
------- | ------------------ | -----------------
onClick | (e, id) | (e, { ...props, id })


----

Fixes #623

This updates the common tests for event handling to ensure any handlers that we wrap are called with `(event, data)` as arguments.