### PR TITLE
fix(Portal): do not take focus after first render

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentProps.js
+++ b/docs/app/Components/ComponentDoc/ComponentProps.js
@@ -49,7 +49,7 @@ export default class ComponentProps extends Component {
       .join(', ')
 
     const paramDescriptions = params.map(param => (
-      <div style={{ color: '#888' }}>
+      <div style={{ color: '#888' }} key={param.name}>
         <strong>{param.name}</strong> - {param.description}
       </div>
     ))

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -408,9 +408,9 @@ describe('Portal', () => {
       const trigger = <button>button</button>
       const delay = 100
       wrapperMount(
-        <Portal trigger={trigger} defaultOpen closeOnTriggerMouseLeave
-          closeOnPortalMouseLeave mouseLeaveDelay={delay}
-        ><p>Hi</p></Portal>
+        <Portal trigger={trigger} defaultOpen closeOnTriggerMouseLeave closeOnPortalMouseLeave mouseLeaveDelay={delay}>
+          <p>Hi</p>
+        </Portal>
       )
 
       wrapper.find('button').simulate('mouseleave')
@@ -511,7 +511,7 @@ describe('Portal', () => {
   })
 
   describe('focus', () => {
-    it('should take focus when mounted', (done) => {
+    it('should take focus on first render', (done) => {
       attachTo = document.createElement('div')
       document.body.appendChild(attachTo)
       const opts = { attachTo }
@@ -534,6 +534,26 @@ describe('Portal', () => {
         expect(document.activeElement).to.not.equal(portalNode)
         expect(portalNode.getAttribute('tabindex')).to.not.equal('-1')
         expect(portalNode.style.outline).to.not.equal('none')
+        done()
+      })
+    })
+    it('should not take focus on subsequent renders', (done) => {
+      attachTo = document.createElement('div')
+      document.body.appendChild(attachTo)
+      const opts = { attachTo }
+      const portal = wrapperMount(<Portal defaultOpen><input data-focus-me /></Portal>, opts)
+
+      setTimeout(() => {
+        const portalNode = portal.node.node.firstElementChild
+        expect(document.activeElement).to.equal(portalNode)
+
+        const input = document.querySelector('input[data-focus-me]')
+        input.focus()
+        expect(document.activeElement).to.equal(input)
+
+        portal.render()
+        expect(document.activeElement).to.equal(input)
+
         done()
       })
     })


### PR DESCRIPTION
Fixes #1199 

This PR addresses a bug introduced in #1154.  The portal takes focus on render for keyboard access, however, it takes focus on _every_ render.  This means if you have a stateful Portal (Modal, Popup, etc) then it will take focus away from form controls on every render.

This PR simply adds a check/test for the initial render and only takes focus on the initial render.  This way, Portal components are still keyboard accessible but also do not take focus from other controls after the initial render.