### PR TITLE
Add required prop to Dropdown

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -257,6 +257,9 @@ export default class Dropdown extends Component {
      */
     renderLabel: PropTypes.func,
 
+    /** Pass required prop onto input element */
+    required: PropTypes.bool,
+
     /** A dropdown can have its menu scroll. */
     scrolling: PropTypes.bool,
 
@@ -1003,7 +1006,7 @@ export default class Dropdown extends Component {
   }
 
   renderSearchInput = () => {
-    const { disabled, search, name, tabIndex } = this.props
+    const { disabled, search, name, tabIndex, required } = this.props
     const { searchQuery } = this.state
 
     if (!search) return null
@@ -1034,6 +1037,7 @@ export default class Dropdown extends Component {
         tabIndex={computedTabIndex}
         style={{ width: searchWidth }}
         ref={c => (this._search = c)}
+        required={required}
       />
     )
   }

--- a/src/modules/Dropdown/index.d.ts
+++ b/src/modules/Dropdown/index.d.ts
@@ -120,6 +120,9 @@ export interface DropdownProps extends ReactMouseEvents<HTMLElement>, ReactFocus
    */
   renderLabel?: any;
 
+  /** Pass required prop onto input element */
+  required?: boolean,
+
   /** A dropdown can have its menu scroll. */
   scrolling?: boolean;
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -158,6 +158,14 @@ describe('Dropdown Component', () => {
     })
   })
 
+  describe('required', () => {
+    it('passes required prop to input', () => {
+      wrapperShallow(<Dropdown required />)
+        .find('input.search')
+        .should.have.prop('required', true)
+    })
+  })
+
   describe('tabIndex', () => {
     it('defaults to 0', () => {
       wrapperShallow(<Dropdown options={options} />)


### PR DESCRIPTION
As a Dropdown can easily be used in a form it makes sense to pass the `required` prop down to the `<input>` for HTML5 validation (browser will complain if its value is empty.)

I couldn't get the test working but I believe I wrote it correctly, any pointers? The `test:watch` doesn't seem to be doing what it's supposed to... :open_mouth: 

This PR is still incomplete though as when we select an item the `<input>` value is emptied. Any ideas on working around that?