### PR TITLE
fix(Header): Remove duplicate class

### DIFF
--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -53,7 +53,7 @@ function Header(props) {
 
   const iconElement = Icon.create(icon)
   const imageElement = Image.create(image)
-  const subheaderElement = HeaderSubheader.create(subheader, { className: 'sub header' })
+  const subheaderElement = HeaderSubheader.create(subheader)
 
   if (iconElement || imageElement) {
     return (

--- a/test/specs/elements/Header/Header-test.js
+++ b/test/specs/elements/Header/Header-test.js
@@ -29,7 +29,6 @@ describe('Header', () => {
   common.implementsShorthandProp(Header, {
     propKey: 'subheader',
     ShorthandComponent: HeaderSubheader,
-    shorthandDefaultProps: { className: 'sub header' },
     mapValueToProps: val => ({ content: val }),
   })
 


### PR DESCRIPTION
Using the `subheader` shorthand would result in the `sub header` classes being applied twice:
```
<Header subheader='hey' />

<div class="sub header sub header">hey</div>
```

This fixes that.