### PR TITLE
fix(typings): fix typings spelling on `Accordion`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1146,7 +1146,7 @@ export const TableRow: React.ComponentClass<TableRowProps>;
 
 // Accordion
 // ----------------------------------
-interface AccordianProps {
+interface AccordionProps {
   activeIndex?: number;
   as?: any;
   children?: React.ReactNode;
@@ -1159,30 +1159,30 @@ interface AccordianProps {
   styled?: boolean;
 }
 
-interface AccordianClass extends React.ComponentClass<AccordianProps> {
-  Content: typeof AccordianContent;
-  Title: typeof AccordianTitle;
+interface AccordionClass extends React.ComponentClass<AccordionProps> {
+  Content: typeof AccordionContent;
+  Title: typeof AccordionTitle;
 }
 
-export const Accordian: AccordianClass;
+export const Accordion: AccordionClass;
 
-interface AccordianContentProps {
+interface AccordionContentProps {
   active?: boolean;
   as?: any;
   children?: React.ReactNode;
   className?: string;
 }
 
-export const AccordianContent: React.ComponentClass<AccordianContentProps>;
+export const AccordionContent: React.ComponentClass<AccordionContentProps>;
 
-interface AccordianTitleProps extends ReactMouseEvents<HTMLElement> {
+interface AccordionTitleProps extends ReactMouseEvents<HTMLElement> {
   active?: boolean;
   as?: any;
   children?: React.ReactNode;
   className?: string;
 }
 
-export const AccordianTitle: React.ComponentClass<AccordianTitleProps>;
+export const AccordionTitle: React.ComponentClass<AccordionTitleProps>;
 
 // Checkbox
 // ----------------------------------


### PR DESCRIPTION
Typescript typings were spelled `Accordian` instead of `Accordion`.