### PR TITLE
fix(tabIndex): use -1 when disabled, allow override

### DIFF
--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -154,11 +154,17 @@ class Button extends Component {
     /** A button can be formatted to show different levels of emphasis */
     secondary: PropTypes.bool,
 
-    /** A button can be formatted to toggle on and off */
-    toggle: PropTypes.bool,
-
     /** A button can have different sizes */
     size: PropTypes.oneOf(_meta.props.size),
+
+    /** A button can receive focus. */
+    tabIndex: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+
+    /** A button can be formatted to toggle on and off */
+    toggle: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -206,6 +212,7 @@ class Button extends Component {
       primary,
       secondary,
       size,
+      tabIndex,
       toggle,
     } = this.props
 
@@ -238,13 +245,17 @@ class Button extends Component {
     const ElementType = getElementType(Button, this.props, () => {
       if (!_.isNil(label) || !_.isNil(attached)) return 'div'
     })
-    const tabIndex = ElementType === 'div' ? 0 : undefined
+
+    let computedTabIndex
+    if (!_.isNil(tabIndex)) computedTabIndex = tabIndex
+    else if (disabled) computedTabIndex = -1
+    else if (ElementType === 'div') computedTabIndex = 0
 
     if (!_.isNil(children)) {
       const classes = cx('ui', baseClasses, labeledClasses, 'button', className)
       debug('render children:', { classes })
       return (
-        <ElementType {...rest} className={classes} tabIndex={tabIndex} onClick={this.handleClick}>
+        <ElementType {...rest} className={classes} tabIndex={computedTabIndex} onClick={this.handleClick}>
           {children}
         </ElementType>
       )
@@ -274,7 +285,7 @@ class Button extends Component {
       const classes = cx('ui', labeledClasses, baseClasses, 'button', className)
       debug('render icon && !label:', { classes })
       return (
-        <ElementType {...rest} className={classes} tabIndex={tabIndex} onClick={this.handleClick}>
+        <ElementType {...rest} className={classes} tabIndex={computedTabIndex} onClick={this.handleClick}>
           {Icon.create(icon)} {content}
         </ElementType>
       )
@@ -284,7 +295,7 @@ class Button extends Component {
     debug('render default:', { classes })
 
     return (
-      <ElementType {...rest} className={classes} tabIndex={tabIndex} onClick={this.handleClick}>
+      <ElementType {...rest} className={classes} tabIndex={computedTabIndex} onClick={this.handleClick}>
         {content}
       </ElementType>
     )

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -135,6 +135,12 @@ class Input extends Component {
     /** An Input can vary in size */
     size: PropTypes.oneOf(_meta.props.size),
 
+    /** An Input can receive focus. */
+    tabIndex: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+
     /** Transparent Input has no background */
     transparent: PropTypes.bool,
 
@@ -173,6 +179,7 @@ class Input extends Component {
       loading,
       onChange,
       size,
+      tabIndex,
       type,
       input,
       transparent,
@@ -203,6 +210,12 @@ class Input extends Component {
 
     const ElementType = getElementType(Input, this.props)
 
+    // tabIndex
+    if (!_.isNil(tabIndex)) htmlInputProps.tabIndex = tabIndex
+    else if (disabled) htmlInputProps.tabIndex = -1
+
+    // Render with children
+    // ----------------------------------------
     if (!_.isNil(children)) {
       // add htmlInputProps to the `<input />` child
       const childElements = Children.map(children, (child) => {
@@ -214,6 +227,8 @@ class Input extends Component {
       return <ElementType {...rest} className={classes}>{childElements}</ElementType>
     }
 
+    // Render Shorthand
+    // ----------------------------------------
     const actionElement = Button.create(action, elProps => ({
       className: cx(
         // all action components should have the button className

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp'
 import cx from 'classnames'
 import React, { PropTypes } from 'react'
 
@@ -11,7 +12,6 @@ import {
   META,
   useKeyOnly,
 } from '../../lib'
-
 const debug = makeDebugger('checkbox')
 
 const _meta = {
@@ -104,6 +104,12 @@ export default class Checkbox extends Component {
 
     /** The HTML input value. */
     value: PropTypes.string,
+
+    /** A checkbox can receive focus. */
+    tabIndex: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
   }
 
   static defaultProps = {
@@ -168,6 +174,7 @@ export default class Checkbox extends Component {
       radio,
       readOnly,
       slider,
+      tabIndex,
       toggle,
       type,
       value,
@@ -192,6 +199,10 @@ export default class Checkbox extends Component {
     const rest = getUnhandledProps(Checkbox, this.props)
     const ElementType = getElementType(Checkbox, this.props)
 
+    let computedTabIndex
+    if (!_.isNil(tabIndex)) computedTabIndex = tabIndex
+    else computedTabIndex = disabled ? -1 : 0
+
     return (
       <ElementType {...rest} className={classes} onClick={this.handleClick} onChange={this.handleClick}>
         <input
@@ -200,7 +211,7 @@ export default class Checkbox extends Component {
           name={name}
           readOnly
           ref={this.handleRef}
-          tabIndex={0}
+          tabIndex={computedTabIndex}
           type={type}
           value={value}
         />

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -525,7 +525,7 @@ export default class Dropdown extends Component {
     if (!value || !open) return
 
     // notify the onAddItem prop if this is a new value
-    if (onAddItem && item.additional) {
+    if (onAddItem && item['data-additional']) {
       onAddItem(e, { ...this.props, value })
     }
     // notify the onChange prop that the user is trying to change value
@@ -626,7 +626,7 @@ export default class Dropdown extends Component {
     if (item.disabled) return
 
     // notify the onAddItem prop if this is a new value
-    if (onAddItem && item.additional) {
+    if (onAddItem && item['data-additional']) {
       onAddItem(e, { ...this.props, value })
     }
 
@@ -721,7 +721,7 @@ export default class Dropdown extends Component {
         ],
         value: searchQuery,
         className: 'addition',
-        additional: true,
+        'data-additional': true,
       }
       if (additionPosition === 'top') filteredOptions.unshift(addItem)
       else filteredOptions.push(addItem)

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -288,7 +288,10 @@ export default class Dropdown extends Component {
     simple: PropTypes.bool,
 
     /** A dropdown can receive focus. */
-    tabIndex: PropTypes.string,
+    tabIndex: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
 
     /** The text displayed in the dropdown, usually for the active item. */
     text: PropTypes.string,
@@ -317,7 +320,6 @@ export default class Dropdown extends Component {
     noResultsMessage: 'No results found.',
     renderLabel: ({ text }) => text,
     selectOnBlur: true,
-    tabIndex: '0',
   }
 
   static autoControlledProps = [
@@ -982,7 +984,7 @@ export default class Dropdown extends Component {
     // a dropdown without an active item will have an empty string value
     return (
       <select type='hidden' aria-hidden='true' name={name} value={value} multiple={multiple}>
-        <option key='empty' value=''></option>
+        <option value='' />
         {_.map(options, option => (
           <option key={option.value} value={option.value}>{option.text}</option>
         ))}
@@ -991,10 +993,15 @@ export default class Dropdown extends Component {
   }
 
   renderSearchInput = () => {
-    const { search, name, tabIndex } = this.props
+    const { disabled, search, name, tabIndex } = this.props
     const { searchQuery } = this.state
 
     if (!search) return null
+
+    // tabIndex
+    let computedTabIndex
+    if (!_.isNil(tabIndex)) computedTabIndex = tabIndex
+    else computedTabIndex = disabled ? -1 : 0
 
     // resize the search input, temporarily show the sizer so we can measure it
     let searchWidth
@@ -1014,7 +1021,7 @@ export default class Dropdown extends Component {
         className='search'
         name={[name, 'search'].join('-')}
         autoComplete='off'
-        tabIndex={tabIndex}
+        tabIndex={computedTabIndex}
         style={{ width: searchWidth }}
         ref={c => (this._search = c)}
       />
@@ -1171,6 +1178,14 @@ export default class Dropdown extends Component {
     const ElementType = getElementType(Dropdown, this.props)
     const ariaOptions = this.getDropdownAriaOptions(ElementType, this.props)
 
+    let computedTabIndex
+    if (!_.isNil(tabIndex)) {
+      computedTabIndex = tabIndex
+    } else if (!search) {
+      // don't set a root node tabIndex as the search input has its own tabIndex
+      computedTabIndex = disabled ? -1 : 0
+    }
+
     return (
       <ElementType
         {...rest}
@@ -1181,7 +1196,7 @@ export default class Dropdown extends Component {
         onMouseDown={this.handleMouseDown}
         onFocus={this.handleFocus}
         onChange={this.handleChange}
-        tabIndex={(disabled || search) ? undefined : tabIndex}
+        tabIndex={computedTabIndex}
         ref={c => (this._dropdown = c)}
       >
         {this.renderHiddenInput()}

--- a/test/specs/commonTests.js
+++ b/test/specs/commonTests.js
@@ -428,24 +428,6 @@ export const hasSubComponents = (Component, subComponents) => {
 }
 
 /**
- * Assert a component can be receive focus via the tab key.
- * @param {React.Component|Function} Component The Component.
- * @param {Object} [options={}]
- * @param {Object} [options.requiredProps={}] Props required to render the component.
- */
-export const isTabbable = (Component, options = {}) => {
-  const { requiredProps = {} } = options
-  const { assertRequired } = commonTestHelpers('isTabbable', Component)
-
-  it('is tabbable', () => {
-    assertRequired(Component, 'a `Component`')
-
-    shallow(<Component {...requiredProps} />)
-      .should.have.attr('tabindex', '0')
-  })
-}
-
-/**
  * Assert a component renders children somewhere in the tree.
  * @param {React.Component|Function} Component A component that should render children.
  * @param {Object} [options={}]

--- a/test/specs/elements/Button/Button-test.js
+++ b/test/specs/elements/Button/Button-test.js
@@ -51,31 +51,6 @@ describe('Button', () => {
       .should.have.tagName('button')
   })
 
-  it('adds tabIndex=0 when tag type is div', () => {
-    shallow(<Button as='div' />)
-      .should.have.prop('tabIndex', 0)
-  })
-
-  describe('onClick', () => {
-    it('is called when clicked', () => {
-      const handleClick = sandbox.spy()
-
-      shallow(<Button type='submit' onClick={handleClick} />)
-        .simulate('click', syntheticEvent)
-
-      handleClick.should.have.been.calledOnce()
-    })
-
-    it('is not called when button is disabled', () => {
-      const handleClick = sandbox.spy()
-
-      shallow(<Button type='submit' disabled onClick={handleClick} />)
-        .simulate('click', syntheticEvent)
-
-      handleClick.should.not.have.been.calledOnce()
-    })
-  })
-
   describe('attached', () => {
     it('renders a div', () => {
       shallow(<Button attached />)
@@ -149,6 +124,49 @@ describe('Button', () => {
         .should.have.tagName('button')
       shallow(<Button labelPosition='right' icon='user' />)
         .should.have.tagName('button')
+    })
+  })
+
+  describe('onClick', () => {
+    it('is called when clicked', () => {
+      const handleClick = sandbox.spy()
+
+      shallow(<Button type='submit' onClick={handleClick} />)
+        .simulate('click', syntheticEvent)
+
+      handleClick.should.have.been.calledOnce()
+    })
+
+    it('is not called when button is disabled', () => {
+      const handleClick = sandbox.spy()
+
+      shallow(<Button type='submit' disabled onClick={handleClick} />)
+        .simulate('click', syntheticEvent)
+
+      handleClick.should.not.have.been.calledOnce()
+    })
+  })
+
+  describe('tabIndex', () => {
+    it('is not set by default', () => {
+      shallow(<Button />)
+        .should.not.have.prop('tabIndex')
+    })
+    it('defaults to 0 as div', () => {
+      shallow(<Button as='div' />)
+        .should.have.prop('tabIndex', 0)
+    })
+    it('defaults to -1 when disabled', () => {
+      shallow(<Button disabled />)
+        .should.have.prop('tabIndex', -1)
+    })
+    it('can be set explicitly', () => {
+      shallow(<Button tabIndex={123} />)
+        .should.have.prop('tabIndex', 123)
+    })
+    it('can be set explicitly when disabled', () => {
+      shallow(<Button tabIndex={123} disabled />)
+        .should.have.prop('tabIndex', 123)
     })
   })
 })

--- a/test/specs/elements/Input/Input-test.js
+++ b/test/specs/elements/Input/Input-test.js
@@ -164,4 +164,27 @@ describe('Input', () => {
       spy.should.have.been.calledWithMatch(e, { ...props, value: e.target.value })
     })
   })
+
+  describe('tabIndex', () => {
+    it('is not set by default', () => {
+      shallow(<Input />)
+        .find('input')
+        .should.not.have.prop('tabIndex')
+    })
+    it('defaults to -1 when disabled', () => {
+      shallow(<Input disabled />)
+        .find('input')
+        .should.have.prop('tabIndex', -1)
+    })
+    it('can be set explicitly', () => {
+      shallow(<Input tabIndex={123} />)
+        .find('input')
+        .should.have.prop('tabIndex', 123)
+    })
+    it('can be set explicitly when disabled', () => {
+      shallow(<Input tabIndex={123} disabled />)
+        .find('input')
+        .should.have.prop('tabIndex', 123)
+    })
+  })
 })

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -176,6 +176,29 @@ describe('Checkbox', () => {
     })
   })
 
+  describe('tabIndex', () => {
+    it('defaults to 0', () => {
+      shallow(<Checkbox />)
+        .find('input')
+        .should.have.prop('tabIndex', 0)
+    })
+    it('defaults to -1 when disabled', () => {
+      shallow(<Checkbox disabled />)
+        .find('input')
+        .should.have.prop('tabIndex', -1)
+    })
+    it('can be set explicitly', () => {
+      shallow(<Checkbox tabIndex={123} />)
+        .find('input')
+        .should.have.prop('tabIndex', 123)
+    })
+    it('can be set explicitly when disabled', () => {
+      shallow(<Checkbox tabIndex={123} disabled />)
+        .find('input')
+        .should.have.prop('tabIndex', 123)
+    })
+  })
+
   describe('type', () => {
     it('renders an input of type checkbox when not set', () => {
       shallow(<Checkbox />)

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -71,7 +71,6 @@ describe('Dropdown Component', () => {
   common.isConformant(Dropdown)
   common.hasUIClassName(Dropdown)
   common.hasSubComponents(Dropdown, [DropdownDivider, DropdownHeader, DropdownItem, DropdownMenu])
-  common.isTabbable(Dropdown)
   common.implementsIconProp(Dropdown)
   common.implementsShorthandProp(Dropdown, {
     propKey: 'header',
@@ -154,6 +153,43 @@ describe('Dropdown Component', () => {
       dropdownMenuIsClosed()
       wrapper.simulate('focus')
       dropdownMenuIsClosed()
+    })
+  })
+
+  describe('tabIndex', () => {
+    it('defaults to 0', () => {
+      wrapperShallow(<Dropdown options={options} />)
+
+      wrapper.should.have.prop('tabIndex', 0)
+    })
+    it('defaults to -1 when disabled', () => {
+      wrapperShallow(<Dropdown options={options} disabled />)
+
+      wrapper.should.have.prop('tabIndex', -1)
+    })
+    it('is not present on the root when `search`', () => {
+      wrapperShallow(<Dropdown options={options} selection search />)
+        .should.not.have.prop('tabIndex')
+    })
+    it('defaults the search input to 0', () => {
+      wrapperShallow(<Dropdown options={options} selection search />)
+        .find('input.search')
+        .should.have.prop('tabIndex', 0)
+    })
+    it('defaults the disabled search input to -1', () => {
+      wrapperShallow(<Dropdown options={options} selection search disabled />)
+        .find('input.search')
+        .should.have.prop('tabIndex', -1)
+    })
+    it('allows explicitly setting the search input value', () => {
+      wrapperShallow(<Dropdown options={options} selection search tabIndex={123} />)
+        .find('input.search')
+        .should.have.prop('tabIndex', 123)
+    })
+    it('allows explicitly setting the search input value when disabled', () => {
+      wrapperShallow(<Dropdown options={options} selection search tabIndex={123} disabled />)
+        .find('input.search')
+        .should.have.prop('tabIndex', 123)
     })
   })
 
@@ -799,8 +835,8 @@ describe('Dropdown Component', () => {
 
     it('opens on arrow down when focused', () => {
       wrapperMount(<Dropdown options={options} selection />)
-        // Note: This mousedown is necessary to get the Dropdown focused
-        // without it being open.
+      // Note: This mousedown is necessary to get the Dropdown focused
+      // without it being open.
         .simulate('mousedown')
         .simulate('focus')
 
@@ -811,8 +847,8 @@ describe('Dropdown Component', () => {
 
     it('opens on space when focused', () => {
       wrapperMount(<Dropdown options={options} selection />)
-        // Note: This mousedown is necessary to get the Dropdown focused
-        // without it being open.
+      // Note: This mousedown is necessary to get the Dropdown focused
+      // without it being open.
         .simulate('mousedown')
         .simulate('focus')
 
@@ -1426,23 +1462,6 @@ describe('Dropdown Component', () => {
       searchIsFocused.should.be.true(
         `Expected "input.search" to be the active element but found ${activeElement} instead.`
       )
-    })
-
-    it('removes Dropdown tabIndex', () => {
-      wrapperShallow(<Dropdown options={options} selection search />)
-        .should.not.have.prop('tabIndex')
-    })
-
-    it('has a search input with a tabIndex of 0', () => {
-      wrapperShallow(<Dropdown options={options} selection search />)
-        .find('input.search')
-        .should.have.prop('tabIndex', '0')
-    })
-
-    it('has a search input props-defined tabIndex', () => {
-      wrapperShallow(<Dropdown options={options} selection search tabIndex='123' />)
-        .find('input.search')
-        .should.have.prop('tabIndex', '123')
     })
 
     it('clears the search query when an item is selected', () => {


### PR DESCRIPTION
Fixes #966 

Disabled components were focusable as their `tabIndex` was not properly set.  Some components did not allow setting `tabIndex`.

Updates:

- Disabled components default to `tabIndex={-1}`
- Required `tabIndex` props default to `0`
- All components now allow `tabIndex` to be set explicitly
- Disabled component default `tabIndex` values (-1) can be overridden
- PropTypes accept string _or_ number `tabIndex` values