### PR TITLE
feat(docs): Active className on Sidebar item

### DIFF
--- a/docs/app/Components/Sidebar/Sidebar.js
+++ b/docs/app/Components/Sidebar/Sidebar.js
@@ -119,6 +119,7 @@ export default class Sidebar extends Component {
           onClick={this.handleItemClick}
           as={Link}
           to={getRoute(_meta)}
+          activeClassName='active'
         />
       ))
     )(parentComponents)


### PR DESCRIPTION
Added an active style when the menu is active on left Sidebar.

![kapture 2016-12-15 at 16 03 47](https://cloud.githubusercontent.com/assets/5749437/21228976/34c000d4-c2e0-11e6-886e-e22f532984a0.gif)
