### PR TITLE
fix(Icon): Incorrect definition in typings

### DIFF
--- a/src/elements/Icon/index.d.ts
+++ b/src/elements/Icon/index.d.ts
@@ -53,7 +53,7 @@ interface IconProps {
 }
 
 interface IconComponent extends React.StatelessComponent<IconProps> {
-  Content: typeof IconGroup;
+  Group: typeof IconGroup;
 }
 
 export const Icon: IconComponent;


### PR DESCRIPTION
Incorrect definition,  thanks to @wcatron for [notification](https://github.com/Semantic-Org/Semantic-UI-React/commit/727177039daf00c9ffafe14f72d83eb65a6c1a83#commitcomment-20612546).