### PR TITLE
fix(Icon): added aria-hidden attribute to icon

### DIFF
--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -45,7 +45,7 @@ function Icon(props) {
   const ElementType = getElementType(Icon, props)
 
   return (
-    <ElementType {...rest} className={classes} />
+    <ElementType {...rest} aria-hidden='true' className={classes} />
   )
 }
 

--- a/test/specs/elements/Icon/Icon-test.js
+++ b/test/specs/elements/Icon/Icon-test.js
@@ -28,4 +28,12 @@ describe('Icon', () => {
     shallow(<Icon />)
       .should.have.tagName('i')
   })
+
+  describe('aria', () => {
+    it('should add aria-hidden to icon', () => {
+      const wrapper = shallow(<Icon />)
+
+      wrapper.should.have.prop('aria-hidden', 'true')
+    })
+  })
 })


### PR DESCRIPTION
Icons are primary for decoration or visual style and should be hidden from screen readers. Additional markup can be added to allow screen readers to read the icons if necessary, but by default all icons should be hidden.

Documentation: http://fontawesome.io/accessibility/