### PR TITLE
docs(StatisticGroup): add color, size, and inverted examples

### DIFF
--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupColored.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupColored.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Statistic } from 'semantic-ui-react'
+
+const items = [
+  { label: 'Faves', value: '22' },
+  { label: 'Views', value: '31,200' },
+  { label: 'Members', value: '22' },
+]
+
+const StatisticExampleGroupColored = () => (
+  <div>
+    <Statistic.Group items={items} color='blue'/>
+  </div>
+)
+
+export default StatisticExampleGroupColored

--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupColored.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupColored.js
@@ -8,9 +8,7 @@ const items = [
 ]
 
 const StatisticExampleGroupColored = () => (
-  <div>
-    <Statistic.Group items={items} color='blue' />
-  </div>
+  <Statistic.Group items={items} color='blue' />
 )
 
 export default StatisticExampleGroupColored

--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupColored.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupColored.js
@@ -9,7 +9,7 @@ const items = [
 
 const StatisticExampleGroupColored = () => (
   <div>
-    <Statistic.Group items={items} color='blue'/>
+    <Statistic.Group items={items} color='blue' />
   </div>
 )
 

--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupInverted.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupInverted.js
@@ -2,17 +2,17 @@ import React from 'react'
 import { Segment, Statistic } from 'semantic-ui-react'
 
 const items = [
-  { label: 'Faves', value: '22'},
+  { label: 'Faves', value: '22' },
   { label: 'Views', value: '31,200' },
   { label: 'Members', value: '22' },
   { label: 'Downloads', value: '3,200' },
-  { label: 'Likes', value: '10,000' }
+  { label: 'Likes', value: '10,000' },
 ]
 
 const StatisticExampleGroupInverted = () => (
   <div>
     <Segment inverted>
-      <Statistic.Group items={items} inverted color='green'/>
+      <Statistic.Group items={items} inverted color='green' />
     </Segment>
   </div>
 )

--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupInverted.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupInverted.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Segment, Statistic } from 'semantic-ui-react'
+
+const items = [
+  { label: 'Faves', value: '22'},
+  { label: 'Views', value: '31,200' },
+  { label: 'Members', value: '22' },
+  { label: 'Downloads', value: '3,200' },
+  { label: 'Likes', value: '10,000' }
+]
+
+const StatisticExampleGroupInverted = () => (
+  <div>
+    <Segment inverted>
+      <Statistic.Group items={items} inverted color='green'/>
+    </Segment>
+  </div>
+)
+
+export default StatisticExampleGroupInverted

--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupInverted.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupInverted.js
@@ -10,11 +10,9 @@ const items = [
 ]
 
 const StatisticExampleGroupInverted = () => (
-  <div>
-    <Segment inverted>
-      <Statistic.Group items={items} inverted color='green' />
-    </Segment>
-  </div>
+  <Segment inverted>
+    <Statistic.Group items={items} inverted color='green' />
+  </Segment>
 )
 
 export default StatisticExampleGroupInverted

--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupSize.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroupSize.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Statistic } from 'semantic-ui-react'
+
+const items = [
+  { label: 'Faves', value: '22' },
+  { label: 'Views', value: '31,200' },
+  { label: 'Members', value: '22' },
+]
+
+const StatisticExampleGroupSize = () => (
+  <div>
+    <Statistic.Group items={items} size='mini' />
+    <Statistic.Group items={items} size='small' />
+    <Statistic.Group items={items} size='large' />
+  </div>
+)
+
+export default StatisticExampleGroupSize

--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroups.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroups.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Statistic } from 'semantic-ui-react'
+import { Segment, Statistic } from 'semantic-ui-react'
 
 const items = [
   { label: 'Faves', value: '22' },
@@ -22,6 +22,14 @@ const StatisticExampleGroups = () => (
     </Statistic.Group>
 
     <Statistic.Group items={items} />
+
+    <Statistic.Group items={items} color='blue' />
+
+    <Statistic.Group items={items} size='huge' />
+
+    <Segment inverted>
+      <Statistic.Group items={items} inverted />
+    </Segment>
   </div>
 )
 

--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroups.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroups.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Segment, Statistic } from 'semantic-ui-react'
+import { Statistic } from 'semantic-ui-react'
 
 const items = [
   { label: 'Faves', value: '22' },

--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroups.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroups.js
@@ -22,10 +22,6 @@ const StatisticExampleGroups = () => (
     </Statistic.Group>
 
     <Statistic.Group items={items} />
-
-    {/* <Segment inverted> */}
-      {/* <Statistic.Group items={items} inverted /> */}
-    {/* </Segment> */}
   </div>
 )
 

--- a/docs/app/Examples/views/Statistic/Types/StatisticExampleGroups.js
+++ b/docs/app/Examples/views/Statistic/Types/StatisticExampleGroups.js
@@ -23,13 +23,9 @@ const StatisticExampleGroups = () => (
 
     <Statistic.Group items={items} />
 
-    <Statistic.Group items={items} color='blue' />
-
-    <Statistic.Group items={items} size='huge' />
-
-    <Segment inverted>
-      <Statistic.Group items={items} inverted />
-    </Segment>
+    {/* <Segment inverted> */}
+      {/* <Statistic.Group items={items} inverted /> */}
+    {/* </Segment> */}
   </div>
 )
 

--- a/docs/app/Examples/views/Statistic/Types/index.js
+++ b/docs/app/Examples/views/Statistic/Types/index.js
@@ -20,14 +20,20 @@ const Types = () => (
 
     <ComponentExample
       title='Statistic Group Colored'
-      description='A group of colored statistics'
+      description='A group of colored statistics.'
       examplePath='views/Statistic/Types/StatisticExampleGroupColored'
     />
 
     <ComponentExample
       title='Statistic Group Size'
-      description='A group of statistics can vary in size'
+      description='A group of statistics can vary in size.'
       examplePath='views/Statistic/Types/StatisticExampleGroupSize'
+    />
+
+    <ComponentExample
+      title='Statistic Group Inverted'
+      description='A group of statistics can be formatted to fit on a dark background.'
+      examplePath='views/Statistic/Types/StatisticExampleGroupInverted'
     />
 
   </ExampleSection>

--- a/docs/app/Examples/views/Statistic/Types/index.js
+++ b/docs/app/Examples/views/Statistic/Types/index.js
@@ -17,6 +17,19 @@ const Types = () => (
       description='A group of statistics.'
       examplePath='views/Statistic/Types/StatisticExampleGroups'
     />
+
+    <ComponentExample
+      title='Statistic Group Colored'
+      description='A group of colored statistics'
+      examplePath='views/Statistic/Types/StatisticExampleGroupColored'
+    />
+
+    <ComponentExample
+      title='Statistic Group Size'
+      description='A group of statistics can vary in size'
+      examplePath='views/Statistic/Types/StatisticExampleGroupSize'
+    />
+
   </ExampleSection>
 )
 


### PR DESCRIPTION
This PR adds documentation for Statistic Group examples for `color`, `size`, and `inverted` props.