### PR TITLE
docs(MenuExampleVerticalDropdown): doesn't work twice

### DIFF
--- a/docs/app/Examples/collections/Menu/Types/MenuExampleVerticalDropdown.js
+++ b/docs/app/Examples/collections/Menu/Types/MenuExampleVerticalDropdown.js
@@ -13,7 +13,7 @@ export default class MenuExampleVerticalDropdown extends Component {
       <Menu secondary vertical>
         <Menu.Item name='account' active={activeItem === 'account'} onClick={this.handleItemClick} />
         <Menu.Item name='settings' active={activeItem === 'settings'} onClick={this.handleItemClick} />
-        <Dropdown as={Menu.Item} text='Display Options'>
+        <Dropdown text='Display Options' pointing='left' className='link item'>
           <Dropdown.Menu>
             <Dropdown.Header>Text Size</Dropdown.Header>
             <Dropdown.Item>Small</Dropdown.Item>


### PR DESCRIPTION
Setting the Dropdown `as={Menu.Item}` makes the dropdown only work the first time when clicked on. 

In addition, it makes the outer element an anchor tag which creates invalid HTML when you nest links in the dropdown which is probably a fairly common use case I would think. Although browsers do the right thing and work on the nested anchor tags it just doesn't feel right.

I borrowed from the DropdownExamplePointingTwo.js code that solves the problem by not setting the dropdown to a Menu.Item and adds in the necessary classes to show that it is a dropdown. That allows it to work multiple times on expanding and gives correct underlying HTML structure for putting anchor tags in the dropdown.

Just as a side question, since I'm fairly new to the Semantic-UI-React world: is that considered good practice to add in the classes like that or should it be something that is done under the covers by the component?