### PR TITLE
Test the typings by trying to render a simple component server-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 docs/build/
 docs/app/docgenInfo.json
 dll/
+.vscode/
 
 .DS_Store
 .idea/

--- a/circle.yml
+++ b/circle.yml
@@ -12,4 +12,6 @@ test:
     - npm run lint
     - npm run tsd:lint
   post:
+    - npm run build:commonjs
+    - npm run tsd:test
     - bash <(curl -s https://codecov.io/bash)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "test:watch": "npm run test --silent -- --watch",
     "tsd": "cpx './src/**/*.d.ts' dist/commonjs",
     "tsd:lint": "tslint './src/**/*.d.ts'",
-    "tsd:lint:fix": "npm run -s tsd:lint -- --fix"
+    "tsd:lint:fix": "npm run -s tsd:lint -- --fix",
+    "tsd:test": "ts-node -P test/typings test/typings/test.tsx"
   },
   "repository": {
     "type": "git",
@@ -55,6 +56,7 @@
   },
   "devDependencies": {
     "@types/react": "^0.14.54",
+    "@types/react-dom": "^0.14.20",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.21.0",
     "babel-eslint": "^7.0.0",
@@ -126,6 +128,7 @@
     "style-loader": "^0.13.1",
     "ta-scripts": "^2.5.2",
     "through2": "^2.0.2",
+    "ts-node": "^2.0.0",
     "tslint": "^4.3.1",
     "tslint-config-typings": "^0.3.1",
     "typescript": "^2.1.5",

--- a/test/typings/test.tsx
+++ b/test/typings/test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+
+import { Button } from '../../'; // Import Button from the main index.d.ts
+import { Icon } from '../../dist/commonjs/elements/Icon'; // Import Icon directly from a subfolder
+
+const Component = () => (
+  <Button>
+    <Icon name="sidebar"/>
+  </Button>
+);
+
+console.log(ReactDOMServer.renderToStaticMarkup(<Component/>));
+
+

--- a/test/typings/tsconfig.json
+++ b/test/typings/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "pretty": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitThis": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "target": "es5",
+    "jsx": "react",
+    "lib": ["dom", "es5"],
+    "importHelpers": false,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
As it stands, the typings seem to break quite easily in new releases. This PR adds a smoke test that tries to render a simple component server-side with typescript. It's run in Circle after the normal test set.