### PR TITLE
feat(Checkbox): Indeterminate state

### DIFF
--- a/docs/app/Examples/modules/Checkbox/States/CheckboxExampleIndeterminate.js
+++ b/docs/app/Examples/modules/Checkbox/States/CheckboxExampleIndeterminate.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Checkbox } from 'semantic-ui-react'
+
+const CheckboxExampleIndeterminate = () => (
+  <Checkbox label='This checkbox is indeterminate' defaultIndeterminate />
+)
+
+export default CheckboxExampleIndeterminate

--- a/docs/app/Examples/modules/Checkbox/States/index.js
+++ b/docs/app/Examples/modules/Checkbox/States/index.js
@@ -6,8 +6,13 @@ import { Message } from 'semantic-ui-react'
 const CheckboxStatesExamples = () => (
   <ExampleSection title='States'>
     <ComponentExample
+      title='Read Only'
+      description='A checkbox can be read-only and unable to change states.'
+      examplePath='modules/Checkbox/States/CheckboxExampleReadOnly'
+    />
+    <ComponentExample
       title='Checked'
-      description='A checkbox can come pre-checked.'
+      description='A checkbox can be checked.'
       examplePath='modules/Checkbox/States/CheckboxExampleChecked'
     >
       <Message>
@@ -19,14 +24,14 @@ const CheckboxStatesExamples = () => (
       </Message>
     </ComponentExample>
     <ComponentExample
-      title='Disabled'
-      description='Checkboxes can be disabled.'
-      examplePath='modules/Checkbox/States/CheckboxExampleDisabled'
+      title='Indeterminate'
+      description='A checkbox can be indeterminate.'
+      examplePath='modules/Checkbox/States/CheckboxExampleIndeterminate'
     />
     <ComponentExample
-      title='Read Only'
-      description='Make the checkbox unable to be edited by the user.'
-      examplePath='modules/Checkbox/States/CheckboxExampleReadOnly'
+      title='Disabled'
+      description='A checkbox can be read-only and unable to change states.'
+      examplePath='modules/Checkbox/States/CheckboxExampleDisabled'
     />
     <ComponentExample
       title='Remote Control'

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -44,11 +44,17 @@ export default class Checkbox extends Component {
     /** The initial value of checked. */
     defaultChecked: PropTypes.bool,
 
+    /** Whether or not checkbox is indeterminate. */
+    defaultIndeterminate: PropTypes.bool,
+
     /** A checkbox can appear disabled and be unable to change states */
     disabled: PropTypes.bool,
 
     /** Removes padding for a label. Auto applied when there is no label. */
     fitted: PropTypes.bool,
+
+    /** Whether or not checkbox is indeterminate. */
+    indeterminate: PropTypes.bool,
 
     /** The text of the associated label element. */
     label: customPropTypes.itemShorthand,
@@ -60,7 +66,7 @@ export default class Checkbox extends Component {
      * Called when the user attempts to change the checked state.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All props and proposed checked state.
+     * @param {object} data - All props and proposed checked/indeterminate state.
      */
     onChange: PropTypes.func,
 
@@ -68,7 +74,7 @@ export default class Checkbox extends Component {
      * Called when the checkbox or label is clicked.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All props and current checked state.
+     * @param {object} data - All props and current checked/indeterminate state.
      */
     onClick: PropTypes.func,
 
@@ -106,6 +112,7 @@ export default class Checkbox extends Component {
 
   static autoControlledProps = [
     'checked',
+    'indeterminate',
   ]
 
   static _meta = _meta
@@ -119,17 +126,37 @@ export default class Checkbox extends Component {
     return !disabled && !readOnly && !(radio && checked)
   }
 
+  componentDidMount = (e) => {
+    this.setIndeterminate()
+  }
+
+  componentDidUpdate = (e) => {
+    this.setIndeterminate()
+  }
+
+  handleRef = (c) => {
+    this.checkboxRef = c
+  }
+
   handleClick = (e) => {
     debug('handleClick()')
     const { onChange, onClick } = this.props
-    const { checked } = this.state
+    const { checked, indeterminate } = this.state
 
     if (this.canToggle()) {
-      if (onClick) onClick(e, { ...this.props, checked: !!checked })
-      if (onChange) onChange(e, { ...this.props, checked: !checked })
+      if (onClick) onClick(e, { ...this.props, checked: !!checked, indeterminate: !!indeterminate })
+      if (onChange) onChange(e, { ...this.props, checked: !checked, indeterminate: false })
 
-      this.trySetState({ checked: !checked })
+      this.trySetState({ checked: !checked, indeterminate: false })
     }
+  }
+
+  // Note: You can't directly set the indeterminate prop on the input, so we
+  // need to maintain a ref to the input and set it manually whenever the
+  // component updates.
+  setIndeterminate = () => {
+    const { indeterminate } = this.state
+    if (this.checkboxRef) this.checkboxRef.indeterminate = !!indeterminate
   }
 
   render() {
@@ -145,12 +172,13 @@ export default class Checkbox extends Component {
       type,
       value,
     } = this.props
-    const { checked } = this.state
+    const { checked, indeterminate } = this.state
 
     const classes = cx(
       'ui',
       useKeyOnly(checked, 'checked'),
       useKeyOnly(disabled, 'disabled'),
+      useKeyOnly(indeterminate, 'indeterminate'),
       // auto apply fitted class to compact white space when there is no label
       // http://semantic-ui.com/modules/checkbox.html#fitted
       useKeyOnly(!label, 'fitted'),
@@ -171,6 +199,7 @@ export default class Checkbox extends Component {
           className='hidden'
           name={name}
           readOnly
+          ref={this.handleRef}
           tabIndex={0}
           type={type}
           value={value}

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -119,19 +119,19 @@ export default class Checkbox extends Component {
 
   state = {}
 
+  componentDidMount() {
+    this.setIndeterminate()
+  }
+
+  componentDidUpdate() {
+    this.setIndeterminate()
+  }
+
   canToggle = () => {
     const { disabled, radio, readOnly } = this.props
     const { checked } = this.state
 
     return !disabled && !readOnly && !(radio && checked)
-  }
-
-  componentDidMount = (e) => {
-    this.setIndeterminate()
-  }
-
-  componentDidUpdate = (e) => {
-    this.setIndeterminate()
   }
 
   handleRef = (c) => {

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { findDOMNode } from 'react-dom'
 
 import Checkbox from 'src/modules/Checkbox/Checkbox'
 import * as common from 'test/specs/commonTests'
@@ -45,6 +46,57 @@ describe('Checkbox', () => {
     })
   })
 
+  describe('indeterminate', () => {
+    it('can be indeterminate', () => {
+      const wrapper = mount(<Checkbox indeterminate />)
+
+      const checkboxNode = findDOMNode(wrapper.instance())
+      const input = checkboxNode.querySelector('input')
+
+      input.indeterminate.should.be.true()
+
+      wrapper.simulate('click').find('input')
+      input.indeterminate.should.be.true()
+    })
+    it('can not be indeterminate', () => {
+      const wrapper = mount(<Checkbox indeterminate={false} />)
+
+      const checkboxNode = findDOMNode(wrapper.instance())
+      const input = checkboxNode.querySelector('input')
+
+      input.indeterminate.should.be.false()
+
+      wrapper.simulate('click').find('input')
+      input.indeterminate.should.be.false()
+    })
+  })
+
+  describe('defaultIndeterminate', () => {
+    it('sets the initial indeterminate state', () => {
+      const wrapper = mount(<Checkbox defaultIndeterminate />)
+
+      const checkboxNode = findDOMNode(wrapper.instance())
+      const input = checkboxNode.querySelector('input')
+
+      input.indeterminate.should.be.true()
+    })
+
+    it('unsets indeterminate state on any click', () => {
+      const wrapper = mount(<Checkbox defaultIndeterminate />)
+
+      const checkboxNode = findDOMNode(wrapper.instance())
+      const input = findDOMNode(checkboxNode.querySelector('input'))
+
+      input.indeterminate.should.be.true()
+
+      wrapper.simulate('click').find('input')
+      input.indeterminate.should.be.false()
+
+      wrapper.simulate('click').find('input')
+      input.indeterminate.should.be.false()
+    })
+  })
+
   describe('disabled', () => {
     it('cannot be checked', () => {
       shallow(<Checkbox disabled />)
@@ -70,7 +122,7 @@ describe('Checkbox', () => {
   describe('onChange', () => {
     it('is called with (event { name, value, !checked }) on click', () => {
       const spy = sandbox.spy()
-      const expectProps = { name: 'foo', value: 'bar', checked: false }
+      const expectProps = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
       mount(<Checkbox onChange={spy} {...expectProps} />)
         .simulate('click')
 
@@ -78,6 +130,7 @@ describe('Checkbox', () => {
       spy.should.have.been.calledWithMatch({}, {
         ...expectProps,
         checked: !expectProps.checked,
+        indeterminate: false,
       })
     })
     it('is not called when the checkbox has the disabled prop set', () => {
@@ -90,7 +143,7 @@ describe('Checkbox', () => {
   describe('onClick', () => {
     it('is called with (event { name, value, checked }) on label click', () => {
       const spy = sandbox.spy()
-      const expectProps = { name: 'foo', value: 'bar', checked: false }
+      const expectProps = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
       mount(<Checkbox onClick={spy} {...expectProps} />)
         .simulate('click')
 
@@ -98,6 +151,7 @@ describe('Checkbox', () => {
       spy.should.have.been.calledWithMatch({}, {
         ...expectProps,
         checked: expectProps.checked,
+        indeterminate: expectProps.indeterminate,
       })
     })
     it('is not called when the checkbox has the disabled prop set', () => {


### PR DESCRIPTION
Adds support for `indeterminate` state for checkbox. See usage in SUI-core here: http://semantic-ui.com/modules/checkbox.html#grouped-checkboxes

<img width="282" alt="screen shot 2016-12-16 at 3 52 22 pm" src="https://cloud.githubusercontent.com/assets/847027/21278177/ae5e64f4-c3a7-11e6-9749-3a637c64b3b3.png">

Initially I thought to just implement this as a plain `indeterminate` prop. However, that would prevent using `indeterminate` with uncontrolled usage since you'd have to maintain the `indeterminate` state and optionally pass the prop.

Instead, this makes `indeterminate` an auto-controlled prop, so to default a toggle to `indeterminate` you pass `defaultIndeterminate` or you could control the usage by passing the `indeterminate` prop.

This follows the standard usage pattern of `indeterminate` in HTML checkboxes (as well as SUI core): you can't get into the indeterminate state by user interaction, only via javascript. If a checkbox starts as indeterminate, once clicked the indeterminate state will be set to false for the rest of its lifecycle and it will function as a normal checkbox.