### PR TITLE
Fix typings for Menu Item onClick handler

### DIFF
--- a/src/collections/Menu/index.d.ts
+++ b/src/collections/Menu/index.d.ts
@@ -154,6 +154,13 @@ interface MenuItemProps extends ReactMouseEvents<HTMLElement> {
   /** Internal name of the MenuItem. */
   name?: string;
 
+   /**
+   * Called after user's click.
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
+   */
+  onClick?: (event: React.MouseEvent<HTMLElement>, data?:MenuItemProps) => void;
+
   /** A menu item can take right position. */
   position?: 'right';
 }


### PR DESCRIPTION
The typings are missing a correct definition for onClick on Menu.Item to add the props as the 2nd parameter.

The typings for Button are correct, so this is a copy of the onClick definition from there for Menu.Item