### PR TITLE
fix(Input): allow conditional rendering of children

### DIFF
--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -205,7 +205,7 @@ class Input extends Component {
 
     if (children) {
       // add htmlInputProps to the `<input />` child
-      const childElements = Children.map(children, (child) => {
+      const childElements = _.map(Children.toArray(children), (child) => {
         if (child.type !== 'input') return child
 
         return cloneElement(child, { ...htmlInputProps, ...child.props })

--- a/test/specs/elements/Input/Input-test.js
+++ b/test/specs/elements/Input/Input-test.js
@@ -93,9 +93,9 @@ describe('Input', () => {
 
   it('renders with conditional children', () => {
     shallow(
-      <Input >
-        { true && <span></span> }
-        { false && <div></div> }
+      <Input>
+        {true && <span></span>}
+        {false && <div></div>}
       </Input>
     )
       .should.contain(<span></span>)

--- a/test/specs/elements/Input/Input-test.js
+++ b/test/specs/elements/Input/Input-test.js
@@ -91,6 +91,17 @@ describe('Input', () => {
 
   common.rendersChildren(Input)
 
+  it('renders with conditional children', () => {
+    shallow(
+      <Input >
+        { true && <span></span> }
+        { false && <div></div> }
+      </Input>
+    )
+      .should.contain(<span></span>)
+      .should.not.contain(<div></div>)
+  })
+
   it('renders a text <input> by default', () => {
     shallow(<Input />)
       .find('input')


### PR DESCRIPTION
Hey there - first of all - big fan of semantic-ui-react!

I have found an issue when trying to render conditional children inside of `<Input>`. When the condition is not met, the child is null, causing the internal check of `child.type` to error. Wondering if you would consider adding my change to support conditional rendering? 