### PR TITLE
docs(Step): remove object destructuring for Step subcomponents

### DIFF
--- a/docs/app/Examples/elements/Step/Content/StepExampleDescriptions.js
+++ b/docs/app/Examples/elements/Step/Content/StepExampleDescriptions.js
@@ -1,31 +1,29 @@
 import React from 'react'
 import { Step } from 'semantic-ui-react'
 
-const { Description, Group, Title } = Step
-
 const StepExampleDescriptions = () => (
   <div>
-    <Group>
+    <Step.Group>
       <Step>
-        <Title>Shipping</Title>
-        <Description>Choose your shipping options</Description>
+        <Step.Title>Shipping</Step.Title>
+        <Step.Description>Choose your shipping options</Step.Description>
       </Step>
-    </Group>
+    </Step.Group>
 
     <br />
 
-    <Group>
+    <Step.Group>
       <Step>
-        <Title title='Shipping' />
-        <Description description='Choose your shipping options' />
+        <Step.Title title='Shipping' />
+        <Step.Description description='Choose your shipping options' />
       </Step>
-    </Group>
+    </Step.Group>
 
     <br />
 
-    <Group>
+    <Step.Group>
       <Step title='Shipping' description='Choose your shipping options' />
-    </Group>
+    </Step.Group>
   </div>
 )
 

--- a/docs/app/Examples/elements/Step/Content/StepExampleIcons.js
+++ b/docs/app/Examples/elements/Step/Content/StepExampleIcons.js
@@ -1,25 +1,23 @@
 import React from 'react'
 import { Icon, Step } from 'semantic-ui-react'
 
-const { Content, Description, Group, Title } = Step
-
 const StepExampleIcons = () => (
-  <Group>
+  <Step.Group>
     <Step>
       <Icon name='truck' />
-      <Content>
-        <Title>Shipping</Title>
-        <Description>Choose your shipping options</Description>
-      </Content>
+      <Step.Content>
+        <Step.Title>Shipping</Step.Title>
+        <Step.Description>Choose your shipping options</Step.Description>
+      </Step.Content>
     </Step>
 
     <Step>
       <Icon name='truck' />
-      <Content title='Shipping' description='Choose your shipping options' />
+      <Step.Content title='Shipping' description='Choose your shipping options' />
     </Step>
 
     <Step icon='truck' title='Shipping' description='Choose your shipping options' />
-  </Group>
+  </Step.Group>
 )
 
 export default StepExampleIcons

--- a/docs/app/Examples/elements/Step/Groups/StepExampleGroups.js
+++ b/docs/app/Examples/elements/Step/Groups/StepExampleGroups.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Icon, Step } from 'semantic-ui-react'
 
-const { Content, Description, Group, Title } = Step
 const steps = [
   { icon: 'truck', title: 'Shipping', description: 'Choose your shipping options' },
   { active: true, icon: 'payment', title: 'Billing', description: 'Enter billing information' },
@@ -10,26 +9,26 @@ const steps = [
 
 const StepExampleGroups = () => (
   <div>
-    <Group>
+    <Step.Group>
       <Step>
         <Icon name='truck' />
-        <Content>
-          <Title>Shipping</Title>
-          <Description>Choose your shipping options</Description>
-        </Content>
+        <Step.Content>
+          <Step.Title>Shipping</Step.Title>
+          <Step.Description>Choose your shipping options</Step.Description>
+        </Step.Content>
       </Step>
 
       <Step active>
         <Icon name='payment' />
-        <Content title='Billing' description='Enter billing information' />
+        <Step.Content title='Billing' description='Enter billing information' />
       </Step>
 
       <Step disabled icon='info' title='Confirm Order' />
-    </Group>
+    </Step.Group>
 
     <br />
 
-    <Group items={steps} />
+    <Step.Group items={steps} />
   </div>
 )
 

--- a/docs/app/Examples/elements/Step/Groups/StepExampleOrdered.js
+++ b/docs/app/Examples/elements/Step/Groups/StepExampleOrdered.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Step } from 'semantic-ui-react'
 
-const { Content, Description, Group, Title } = Step
 const steps = [
   { completed: true, title: 'Shipping', description: 'Choose your shipping options' },
   { completed: true, title: 'Billing', description: 'Enter billing information' },
@@ -10,22 +9,22 @@ const steps = [
 
 const StepExampleOrdered = () => (
   <div>
-    <Group ordered>
+    <Step.Group ordered>
       <Step completed>
-        <Content>
-          <Title>Shipping</Title>
-          <Description>Choose your shipping options</Description>
-        </Content>
+        <Step.Content>
+          <Step.Title>Shipping</Step.Title>
+          <Step.Description>Choose your shipping options</Step.Description>
+        </Step.Content>
       </Step>
 
       <Step completed title='Billing' description='Enter billing information' />
 
       <Step active title='Confirm Order' description='Verify order details' />
-    </Group>
+    </Step.Group>
 
     <br />
 
-    <Group ordered items={steps} />
+    <Step.Group ordered items={steps} />
   </div>
 )
 

--- a/docs/app/Examples/elements/Step/Groups/StepExampleVertical.js
+++ b/docs/app/Examples/elements/Step/Groups/StepExampleVertical.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Icon, Step } from 'semantic-ui-react'
 
-const { Content, Description, Group, Title } = Step
 const steps = [
   { completed: true, icon: 'truck', title: 'Shipping', description: 'Choose your shipping options' },
   { completed: true, icon: 'credit card', title: 'Billing', description: 'Enter billing information' },
@@ -10,26 +9,26 @@ const steps = [
 
 const StepExampleVertical = () => (
   <div>
-    <Group vertical>
+    <Step.Group vertical>
       <Step completed>
         <Icon name='truck' />
-        <Content>
-          <Title>Shipping</Title>
-          <Description>Choose your shipping options</Description>
-        </Content>
+        <Step.Content>
+          <Step.Title>Shipping</Step.Title>
+          <Step.Description>Choose your shipping options</Step.Description>
+        </Step.Content>
       </Step>
 
       <Step completed>
         <Icon name='credit card' />
-        <Content title='Billing' description='Enter billing information' />
+        <Step.Content title='Billing' description='Enter billing information' />
       </Step>
 
       <Step active icon='info' title='Confirm Order' description='Verify order details' />
-    </Group>
+    </Step.Group>
 
     <br />
 
-    <Group vertical items={steps} />
+    <Step.Group vertical items={steps} />
   </div>
 )
 

--- a/docs/app/Examples/elements/Step/States/StepExampleActive.js
+++ b/docs/app/Examples/elements/Step/States/StepExampleActive.js
@@ -1,20 +1,18 @@
 import React from 'react'
 import { Icon, Step } from 'semantic-ui-react'
 
-const { Content, Description, Group, Title } = Step
-
 const StepExampleActive = () => (
-  <Group>
+  <Step.Group>
     <Step active>
       <Icon name='credit card' />
-      <Content>
-        <Title>Billing</Title>
-        <Description>Enter billing information</Description>
-      </Content>
+      <Step.Content>
+        <Step.Title>Billing</Step.Title>
+        <Step.Description>Enter billing information</Step.Description>
+      </Step.Content>
     </Step>
 
     <Step active icon='credit card' title='Billing' description='Enter billing information' />
-  </Group>
+  </Step.Group>
 )
 
 export default StepExampleActive

--- a/docs/app/Examples/elements/Step/States/StepExampleCompleted.js
+++ b/docs/app/Examples/elements/Step/States/StepExampleCompleted.js
@@ -1,19 +1,17 @@
 import React from 'react'
 import { Step } from 'semantic-ui-react'
 
-const { Group } = Step
-
 const StepExampleCompleted = () => (
   <div>
-    <Group>
+    <Step.Group>
       <Step completed icon='payment' title='Billing' description='Enter billing information' />
-    </Group>
+    </Step.Group>
 
     <br />
 
-    <Group ordered>
+    <Step.Group ordered>
       <Step completed title='Billing' description='Enter billing information' />
-    </Group>
+    </Step.Group>
   </div>
 )
 


### PR DESCRIPTION
This is as discussed previously on another pull request. Removing the ES6 destructuring of the Step subcomponents (Group, Title, etc.) to make the examples consistent with other examples in the docs.

Searched for any other subcomponent destructuring in the examples but didn't find any so looks like these were the only ones.