### PR TITLE
fix(Portal): evaulate mountNode at runtime in Portal component

### DIFF
--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -133,7 +133,7 @@ class Portal extends Component {
     closeOnDocumentClick: true,
     closeOnEscape: true,
     openOnTriggerClick: true,
-    mountNode: isBrowser ? document.body : null,
+    mountNode: null,
   }
 
   static autoControlledProps = [
@@ -392,7 +392,7 @@ class Portal extends Component {
 
     debug('mountPortal()')
 
-    const { mountNode, prepend } = this.props
+    const { mountNode = (isBrowser ? document.body : null), prepend } = this.props
 
     this.node = document.createElement('div')
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -133,7 +133,6 @@ class Portal extends Component {
     closeOnDocumentClick: true,
     closeOnEscape: true,
     openOnTriggerClick: true,
-    mountNode: null,
   }
 
   static autoControlledProps = [


### PR DESCRIPTION
Resolves Issue #1255 

Evaluating document.body in the mountPortal function so that mountNode is usable.