### PR TITLE
style(Menu): update typings and remove propTypes

### DIFF
--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -1,5 +1,5 @@
-import _ from 'lodash'
 import cx from 'classnames'
+import _ from 'lodash'
 import React, { PropTypes } from 'react'
 
 import {
@@ -18,21 +18,6 @@ import MenuHeader from './MenuHeader'
 import MenuItem from './MenuItem'
 import MenuMenu from './MenuMenu'
 
-const _meta = {
-  name: 'Menu',
-  type: META.TYPES.COLLECTION,
-  props: {
-    attached: ['top', 'bottom'],
-    color: SUI.COLORS,
-    floated: ['right'],
-    icon: ['labeled'],
-    fixed: ['left', 'right', 'bottom', 'top'],
-    size: _.without(SUI.SIZES, 'medium', 'big'),
-    tabular: ['right'],
-    widths: SUI.WIDTHS,
-  },
-}
-
 /**
  * A menu displays grouped navigation actions.
  * @see Dropdown
@@ -48,7 +33,7 @@ class Menu extends Component {
     /** A menu may be attached to other content segments. */
     attached: PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.oneOf(_meta.props.attached),
+      PropTypes.oneOf(['top', 'bottom']),
     ]),
 
     /** A menu item or menu can have no borders. */
@@ -61,7 +46,7 @@ class Menu extends Component {
     className: PropTypes.string,
 
     /** Additional colors can be specified. */
-    color: PropTypes.oneOf(_meta.props.color),
+    color: PropTypes.oneOf(SUI.COLORS),
 
     /** A menu can take up only the space necessary to fit its content. */
     compact: PropTypes.bool,
@@ -70,12 +55,12 @@ class Menu extends Component {
     defaultActiveIndex: PropTypes.number,
 
     /** A menu can be fixed to a side of its context. */
-    fixed: PropTypes.oneOf(_meta.props.fixed),
+    fixed: PropTypes.oneOf(['left', 'right', 'bottom', 'top']),
 
     /** A menu can be floated. */
     floated: PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.oneOf(_meta.props.floated),
+      PropTypes.oneOf(['right']),
     ]),
 
     /** A vertical menu may take the size of its container. */
@@ -84,7 +69,7 @@ class Menu extends Component {
     /** A menu may have labeled icons. */
     icon: PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.oneOf(_meta.props.icon),
+      PropTypes.oneOf(['labeled']),
     ]),
 
     /** A menu may have its colors inverted to show greater contrast. */
@@ -113,13 +98,16 @@ class Menu extends Component {
     /** A menu can adjust its appearance to de-emphasize its contents. */
     secondary: PropTypes.bool,
 
+    /** A menu can vary in size. */
+    size: PropTypes.oneOf(_.without(SUI.SIZES, 'medium', 'big')),
+
     /** A menu can stack at mobile resolutions. */
     stackable: PropTypes.bool,
 
     /** A menu can be formatted to show tabs of information. */
     tabular: PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.oneOf(_meta.props.tabular),
+      PropTypes.oneOf(['right']),
     ]),
 
     /** A menu can be formatted for text content. */
@@ -128,14 +116,14 @@ class Menu extends Component {
     /** A vertical menu displays elements vertically. */
     vertical: PropTypes.bool,
 
-    /** A menu can vary in size. */
-    size: PropTypes.oneOf(_meta.props.size),
-
     /** A menu can have its items divided evenly. */
-    widths: PropTypes.oneOf(_meta.props.widths),
+    widths: PropTypes.oneOf(SUI.WIDTHS),
   }
 
-  static _meta = _meta
+  static _meta = {
+    name: 'Menu',
+    type: META.TYPES.COLLECTION,
+  }
 
   static autoControlledProps = [
     'activeIndex',
@@ -147,9 +135,9 @@ class Menu extends Component {
 
   handleItemClick = (e, itemProps) => {
     const { index } = itemProps
+    const { items, onItemClick } = this.props
 
     this.trySetState({ activeIndex: index })
-    const { items, onItemClick } = this.props
 
     if (_.get(items[index], 'onClick')) items[index].onClick(e, itemProps)
     if (onItemClick) onItemClick(e, itemProps)
@@ -168,36 +156,58 @@ class Menu extends Component {
 
   render() {
     const {
-      attached, borderless, children, className, color, compact, fixed, floated, fluid, icon, inverted, pagination,
-      pointing, secondary, stackable, tabular, text, vertical, size, widths,
+      attached,
+      borderless,
+      children,
+      className,
+      color,
+      compact,
+      fixed,
+      floated,
+      fluid,
+      icon,
+      inverted,
+      pagination,
+      pointing,
+      secondary,
+      size,
+      stackable,
+      tabular,
+      text,
+      vertical,
+      widths,
     } = this.props
     const classes = cx(
       'ui',
       color,
       size,
-      useWidthProp(widths, 'item'),
-      useKeyOrValueAndKey(attached, 'attached'),
       useKeyOnly(borderless, 'borderless'),
       useKeyOnly(compact, 'compact'),
-      useValueAndKey(fixed, 'fixed'),
-      useKeyOrValueAndKey(floated, 'floated'),
       useKeyOnly(fluid, 'fluid'),
-      useKeyOrValueAndKey(icon, 'icon'),
       useKeyOnly(inverted, 'inverted'),
       useKeyOnly(pagination, 'pagination'),
       useKeyOnly(pointing, 'pointing'),
       useKeyOnly(secondary, 'secondary'),
       useKeyOnly(stackable, 'stackable'),
-      useKeyOrValueAndKey(tabular, 'tabular'),
       useKeyOnly(text, 'text'),
       useKeyOnly(vertical, 'vertical'),
+      useKeyOrValueAndKey(attached, 'attached'),
+      useKeyOrValueAndKey(floated, 'floated'),
+      useKeyOrValueAndKey(icon, 'icon'),
+      useKeyOrValueAndKey(tabular, 'tabular'),
+      useValueAndKey(fixed, 'fixed'),
+      useWidthProp(widths, 'item'),
       className,
       'menu'
     )
     const rest = getUnhandledProps(Menu, this.props)
     const ElementType = getElementType(Menu, this.props)
 
-    return <ElementType {...rest} className={classes}>{_.isNil(children) ? this.renderItems() : children}</ElementType>
+    return (
+      <ElementType {...rest} className={classes}>
+        {_.isNil(children) ? this.renderItems() : children}
+      </ElementType>
+    )
   }
 }
 

--- a/src/collections/Menu/MenuHeader.js
+++ b/src/collections/Menu/MenuHeader.js
@@ -1,5 +1,5 @@
-import _ from 'lodash'
 import cx from 'classnames'
+import _ from 'lodash'
 import React, { PropTypes } from 'react'
 
 import {
@@ -9,13 +9,20 @@ import {
   META,
 } from '../../lib'
 
+/**
+ * A menu item may include a header or may itself be a header.
+ */
 function MenuHeader(props) {
   const { children, className, content } = props
-  const classes = cx(className, 'header')
+  const classes = cx('header', className)
   const rest = getUnhandledProps(MenuHeader, props)
   const ElementType = getElementType(MenuHeader, props)
 
-  return <ElementType {...rest} className={classes}>{_.isNil(children) ? content : children}</ElementType>
+  return (
+    <ElementType {...rest} className={classes}>
+      {_.isNil(children) ? content : children}
+    </ElementType>
+  )
 }
 
 MenuHeader._meta = {

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -1,5 +1,5 @@
-import _ from 'lodash'
 import cx from 'classnames'
+import _ from 'lodash'
 import React, { Component, PropTypes } from 'react'
 
 import {
@@ -14,17 +14,9 @@ import {
 } from '../../lib'
 import Icon from '../../elements/Icon'
 
-const _meta = {
-  name: 'MenuItem',
-  type: META.TYPES.COLLECTION,
-  parent: 'Menu',
-  props: {
-    color: SUI.COLORS,
-    fitted: ['horizontally', 'vertically'],
-    position: ['right'],
-  },
-}
-
+/**
+ * A menu can contain an item.
+ */
 export default class MenuItem extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
@@ -40,7 +32,7 @@ export default class MenuItem extends Component {
     className: PropTypes.string,
 
     /** Additional colors can be specified. */
-    color: PropTypes.oneOf(_meta.props.color),
+    color: PropTypes.oneOf(SUI.COLORS),
 
     /** Shorthand for primary content. */
     content: customPropTypes.contentShorthand,
@@ -48,7 +40,7 @@ export default class MenuItem extends Component {
     /** A menu item or menu can remove element padding, vertically or horizontally. */
     fitted: PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.oneOf(_meta.props.fitted),
+      PropTypes.oneOf(['horizontally', 'vertically']),
     ]),
 
     /** A menu item may include a header or may itself be a header. */
@@ -79,10 +71,14 @@ export default class MenuItem extends Component {
     onClick: PropTypes.func,
 
     /** A menu item can take right position. */
-    position: PropTypes.oneOf(_meta.props.position),
+    position: PropTypes.oneOf(['right']),
   }
 
-  static _meta = _meta
+  static _meta = {
+    name: 'MenuItem',
+    type: META.TYPES.COLLECTION,
+    parent: 'Menu',
+  }
 
   handleClick = (e) => {
     const { onClick } = this.props

--- a/src/collections/Menu/MenuMenu.js
+++ b/src/collections/Menu/MenuMenu.js
@@ -8,9 +8,17 @@ import {
   META,
 } from '../../lib'
 
+/**
+ * A menu can contain a sub menu.
+ */
 function MenuMenu(props) {
   const { children, className, position } = props
-  const classes = cx(className, position, 'menu')
+
+  const classes = cx(
+    position,
+    'menu',
+    className,
+  )
   const rest = getUnhandledProps(MenuMenu, props)
   const ElementType = getElementType(MenuMenu, props)
 
@@ -21,9 +29,6 @@ MenuMenu._meta = {
   name: 'MenuMenu',
   type: META.TYPES.COLLECTION,
   parent: 'Menu',
-  props: {
-    position: ['right'],
-  },
 }
 
 MenuMenu.propTypes = {
@@ -37,7 +42,7 @@ MenuMenu.propTypes = {
   className: PropTypes.string,
 
   /** A sub menu can take right position. */
-  position: PropTypes.oneOf(MenuMenu._meta.props.position),
+  position: PropTypes.oneOf(['right']),
 }
 
 export default MenuMenu

--- a/src/collections/Menu/index.d.ts
+++ b/src/collections/Menu/index.d.ts
@@ -1,25 +1,17 @@
-import {
-  ReactMouseEvents,
-  SemanticCOLORS,
-  SemanticFLOATS,
-  SemanticSIZES,
-  SemanticWIDTHS
-} from '../..';
 import * as React from 'react';
-
-export type MenuPropsIcon = 'labeled';
-export type MenuPropsTabular = 'right';
-export type MenuPropsFixed = 'left'| 'right'| 'bottom'| 'top';
-export type MenuPropsAttached = 'bottom' | 'top';
+import { SemanticCOLORS, SemanticWIDTHS } from '../..';
 
 export interface MenuProps {
-  activeIndex?: number;
+  [key: string]: any;
 
   /** An element type to render as (string or function). */
   as?: any;
 
+  /** Index of the currently active item. */
+  activeIndex?: number;
+
   /** A menu may be attached to other content segments. */
-  attached?: boolean | MenuPropsAttached;
+  attached?: boolean | 'bottom' | 'top';
 
   /** A menu item or menu can have no borders. */
   borderless?: boolean;
@@ -40,22 +32,22 @@ export interface MenuProps {
   defaultActiveIndex?: number;
 
   /** A menu can be fixed to a side of its context. */
-  fixed?: MenuPropsFixed;
+  fixed?: 'left'| 'right'| 'bottom'| 'top';
 
   /** A menu can be floated. */
-  floated?: boolean | SemanticFLOATS;
+  floated?: boolean | 'right';
 
   /** A vertical menu may take the size of its container. */
   fluid?: boolean;
 
   /** A menu may have labeled icons. */
-  icon?: boolean | MenuPropsIcon;
+  icon?: boolean | 'labeled';
 
   /** A menu may have its colors inverted to show greater contrast. */
   inverted?: boolean;
 
   /** Shorthand array of props for Menu. */
-  items?: any;  // TODO - check type;
+  items?: Array<any>;
 
   /**
    * onClick handler for MenuItem. Mutually exclusive with children.
@@ -63,7 +55,7 @@ export interface MenuProps {
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
    * @param {object} data - All item props.
    */
-  onItemClick?: React.MouseEventHandler<HTMLDivElement>;
+  onItemClick?: (event: React.MouseEvent<HTMLAnchorElement>, data: MenuItemProps) => void;
 
   /** A pagination menu is specially formatted to present links to pages of content. */
   pagination?: boolean;
@@ -75,13 +67,13 @@ export interface MenuProps {
   secondary?: boolean;
 
   /** A menu can vary in size. */
-  size?: SemanticSIZES;  // TODO - remove medium and big.
+  size?: 'mini' | 'tiny' | 'small' | 'large' | 'huge' | 'massive';
 
   /** A menu can stack at mobile resolutions. */
   stackable?: boolean;
 
   /** A menu can be formatted to show tabs of information. */
-  tabular?: boolean | MenuPropsTabular;
+  tabular?: boolean | 'right';
 
   /** A menu can be formatted for text content. */
   text?: boolean;
@@ -93,15 +85,16 @@ export interface MenuProps {
   widths?: SemanticWIDTHS;
 }
 
-interface MenuClass extends React.ComponentClass<MenuProps> {
+interface MenuComponent extends React.ComponentClass<MenuProps> {
   Header: typeof MenuHeader;
   Item: typeof MenuItem;
-  Menu: typeof MenuMenuItem;
+  Menu: typeof MenuMenu;
 }
 
-export const Menu: MenuClass;
+export const Menu: MenuComponent;
 
 interface MenuHeaderProps {
+  [key: string]: any;
 
   /** An element type to render as (string or function). */
   as?: any;
@@ -113,16 +106,18 @@ interface MenuHeaderProps {
   className?: string;
 
   /** Shorthand for primary content. */
-  content?: any;
+  content?: React.ReactNode;
 }
 export const MenuHeader: React.ComponentClass<MenuHeaderProps>;
 
-interface MenuItemProps extends ReactMouseEvents<HTMLElement> {
-  /** A menu item can be active. */
-  active?: boolean;
+interface MenuItemProps {
+  [key: string]: any;
 
   /** An element type to render as (string or function). */
   as?: any;
+
+  /** A menu item can be active. */
+  active?: boolean;
 
   /** Primary content. */
   children?: React.ReactNode;
@@ -142,8 +137,8 @@ interface MenuItemProps extends ReactMouseEvents<HTMLElement> {
   /** A menu item may include a header or may itself be a header. */
   header?: boolean;
 
-  /** Add an icon by icon name or pass an <Icon /.> */
-  icon?: any; // TODO - check type.
+  /** MenuItem can be only icon. */
+  icon?: any | boolean;
 
   /** MenuItem index inside Menu. */
   index?: number;
@@ -154,12 +149,24 @@ interface MenuItemProps extends ReactMouseEvents<HTMLElement> {
   /** Internal name of the MenuItem. */
   name?: string;
 
+  /**
+   * Called on click. When passed, the component will render as an `a`
+   * tag by default instead of a `div`.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
+   */
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>, data: MenuItemProps) => void;
+
   /** A menu item can take right position. */
   position?: 'right';
 }
+
 export const MenuItem: React.ComponentClass<MenuItemProps>;
 
 interface MenuMenuProps {
+  [key: string]: any;
+
   /** An element type to render as (string or function). */
   as?: any;
 
@@ -172,4 +179,5 @@ interface MenuMenuProps {
   /** A sub menu can take right position. */
   position?: 'right';
 }
-export const MenuMenuItem: React.ComponentClass<MenuMenuProps>;
+
+export const MenuMenu: React.StatelessComponent<MenuMenuProps>;

--- a/test/specs/collections/Menu/Menu-test.js
+++ b/test/specs/collections/Menu/Menu-test.js
@@ -11,8 +11,8 @@ import { sandbox } from 'test/utils'
 
 describe('Menu', () => {
   common.isConformant(Menu)
-  common.hasUIClassName(Menu)
   common.hasSubComponents(Menu, [MenuHeader, MenuItem, MenuMenu])
+  common.hasUIClassName(Menu)
   common.rendersChildren(Menu)
 
   common.implementsWidthProp(Menu, { propKey: 'widths', canEqual: false })


### PR DESCRIPTION
This PR is part of work for removing propTypes in production bundle (#524, #731).
Also, cleanups and updates typings for #1072.

Fixes #1262.