### PR TITLE
fix(typings): inherit Radio props from Checkbox

### DIFF
--- a/src/addons/Radio/index.d.ts
+++ b/src/addons/Radio/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CheckboxProps } from '../../modules/Checkbox'
+import { CheckboxProps } from '../../modules/Checkbox';
 
 interface RadioProps extends CheckboxProps {
   [key: string]: any;

--- a/src/addons/Radio/index.d.ts
+++ b/src/addons/Radio/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { CheckboxProps } from '../../modules/Checkbox'
 
-interface RadioProps {
+interface RadioProps extends CheckboxProps {
   [key: string]: any;
 
   /** Format to emphasize the current selection state. */


### PR DESCRIPTION
After #1155 the Radio component did not inherit the checkbox props. This might help with #1169