### PR TITLE
fix(ComponentExample): use explicit babel presets

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentExample.js
+++ b/docs/app/Components/ComponentDoc/ComponentExample.js
@@ -8,10 +8,9 @@ import copyToClipboard from 'copy-to-clipboard'
 import { exampleContext, repoURL } from 'docs/app/utils'
 import { Divider, Grid, Icon, Header, Menu } from 'src'
 import Editor from 'docs/app/Components/Editor/Editor'
-import babelrc from '.babelrc'
 
 const babelConfig = {
-  presets: [...babelrc.presets],
+  presets: ['es2015', 'react', 'stage-1'],
 }
 
 const showCodeStyle = {


### PR DESCRIPTION
The esnext support introduced some babel config that the in-browser editor doesn't understand, #1210.  This means you cannot edit the doc examples.  This PR hard codes the babel presets to overcome the logic surrounding the preset selection.