### PR TITLE
docs(Popup): make allowed content types statically analyzable

### DIFF
--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -21,7 +21,6 @@ const _meta = {
   name: 'Popup',
   type: META.TYPES.MODULE,
   props: {
-    content: [PropTypes.string, PropTypes.node],
     on: ['hover', 'click', 'focus'],
     positioning: [
       'top left',
@@ -53,7 +52,7 @@ export default class Popup extends Component {
     className: PropTypes.string,
 
     /** Simple text content for the popover */
-    content: PropTypes.oneOfType(_meta.props.content),
+    content: PropTypes.node,
 
     /** A Flowing popup have no maximum width and continue to flow to fit its content */
     flowing: PropTypes.bool,


### PR DESCRIPTION
This is presumably an issue with all `propType` definitions that reuse propTypes defined in another variable. I traced it down to `react-docgen` being unable to parse the union type because it viewed it as dynamic, which is technically true because that type definition is referenced from a variable and as such the propType is resolved at runtime.

## Before
<img width="654" alt="screen shot 2016-12-05 at 9 42 50 pm" src="https://cloud.githubusercontent.com/assets/6439050/20912258/d05d0c3a-bb33-11e6-94e4-f87830ca67e9.png">

## After
<img width="664" alt="screen shot 2016-12-05 at 9 40 50 pm" src="https://cloud.githubusercontent.com/assets/6439050/20912243/bb655382-bb33-11e6-9408-933174498701.png">