### PR TITLE
fix(docs): more permissive exampleContext regex

### DIFF
--- a/docs/app/utils.js
+++ b/docs/app/utils.js
@@ -18,7 +18,7 @@ export const parentComponents = _.flow(
 /**
  * Get the Webpack Context for all doc site examples.
  */
-export const exampleContext = require.context('docs/app/Examples/', true, /(\w+Example\w+|index)\.js$/)
+export const exampleContext = require.context('docs/app/Examples/', true, /(\w+Example\w*|index)\.js$/)
 
 export const repoURL = 'https://github.com/Semantic-Org/Semantic-UI-React'
 export const semanticUIDocsURL = 'http://semantic-ui.com/'


### PR DESCRIPTION
Fixes #1055 

The regex currently in place precludes example files that end in `Example.js`.  This PR allows 0 or more word characters after the `Example` word.