### PR TITLE
fix(Editor): use handledProps instead of propTypes

### DIFF
--- a/docs/app/Components/Editor/Editor.js
+++ b/docs/app/Components/Editor/Editor.js
@@ -22,8 +22,8 @@ const semanticUIReactCompleter = {
       // Component
       completions.push({ caption: name, value: name, meta: 'Component' })
 
-      // Its props
-      _.each(component.propTypes, (val, propName) => {
+      // Its props (propTypes do not exist in prod, use handledProps added by babel)
+      _.each(component.handledProps, (propName) => {
         // don't add duplicate prop completions
         if (_.find(completions, { value: propName })) return
 


### PR DESCRIPTION
The editor uses propTypes to generate completions.  However, we now strip propTypes in production.  The docs, therefore, have no prop completions.


This PR gets prop completions from the `handledProps` array, which includes all props.