### PR TITLE
feat(AutoControlledComponent): Default values

### DIFF
--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -52,10 +52,11 @@ export const getAutoControlledStateValue = (propName, props, state, includeDefau
     const defaultProp = props[getDefaultPropName(propName)]
     if (defaultProp !== undefined) return defaultProp
 
-    // initial state
-    // check for an object as React initializes state as `null` if it is `undefined`
-    const initialState = ({}).toString.call(state) === '[object Object]' && state[propName]
-    if (initialState) return initialState
+    // initial state - state may be null or undefined
+    if (state) {
+      const initialState = state[propName]
+      if (initialState !== undefined) return initialState
+    }
   }
 
   // React doesn't allow changing from uncontrolled to controlled components,

--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -30,27 +30,33 @@ const getDefaultPropName = (prop) => `default${prop[0].toUpperCase() + prop.slic
 
 /**
  * Return the auto controlled state value for a give prop. The initial value is chosen in this order:
- *  - default props
- *  - then, regular props
+ *  - regular props
+ *  - then, default props
+ *  - then, initial state
  *  - then, `checked` defaults to false
  *  - then, `value` defaults to '' or [] if props.multiple
  *  - else, undefined
  *
- *  @param {object} props A props object
  *  @param {string} propName A prop name
- *  @param {boolean} [includeDefaultProps=false] Whether or not to heed the default prop value
+ *  @param {object} [props] A props object
+ *  @param {object} [state] A state object
+ *  @param {boolean} [includeDefaults=false] Whether or not to heed the default props or initial state
  */
-export const getAutoControlledStateValue = (props, propName, includeDefaultProps = false) => {
-  const defaultPropName = getDefaultPropName(propName)
-  const prop = props[propName]
-  const defaultProp = props[defaultPropName]
+export const getAutoControlledStateValue = (propName, props, state, includeDefaults = false) => {
+  // regular props
+  const propValue = props[propName]
+  if (propValue !== undefined) return propValue
 
-  const hasProp = prop !== undefined
-  const hasDefaultProp = defaultProp !== undefined
+  if (includeDefaults) {
+    // defaultProps
+    const defaultProp = props[getDefaultPropName(propName)]
+    if (defaultProp !== undefined) return defaultProp
 
-  // defaultProps & props
-  if (includeDefaultProps && !hasProp && hasDefaultProp) return defaultProp
-  if (hasProp) return prop
+    // initial state
+    // check for an object as React initializes state as `null` if it is `undefined`
+    const initialState = ({}).toString.call(state) === '[object Object]' && state[propName]
+    if (initialState) return initialState
+  }
 
   // React doesn't allow changing from uncontrolled to controlled components,
   // default checked/value if they were not present.
@@ -62,7 +68,6 @@ export const getAutoControlledStateValue = (props, propName, includeDefaultProps
 
 export default class AutoControlledComponent extends Component {
   componentWillMount() {
-    if (super.componentWillMount) super.componentWillMount()
     const { autoControlledProps } = this.constructor
 
     if (process.env.NODE_ENV !== 'production') {
@@ -119,25 +124,12 @@ export default class AutoControlledComponent extends Component {
       }
     }
 
-    // To set defaults for autoControlledProps, use initial state. This can
-    // done by:
-    // - setting state in the constructor
-    // - using ES7 property initializers, see:
-    //   https://babeljs.io/blog/2015/06/07/react-on-es6-plus#property-initializers
-    const defaultAutoControlledProps = this.state && _.pick(this.state, autoControlledProps)
-
     // Auto controlled props are copied to state.
     // Set initial state by copying auto controlled props to state.
     // Also look for the default prop for any auto controlled props (foo => defaultFoo)
     // so we can set initial values from defaults.
-    const stateFromProps = autoControlledProps.reduce((acc, prop) => {
-      acc[prop] = getAutoControlledStateValue(this.props, prop, true)
-
-      // If the value couldn't be determined from the props, use the
-      // defaultAutoControlledProps which are derived from the initial state.
-      if (acc[prop] === undefined && defaultAutoControlledProps) {
-        acc[prop] = defaultAutoControlledProps[prop]
-      }
+    const initialAutoControlledState = autoControlledProps.reduce((acc, prop) => {
+      acc[prop] = getAutoControlledStateValue(prop, this.props, this.state, true)
 
       if (process.env.NODE_ENV !== 'production') {
         const defaultPropName = getDefaultPropName(prop)
@@ -153,13 +145,10 @@ export default class AutoControlledComponent extends Component {
       return acc
     }, {})
 
-    this.state = this.state
-      ? { ...this.state, ...stateFromProps }
-      : stateFromProps
+    this.state = { ...this.state, ...initialAutoControlledState }
   }
 
   componentWillReceiveProps(nextProps) {
-    if (super.componentWillReceiveProps) super.componentWillReceiveProps(nextProps)
     const { autoControlledProps } = this.constructor
 
     // Solve the next state for autoControlledProps
@@ -171,7 +160,7 @@ export default class AutoControlledComponent extends Component {
       if (!isNextUndefined) acc[prop] = nextProps[prop]
 
       // reinitialize state for props just removed / set undefined
-      else if (propWasRemoved) acc[prop] = getAutoControlledStateValue(nextProps, prop)
+      else if (propWasRemoved) acc[prop] = getAutoControlledStateValue(prop, nextProps)
 
       return acc
     }, {})

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -90,14 +90,10 @@ export default class Accordion extends Component {
 
   state = {}
 
-  componentWillMount() {
-    super.componentWillMount()
-    // TODO AutoControlledComponent should consider default prop values when trySetState is called before mount.
-    // Otherwise, on first render we're allowed to set state for a prop that might have a default.
-    // The default prop should always win on first render.
-    // This default check should then be removed.
-    if (typeof this.props.defaultActiveIndex === 'undefined') {
-      this.trySetState({ activeIndex: this.props.exclusive ? -1 : [-1] })
+  constructor(...args) {
+    super(...args)
+    this.state = {
+      activeIndex: this.props.exclusive ? -1 : [-1],
     }
   }
 

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -167,7 +167,27 @@ describe('extending AutoControlledComponent', () => {
       _.each(props, (val, key) => wrapper.should.not.have.state(key, val))
     })
 
-    it('uses the default prop is the regular prop is undefined', () => {
+    it('includes non autoControlled state', () => {
+      const props = makeProps()
+
+      TestClass = createTestClass({ autoControlledProps: [], state: { foo: 'bar' } })
+      shallow(<TestClass {...props} />)
+        .should.have.state('foo', 'bar')
+    })
+
+    it('uses the initial state if default and regular props are undefined', () => {
+      consoleUtil.disableOnce()
+
+      const defaultProps = { defaultFoo: undefined }
+      const autoControlledProps = ['foo']
+
+      TestClass = createTestClass({ autoControlledProps, defaultProps, state: { foo: 'bar' } })
+
+      shallow(<TestClass foo={undefined} />)
+        .should.have.state('foo', 'bar')
+    })
+
+    it('uses the default prop if the regular prop is undefined', () => {
       consoleUtil.disableOnce()
 
       const defaultProps = { defaultFoo: 'default' }

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -32,6 +32,11 @@ describe('extending AutoControlledComponent', () => {
     TestClass = createTestClass({ autoControlledProps: [], state: {} })
   })
 
+  it('does not throw with a `null` state', () => {
+    TestClass = createTestClass({ autoControlledProps: [], state: null })
+    shallow(<TestClass />)
+  })
+
   describe('trySetState', () => {
     it('is an instance method', () => {
       shallow(<TestClass />)


### PR DESCRIPTION
Fixes #764

I noticed a bug using `AutoControlledComponent` where initial state for non-AutoControlled props was getting clobbered in the `componentWillMount` of the ACC. This is because ACC uses `this.state = ...` instead of `this.setState` to set the state.

Example of the bug:
```js
class MyComponent extends AutoControlledComponent {
  state = { someField: 'default' }

  render () => <div />
}

// Actual
shallow(<MyComponent />).state() === {}

// Expected
shallow(<MyComponent />).state() === { someField: 'default' }
```

In fixing that bug, I came across the #764 issue which I realized could be solved simultaneously. The initial state is set within the constructor which means it's available in the ACC's `componentWillMount`.  I updated the `componentWillMount` to use the initial state if the value of the prop was not defined via props.

For example:
```js
class MyComponent extends AutoControlledComponent {
  state = { someField: 'default' }

  static autoControlledProps = ['someField']

  render () => <div />
}

shallow(<MyComponent />).state() === { someField: 'default' }
shallow(<MyComponent defaultSomeField='propDefault' />).state() === { someField: 'propDefault' }
shallow(<MyComponent someField='prop' />).state() === { someField: 'prop' }
```

This seems pretty intuitive to me. The props are being passed directly to state, so to specify a "global default" outside of props, you set the state yourself in the constructor (or use the es7 property initializer, which is basically just sugar on the same thing).

----

_Edit_ As an aside, I've been using `AutoControlledComponent` as a base for some of my own components via:
```js
import AutoControlledComponent from 'semantic-ui-react/dist/commonjs/lib/AutoControlledComponent'
```

I think it's a really cool abstraction and lets you write super flexible/reusable components that either do all the work (control the state) or let the user do it from higher up.

@levithomason - Thoughts on open-sourcing it as a separate package? Its only dependency is `lodash` (which you could probably even drop) so would probably be pretty simple.