### PR TITLE
fix(Button): fix `tabIndex` in typings

### DIFF
--- a/src/elements/Button/index.d.ts
+++ b/src/elements/Button/index.d.ts
@@ -89,7 +89,7 @@ export interface ButtonProps {
   size?: SemanticSIZES;
 
   /** A button can receive focus. */
-  tabIndex: number | string;
+  tabIndex?: number | string;
 
   /** A button can be formatted to toggle on and off. */
   toggle?: boolean;


### PR DESCRIPTION
`tabIndex` is optional prop, thanks to @wcatron for [notification](https://github.com/Semantic-Org/Semantic-UI-React/commit/7c2bfee9d9029119e3ccf4fcd84bc430eb97900c#commitcomment-20610490).