### PR TITLE
docs(StepExampleGroups): remove object destructuring

### DIFF
--- a/docs/app/Examples/elements/Step/Groups/StepExampleGroups.js
+++ b/docs/app/Examples/elements/Step/Groups/StepExampleGroups.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Icon, Step } from 'semantic-ui-react'
 
-const { Content, Description, Group, Title } = Step
 const steps = [
   { icon: 'truck', title: 'Shipping', description: 'Choose your shipping options' },
   { active: true, icon: 'payment', title: 'Billing', description: 'Enter billing information' },
@@ -10,26 +9,26 @@ const steps = [
 
 const StepExampleGroups = () => (
   <div>
-    <Group>
+    <Step.Group>
       <Step>
         <Icon name='truck' />
-        <Content>
-          <Title>Shipping</Title>
-          <Description>Choose your shipping options</Description>
-        </Content>
+        <Step.Content>
+          <Step.Title>Shipping</Step.Title>
+          <Step.Description>Choose your shipping options</Step.Description>
+        </Step.Content>
       </Step>
 
       <Step active>
         <Icon name='payment' />
-        <Content title='Billing' description='Enter billing information' />
+        <Step.Content title='Billing' description='Enter billing information' />
       </Step>
 
       <Step disabled icon='info' title='Confirm Order' />
-    </Group>
+    </Step.Group>
 
     <br />
 
-    <Group items={steps} />
+    <Step.Group items={steps} />
   </div>
 )
 


### PR DESCRIPTION
Although this isn't a bug and isn't necessary, I'd like to propose reworking the Step examples that use object destructuring. All of the other examples that I've seen in the docs that have subcomponents don't use destructuring. Because of that, it is easy to get mixed up on the destructuring when looking at tags without the base component name in there. It looks like maybe there's a Group tag, etc. Once it is understood then developers can do the destructuring and be aware, but this creates a sort of lowest common denominator for all styles of programming and keeps it consistent with what I've observed in the rest of the examples.

If this is agreeable I can go through and change the other Step examples that have the same destructuring in them.