### PR TITLE
feat(Dropdown): remove noResultsMessage when null

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleCustomNoResultsMessage.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleCustomNoResultsMessage.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Dropdown } from 'semantic-ui-react'
+
+const DropdownExampleCustomNoResultsMessage = () => (
+  <Dropdown
+    options={[]}
+    search
+    selection
+    placeholder='A custom message...'
+    noResultsMessage='Try another search.'
+  />
+)
+
+export default DropdownExampleCustomNoResultsMessage

--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleRemoveNoResultsMessage.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleRemoveNoResultsMessage.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Dropdown } from 'semantic-ui-react'
+
+const DropdownExampleRemoveNoResultsMessage = () => (
+  <Dropdown
+    options={[]}
+    search
+    selection
+    placeholder='No message...'
+    noResultsMessage={null}
+  />
+)
+
+export default DropdownExampleRemoveNoResultsMessage

--- a/docs/app/Examples/modules/Dropdown/Usage/index.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/index.js
@@ -10,6 +10,15 @@ const DropdownUsageExamples = () => (
       examplePath='modules/Dropdown/Usage/DropdownExampleUncontrolled'
     />
     <ComponentExample
+      title='No Results Message'
+      description='You can change the no results message.'
+      examplePath='modules/Dropdown/Usage/DropdownExampleCustomNoResultsMessage'
+    />
+    <ComponentExample
+      description='You can remove the no results message.'
+      examplePath='modules/Dropdown/Usage/DropdownExampleRemoveNoResultsMessage'
+    />
+    <ComponentExample
       title='Remote'
       description="A dropdown's options can be controlled from outside based on search change."
       examplePath='modules/Dropdown/Usage/DropdownExampleRemote'

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1070,7 +1070,7 @@ export default class Dropdown extends Component {
     const { selectedIndex, value } = this.state
     const options = this.getMenuOptions()
 
-    if (search && _.isEmpty(options)) {
+    if (noResultsMessage !== null && search && _.isEmpty(options)) {
       return <div className='message'>{noResultsMessage}</div>
     }
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1677,6 +1677,15 @@ describe('Dropdown Component', () => {
         .find('.message')
         .should.have.text('')
     })
+    it('is not shown when set to `null`', () => {
+      const search = wrapperMount(<Dropdown options={options} selection search noResultsMessage={null} />)
+        .find('input.search')
+
+      // search for something we know will not exist
+      search.simulate('change', { target: { value: '_________________' } })
+
+      wrapper.should.not.have.descendants('.message')
+    })
   })
 
   describe('placeholder', () => {


### PR DESCRIPTION
The `noResultsMessage` in a search Dropdown is always present.  We currently allow passing `null` to remove shorthand components and other component parts.  This PR allows removing the `noResultsMessage` by passing `null` as well.

This is especially useful for Dropdowns where all options are expected to be entered by the user.