### PR TITLE
feat(Table): add `sortable` and `sorted` props

### DIFF
--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -43,6 +43,7 @@ function Table(props) {
     selectable,
     singleLine,
     size,
+    sortable,
     stackable,
     striped,
     structured,
@@ -65,6 +66,7 @@ function Table(props) {
     useKeyOrValueAndKey(padded, 'padded'),
     useKeyOnly(selectable, 'selectable'),
     useKeyOnly(singleLine, 'single line'),
+    useKeyOnly(sortable, 'sortable'),
     useKeyOnly(stackable, 'stackable'),
     useKeyOnly(striped, 'striped'),
     useKeyOnly(structured, 'structured'),
@@ -190,6 +192,9 @@ Table.propTypes = {
 
   /** A table can also be small or large. */
   size: PropTypes.oneOf(Table._meta.props.size),
+
+  /** A table may allow a user to sort contents by clicking on a table header. */
+  sortable: PropTypes.bool,
 
   /** A table can specify how it stacks table content responsively. */
   stackable: PropTypes.bool,

--- a/src/collections/Table/TableHeaderCell.js
+++ b/src/collections/Table/TableHeaderCell.js
@@ -1,16 +1,41 @@
-import React from 'react'
-
-import { META } from '../../lib'
+import cx from 'classnames'
+import React, { PropTypes } from 'react'
+import {
+  customPropTypes,
+  getUnhandledProps,
+  META,
+  useValueAndKey,
+} from '../../lib'
 import TableCell from './TableCell'
 
 function TableHeaderCell(props) {
-  return <TableCell {...props} />
+  const { as, className, sorted } = props
+  const classes = cx(
+    useValueAndKey(sorted, 'sorted'),
+    className
+  )
+  const rest = getUnhandledProps(TableHeaderCell, props)
+  return <TableCell as={as} {...rest} className={classes} />
 }
 
 TableHeaderCell._meta = {
   name: 'TableHeaderCell',
   type: META.TYPES.COLLECTION,
   parent: 'Table',
+  props: {
+    sorted: ['ascending', 'descending'],
+  },
+}
+
+TableHeaderCell.propTypes = {
+  /** An element type to render as (string or function). */
+  as: customPropTypes.as,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+
+  /** A header cell can be sorted in ascending or descending order. */
+  sorted: PropTypes.oneOf(TableHeaderCell._meta.props.sorted),
 }
 
 TableHeaderCell.defaultProps = {

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -27,6 +27,7 @@ describe('Table', () => {
     className: 'single line',
   })
   common.propKeyOnlyToClassName(Table, 'stackable')
+  common.propKeyOnlyToClassName(Table, 'sortable')
   common.propKeyOnlyToClassName(Table, 'striped')
   common.propKeyOnlyToClassName(Table, 'structured')
   common.propKeyOnlyToClassName(Table, 'unstackable')

--- a/test/specs/collections/Table/TableHeaderCell-test.js
+++ b/test/specs/collections/Table/TableHeaderCell-test.js
@@ -5,6 +5,7 @@ import TableHeaderCell from 'src/collections/Table/TableHeaderCell'
 
 describe('TableHeaderCell', () => {
   common.isConformant(TableHeaderCell)
+  common.propKeyAndValueToClassName(TableHeaderCell, 'sorted')
 
   it('renders as a th by default', () => {
     shallow(<TableHeaderCell />)


### PR DESCRIPTION
#926 for details.
Package is missing functionality to mark columns as sorted with. 
Added:

- add `sortable` to `Table`
- add `sorted="ascending"` OR `sorted="descending"` to `Table.HeaderCell`
- added tests