### PR TITLE
fix(Modal|Popup): fix propTypes usage

### DIFF
--- a/src/elements/Segment/Segment.js
+++ b/src/elements/Segment/Segment.js
@@ -87,7 +87,7 @@ Segment.propTypes = {
   /** Attach segment to other content, like a header. */
   attached: PropTypes.oneOfType([
     PropTypes.bool,
-    PropTypes.oneOf('top', 'bottom'),
+    PropTypes.oneOf(['top', 'bottom']),
   ]),
 
   /** A basic segment has no special formatting. */

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -236,7 +236,7 @@ class Modal extends Component {
       className,
     )
     const unhandled = getUnhandledProps(Modal, this.props)
-    const portalPropNames = _.keys(Portal.propTypes)
+    const portalPropNames = Portal.handledProps
 
     const rest = _.omit(unhandled, portalPropNames)
     const portalProps = _.pick(unhandled, portalPropNames)

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -340,7 +340,7 @@ export default class Popup extends Component {
     if (closed) return trigger
 
     const unhandled = getUnhandledProps(Popup, this.props)
-    const portalPropNames = _.keys(Portal.propTypes)
+    const portalPropNames = Portal.handledProps
 
     const rest = _.omit(unhandled, portalPropNames)
     const portalProps = _.pick(unhandled, portalPropNames)


### PR DESCRIPTION
This PR fixes #1175, fixes #1177.

@levithomason I think you will notice that I missed. I don't see anywhere else `propTypes` usage.