### PR TITLE
Clean up mixed imports in debug.js

### DIFF
--- a/src/lib/debug.js
+++ b/src/lib/debug.js
@@ -1,4 +1,4 @@
-import isBrowser from './isBrowser'
+const isBrowser = require('./isBrowser')
 let _debug
 const noop = () => undefined
 
@@ -36,7 +36,7 @@ if (isBrowser && process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !
  * debug('Some message')
  * @returns {Function}
  */
-export const makeDebugger = (namespace) => {
+const makeDebugger = exports.makeDebugger = (namespace) => {
   return _debug(`semanticUIReact:${namespace}`)
 }
 
@@ -46,4 +46,4 @@ export const makeDebugger = (namespace) => {
  * import { debug } from 'src/lib'
  * debug('Some message')
  */
-export const debug = makeDebugger('log')
+exports.debug = makeDebugger('log')


### PR DESCRIPTION
This module was using a mix of es6 and CommonJS imports/exports when it clearly needs CommonJS's dynamic requires.  It has been updated to use CommonJS throughout.

Without this fix, I get the error `require is not defined` in StealJS projects, because it doesn't support mixing syntaxes in a single file the way that Webpack does.