### PR TITLE
feat(Dropdown): multiple search dropdown should refocus the search on select of an option

### DIFF
--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1167,6 +1167,19 @@ describe('Dropdown Component', () => {
 
         spy.should.have.been.calledWithMatch({}, { value: randomValue })
       })
+
+      it('refocuses search on select', () => {
+        const randomIndex = _.random(options.length - 1)
+
+        wrapperMount(<Dropdown options={options} search selection multiple />)
+          .simulate('click', nativeEvent)
+          .find('DropdownItem')
+          .at(randomIndex)
+          .simulate('click', nativeEvent)
+
+        wrapper.instance()
+          ._search.should.eq(document.activeElement)
+      })
     })
     describe('removing items', () => {
       it('calls onChange without the clicked value', () => {


### PR DESCRIPTION
fixes issue #1243 

Before:
![before](https://d17oy1vhnax1f7.cloudfront.net/items/0u1V3h1a223r0e0u1a31/Screen%20Recording%202017-01-30%20at%2004.10%20PM.gif?v=ac18f632)

After:
![after](https://d17oy1vhnax1f7.cloudfront.net/items/3r1p2f0i0h3j2l2g3k29/Screen%20Recording%202017-01-30%20at%2004.12%20PM.gif?v=612df1f6)