### PR TITLE
style(Message): update typings and remove propTypes

### DIFF
--- a/src/collections/Message/Message.js
+++ b/src/collections/Message/Message.js
@@ -1,6 +1,6 @@
-import _ from 'lodash'
-import React, { PropTypes } from 'react'
 import cx from 'classnames'
+import _ from 'lodash'
+import React, { Component, PropTypes } from 'react'
 
 import {
   createShorthand,
@@ -13,175 +13,178 @@ import {
   useKeyOrValueAndKey,
 } from '../../lib'
 import Icon from '../../elements/Icon'
-
 import MessageContent from './MessageContent'
 import MessageHeader from './MessageHeader'
 import MessageList from './MessageList'
 import MessageItem from './MessageItem'
 
 /**
- * A message displays information that explains nearby content
+ * A message displays information that explains nearby content.
  * @see Form
  */
-function Message(props) {
-  const {
-    children,
-    className,
-    content,
-    header,
-    icon,
-    list,
-    onDismiss,
-    hidden,
-    visible,
-    floating,
-    compact,
-    attached,
-    warning,
-    info,
-    positive,
-    success,
-    negative,
-    error,
-    color,
-    size,
-  } = props
+export default class Message extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-  const classes = cx(
-    'ui',
-    size,
-    color,
-    useKeyOnly(icon, 'icon'),
-    useKeyOnly(hidden, 'hidden'),
-    useKeyOnly(visible, 'visible'),
-    useKeyOnly(floating, 'floating'),
-    useKeyOnly(compact, 'compact'),
-    useKeyOrValueAndKey(attached, 'attached'),
-    useKeyOnly(warning, 'warning'),
-    useKeyOnly(info, 'info'),
-    useKeyOnly(positive, 'positive'),
-    useKeyOnly(success, 'success'),
-    useKeyOnly(negative, 'negative'),
-    useKeyOnly(error, 'error'),
-    'message',
-    className,
-  )
+    /** A message can be formatted to attach itself to other content. */
+    attached: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(['bottom']),
+    ]),
 
-  const dismissIcon = onDismiss && <Icon name='close' onClick={onDismiss} />
-  const rest = getUnhandledProps(Message, props)
-  const ElementType = getElementType(Message, props)
+    /** Primary content. */
+    children: PropTypes.node,
 
-  if (!_.isNil(children)) {
+    /** Additional classes. */
+    className: PropTypes.string,
+
+    /** A message can be formatted to be different colors. */
+    color: PropTypes.oneOf(SUI.COLORS),
+
+    /** A message can only take up the width of its content. */
+    compact: PropTypes.bool,
+
+    /** Shorthand for primary content. */
+    content: customPropTypes.contentShorthand,
+
+    /** A message may be formatted to display a negative message. Same as `negative`. */
+    error: PropTypes.bool,
+
+    /** A message can float above content that it is related to. */
+    floating: PropTypes.bool,
+
+    /** Shorthand for MessageHeader. */
+    header: customPropTypes.itemShorthand,
+
+    /** A message can be hidden. */
+    hidden: PropTypes.bool,
+
+    /** A message can contain an icon. */
+    icon: PropTypes.oneOfType([
+      customPropTypes.itemShorthand,
+      PropTypes.bool,
+    ]),
+
+    /** A message may be formatted to display information. */
+    info: PropTypes.bool,
+
+    /** Array shorthand items for the MessageList. Mutually exclusive with children. */
+    list: customPropTypes.collectionShorthand,
+
+    /** A message may be formatted to display a negative message. Same as `error`. */
+    negative: PropTypes.bool,
+
+    /**
+     * A message that the user can choose to hide.
+     * Called when the user clicks the "x" icon. This also adds the "x" icon.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onDismiss: PropTypes.func,
+
+    /** A message may be formatted to display a positive message.  Same as `success`. */
+    positive: PropTypes.bool,
+
+    /** A message may be formatted to display a positive message.  Same as `positive`. */
+    success: PropTypes.bool,
+
+    /** A message can have different sizes. */
+    size: PropTypes.oneOf(_.without(SUI.SIZES, 'medium')),
+
+    /** A message can be set to visible to force itself to be shown. */
+    visible: PropTypes.bool,
+
+    /** A message may be formatted to display warning messages. */
+    warning: PropTypes.bool,
+  }
+
+  static _meta = {
+    name: 'Message',
+    type: META.TYPES.COLLECTION,
+  }
+
+  static Content = MessageContent
+  static Header = MessageHeader
+  static List = MessageList
+  static Item = MessageItem
+
+  handleDismiss = e => {
+    const { onDismiss } = this.props
+
+    if (onDismiss) onDismiss(e, this.props)
+  }
+
+  render() {
+    const {
+      attached,
+      children,
+      className,
+      color,
+      compact,
+      content,
+      error,
+      floating,
+      header,
+      hidden,
+      icon,
+      info,
+      list,
+      negative,
+      onDismiss,
+      positive,
+      size,
+      success,
+      visible,
+      warning,
+    } = this.props
+
+    const classes = cx(
+      'ui',
+      color,
+      size,
+      useKeyOnly(compact, 'compact'),
+      useKeyOnly(error, 'error'),
+      useKeyOnly(floating, 'floating'),
+      useKeyOnly(hidden, 'hidden'),
+      useKeyOnly(icon, 'icon'),
+      useKeyOnly(info, 'info'),
+      useKeyOnly(negative, 'negative'),
+      useKeyOnly(positive, 'positive'),
+      useKeyOnly(success, 'success'),
+      useKeyOnly(visible, 'visible'),
+      useKeyOnly(warning, 'warning'),
+      useKeyOrValueAndKey(attached, 'attached'),
+      'message',
+      className,
+    )
+
+    const dismissIcon = onDismiss && <Icon name='close' onClick={this.handleDismiss} />
+    const rest = getUnhandledProps(Message, this.props)
+    const ElementType = getElementType(Message, this.props)
+
+    if (!_.isNil(children)) {
+      return (
+        <ElementType {...rest} className={classes}>
+          {dismissIcon}
+          {children}
+        </ElementType>
+      )
+    }
+
     return (
       <ElementType {...rest} className={classes}>
         {dismissIcon}
-        {children}
+        {Icon.create(icon)}
+        {(!_.isNil(header) || !_.isNil(content) || !_.isNil(list)) && (
+          <MessageContent>
+            {MessageHeader.create(header)}
+            {MessageList.create(list)}
+            {createShorthand('p', val => ({ children: val }), content)}
+          </MessageContent>
+        )}
       </ElementType>
     )
   }
-
-  return (
-    <ElementType {...rest} className={classes}>
-      {dismissIcon}
-      {Icon.create(icon)}
-      {(!_.isNil(header) || !_.isNil(content) || !_.isNil(list)) && (
-        <MessageContent>
-          {MessageHeader.create(header)}
-          {MessageList.create(list)}
-          {createShorthand('p', val => ({ children: val }), content)}
-        </MessageContent>
-      )}
-    </ElementType>
-  )
 }
-
-Message._meta = {
-  name: 'Message',
-  type: META.TYPES.COLLECTION,
-  props: {
-    attached: ['bottom'],
-    color: SUI.COLORS,
-    size: _.without(SUI.SIZES, 'medium'),
-  },
-}
-
-Message.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
-
-  /** Primary content. */
-  children: PropTypes.node,
-
-  /** Additional classes. */
-  className: PropTypes.string,
-
-  /** Shorthand for primary content. */
-  content: customPropTypes.contentShorthand,
-
-  /** Shorthand for MessageHeader. */
-  header: customPropTypes.itemShorthand,
-
-  /** A message can contain an icon. */
-  icon: PropTypes.oneOfType([
-    PropTypes.bool,
-    customPropTypes.itemShorthand,
-  ]),
-
-  /** Array shorthand items for the MessageList. Mutually exclusive with children. */
-  list: customPropTypes.collectionShorthand,
-
-  /**
-   * A message that the user can choose to hide.
-   * Called when the user clicks the "x" icon. This also adds the "x" icon.
-   */
-  onDismiss: PropTypes.func,
-
-  /** A message can be hidden. */
-  hidden: PropTypes.bool,
-
-  /** A message can be set to visible to force itself to be shown. */
-  visible: PropTypes.bool,
-
-  /** A message can float above content that it is related to. */
-  floating: PropTypes.bool,
-
-  /** A message can only take up the width of its content. */
-  compact: PropTypes.bool,
-
-  /** A message can be formatted to attach itself to other content. */
-  attached: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.oneOf(Message._meta.props.attached),
-  ]),
-
-  /** A message may be formatted to display warning messages. */
-  warning: PropTypes.bool,
-
-  /** A message may be formatted to display information. */
-  info: PropTypes.bool,
-
-  /** A message may be formatted to display a positive message.  Same as `success`. */
-  positive: PropTypes.bool,
-
-  /** A message may be formatted to display a positive message.  Same as `positive`. */
-  success: PropTypes.bool,
-
-  /** A message may be formatted to display a negative message. Same as `error`. */
-  negative: PropTypes.bool,
-
-  /** A message may be formatted to display a negative message. Same as `negative`. */
-  error: PropTypes.bool,
-
-  /** A message can be formatted to be different colors. */
-  color: PropTypes.oneOf(Message._meta.props.color),
-
-  /** A message can have different sizes. */
-  size: PropTypes.oneOf(Message._meta.props.size),
-}
-
-Message.Content = MessageContent
-Message.Header = MessageHeader
-Message.List = MessageList
-Message.Item = MessageItem
-
-export default Message

--- a/src/collections/Message/MessageContent.js
+++ b/src/collections/Message/MessageContent.js
@@ -8,6 +8,9 @@ import {
   META,
 } from '../../lib'
 
+/**
+ * A message can contain a content.
+ */
 function MessageContent(props) {
   const { children, className } = props
   const classes = cx('content', className)

--- a/src/collections/Message/MessageHeader.js
+++ b/src/collections/Message/MessageHeader.js
@@ -1,5 +1,5 @@
-import _ from 'lodash'
 import cx from 'classnames'
+import _ from 'lodash'
 import React, { PropTypes } from 'react'
 
 import {
@@ -10,13 +10,20 @@ import {
   META,
 } from '../../lib'
 
+/**
+ * A message can contain a header.
+ */
 function MessageHeader(props) {
   const { children, className, content } = props
   const classes = cx('header', className)
   const rest = getUnhandledProps(MessageHeader, props)
   const ElementType = getElementType(MessageHeader, props)
 
-  return <ElementType {...rest} className={classes}>{_.isNil(children) ? content : children}</ElementType>
+  return (
+    <ElementType {...rest} className={classes}>
+      {_.isNil(children) ? content : children}
+    </ElementType>
+  )
 }
 
 MessageHeader._meta = {
@@ -32,11 +39,11 @@ MessageHeader.propTypes = {
   /** Primary content. */
   children: PropTypes.node,
 
-  /** Shorthand for primary content. */
-  content: customPropTypes.itemShorthand,
-
   /** Additional classes. */
   className: PropTypes.string,
+
+  /** Shorthand for primary content. */
+  content: customPropTypes.itemShorthand,
 }
 
 MessageHeader.create = createShorthandFactory(MessageHeader, val => ({ content: val }))

--- a/src/collections/Message/MessageItem.js
+++ b/src/collections/Message/MessageItem.js
@@ -11,7 +11,7 @@ import {
 } from '../../lib'
 
 /**
- * A message can contain an item.
+ * A message list can contain an item.
  */
 function MessageItem(props) {
   const { children, className, content } = props

--- a/src/collections/Message/MessageItem.js
+++ b/src/collections/Message/MessageItem.js
@@ -1,4 +1,5 @@
 import cx from 'classnames'
+import _ from 'lodash'
 import React, { PropTypes } from 'react'
 
 import {
@@ -9,13 +10,20 @@ import {
   META,
 } from '../../lib'
 
+/**
+ * A message can contain an item.
+ */
 function MessageItem(props) {
   const { children, className, content } = props
   const classes = cx('content', className)
   const rest = getUnhandledProps(MessageItem, props)
   const ElementType = getElementType(MessageItem, props)
 
-  return <ElementType {...rest} className={classes}>{content || children}</ElementType>
+  return (
+    <ElementType {...rest} className={classes}>
+      {_.isNil(children) ? content : children}
+    </ElementType>
+  )
 }
 
 MessageItem._meta = {
@@ -31,11 +39,11 @@ MessageItem.propTypes = {
   /** Primary content. */
   children: PropTypes.node,
 
-  /** Shorthand for primary content. */
-  content: customPropTypes.itemShorthand,
-
   /** Additional classes. */
   className: PropTypes.string,
+
+  /** Shorthand for primary content. */
+  content: customPropTypes.itemShorthand,
 }
 
 MessageItem.defaultProps = {

--- a/src/collections/Message/MessageList.js
+++ b/src/collections/Message/MessageList.js
@@ -1,5 +1,5 @@
-import _ from 'lodash/fp'
 import cx from 'classnames'
+import _ from 'lodash'
 import React, { PropTypes } from 'react'
 
 import {
@@ -9,9 +9,11 @@ import {
   getUnhandledProps,
   META,
 } from '../../lib'
-
 import MessageItem from './MessageItem'
 
+/**
+ * A message can contain a list of items.
+ */
 function MessageList(props) {
   const { children, className, items } = props
   const classes = cx('list', className)
@@ -20,7 +22,7 @@ function MessageList(props) {
 
   return (
     <ElementType {...rest} className={classes}>
-      {_.isNil(children) ? _.map(MessageItem.create, items) : children}
+      {_.isNil(children) ? _.map(items, MessageItem.create) : children}
     </ElementType>
   )
 }

--- a/src/collections/Message/index.d.ts
+++ b/src/collections/Message/index.d.ts
@@ -1,7 +1,9 @@
-import { SemanticCOLORS, SemanticSIZES } from '../..';
 import * as React from 'react';
+import { SemanticCOLORS } from '../..';
 
 interface MessageProps {
+  [key: string]: any;
+
 	/** An element type to render as (string or function). */
   as?: any;
 
@@ -21,7 +23,7 @@ interface MessageProps {
   compact?: boolean;
 
   /** Shorthand for primary content. */
-  content?: any;
+  content?: React.ReactNode;
 
   /** A message may be formatted to display a negative message. Same as `negative`. */
   error?: boolean;
@@ -36,7 +38,7 @@ interface MessageProps {
   hidden?: boolean;
 
   /** Add an icon by icon name or pass an <Icon /.> */
-  icon?: any;
+  icon?: any | boolean;
 
   /** A message may be formatted to display information. */
   info?: boolean;
@@ -50,14 +52,17 @@ interface MessageProps {
   /**
    * A message that the user can choose to hide.
    * Called when the user clicks the "x" icon. This also adds the "x" icon.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
    */
-  onDismiss?: React.MouseEventHandler<HTMLDivElement>;
+  onDismiss?: (event: React.MouseEvent<HTMLElement>, data: MessageProps) => void;
 
   /** A message may be formatted to display a positive message.  Same as `success`. */
   positive?: boolean;
 
   /** A message can have different sizes. */
-  size?: SemanticSIZES;
+  size?: 'mini' | 'tiny' | 'small' | 'large' | 'big' | 'huge' | 'massive';
 
   /** A message may be formatted to display a positive message.  Same as `positive`. */
   success?: boolean;
@@ -69,16 +74,18 @@ interface MessageProps {
   warning?: boolean;
 }
 
-interface MessageClass extends React.ComponentClass<MessageProps> {
+interface MessageComponent extends React.ComponentClass<MessageProps> {
   Content: typeof MessageContent;
   Header: typeof MessageHeader;
   List: typeof MessageList;
   Item: typeof MessageItem;
 }
 
-export const Message: MessageClass;
+export const Message: MessageComponent;
 
 interface MessageContentProps {
+  [key: string]: any;
+
   /** An element type to render as (string or function). */
   as?: any;
 
@@ -89,9 +96,11 @@ interface MessageContentProps {
   className?: string;
 }
 
-export const MessageContent: React.ComponentClass<MessageContentProps>;
+export const MessageContent: React.StatelessComponent<MessageContentProps>;
 
 interface MessageHeaderProps {
+  [key: string]: any;
+
   /** An element type to render as (string or function). */
   as?: any;
 
@@ -100,11 +109,34 @@ interface MessageHeaderProps {
 
   /** Additional classes. */
   className?: string;
+
+  /** Shorthand for primary content. */
+  content?: React.ReactNode;
 }
 
-export const MessageHeader: React.ComponentClass<MessageHeaderProps>;
+export const MessageHeader: React.StatelessComponent<MessageHeaderProps>;
+
+interface MessageItemProps {
+  [key: string]: any;
+
+  /** An element type to render as (string or function). */
+  as?: any;
+
+  /** Primary content. */
+  children?: React.ReactNode;
+
+  /** Additional classes. */
+  className?: string;
+
+  /** Shorthand for primary content. */
+  content?: React.ReactNode;
+}
+
+export const MessageItem: React.StatelessComponent<MessageItemProps>;
 
 interface MessageListProps {
+  [key: string]: any;
+
   /** An element type to render as (string or function). */
   as?: any;
 
@@ -118,17 +150,4 @@ interface MessageListProps {
   items?: Array<any>;
 }
 
-export const MessageList: React.ComponentClass<MessageListProps>;
-
-interface MessageItemProps {
-  /** An element type to render as (string or function). */
-  as?: any;
-
-  /** Primary content. */
-  children?: React.ReactNode;
-
-  /** Additional classes. */
-  className?: string;
-}
-
-export const MessageItem: React.ComponentClass<MessageItemProps>;
+export const MessageList: React.StatelessComponent<MessageListProps>;

--- a/test/specs/collections/Message/Message-test.js
+++ b/test/specs/collections/Message/Message-test.js
@@ -11,8 +11,8 @@ import { sandbox } from 'test/utils'
 
 describe('Message', () => {
   common.isConformant(Message)
-  common.hasUIClassName(Message)
   common.hasSubComponents(Message, [MessageContent, MessageHeader, MessageList])
+  common.hasUIClassName(Message)
   common.rendersChildren(Message)
 
   common.implementsIconProp(Message)
@@ -85,22 +85,25 @@ describe('Message', () => {
       shallow(<Message />)
         .should.not.have.descendants('.close.icon')
     })
+
     it('adds a close icon when defined', () => {
       render(<Message onDismiss={() => undefined} />)
         .should.have.descendants('.close.icon')
     })
+
     it('is called with (event) on close icon click', () => {
+      const event = { fake: 'event data' }
+      const props = { icon: true }
+
       const spy = sandbox.spy()
-      const wrapper = mount(<Message onDismiss={spy} />)
+      const wrapper = mount(<Message {...props} onDismiss={spy} />)
 
       wrapper.should.have.descendants('.close.icon')
-
-      wrapper
-        .find('.close.icon')
-        .simulate('click')
+      wrapper.find('.close.icon')
+        .simulate('click', event)
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({})
+      spy.should.have.been.calledWithMatch(event, props)
     })
   })
 })


### PR DESCRIPTION
This PR is part of work for removing propTypes in production bundle (#524, #731).
Also, cleanups and updates typings for #1072.

---

Also, it converts `Message` to statefull components and update `onDismiss` behavior.