### PR TITLE
fix(Dropdown): fix crash when setting defaultOpen on a search dropdown

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -884,7 +884,7 @@ export default class Dropdown extends Component {
 
     const { disabled, onOpen, search } = this.props
     if (disabled) return
-    if (search) this._search.focus()
+    if (search && this._search) this._search.focus()
     if (onOpen) onOpen(e, this.props)
 
     this.trySetState({ open: true })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -867,6 +867,10 @@ describe('Dropdown Component', () => {
       wrapperShallow(<Dropdown options={options} selection defaultOpen />)
       dropdownMenuIsOpen()
     })
+    it('defaultOpen opens the menu on search dropdowns', () => {
+      wrapperShallow(<Dropdown search options={options} selection defaultOpen />)
+      dropdownMenuIsOpen()
+    })
     it('defaultOpen closes the menu when false', () => {
       wrapperShallow(<Dropdown options={options} selection defaultOpen={false} />)
       dropdownMenuIsClosed()


### PR DESCRIPTION
Because the this.open() call happens inside componentWillMount(), the search input hasn't been built yet and the this._search.focus() crashes. This simply moves the open call to a componentDidMount() function