### PR TITLE
chore(package): remove transform-react-constant-elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "babel-plugin-__coverage__": "^11.0.0",
     "babel-plugin-lodash": "^3.2.10",
     "babel-plugin-react-transform": "^2.0.2",
-    "babel-plugin-transform-react-constant-elements": "^6.9.1",
     "babel-plugin-transform-react-handled-props": "^0.2.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.10",
     "babel-plugin-transform-runtime": "^6.15.0",


### PR DESCRIPTION
We [decided](https://github.com/Semantic-Org/Semantic-UI-React/pull/731#issuecomment-271340793) not to use it at #731, but I missed the included dependency, this PR removes it.