### PR TITLE
docs(ComponentProps): show func signatures

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentProps.js
+++ b/docs/app/Components/ComponentDoc/ComponentProps.js
@@ -40,6 +40,31 @@ export default class ComponentProps extends Component {
     )
   }
 
+  renderFunctionSignature = (item) => {
+    if (item.type !== '{func}') return
+
+    const params = _.filter(item.tags, { title: 'param' })
+    const paramSignature = params
+      .map(param => `${param.name}: ${param.type.name}`)
+      .join(', ')
+
+    const paramDescriptions = params.map(param => (
+      <div style={{ color: '#888' }}>
+        <strong>{param.name}</strong> - {param.description}
+      </div>
+    ))
+
+    const signature = <pre><code>{item.name}({paramSignature})</code></pre>
+
+    return (
+      <div>
+        <strong>Signature:</strong>
+        {signature}
+        {paramDescriptions}
+      </div>
+    )
+  }
+
   render() {
     const { props: propsDefinition } = this.props
     const content = _.sortBy(_.map(propsDefinition, (config, name) => {
@@ -56,6 +81,7 @@ export default class ComponentProps extends Component {
         name,
         type,
         value,
+        tags: _.get(config, 'docBlock.tags'),
         required: config.required,
         defaultValue: config.defaultValue,
         description: description && description.split('\n').map(l => ([l, <br key={l} />])),
@@ -80,7 +106,10 @@ export default class ComponentProps extends Component {
               <Table.Cell>{this.requiredRenderer(item)}</Table.Cell>
               <Table.Cell>{item.type}</Table.Cell>
               <Table.Cell>{this.renderDefaultValue(item.defaultValue)}</Table.Cell>
-              <Table.Cell>{item.description && <p>{item.description}</p>}</Table.Cell>
+              <Table.Cell>
+                {item.description && <p>{item.description}</p>}
+                {this.renderFunctionSignature(item)}
+              </Table.Cell>
             </Table.Row>
           ))}
         </Table.Body>

--- a/docs/app/index.ejs
+++ b/docs/app/index.ejs
@@ -111,10 +111,10 @@
 
     code:not(.hljs) {
       padding: 0;
-      padding-top: 0.2em;
+      padding-top: 0.1em;
       padding-bottom: 0.2em;
       margin: 0;
-      font-size: 85%;
+      font-size: 87.5%;
       background-color: rgba(0, 0, 0, 0.04);
       border-radius: 3px;
     }


### PR DESCRIPTION
This PR displays function signatures in the docs as part of https://github.com/Semantic-Org/Semantic-UI-React/issues/623.

![image](https://cloud.githubusercontent.com/assets/5067638/22143218/23acb0fa-deae-11e6-8a77-9d067e02f46d.png)

These are generated from our doc block comments:

**Button.js**
```js
/**
 * Called after user's click.
 * @param {SyntheticEvent} event - React's original SyntheticEvent.
 * @param {object} data - All props.
 */
onClick: PropTypes.func,
```

There is a known limitation with this PR.  Only props with type `func` have their signatures displayed.  If a prop uses a more complicated propType, it is parsed by `react-docgen` as type `custom` which we do not yet parse for a signature.  We should consider adding `@type {function}` or `@callback` to callbacks with custom propType checkers, which we can parse to ensure their signatures are displayed.