### PR TITLE
fix(Dropdown): added role/aria attributes to Dropdown and DropdownItem

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -18,6 +18,7 @@ import {
 } from '../../lib'
 import Icon from '../../elements/Icon'
 import Label from '../../elements/Label'
+import Menu from '../../collections/Menu'
 
 import DropdownDivider from './DropdownDivider'
 import DropdownItem from './DropdownItem'
@@ -755,6 +756,38 @@ export default class Dropdown extends Component {
     return _.findIndex(options, ['value', value])
   }
 
+  getDropdownAriaOptions = (ElementType) => {
+    const { loading, disabled, search, multiple } = this.props
+    const { open } = this.state
+    const ariaOptions = {
+      role: 'listbox',
+      'aria-busy': loading,
+      'aria-disabled': disabled,
+      'aria-expanded': !!open,
+    }
+    if (search) {
+      ariaOptions.role = 'combobox'
+    } else if (ElementType === Menu.Item) {
+      ariaOptions.role = 'menuitem'
+    } else {
+      ariaOptions['aria-multiselectable'] = multiple
+    }
+    return ariaOptions
+  }
+
+  getDropdownMenuAriaOptions() {
+    const { search, multiple } = this.props
+    const ariaOptions = {}
+
+    if (search) {
+      ariaOptions['aria-multiselectable'] = multiple
+      ariaOptions.role = 'listbox'
+    } else if (getElementType(Dropdown, this.props) === Menu.Item) {
+      ariaOptions.role = 'menu'
+    }
+    return ariaOptions
+  }
+
   // ----------------------------------------
   // Setters
   // ----------------------------------------
@@ -1058,15 +1091,10 @@ export default class Dropdown extends Component {
   }
 
   renderMenu = () => {
-    const { children, header, search, multiple } = this.props
+    const { children, header } = this.props
     const { open } = this.state
     const menuClasses = open ? 'visible' : ''
-    const ariaOptions = {}
-
-    if (search) {
-      ariaOptions['aria-multiselectable'] = multiple
-      ariaOptions.role = 'listbox'
-    }
+    const ariaOptions = this.getDropdownMenuAriaOptions()
 
     // single menu child
     if (children) {
@@ -1147,17 +1175,7 @@ export default class Dropdown extends Component {
     )
     const rest = getUnhandledProps(Dropdown, this.props)
     const ElementType = getElementType(Dropdown, this.props)
-    const ariaOptions = {
-      role: 'listbox',
-      'aria-busy': loading,
-      'aria-disabled': disabled,
-      'aria-expanded': !!open,
-    }
-    if (search) {
-      ariaOptions.role = 'combobox'
-    } else {
-      ariaOptions['aria-multiselectable'] = multiple
-    }
+    const ariaOptions = this.getDropdownAriaOptions(ElementType, this.props)
 
     return (
       <ElementType

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -981,6 +981,8 @@ export default class Dropdown extends Component {
     return (
       <input
         value={searchQuery}
+        type='text'
+        aria-autocomplete='list'
         onChange={this.handleSearchChange}
         className='search'
         name={[name, 'search'].join('-')}
@@ -1056,20 +1058,26 @@ export default class Dropdown extends Component {
   }
 
   renderMenu = () => {
-    const { children, header } = this.props
+    const { children, header, search, multiple } = this.props
     const { open } = this.state
     const menuClasses = open ? 'visible' : ''
+    const ariaOptions = {}
+
+    if (search) {
+      ariaOptions['aria-multiselectable'] = multiple
+      ariaOptions.role = 'listbox'
+    }
 
     // single menu child
     if (children) {
       const menuChild = Children.only(children)
       const className = cx(menuClasses, menuChild.props.className)
 
-      return cloneElement(menuChild, { className })
+      return cloneElement(menuChild, { className, ...ariaOptions })
     }
 
     return (
-      <DropdownMenu className={menuClasses}>
+      <DropdownMenu {...ariaOptions} className={menuClasses}>
         {createShorthand(DropdownHeader, val => ({ content: val }), header)}
         {this.renderOptions()}
       </DropdownMenu>
@@ -1139,10 +1147,22 @@ export default class Dropdown extends Component {
     )
     const rest = getUnhandledProps(Dropdown, this.props)
     const ElementType = getElementType(Dropdown, this.props)
+    const ariaOptions = {
+      role: 'listbox',
+      'aria-busy': loading,
+      'aria-disabled': disabled,
+      'aria-expanded': !!open,
+    }
+    if (search) {
+      ariaOptions.role = 'combobox'
+    } else {
+      ariaOptions['aria-multiselectable'] = multiple
+    }
 
     return (
       <ElementType
         {...rest}
+        {...ariaOptions}
         className={classes}
         onBlur={this.handleBlur}
         onClick={this.handleClick}

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -18,7 +18,6 @@ import {
 } from '../../lib'
 import Icon from '../../elements/Icon'
 import Label from '../../elements/Label'
-import Menu from '../../collections/Menu'
 
 import DropdownDivider from './DropdownDivider'
 import DropdownItem from './DropdownItem'
@@ -778,8 +777,6 @@ export default class Dropdown extends Component {
     if (search) {
       ariaOptions['aria-multiselectable'] = multiple
       ariaOptions.role = 'listbox'
-    } else if (getElementType(Dropdown, this.props) === Menu.Item) {
-      ariaOptions.role = 'menu'
     }
     return ariaOptions
   }
@@ -983,7 +980,7 @@ export default class Dropdown extends Component {
 
     // a dropdown without an active item will have an empty string value
     return (
-      <select type='hidden' name={name} value={value} multiple={multiple}>
+      <select type='hidden' aria-hidden='true' name={name} value={value} multiple={multiple}>
         <option key='empty' value=''></option>
         {_.map(options, option => (
           <option key={option.value} value={option.value}>{option.text}</option>

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -760,16 +760,12 @@ export default class Dropdown extends Component {
     const { loading, disabled, search, multiple } = this.props
     const { open } = this.state
     const ariaOptions = {
-      role: 'listbox',
+      role: search ? 'combobox' : 'listbox',
       'aria-busy': loading,
       'aria-disabled': disabled,
       'aria-expanded': !!open,
     }
-    if (search) {
-      ariaOptions.role = 'combobox'
-    } else if (ElementType === Menu.Item) {
-      ariaOptions.role = 'menuitem'
-    } else {
+    if (ariaOptions.role === 'listbox') {
       ariaOptions['aria-multiselectable'] = multiple
     }
     return ariaOptions

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -116,9 +116,19 @@ export default class DropdownItem extends Component {
     const iconName = icon || childrenUtils.someByType(children, 'DropdownMenu') && 'dropdown'
     const rest = getUnhandledProps(DropdownItem, this.props)
     const ElementType = getElementType(DropdownItem, this.props)
+    const ariaOptions = {
+      role: 'option',
+      'aria-disabled': disabled,
+      'aria-checked': active,
+      'aria-selected': selected,
+    }
 
     if (children) {
-      return <ElementType {...rest} className={classes} onClick={this.handleClick}>{children}</ElementType>
+      return (
+        <ElementType {...rest} {...ariaOptions} className={classes} onClick={this.handleClick}>
+          {children}
+        </ElementType>
+      )
     }
 
     const flagElement = Flag.create(flag)
@@ -133,7 +143,7 @@ export default class DropdownItem extends Component {
 
     if (descriptionElement) {
       return (
-        <ElementType {...rest} className={classes} onClick={this.handleClick}>
+        <ElementType {...rest} {...ariaOptions} className={classes} onClick={this.handleClick}>
           {imageElement}
           {iconElement}
           {flagElement}
@@ -145,7 +155,7 @@ export default class DropdownItem extends Component {
     }
 
     return (
-      <ElementType {...rest} className={classes} onClick={this.handleClick}>
+      <ElementType {...rest} {...ariaOptions} className={classes} onClick={this.handleClick}>
         {imageElement}
         {iconElement}
         {flagElement}

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -167,7 +167,7 @@ describe('Dropdown Component', () => {
       wrapperMount(<Dropdown search />)
       wrapper.find('div').at(0).should.have.prop('role', 'combobox')
     })
-    it('should label menu dropdown as a menuitem', () => {
+    it.skip('should label menu dropdown as a menuitem', () => {
       wrapperMount(<Dropdown as={Menu.Item} />)
       wrapper.find('MenuItem').at(0).should.have.prop('role', 'menuitem')
     })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -4,6 +4,7 @@ import React from 'react'
 
 import * as common from 'test/specs/commonTests'
 import { consoleUtil, domEvent, sandbox } from 'test/utils'
+import Menu from 'src/collections/Menu'
 import Dropdown from 'src/modules/Dropdown/Dropdown'
 import DropdownDivider from 'src/modules/Dropdown/DropdownDivider'
 import DropdownHeader from 'src/modules/Dropdown/DropdownHeader'
@@ -165,6 +166,14 @@ describe('Dropdown Component', () => {
     it('should label search dropdown as a combobox', () => {
       wrapperMount(<Dropdown search />)
       wrapper.find('div').at(0).should.have.prop('role', 'combobox')
+    })
+    it('should label menu dropdown as a menuitem', () => {
+      wrapperMount(<Dropdown as={Menu.Item} />)
+      wrapper.find('MenuItem').at(0).should.have.prop('role', 'menuitem')
+    })
+    it('should label menu dropdownMenu as a menu', () => {
+      wrapperMount(<Dropdown as={Menu.Item} />)
+      wrapper.find('DropdownMenu').at(0).should.have.prop('role', 'menu')
     })
     it('should label search dropdownMenu as a listbox', () => {
       wrapperMount(<Dropdown search />)

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -4,7 +4,6 @@ import React from 'react'
 
 import * as common from 'test/specs/commonTests'
 import { consoleUtil, domEvent, sandbox } from 'test/utils'
-import Menu from 'src/collections/Menu'
 import Dropdown from 'src/modules/Dropdown/Dropdown'
 import DropdownDivider from 'src/modules/Dropdown/DropdownDivider'
 import DropdownHeader from 'src/modules/Dropdown/DropdownHeader'
@@ -163,17 +162,13 @@ describe('Dropdown Component', () => {
       wrapperMount(<Dropdown />)
       wrapper.find('div').at(0).should.have.prop('role', 'listbox')
     })
+    it('should label selection dropdown with aria-hidden=true', () => {
+      wrapperMount(<Dropdown selection />)
+      wrapper.find('select').at(0).should.have.prop('aria-hidden', 'true')
+    })
     it('should label search dropdown as a combobox', () => {
       wrapperMount(<Dropdown search />)
       wrapper.find('div').at(0).should.have.prop('role', 'combobox')
-    })
-    it.skip('should label menu dropdown as a menuitem', () => {
-      wrapperMount(<Dropdown as={Menu.Item} />)
-      wrapper.find('MenuItem').at(0).should.have.prop('role', 'menuitem')
-    })
-    it('should label menu dropdownMenu as a menu', () => {
-      wrapperMount(<Dropdown as={Menu.Item} />)
-      wrapper.find('DropdownMenu').at(0).should.have.prop('role', 'menu')
     })
     it('should label search dropdownMenu as a listbox', () => {
       wrapperMount(<Dropdown search />)

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -157,6 +157,65 @@ describe('Dropdown Component', () => {
     })
   })
 
+  describe('aria', () => {
+    it('should label normal dropdown as a listbox', () => {
+      wrapperMount(<Dropdown />)
+      wrapper.find('div').at(0).should.have.prop('role', 'listbox')
+    })
+    it('should label search dropdown as a combobox', () => {
+      wrapperMount(<Dropdown search />)
+      wrapper.find('div').at(0).should.have.prop('role', 'combobox')
+    })
+    it('should label search dropdownMenu as a listbox', () => {
+      wrapperMount(<Dropdown search />)
+      wrapper.find('DropdownMenu').should.have.prop('role', 'listbox')
+    })
+    it('should label search multiple dropdownMenu as aria-multiselectable', () => {
+      wrapperMount(<Dropdown search multiple />)
+      wrapper.find('DropdownMenu').should.have.prop('aria-multiselectable', true)
+    })
+    it('should not label normal dropdownMenu with a role', () => {
+      wrapperMount(<Dropdown />)
+      wrapper.find('DropdownMenu').should.not.have.prop('role')
+    })
+    it('should label disabled dropdown as aria-disabled', () => {
+      wrapperMount(<Dropdown disabled />)
+      wrapper.find('div').at(0).should.have.prop('aria-disabled', true)
+    })
+    it('should label normal dropdown without aria-disabled', () => {
+      wrapperMount(<Dropdown />)
+      wrapper.find('div').at(0).should.not.have.prop('aria-disabled')
+    })
+    it('should label multiple dropdown as aria-multiselectable', () => {
+      wrapperMount(<Dropdown multiple />)
+      wrapper.find('div').at(0).should.have.prop('aria-multiselectable', true)
+    })
+    it('should not label multiple search dropdown as aria-multiselectable', () => {
+      wrapperMount(<Dropdown search multiple />)
+      wrapper.find('div').at(0).should.not.have.prop('aria-multiselectable')
+    })
+    it('should label normal dropdown without aria-multiselectable', () => {
+      wrapperMount(<Dropdown />)
+      wrapper.find('div').at(0).should.not.have.prop('aria-multiselectable')
+    })
+    it('should label loading dropdown as aria-busy', () => {
+      wrapperMount(<Dropdown loading />)
+      wrapper.find('div').at(0).should.have.prop('aria-busy', true)
+    })
+    it('should label normal dropdown without aria-busy', () => {
+      wrapperMount(<Dropdown />)
+      wrapper.find('div').at(0).should.not.have.prop('aria-busy')
+    })
+    it('should label search dropdown input aria-autocomplete=list', () => {
+      wrapperMount(<Dropdown search />)
+      wrapper.find('input').should.have.prop('aria-autocomplete', 'list')
+    })
+    it('should label search dropdown input type=text', () => {
+      wrapperMount(<Dropdown search />)
+      wrapper.find('input').should.have.prop('type', 'text')
+    })
+  })
+
   describe('handleBlur', () => {
     it('passes the event to the onBlur prop', () => {
       const spy = sandbox.spy()

--- a/test/specs/modules/Dropdown/DropdownItem-test.js
+++ b/test/specs/modules/Dropdown/DropdownItem-test.js
@@ -32,6 +32,45 @@ describe('DropdownItem', () => {
     }),
   })
 
+  describe('aria', () => {
+    it('should render DropdownItem as role=option', () => {
+      const wrapper = shallow(<DropdownItem />)
+      wrapper.should.have.prop('role', 'option')
+    })
+    it('should render DropdownItem with children as role=option', () => {
+      const wrapper = shallow(<DropdownItem>Text</DropdownItem>)
+      wrapper.should.have.prop('role', 'option')
+    })
+    it('should render DropdownItem with description as role=option', () => {
+      const wrapper = shallow(<DropdownItem description='Text' />)
+      wrapper.should.have.prop('role', 'option')
+    })
+    it('should render disabled DropdownItem with aria-disabled', () => {
+      const wrapper = shallow(<DropdownItem disabled />)
+      wrapper.should.have.prop('aria-disabled', true)
+    })
+    it('should render normal DropdownItem without aria-disabled', () => {
+      const wrapper = shallow(<DropdownItem />)
+      wrapper.should.not.have.prop('aria-disabled')
+    })
+    it('should render active DropdownItem with aria-checked', () => {
+      const wrapper = shallow(<DropdownItem active />)
+      wrapper.should.have.prop('aria-checked', true)
+    })
+    it('should render normal DropdownItem without aria-disabled', () => {
+      const wrapper = shallow(<DropdownItem />)
+      wrapper.should.not.have.prop('aria-checked')
+    })
+    it('should render selected DropdownItem with aria-selected', () => {
+      const wrapper = shallow(<DropdownItem selected />)
+      wrapper.should.have.prop('aria-selected', true)
+    })
+    it('should render normal DropdownItem without aria-selected', () => {
+      const wrapper = shallow(<DropdownItem />)
+      wrapper.should.not.have.prop('aria-selected')
+    })
+  })
+
   describe('text', () => {
     it('renders with wrapping span when description', () => {
       const wrapper = shallow(<DropdownItem text='hey' description='description' />)


### PR DESCRIPTION
This will fail tests until #1005 lands, but I wanted to get feedback on what I've done and the problems I ran into making the Dropdown truly accessible. 

**Things accomplished in this pull request**
* adds a role="listbox" to the normal Dropdown component
* adds a role="combobox" to the Dropdown component in search mode, with DropdownMenu getting role="listbox"
* adds a role="option" to the DropdownItem component
* adds aria flags for disabled, busy, expanded on the Dropdown component
* adds aria flags for disabled, checked, selected on DropdownItem component
* adds aria flags for multiselectable on Dropdown normal component, and DropdownMenu search components
* sets an aria-autocomplete="list" on the input field for search Dropdowns

So this mostly works in bringing it up to some basic accessibility standards. 

So let me dump some thoughts here for discussion:

**listbox/option vs menu/menuitem**
So one thing that will probably jump out to you is how similar listbox/option is to menu/menuitem. I've been reading up a lot on them and menu's are truly used for desktop style menus, where you drop down an entry and trigger an action and it goes away. This is backed up by this article: https://www.marcozehe.de/2014/03/11/easy-aria-tip-7-use-listbox-and-option-roles-when-constructing-autocomplete-lists/ Dropdowns are really a fancy select vs a real menu. EXCEPT when Dropdowns are added to Menu components, then they really are menu/menuitems. So I added an if statement to check if the as prop === Menu.Item. Not 100% certain the best way to switch the dropdown item from role=option to role=menuitem (though menuitemcheckbox might be better, need to ponder that one), thoughts?

**combobox and search dropdowns**
So this is where things get a little weird. Dropdowns can act like combobox's in search mode. So the roles and markup changes under those circumstances. I'm taking a lot of this from here: https://www.w3.org/TR/wai-aria-1.1/#combobox which has a nice pretty example to follow that follows a similar stucture to this Dropdown. I had to add the type="text" to the input to get the role="textbox", and the listbox role and aria-multiselectable had to move to the DropdownMenu since aria-multiselectable isn't a valid option for combobox. Now this leads into the next problem. 

**problems with ids**
Most accessibility attributes use page ids to link separate dom elements together. So for the combobox, it wants to have 2 ids:
* aria-owns and aria-controls both need an id to identify the listbox the combobox is controlling
* aria-activedescendant needs an id of the selected dropdown menu item

The first solution that comes to mind for me is to allow an id prop, with a default prop of some ComponentName + incrementingCounter. Thoughts?

**sub dropdowns**
Whenever support gets added for sub menus, the flag aria-haspopup=true needs to be set, thoughts on where to put that so it isn't forgotten?