### PR TITLE
fix(core): require('debug') throws exception in browser

### DIFF
--- a/src/lib/debug.js
+++ b/src/lib/debug.js
@@ -1,4 +1,6 @@
 import isBrowser from './isBrowser'
+import requireDebug from 'debug'
+
 let _debug
 const noop = () => undefined
 
@@ -18,7 +20,7 @@ if (isBrowser && process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !
    /* eslint-enable no-console */
   }
 
-  _debug = require('debug')
+  _debug = requireDebug
 
   // enable what ever settings we got from storage
   _debug.enable(DEBUG)


### PR DESCRIPTION
Remove 'require()' call from debug.js because it breaks es builds in browser via rollup.js

Fixes it