### PR TITLE
breaking(shorthand): only generate keys from strings and numbers

### DIFF
--- a/docs/app/Examples/collections/Breadcrumb/Types/BreadcrumbExampleProps.js
+++ b/docs/app/Examples/collections/Breadcrumb/Types/BreadcrumbExampleProps.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { Breadcrumb } from 'semantic-ui-react'
 
 const sections = [
-  { content: 'Home', link: true },
-  { content: 'Store', link: true },
-  { content: 'T-Shirt', active: true },
+  { key: 'Home', content: 'Home', link: true },
+  { key: 'Store', content: 'Store', link: true },
+  { key: 'Shirt', content: 'T-Shirt', active: true },
 ]
 
 const BreadcrumbExampleProps = () => (

--- a/docs/app/Examples/collections/Menu/Types/MenuExampleProps.js
+++ b/docs/app/Examples/collections/Menu/Types/MenuExampleProps.js
@@ -1,16 +1,14 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Menu } from 'semantic-ui-react'
 
-export default class MenuExampleProps extends Component {
-  state = {}
+const items = [
+  { key: 'editorials', active: true, name: 'Editorials' },
+  { key: 'review', name: 'Reviews' },
+  { key: 'events', name: 'Upcoming Events' },
+]
 
-  render() {
-    const items = [
-      { active: true, name: 'Editorials' },
-      { name: 'Reviews' },
-      { name: 'Upcoming Events' },
-    ]
+const MenuExampleProps = () => (
+  <Menu items={items} />
+)
 
-    return <Menu items={items} />
-  }
-}
+export default MenuExampleProps

--- a/src/lib/factories.js
+++ b/src/lib/factories.js
@@ -3,47 +3,6 @@ import cx from 'classnames'
 import React, { cloneElement, isValidElement } from 'react'
 
 // ============================================================
-// Factory Utilities
-// ============================================================
-/**
- * A pure function that generates a unique child key hash code from an element's props.
- *
- * @param {object} props A ReactElement's props object.
- * @returns {number}
- */
-export const getChildKey = (props) => {
-  const { key, childKey } = props
-
-  // already defines a key
-  if (key) return key
-
-  // defines a childKey function or value
-  if (childKey) return typeof childKey === 'function' ? childKey(props) : childKey
-
-  // 1. Stringify props to a short as possible run on string of key/values.
-  // 2. Don't stringify entire functions, use the function name || 'f'.
-  // 3. Generate a short hash number from the string.
-  //     props  : { color: 'red', onClick: handleClick }
-  //     string : 'color:"red",onClick:handleClick'
-  //     hash   : 110042245
-  return Object.keys(props).map(name => {
-    const val = props[name]
-    const type = typeof val
-
-    const valueString = type === 'string' && val
-      || type === 'number' && val
-      || type === 'boolean' && (val ? 'true' : 'false')
-      || type === 'function' && (val.name || 'function')
-      || Array.isArray(val) && ['[', val.join(','), ']'].join('')
-      || val === null && 'null'
-      || type === 'object' && ['{', Object.keys(val).map(k => [k, ':', val[k]].join('')), '}'].join('')
-      || val === undefined && 'undefined'
-
-    return [name, ':', valueString].join('')
-  }).join(',')
-}
-
-// ============================================================
 // Factories
 // ============================================================
 
@@ -63,10 +22,12 @@ export function createShorthand(Component, mapValueToProps, val, defaultProps = 
   }
   // short circuit for disabling shorthand
   if (val === null) return null
+  const valIsString = _.isString(val)
+  const valIsNumber = _.isNumber(val)
 
   const isReactElement = isValidElement(val)
   const isPropsObject = _.isPlainObject(val)
-  const isPrimitiveValue = _.isString(val) || _.isNumber(val) || _.isArray(val)
+  const isPrimitiveValue = valIsString || valIsNumber || _.isArray(val)
 
   // ----------------------------------------
   // Build up props
@@ -80,15 +41,38 @@ export function createShorthand(Component, mapValueToProps, val, defaultProps = 
   // Default props
   defaultProps = _.isFunction(defaultProps) ? defaultProps(usersProps) : defaultProps
 
-  // Merge props and className
+  // Merge props
+  /* eslint-disable react/prop-types */
   const props = { ...defaultProps, ...usersProps }
 
-  if (_.has(usersProps, 'className') || _.has(defaultProps.className)) {
-    props.className = cx(defaultProps.className, usersProps.className) // eslint-disable-line react/prop-types
+  // Merge className
+  if (usersProps.className && defaultProps.className) {
+    props.className = cx(defaultProps.className, usersProps.className)
   }
 
-  // Generate child key
-  if (generateKey) props.key = getChildKey(props) // eslint-disable-line react/prop-types
+  // Merge style
+  if (usersProps.style && defaultProps.style) {
+    props.style = { ...defaultProps.style, ...usersProps.style }
+  }
+
+  // ----------------------------------------
+  // Get key
+  // ----------------------------------------
+
+  // Use key, childKey, or generate key
+  if (!props.key) {
+    const { childKey } = props
+
+    if (childKey) {
+      // apply and consume the childKey
+      props.key = typeof childKey === 'function' ? childKey(props) : childKey
+      delete props.childKey
+    } else if (generateKey && (valIsString || valIsNumber)) {
+      // use string/number shorthand values as the key
+      props.key = val
+    }
+  }
+  /* eslint-enable react/prop-types */
 
   // ----------------------------------------
   // Create Element
@@ -105,7 +89,7 @@ export function createShorthand(Component, mapValueToProps, val, defaultProps = 
 }
 
 // ============================================================
-// Factories Creators
+// Factory Creators
 // ============================================================
 
 export function createShorthandFactory(Component, mapValueToProps, generateKey) {

--- a/test/specs/collections/Menu/Menu-test.js
+++ b/test/specs/collections/Menu/Menu-test.js
@@ -40,8 +40,8 @@ describe('Menu', () => {
 
   describe('activeIndex', () => {
     const items = [
-      { name: 'home' },
-      { name: 'users' },
+      { key: 'home', name: 'home' },
+      { key: 'users', name: 'users' },
     ]
 
     it('is null by default', () => {
@@ -68,8 +68,8 @@ describe('Menu', () => {
   describe('items', () => {
     const spy = sandbox.spy()
     const items = [
-      { name: 'home', onClick: spy, 'data-foo': 'something' },
-      { name: 'users', active: true, 'data-foo': 'something' },
+      { key: 'home', name: 'home', onClick: spy, 'data-foo': 'something' },
+      { key: 'users', name: 'users', active: true, 'data-foo': 'something' },
     ]
     const children = mount(<Menu items={items} />).find('MenuItem')
 
@@ -100,8 +100,8 @@ describe('Menu', () => {
 
   describe('onItemClick', () => {
     const items = [
-      { name: 'home' },
-      { name: 'users' },
+      { key: 'home', name: 'home' },
+      { key: 'users', name: 'users' },
     ]
 
     it('can be omitted', () => {

--- a/test/specs/lib/factories-test.js
+++ b/test/specs/lib/factories-test.js
@@ -203,20 +203,24 @@ describe('factories', () => {
     })
 
     describe('child key', () => {
+      it('uses the `key` prop from an element', () => {
+        getShorthand({ value: <div key='foo' /> })
+          .should.have.property('key', 'foo')
+      })
       it('uses the `key` prop as a string', () => {
-        getShorthand({ value: { key: 'foo' }, generateKey: true })
+        getShorthand({ value: { key: 'foo' } })
           .should.have.property('key', 'foo')
       })
       it('uses the `key` prop as a number', () => {
-        getShorthand({ value: { key: 123 }, generateKey: true })
+        getShorthand({ value: { key: 123 } })
           .should.have.property('key', '123')
       })
       it('uses the `childKey` prop as a string', () => {
-        getShorthand({ value: { childKey: 'foo' }, generateKey: true })
+        getShorthand({ value: { childKey: 'foo' } })
           .should.have.property('key', 'foo')
       })
       it('uses the `childKey` prop as a number', () => {
-        getShorthand({ value: { childKey: 123 }, generateKey: true })
+        getShorthand({ value: { childKey: 123 } })
           .should.have.property('key', '123')
       })
       it('calls `childKey` with the final `props` if it is a function', () => {
@@ -230,7 +234,7 @@ describe('factories', () => {
         element.key.should.equal('foo')
       })
       it('consumes the childKey prop', () => {
-        getShorthand({ value: { childKey: 123 }, generateKey: true })
+        getShorthand({ value: { childKey: 123 } })
           .props.should.not.have.property('childKey')
       })
       it('is generated from shorthand string values', () => {

--- a/test/specs/lib/factories-test.js
+++ b/test/specs/lib/factories-test.js
@@ -19,7 +19,8 @@ const getShorthand = ({
   mapValueToProps = val => ({}),
   value,
   defaultProps,
-}) => createShorthand(Component, mapValueToProps, value, defaultProps)
+  generateKey,
+}) => createShorthand(Component, mapValueToProps, value, defaultProps, generateKey)
 
 // ----------------------------------------
 // Common tests
@@ -198,6 +199,54 @@ describe('factories', () => {
         shallow(getShorthand({ value, mapValueToProps, defaultProps }))
 
         defaultProps.should.have.been.calledWith(mapValueToProps(value))
+      })
+    })
+
+    describe('child key', () => {
+      it('uses the `key` prop as a string', () => {
+        getShorthand({ value: { key: 'foo' }, generateKey: true })
+          .should.have.property('key', 'foo')
+      })
+      it('uses the `key` prop as a number', () => {
+        getShorthand({ value: { key: 123 }, generateKey: true })
+          .should.have.property('key', '123')
+      })
+      it('uses the `childKey` prop as a string', () => {
+        getShorthand({ value: { childKey: 'foo' }, generateKey: true })
+          .should.have.property('key', 'foo')
+      })
+      it('uses the `childKey` prop as a number', () => {
+        getShorthand({ value: { childKey: 123 }, generateKey: true })
+          .should.have.property('key', '123')
+      })
+      it('calls `childKey` with the final `props` if it is a function', () => {
+        const props = { foo: 'foo', childKey: sandbox.spy(({ foo }) => foo) }
+
+        const element = getShorthand({ value: props })
+
+        props.childKey.should.have.been.calledOnce()
+        props.childKey.should.have.been.calledWithExactly({ foo: 'foo', key: 'foo' })
+
+        element.key.should.equal('foo')
+      })
+      it('consumes the childKey prop', () => {
+        getShorthand({ value: { childKey: 123 }, generateKey: true })
+          .props.should.not.have.property('childKey')
+      })
+      it('is generated from shorthand string values', () => {
+        getShorthand({ value: 'foo', generateKey: true })
+          .should.have.property('key', 'foo')
+      })
+      it('is generated from shorthand number values', () => {
+        getShorthand({ value: 123, generateKey: true })
+          .should.have.property('key', '123')
+      })
+      it('is not generated if generateKey is false', () => {
+        getShorthand({ value: 'foo', generateKey: false })
+          .should.have.property('key', null)
+
+        getShorthand({ value: 123, generateKey: false })
+          .should.have.property('key', null)
       })
     })
 


### PR DESCRIPTION
## Breaking Changes!

When passing an array of props objects or an array of elements, such as `items` to a Menu, you must now define a [React `key`](https://facebook.github.io/react/docs/lists-and-keys.html#keys).

### Before

SUIR attempted to autogenerate keys for objects and elements.

```jsx
const items = [
  { name: 'Home' },
  <Menu.Item name='Search' />,
]

<Menu items={items} />
```

### After

Note, any unique unchanging `key` will work.

```jsx
const items = [
  { key: 'home', name: 'Home' },
  <Menu.Item key='search' name='Search' />,
]

<Menu items={items} />
```

### Unchanged

Shorthand strings and numbers continue to be used as the element's `key`.  This means shorthand string/number values must still be unique in a list.  If they are not, use an object or element and define a unique `key`.

***

Fixes #1057

### New Key Generation

This PR simplifies auto child key generation.  We now only generate keys for shorthand string and number primitive values.  If the user passes a props object or element, they must include a `key`.

This is faster, simpler, and was the original intent of auto key generation (handling elements from strings/numbers).

### Styles are now merged

Just as className is merged when using shorthand object or elements, style objects are now merged. 