### PR TITLE
fix(Portal): fix several event related behaviors

### DIFF
--- a/docs/app/Examples/modules/Dimmer/States/DimmerExampleActive.js
+++ b/docs/app/Examples/modules/Dimmer/States/DimmerExampleActive.js
@@ -1,15 +1,15 @@
 import React from 'react'
-import { Dimmer, Segment } from 'semantic-ui-react'
+import { Dimmer, Image, Segment } from 'semantic-ui-react'
 
 const DimmerExampleActive = () => (
   <Segment>
     <Dimmer active />
 
     <p>
-      <img src='http://semantic-ui.com/images/wireframe/short-paragraph.png' />
+      <Image src='/assets/images/wireframe/short-paragraph.png' />
     </p>
     <p>
-      <img src='http://semantic-ui.com/images/wireframe/short-paragraph.png' />
+      <Image src='/assets/images/wireframe/short-paragraph.png' />
     </p>
   </Segment>
 )

--- a/docs/app/Examples/modules/Dimmer/Types/DimmerExampleContent.js
+++ b/docs/app/Examples/modules/Dimmer/Types/DimmerExampleContent.js
@@ -23,12 +23,12 @@ export default class DimmerExampleDimmer extends Component {
           <Header as='h3'>Overlayable Section</Header>
 
           <Image.Group size='small' className='ui small images'>
-            <Image src='http://semantic-ui.com/images/wireframe/image.png' />
-            <Image src='http://semantic-ui.com/images/wireframe/image.png' />
-            <Image src='http://semantic-ui.com/images/wireframe/image.png' />
+            <Image src='/assets/images/wireframe/image.png' />
+            <Image src='/assets/images/wireframe/image.png' />
+            <Image src='/assets/images/wireframe/image.png' />
           </Image.Group>
 
-          <Image size='medium' src='http://semantic-ui.com/images/wireframe/media-paragraph.png' />
+          <Image size='medium' src='/assets/images/wireframe/media-paragraph.png' />
         </Dimmer.Dimmable>
 
         <Button.Group>

--- a/docs/app/Examples/modules/Dimmer/Types/DimmerExampleDimmer.js
+++ b/docs/app/Examples/modules/Dimmer/Types/DimmerExampleDimmer.js
@@ -18,12 +18,12 @@ export default class DimmerExampleDimmer extends Component {
           <Header as='h3'>Overlayable Section</Header>
 
           <Image.Group size='small' className='ui small images'>
-            <Image src='http://semantic-ui.com/images/wireframe/image.png' />
-            <Image src='http://semantic-ui.com/images/wireframe/image.png' />
-            <Image src='http://semantic-ui.com/images/wireframe/image.png' />
+            <Image src='/assets/images/wireframe/image.png' />
+            <Image src='/assets/images/wireframe/image.png' />
+            <Image src='/assets/images/wireframe/image.png' />
           </Image.Group>
 
-          <Image size='medium' src='http://semantic-ui.com/images/wireframe/media-paragraph.png' />
+          <Image size='medium' src='/assets/images/wireframe/media-paragraph.png' />
         </Dimmer.Dimmable>
 
         <Button.Group>

--- a/docs/app/Examples/modules/Dimmer/Usage/DimmerExampleEvents.js
+++ b/docs/app/Examples/modules/Dimmer/Usage/DimmerExampleEvents.js
@@ -26,7 +26,7 @@ export default class DimmerExampleEvents extends Component {
         onMouseEnter={this.handleShow}
         onMouseLeave={this.handleHide}
         size='medium'
-        src='http://semantic-ui.com/images/wireframe/image.png'
+        src='/assets/images/wireframe/image.png'
       />
     )
   }

--- a/docs/app/Examples/modules/Dimmer/Usage/DimmerExampleLoader.js
+++ b/docs/app/Examples/modules/Dimmer/Usage/DimmerExampleLoader.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Button, Dimmer, Loader, Segment } from 'semantic-ui-react'
+import { Button, Dimmer, Image, Loader, Segment } from 'semantic-ui-react'
 
 export default class DimmerExampleLoader extends Component {
   state = {}
@@ -18,10 +18,10 @@ export default class DimmerExampleLoader extends Component {
           </Dimmer>
 
           <p>
-            <img src='http://semantic-ui.com/images/wireframe/short-paragraph.png' />
+            <Image src='/assets/images/wireframe/short-paragraph.png' />
           </p>
           <p>
-            <img src='http://semantic-ui.com/images/wireframe/short-paragraph.png' />
+            <Image src='/assets/images/wireframe/short-paragraph.png' />
           </p>
         </Dimmer.Dimmable>
 

--- a/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleBlurring.js
+++ b/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleBlurring.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Button, Dimmer, Segment } from 'semantic-ui-react'
+import { Button, Dimmer, Image, Segment } from 'semantic-ui-react'
 
 export default class DimmerExampleBlurring extends Component {
   state = {}
@@ -16,10 +16,10 @@ export default class DimmerExampleBlurring extends Component {
           <Dimmer active={active} onClickOutside={this.handleHide} />
 
           <p>
-            <img src='http://semantic-ui.com/images/wireframe/short-paragraph.png' />
+            <Image src='/assets/images/wireframe/short-paragraph.png' />
           </p>
           <p>
-            <img src='http://semantic-ui.com/images/wireframe/short-paragraph.png' />
+            <Image src='/assets/images/wireframe/short-paragraph.png' />
           </p>
         </Dimmer.Dimmable>
 

--- a/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleBlurringInverted.js
+++ b/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleBlurringInverted.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Button, Dimmer, Segment } from 'semantic-ui-react'
+import { Button, Dimmer, Image, Segment } from 'semantic-ui-react'
 
 export default class DimmerExampleBlurringInverted extends Component {
   state = {}
@@ -16,10 +16,10 @@ export default class DimmerExampleBlurringInverted extends Component {
           <Dimmer active={active} inverted onClickOutside={this.handleHide} />
 
           <p>
-            <img src='http://semantic-ui.com/images/wireframe/short-paragraph.png' />
+            <Image src='/assets/images/wireframe/short-paragraph.png' />
           </p>
           <p>
-            <img src='http://semantic-ui.com/images/wireframe/short-paragraph.png' />
+            <Image src='/assets/images/wireframe/short-paragraph.png' />
           </p>
         </Dimmer.Dimmable>
 

--- a/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleInverted.js
+++ b/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleInverted.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Button, Dimmer, Segment } from 'semantic-ui-react'
+import { Button, Dimmer, Image, Segment } from 'semantic-ui-react'
 
 export default class DimmerExampleInverted extends Component {
   state = {}
@@ -16,10 +16,10 @@ export default class DimmerExampleInverted extends Component {
           <Dimmer active={active} inverted onClickOutside={this.handleHide} />
 
           <p>
-            <img src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+            <Image src='/assets/images/wireframe/paragraph.png' />
           </p>
           <p>
-            <img src='http://semantic-ui.com/images/wireframe/paragraph.png' />
+            <Image src='/assets/images/wireframe/paragraph.png' />
           </p>
         </Dimmer.Dimmable>
 

--- a/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleSimple.js
+++ b/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleSimple.js
@@ -1,15 +1,15 @@
 import React from 'react'
-import { Dimmer, Segment } from 'semantic-ui-react'
+import { Dimmer, Image, Segment } from 'semantic-ui-react'
 
 const DimmerExampleSimple = () => (
   <Dimmer.Dimmable as={Segment} dimmed>
     <Dimmer simple />
 
     <p>
-      <img src='http://semantic-ui.com/images/wireframe/short-paragraph.png' />
+      <Image src='/assets/images/wireframe/short-paragraph.png' />
     </p>
     <p>
-      <img src='http://semantic-ui.com/images/wireframe/short-paragraph.png' />
+      <Image src='/assets/images/wireframe/short-paragraph.png' />
     </p>
   </Dimmer.Dimmable>
 )

--- a/docs/app/Examples/modules/Popup/Usage/PopupExampleNested.js
+++ b/docs/app/Examples/modules/Popup/Usage/PopupExampleNested.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Button, Grid, Popup } from 'semantic-ui-react'
+
+const PopupExampleNested = () => (
+  <Popup wide trigger={<Button content='Are you the one?' />} on='click'>
+    <Grid divided columns='equal'>
+      <Grid.Column>
+        <Popup
+          trigger={<Button color='blue' content='Blue Pill' fluid />}
+          content='The story ends. You wake up in your bed and believe whatever you want to believe.'
+          positioning='top center'
+          size='tiny'
+          inverted
+        />
+      </Grid.Column>
+      <Grid.Column>
+        <Popup
+          trigger={<Button color='red' content='Red Pill' fluid />}
+          content='Stay in Wonderland, and I show you how deep the rabbit hole goes.'
+          positioning='top center'
+          size='tiny'
+          inverted
+        />
+      </Grid.Column>
+    </Grid>
+  </Popup>
+)
+
+export default PopupExampleNested

--- a/docs/app/Examples/modules/Popup/Usage/index.js
+++ b/docs/app/Examples/modules/Popup/Usage/index.js
@@ -20,6 +20,11 @@ const PopupUsageExamples = () => (
       examplePath='modules/Popup/Usage/PopupExampleFocus'
     />
     <ComponentExample
+      title='Nesting'
+      description='A popup can be nested inside another.'
+      examplePath='modules/Popup/Usage/PopupExampleNested'
+    />
+    <ComponentExample
       title='Controlled'
       description='A popup can have its visibility controlled from outside.'
       examplePath='modules/Popup/Usage/PopupExampleControlled'

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -1,10 +1,9 @@
 import _ from 'lodash'
-import React, { Children, PropTypes } from 'react'
+import { Children, cloneElement, PropTypes } from 'react'
 import ReactDOM from 'react-dom'
 
 import {
   AutoControlledComponent as Component,
-  customPropTypes,
   keyboardKey,
   isBrowser,
   makeDebugger,
@@ -36,16 +35,10 @@ class Portal extends Component {
      * - DocumentClick - any click not within the portal
      * - RootNodeClick - a click not within the portal but within the portal's wrapper
      */
-    closeOnRootNodeClick: customPropTypes.every([
-      customPropTypes.disallow(['closeOnDocumentClick']),
-      PropTypes.bool,
-    ]),
+    closeOnRootNodeClick: PropTypes.bool,
 
-    /** Controls whether or not the portal should close on a click outside. */
-    closeOnDocumentClick: customPropTypes.every([
-      customPropTypes.disallow(['closeOnRootNodeClick']),
-      PropTypes.bool,
-    ]),
+    /** Controls whether or not the portal should close when the document is clicked. */
+    closeOnDocumentClick: PropTypes.bool,
 
     /** Controls whether or not the portal should close when escape is pressed is displayed. */
     closeOnEscape: PropTypes.bool,
@@ -178,13 +171,18 @@ class Portal extends Component {
   handleDocumentClick = (e) => {
     const { closeOnDocumentClick, closeOnRootNodeClick } = this.props
 
-    // If not mounted, no portal, or event happened in the portal, ignore it
-    if (!this.node || !this.portal || this.portal.contains(e.target)) return
+    if (
+      !this.rootNode                                      // not mounted
+      || !this.portalNode                                 // no portal
+      || _.invoke(this, 'triggerNode.contains', e.target) // event happened in trigger (delegate to trigger handlers)
+      || _.invoke(this, 'portalNode.contains', e.target)  // event happened in the portal
+    ) return                                              // ignore the click
 
-    if (closeOnDocumentClick || (closeOnRootNodeClick && this.node.contains(e.target))) {
+    const didClickInRootNode = this.rootNode.contains(e.target)
+
+    if (closeOnDocumentClick && !didClickInRootNode || closeOnRootNodeClick && didClickInRootNode) {
       debug('handleDocumentClick()')
 
-      e.stopPropagation()
       this.close(e)
     }
   }
@@ -195,7 +193,6 @@ class Portal extends Component {
 
     debug('handleEscape()')
 
-    e.preventDefault()
     this.close(e)
   }
 
@@ -229,7 +226,10 @@ class Portal extends Component {
     // Call original event handler
     _.invoke(trigger, 'props.onBlur', e)
 
-    if (!closeOnTriggerBlur) return
+    // do not close if focus is given to the portal
+    const didFocusPortal = _.invoke(this, 'rootNode.contains', e.relatedTarget)
+
+    if (!closeOnTriggerBlur || didFocusPortal) return
 
     debug('handleTriggerBlur()')
     this.close(e)
@@ -245,19 +245,12 @@ class Portal extends Component {
     if (open && closeOnTriggerClick) {
       debug('handleTriggerClick() - close')
 
-      e.stopPropagation()
       this.close(e)
     } else if (!open && openOnTriggerClick) {
       debug('handleTriggerClick() - open')
 
-      e.stopPropagation()
       this.open(e)
     }
-
-    // Prevents handleDocumentClick from closing the portal when
-    // openOnTriggerFocus is set. Focus shifts on mousedown so the portal opens
-    // before the click finishes so it may actually wind up on the document.
-    e.nativeEvent.stopImmediatePropagation()
   }
 
   handleTriggerFocus = (e) => {
@@ -314,6 +307,7 @@ class Portal extends Component {
   }
 
   openWithTimeout = (e, delay) => {
+    debug('openWithTimeout()', delay)
     // React wipes the entire event object and suggests using e.persist() if
     // you need the event for async access. However, even with e.persist
     // certain required props (e.g. currentTarget) are null so we're forced to clone.
@@ -331,6 +325,7 @@ class Portal extends Component {
   }
 
   closeWithTimeout = (e, delay) => {
+    debug('closeWithTimeout()', delay)
     // React wipes the entire event object and suggests using e.persist() if
     // you need the event for async access. However, even with e.persist
     // certain required props (e.g. currentTarget) are null so we're forced to clone.
@@ -342,62 +337,65 @@ class Portal extends Component {
     if (!this.state.open) return
     debug('renderPortal()')
 
-    const { children, className, closeOnTriggerBlur } = this.props
+    const { children, className, closeOnTriggerBlur, openOnTriggerFocus } = this.props
 
     this.mountPortal()
 
     // Server side rendering
     if (!isBrowser) return null
 
-    this.node.className = className || ''
+    this.rootNode.className = className || ''
 
     // when re-rendering, first remove listeners before re-adding them to the new node
-    if (this.portal) {
-      this.portal.removeEventListener('mouseleave', this.handlePortalMouseLeave)
-      this.portal.removeEventListener('mouseenter', this.handlePortalMouseEnter)
+    if (this.portalNode) {
+      this.portalNode.removeEventListener('mouseleave', this.handlePortalMouseLeave)
+      this.portalNode.removeEventListener('mouseenter', this.handlePortalMouseEnter)
     }
 
     ReactDOM.unstable_renderSubtreeIntoContainer(
       this,
       Children.only(children),
-      this.node
+      this.rootNode
     )
 
-    this.portal = this.node.firstElementChild
+    this.portalNode = this.rootNode.firstElementChild
 
-    // don't take focus away from portals that close on blur
-    if (!this.didInitialRender && !closeOnTriggerBlur) {
+    // don't take focus away from for focus based portal triggers
+    if (!this.didInitialRender && !(openOnTriggerFocus || closeOnTriggerBlur)) {
       this.didInitialRender = true
 
       // add a tabIndex so we can focus it, remove outline
-      this.portal.tabIndex = -1
-      this.portal.style.outline = 'none'
+      this.portalNode.tabIndex = -1
+      this.portalNode.style.outline = 'none'
 
       // Wait a tick for things like popups which need to calculate where the popup shows up.
       // Otherwise, the element is focused at its initial position, scrolling the browser, then
       // it is immediately repositioned at the proper location.
       setTimeout(() => {
-        if (this.portal) this.portal.focus()
+        if (this.portalNode) this.portalNode.focus()
       })
     }
 
-    this.portal.addEventListener('mouseleave', this.handlePortalMouseLeave)
-    this.portal.addEventListener('mouseenter', this.handlePortalMouseEnter)
+    this.portalNode.addEventListener('mouseleave', this.handlePortalMouseLeave)
+    this.portalNode.addEventListener('mouseenter', this.handlePortalMouseEnter)
   }
 
   mountPortal = () => {
-    if (!isBrowser || this.node) return
+    if (!isBrowser || this.rootNode) return
 
     debug('mountPortal()')
 
-    const { mountNode = (isBrowser ? document.body : null), prepend } = this.props
+    const {
+      mountNode = isBrowser ? document.body : null,
+      prepend,
+    } = this.props
 
-    this.node = document.createElement('div')
+    this.rootNode = document.createElement('div')
 
     if (prepend) {
-      mountNode.insertBefore(this.node, mountNode.firstElementChild)
+      mountNode.insertBefore(this.rootNode, mountNode.firstElementChild)
     } else {
-      mountNode.appendChild(this.node)
+      mountNode.appendChild(this.rootNode)
     }
 
     document.addEventListener('click', this.handleDocumentClick)
@@ -408,19 +406,19 @@ class Portal extends Component {
   }
 
   unmountPortal = () => {
-    if (!isBrowser || !this.node) return
+    if (!isBrowser || !this.rootNode) return
     this.didInitialRender = false
 
     debug('unmountPortal()')
 
-    ReactDOM.unmountComponentAtNode(this.node)
-    this.node.parentNode.removeChild(this.node)
+    ReactDOM.unmountComponentAtNode(this.rootNode)
+    this.rootNode.parentNode.removeChild(this.rootNode)
 
-    this.portal.removeEventListener('mouseleave', this.handlePortalMouseLeave)
-    this.portal.removeEventListener('mouseenter', this.handlePortalMouseEnter)
+    this.portalNode.removeEventListener('mouseleave', this.handlePortalMouseLeave)
+    this.portalNode.removeEventListener('mouseenter', this.handlePortalMouseEnter)
 
-    this.node = null
-    this.portal = null
+    this.rootNode = null
+    this.portalNode = null
 
     document.removeEventListener('click', this.handleDocumentClick)
     document.removeEventListener('keydown', this.handleEscape)
@@ -429,12 +427,17 @@ class Portal extends Component {
     if (onUnmount) onUnmount(null, this.props)
   }
 
+  handleRef = c => {
+    this.triggerNode = ReactDOM.findDOMNode(c)
+  }
+
   render() {
     const { trigger } = this.props
 
     if (!trigger) return null
 
-    return React.cloneElement(trigger, {
+    return cloneElement(trigger, {
+      ref: this.handleRef,
       onBlur: this.handleTriggerBlur,
       onClick: this.handleTriggerClick,
       onFocus: this.handleTriggerFocus,

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -368,7 +368,6 @@ class Portal extends Component {
     // don't take focus away from portals that close on blur
     if (!this.didInitialRender && !closeOnTriggerBlur) {
       this.didInitialRender = true
-      this.previousActiveElement = document.activeElement
 
       // add a tabIndex so we can focus it, remove outline
       this.portal.tabIndex = -1
@@ -416,7 +415,6 @@ class Portal extends Component {
 
     ReactDOM.unmountComponentAtNode(this.node)
     this.node.parentNode.removeChild(this.node)
-    if (this.previousActiveElement) this.previousActiveElement.focus()
 
     this.portal.removeEventListener('mouseleave', this.handlePortalMouseLeave)
     this.portal.removeEventListener('mouseenter', this.handlePortalMouseEnter)

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -208,6 +208,4 @@ export default class Label extends Component {
   }
 }
 
-// Label is not yet defined inside the class
-// Do not use a static property initializer
 Label.create = createShorthandFactory(Label, value => ({ content: value }))

--- a/src/modules/Dimmer/Dimmer.js
+++ b/src/modules/Dimmer/Dimmer.js
@@ -86,6 +86,8 @@ export default class Dimmer extends Component {
     if (onClickOutside) onClickOutside(e, this.props)
   }
 
+  handleCenterRef = c => (this.center = c)
+
   render() {
     const {
       active,
@@ -112,13 +114,18 @@ export default class Dimmer extends Component {
     const ElementType = getElementType(Dimmer, this.props)
 
     const childrenContent = _.isNil(children) ? content : children
-    const childrenJSX = childrenContent && (
-        <div className='content'>
-          <div className='center' ref={center => (this.center = center)}>
-            { childrenContent }
+
+    const dimmerElement = (
+      <ElementType{...rest} className={classes} onClick={this.handleClick}>
+        {childrenContent && (
+          <div className='content'>
+            <div className='center' ref={this.handleCenterRef}>
+              {childrenContent}
+            </div>
           </div>
-        </div>
-      )
+        )}
+      </ElementType>
+    )
 
     if (page) {
       return (
@@ -130,15 +137,13 @@ export default class Dimmer extends Component {
           open={active}
           openOnTriggerClick={false}
         >
-          <ElementType{...rest} className={classes} onClick={this.handleClick}>{childrenJSX}</ElementType>
+          {dimmerElement}
         </Portal>
       )
     }
 
-    return <ElementType{...rest} className={classes} onClick={this.handleClick}>{childrenJSX}</ElementType>
+    return dimmerElement
   }
 }
 
-// Dimmer is not yet defined inside the class
-// Do not use a static property initializer
 Dimmer.create = createShorthandFactory(Dimmer, value => ({ content: value }))

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -54,6 +54,14 @@ class Modal extends Component {
       PropTypes.bool,
     ]),
 
+    /**
+     * Whether or not the Modal should close when the dimmer is clicked.
+     */
+    closeOnDimmerClick: PropTypes.bool,
+
+    /** Whether or not the Modal should close when the document is clicked. */
+    closeOnDocumentClick: PropTypes.bool,
+
     /** A modal can reduce its complexity */
     basic: PropTypes.bool,
 
@@ -66,7 +74,7 @@ class Modal extends Component {
       PropTypes.oneOf(_meta.props.dimmer),
     ]),
 
-    /** The node where the modal should mount.. */
+    /** The node where the modal should mount.  Defaults to document.body. */
     mountNode: PropTypes.any,
 
     /**
@@ -115,8 +123,8 @@ class Modal extends Component {
 
   static defaultProps = {
     dimmer: true,
-    // Do not access document when server side rendering
-    mountNode: isBrowser ? document.body : null,
+    closeOnDimmerClick: true,
+    closeOnDocumentClick: false,
   }
 
   static autoControlledProps = [
@@ -135,6 +143,9 @@ class Modal extends Component {
     debug('componentWillUnmount()')
     this.handlePortalUnmount()
   }
+
+  // Do not access document when server side rendering
+  getMountNode = () => isBrowser ? this.props.mountNode || document.body : null
 
   handleClose = (e) => {
     debug('close()')
@@ -156,7 +167,8 @@ class Modal extends Component {
 
   handlePortalMount = (e) => {
     debug('handlePortalMount()')
-    const { dimmer, mountNode } = this.props
+    const { dimmer } = this.props
+    const mountNode = this.getMountNode()
 
     if (dimmer) {
       debug('adding dimmer')
@@ -180,7 +192,7 @@ class Modal extends Component {
     // Always remove all dimmer classes.
     // If the dimmer value changes while the modal is open, then removing its
     // current value could leave cruft classes previously added.
-    const { mountNode } = this.props
+    const mountNode = this.getMountNode()
     mountNode.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
 
     cancelAnimationFrame(this.animationRequestId)
@@ -191,7 +203,7 @@ class Modal extends Component {
 
   setPosition = () => {
     if (this._modalNode) {
-      const { mountNode } = this.props
+      const mountNode = this.getMountNode()
       const { height } = this._modalNode.getBoundingClientRect()
 
       const marginTop = -Math.round(height / 2)
@@ -221,7 +233,18 @@ class Modal extends Component {
 
   render() {
     const { open } = this.state
-    const { basic, children, className, closeIcon, dimmer, mountNode, size } = this.props
+    const {
+      basic,
+      children,
+      className,
+      closeIcon,
+      closeOnDimmerClick,
+      closeOnDocumentClick,
+      dimmer,
+      size,
+    } = this.props
+
+    const mountNode = this.getMountNode()
 
     // Short circuit when server side rendering
     if (!isBrowser) return null
@@ -252,11 +275,13 @@ class Modal extends Component {
     )
 
     // wrap dimmer modals
-    const dimmerClasses = !dimmer ? null : cx(
-      'ui',
-      dimmer === 'inverted' && 'inverted',
-      'page modals dimmer transition visible active',
-    )
+    const dimmerClasses = !dimmer
+      ? null
+      : cx(
+        'ui',
+        dimmer === 'inverted' && 'inverted',
+        'page modals dimmer transition visible active',
+      )
 
     // Heads up!
     //
@@ -271,8 +296,8 @@ class Modal extends Component {
 
     return (
       <Portal
-        closeOnRootNodeClick
-        closeOnDocumentClick={false}
+        closeOnRootNodeClick={closeOnDimmerClick}
+        closeOnDocumentClick={closeOnDocumentClick}
         {...portalProps}
         className={dimmerClasses}
         mountNode={mountNode}

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -557,19 +557,5 @@ describe('Portal', () => {
         done()
       })
     })
-    it('should restore focus when unmounted', (done) => {
-      const activeElement = document.activeElement
-      attachTo = document.createElement('div')
-      document.body.appendChild(attachTo)
-      const opts = { attachTo }
-      const portal = wrapperMount(<Portal open><p>Hi</p></Portal>, opts)
-      setTimeout(() => {
-        portal.setProps({
-          open: false,
-        })
-        expect(document.activeElement).to.equal(activeElement)
-        done()
-      })
-    })
   })
 })

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import React from 'react'
 import { unmountComponentAtNode } from 'react-dom'
 
@@ -12,8 +11,6 @@ const wrapperMount = (node, opts) => {
   wrapper = mount(node, opts)
   return wrapper
 }
-
-const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }
 
 describe('Portal', () => {
   beforeEach(() => {
@@ -31,56 +28,70 @@ describe('Portal', () => {
     Portal.propTypes.children.should.equal(React.PropTypes.node.isRequired)
   })
 
-  it('Portal.node should be undefined if portal is not open', () => {
-    wrapperMount(<Portal><p>Hi</p></Portal>)
+  it('this.rootNode should be undefined if portal is not open', () => {
+    wrapperMount(<Portal><p /></Portal>)
     const instance = wrapper.instance()
 
-    expect(instance.node).to.equal(undefined)
+    expect(instance.rootNode).to.equal(undefined)
   })
 
-  it('should append portal with children to the document.body', () => {
-    wrapperMount(<Portal open><p>Hi</p></Portal>)
+  it('appends portal with children to the document.body', () => {
+    wrapperMount(<Portal open><p /></Portal>)
     const instance = wrapper.instance()
 
-    instance.node.firstElementChild.tagName.should.equal('P')
-    document.body.lastElementChild.should.equal(instance.node)
+    instance.rootNode.firstElementChild.tagName.should.equal('P')
+    document.body.lastElementChild.should.equal(instance.rootNode)
     document.body.childElementCount.should.equal(1)
   })
 
-  it('when props.open is false and then set to true should open portal', () => {
-    wrapperMount(<Portal open={false}><p>Hi</p></Portal>)
-    const instance = wrapper.instance()
+  it('does not call this.setState() if portal is unmounted', () => {
+    const div = document.createElement('div')
+    const props = { open: true }
+    wrapperMount(<Portal {...props}><p /></Portal>, { attachTo: div })
 
-    document.body.childElementCount.should.equal(0)
-
-    // Enzyme docs say it merges previous props but without children, react complains
-    wrapper.setProps({ open: true, children: <p>Hi</p> })
-    document.body.lastElementChild.should.equal(instance.node)
-    document.body.childElementCount.should.equal(1)
+    const spy = sandbox.spy(wrapper, 'setState')
+    unmountComponentAtNode(div)
+    spy.should.not.have.been.called()
   })
 
-  it('when props.open is true and then set to false should close portal', () => {
-    wrapperMount(<Portal open><p>Hi</p></Portal>)
-    const instance = wrapper.instance()
+  describe('open', () => {
+    it('opens the portal when toggled from false to true', () => {
+      wrapperMount(<Portal open={false}><p /></Portal>)
+      const instance = wrapper.instance()
 
-    document.body.lastElementChild.should.equal(instance.node)
-    document.body.childElementCount.should.equal(1)
+      document.body.childElementCount.should.equal(0)
 
-    wrapper.setProps({ open: false, children: <p>Hi</p> })
-    document.body.childElementCount.should.equal(0)
+      // Enzyme docs say it merges previous props but without children, react complains
+      wrapper.setProps({ open: true, children: <p /> })
+      document.body.lastElementChild.should.equal(instance.rootNode)
+      document.body.childElementCount.should.equal(1)
+    })
+
+    it('closes the portal when toggled from true to false ', () => {
+      wrapperMount(<Portal open><p /></Portal>)
+      const instance = wrapper.instance()
+
+      document.body.lastElementChild.should.equal(instance.rootNode)
+      document.body.childElementCount.should.equal(1)
+
+      wrapper.setProps({ open: false, children: <p /> })
+      document.body.childElementCount.should.equal(0)
+    })
   })
 
-  it('should add className to the portal\'s wrapping node', () => {
-    wrapperMount(<Portal className='some-class' open><p>Hi</p></Portal>)
+  describe('className', () => {
+    it('is added to the portal\'s wrapping node', () => {
+      wrapperMount(<Portal className='some-class' open><p /></Portal>)
 
-    document.body.lastElementChild.className.should.equal('some-class')
-  })
+      document.body.lastElementChild.className.should.equal('some-class')
+    })
 
-  it('should update className on the portal\'s wrapping node when props.className changes', () => {
-    wrapperMount(<Portal className='some-class' open><p>Hi</p></Portal>)
+    it('updates the portal\'s wrapping node className when changed', () => {
+      wrapperMount(<Portal className='some-class' open><p /></Portal>)
 
-    wrapper.setProps({ className: 'some-other-class', children: <p>Hi</p> })
-    document.body.lastElementChild.className.should.equal('some-other-class')
+      wrapper.setProps({ className: 'some-other-class', children: <p /> })
+      document.body.lastElementChild.className.should.equal('some-other-class')
+    })
   })
 
   describe('prepend', () => {
@@ -89,116 +100,108 @@ describe('Portal', () => {
     })
 
     it('appends portal by default', () => {
-      wrapperMount(<Portal open><p>Hi</p></Portal>)
+      wrapperMount(<Portal open><p /></Portal>)
       const instance = wrapper.instance()
 
       document.body.childElementCount.should.equal(2)
-      document.body.lastElementChild.should.equal(instance.node)
+      document.body.lastElementChild.should.equal(instance.rootNode)
     })
 
     it('prepends portal by when passed', () => {
-      wrapperMount(<Portal open prepend><p>Hi</p></Portal>)
+      wrapperMount(<Portal open prepend><p /></Portal>)
       const instance = wrapper.instance()
 
       document.body.childElementCount.should.equal(2)
-      document.body.firstElementChild.should.equal(instance.node)
+      document.body.firstElementChild.should.equal(instance.rootNode)
     })
   })
 
-  describe('callbacks', () => {
-    it('should call props.onMount() when portal opens', () => {
+  describe('onMount', () => {
+    it('called when portal opens', () => {
       const props = { open: false, onMount: sandbox.spy() }
-      wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
+      wrapperMount(<Portal {...props}><p /></Portal>)
 
-      wrapper.setProps({ open: true, children: <p>Hi</p> })
+      wrapper.setProps({ open: true, children: <p /> })
       props.onMount.should.have.been.calledOnce()
     })
 
-    it('should not call props.onMount() when portal receives props', () => {
+    it('is not called when portal receives props', () => {
       const props = { open: false, onMount: sandbox.spy() }
-      wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
+      wrapperMount(<Portal {...props}><p /></Portal>)
 
-      wrapper.setProps({ open: true, children: <p>Hi</p>, className: 'old' })
+      wrapper.setProps({ open: true, children: <p />, className: 'old' })
       props.onMount.should.have.been.calledOnce()
 
-      wrapper.setProps({ open: true, children: <p>Hi</p>, className: 'new' })
+      wrapper.setProps({ open: true, children: <p />, className: 'new' })
       props.onMount.should.have.been.calledOnce()
     })
+  })
 
-    it('should call props.onUnmount() when portal closes', () => {
+  describe('onUnmount', () => {
+    it('is called when portal closes', () => {
       const props = { open: true, onUnmount: sandbox.spy() }
-      wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
+      wrapperMount(<Portal {...props}><p /></Portal>)
 
-      wrapper.setProps({ open: false, children: <p>Hi</p> })
+      wrapper.setProps({ open: false, children: <p /> })
       props.onUnmount.should.have.been.calledOnce()
     })
 
-    it('should not call props.onUnmount() when portal receives props', () => {
+    it('is not called when portal receives props', () => {
       const props = { open: true, onUnmount: sandbox.spy() }
-      wrapperMount(<Portal {...props}><p>Hi</p></Portal>)
+      wrapperMount(<Portal {...props}><p /></Portal>)
 
-      wrapper.setProps({ open: false, children: <p>Hi</p>, className: 'old' })
+      wrapper.setProps({ open: false, children: <p />, className: 'old' })
       props.onUnmount.should.have.been.calledOnce()
 
-      wrapper.setProps({ open: false, children: <p>Hi</p>, className: 'new' })
+      wrapper.setProps({ open: false, children: <p />, className: 'new' })
       props.onUnmount.should.have.been.calledOnce()
     })
 
-    it('should call props.onUnmount() only once when portal closes and then is unmounted', () => {
+    it('is called only once when portal closes and then is unmounted', () => {
       const div = document.createElement('div')
       const props = { open: true, onUnmount: sandbox.spy() }
-      wrapperMount(<Portal {...props}><p>Hi</p></Portal>, { attachTo: div })
+      wrapperMount(<Portal {...props}><p /></Portal>, { attachTo: div })
 
-      wrapper.setProps({ open: false, children: <p>Hi</p> })
+      wrapper.setProps({ open: false, children: <p /> })
       unmountComponentAtNode(div)
       props.onUnmount.should.have.been.calledOnce()
     })
 
-    it('should call props.onUnmount() only once when directly unmounting', () => {
+    it('is called only once when directly unmounting', () => {
       const div = document.createElement('div')
       const props = { open: true, onUnmount: sandbox.spy() }
 
-      wrapperMount(<Portal {...props}><p>Hi</p></Portal>, { attachTo: div })
+      wrapperMount(<Portal {...props}><p /></Portal>, { attachTo: div })
       unmountComponentAtNode(div)
       props.onUnmount.should.have.been.calledOnce()
-    })
-
-    it('should not call this.setState() if portal is unmounted', () => {
-      const div = document.createElement('div')
-      const props = { open: true }
-      wrapperMount(<Portal {...props}><p>Hi</p></Portal>, { attachTo: div })
-
-      const spy = sandbox.spy(wrapper, 'setState')
-      unmountComponentAtNode(div)
-      spy.should.not.have.been.called()
     })
   })
 
   describe('portal ref', () => {
     it('maintains ref to DOM node with host element', () => {
-      wrapperMount(<Portal open><p>Hi</p></Portal>)
-      wrapper.instance().portal.tagName.should.equal('P')
+      wrapperMount(<Portal open><p /></Portal>)
+      wrapper.instance().portalNode.tagName.should.equal('P')
     })
 
     it('maintains ref to DOM node with React component', () => {
-      const Component = (props) => <p>Hi</p>
+      const Component = (props) => <p />
 
       wrapperMount(<Portal open><Component /></Portal>)
-      wrapper.instance().portal.tagName.should.equal('P')
+      wrapper.instance().portalNode.tagName.should.equal('P')
     })
   })
 
   describe('trigger', () => {
-    it('render should return null if no props.trigger', () => {
-      wrapperMount(<Portal><p>Hi</p></Portal>)
+    it('renders null when not set', () => {
+      wrapperMount(<Portal><p /></Portal>)
 
       expect(wrapper.html()).to.equal(null)
     })
 
-    it('should render the props.trigger element', () => {
+    it('renders the trigger when set', () => {
       const text = 'open by click on me'
       const trigger = <button>{text}</button>
-      wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
+      wrapperMount(<Portal trigger={trigger}><p /></Portal>)
 
       wrapper.text().should.equal(text)
     })
@@ -209,192 +212,152 @@ describe('Portal', () => {
       const mountNode = document.createElement('div')
       document.body.appendChild(mountNode)
 
-      wrapperMount(<Portal mountNode={mountNode} open><p>Hi</p></Portal>)
+      wrapperMount(<Portal mountNode={mountNode} open><p /></Portal>)
       const instance = wrapper.instance()
 
-      mountNode.lastElementChild.should.equal(instance.node)
+      mountNode.lastElementChild.should.equal(instance.rootNode)
       mountNode.childElementCount.should.equal(1)
     })
   })
 
   describe('openOnTriggerClick', () => {
-    it('should open portal on click by default', () => {
-      const spy = sandbox.spy()
-      const trigger = <button onClick={spy}>button</button>
-      wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
-
-      wrapper.find('button').simulate('click', nativeEvent)
-      document.body.lastElementChild.should.equal(wrapper.instance().node)
-      spy.should.have.been.calledOnce()
+    it('defaults to true', () => {
+      Portal.defaultProps.openOnTriggerClick.should.equal(true)
     })
 
-    it('should not open portal on click when false', () => {
+    it('does not open the portal on trigger click when false', () => {
       const spy = sandbox.spy()
       const trigger = <button onClick={spy}>button</button>
-      wrapperMount(<Portal trigger={trigger} openOnTriggerClick={false}><p>Hi</p></Portal>)
+      wrapperMount(<Portal trigger={trigger} openOnTriggerClick={false}><p /></Portal>)
 
-      wrapper.find('button').simulate('click', nativeEvent)
+      wrapper.find('button').simulate('click')
       document.body.childElementCount.should.equal(0)
       spy.should.have.been.calledOnce()
     })
 
-    it('should open portal on click when set', () => {
+    it('opens the portal on trigger click when true', () => {
       const spy = sandbox.spy()
       const trigger = <button onClick={spy}>button</button>
-      wrapperMount(<Portal trigger={trigger} openOnTriggerClick><p>Hi</p></Portal>)
+      wrapperMount(<Portal trigger={trigger} openOnTriggerClick><p /></Portal>)
 
-      wrapper.find('button').simulate('click', nativeEvent)
-      document.body.lastElementChild.should.equal(wrapper.instance().node)
+      wrapper.find('button').simulate('click')
+      document.body.lastElementChild.should.equal(wrapper.instance().rootNode)
       spy.should.have.been.calledOnce()
     })
   })
 
   describe('closeOnTriggerClick', () => {
-    it('should not close portal on click', () => {
-      const spy = sandbox.spy()
-      const trigger = <button onClick={spy}>button</button>
-      wrapperMount(<Portal trigger={trigger} defaultOpen><p>Hi</p></Portal>)
+    it('does not close the portal on click', () => {
+      wrapperMount(<Portal trigger={<button />} defaultOpen><p /></Portal>)
 
-      wrapper.find('button').simulate('click', nativeEvent)
-      document.body.lastElementChild.should.equal(wrapper.instance().node)
-      spy.should.have.been.calledOnce()
+      wrapper.find('button').simulate('click')
+      document.body.lastElementChild.should.equal(wrapper.instance().rootNode)
     })
 
-    it('should close portal on click when set', () => {
-      const spy = sandbox.spy()
-      const trigger = <button onClick={spy}>button</button>
-      wrapperMount(<Portal trigger={trigger} defaultOpen closeOnTriggerClick><p>Hi</p></Portal>)
+    it('closes the portal on click when set', () => {
+      wrapperMount(
+        <Portal trigger={<button />} defaultOpen closeOnTriggerClick>
+          <p />
+        </Portal>
+      )
 
-      wrapper.find('button').simulate('click', nativeEvent)
+      wrapper.find('button').simulate('click')
       document.body.childElementCount.should.equal(0)
-      spy.should.have.been.calledOnce()
     })
   })
 
   describe('openOnTriggerMouseEnter', () => {
-    it('should not open portal on mouseenter when not set', (done) => {
-      const spy = sandbox.spy()
-      const trigger = <button onMouseEnter={spy}>button</button>
-      const mouseEnterDelay = 100
-      wrapperMount(<Portal trigger={trigger} mouseEnterDelay={mouseEnterDelay}><p>Hi</p></Portal>)
+    it('does not open the portal on mouseenter when not set', () => {
+      wrapperMount(<Portal trigger={<button />}><p /></Portal>)
 
       wrapper.find('button').simulate('mouseenter')
       document.body.childElementCount.should.equal(0)
-      spy.should.have.been.calledOnce()
-
-      setTimeout(() => {
-        document.body.childElementCount.should.equal(0)
-        spy.should.have.been.calledOnce()
-        done()
-      }, mouseEnterDelay + 1)
     })
 
-    it('should open portal on mouseenter when set', (done) => {
-      const spy = sandbox.spy()
-      const trigger = <button onMouseEnter={spy}>button</button>
-      const mouseEnterDelay = 100
-      wrapperMount(
-        <Portal trigger={trigger} openOnTriggerMouseEnter mouseEnterDelay={mouseEnterDelay}><p>Hi</p></Portal>
-      )
+    it('opens the portal on mouseenter when set', (done) => {
+      wrapperMount(<Portal trigger={<button />} openOnTriggerMouseEnter mouseEnterDelay={0}><p /></Portal>)
 
+      document.body.childElementCount.should.equal(0)
       wrapper.find('button').simulate('mouseenter')
-      setTimeout(() => {
-        document.body.childElementCount.should.equal(0)
-        spy.should.have.been.calledOnce()
-      }, mouseEnterDelay - 1)
 
       setTimeout(() => {
-        document.body.lastElementChild.should.equal(wrapper.instance().node)
-        spy.should.have.been.calledOnce()
+        document.body.childElementCount.should.equal(1)
+        document.body.lastElementChild.should.equal(wrapper.instance().rootNode)
         done()
-      }, mouseEnterDelay + 1)
+      }, 1)
     })
   })
 
   describe('closeOnTriggerMouseLeave', () => {
-    it('should not close portal on mouseleave when not set', (done) => {
-      const spy = sandbox.spy()
-      const trigger = <button onMouseLeave={spy}>button</button>
-      const delay = 100
-      wrapperMount(<Portal trigger={trigger} defaultOpen mouseLeaveDelay={delay}><p>Hi</p></Portal>)
+    it('does not close the portal on mouseleave when not set', (done) => {
+      wrapperMount(<Portal trigger={<button />} defaultOpen mouseLeaveDelay={0}><p /></Portal>)
 
       wrapper.find('button').simulate('mouseleave')
+
       setTimeout(() => {
-        document.body.lastElementChild.should.equal(wrapper.instance().node)
-        spy.should.have.been.calledOnce()
+        document.body.lastElementChild.should.equal(wrapper.instance().rootNode)
         done()
-      }, delay + 1)
+      }, 1)
     })
 
-    it('should close portal on mouseleave when set', (done) => {
-      const spy = sandbox.spy()
-      const trigger = <button onMouseLeave={spy}>button</button>
-      const delay = 100
+    it('closes the portal on mouseleave when set', (done) => {
       wrapperMount(
-        <Portal trigger={trigger} defaultOpen closeOnTriggerMouseLeave mouseLeaveDelay={delay}><p>Hi</p></Portal>
+        <Portal trigger={<button />} defaultOpen closeOnTriggerMouseLeave mouseLeaveDelay={0}>
+          <p />
+        </Portal>
       )
 
+      document.body.lastElementChild.should.equal(wrapper.instance().rootNode)
       wrapper.find('button').simulate('mouseleave')
-      setTimeout(() => {
-        document.body.lastElementChild.should.equal(wrapper.instance().node)
-        spy.should.have.been.calledOnce()
-      }, delay - 1)
 
       setTimeout(() => {
         document.body.childElementCount.should.equal(0)
-        spy.should.have.been.calledOnce()
         done()
-      }, delay + 1)
+      }, 1)
     })
   })
 
   describe('closeOnPortalMouseLeave', () => {
-    it('should not close portal on mouseleave of portal when not set', (done) => {
-      const trigger = <button>button</button>
-      const delay = 100
-      wrapperMount(<Portal trigger={trigger} defaultOpen mouseLeaveDelay={delay}><p>Hi</p></Portal>)
+    it('does not close the portal on mouseleave of portal when not set', (done) => {
+      wrapperMount(<Portal trigger={<button />} defaultOpen mouseLeaveDelay={0}><p /></Portal>)
 
-      domEvent.mouseLeave(wrapper.instance().node.firstElementChild)
+      domEvent.mouseLeave(wrapper.instance().rootNode.firstElementChild)
 
       setTimeout(() => {
-        document.body.lastElementChild.should.equal(wrapper.instance().node)
+        document.body.lastElementChild.should.equal(wrapper.instance().rootNode)
         done()
-      }, delay + 1)
+      }, 1)
     })
 
-    it('should close portal on mouseleave of portal when set', (done) => {
-      const trigger = <button>button</button>
-      const delay = 100
+    it('closes the portal on mouseleave of portal when set', (done) => {
       wrapperMount(
-        <Portal trigger={trigger} defaultOpen closeOnPortalMouseLeave mouseLeaveDelay={delay}><p>Hi</p></Portal>
+        <Portal trigger={<button />} defaultOpen closeOnPortalMouseLeave mouseLeaveDelay={0}>
+          <p />
+        </Portal>
       )
 
-      domEvent.mouseLeave(wrapper.instance().node.firstElementChild)
-
-      setTimeout(() => {
-        document.body.lastElementChild.should.equal(wrapper.instance().node)
-      }, delay - 1)
+      document.body.lastElementChild.should.equal(wrapper.instance().rootNode)
+      domEvent.mouseLeave(wrapper.instance().rootNode.firstElementChild)
 
       setTimeout(() => {
         document.body.childElementCount.should.equal(0)
         done()
-      }, delay + 1)
+      }, 1)
     })
   })
 
   describe('closeOnTriggerMouseLeave + closeOnPortalMouseLeave', () => {
-    it('should close portal on trigger mouseleave even when portal receives mouseenter within limit', (done) => {
-      const trigger = <button>button</button>
-      const delay = 100
+    it('closes the portal on trigger mouseleave even when portal receives mouseenter within limit', (done) => {
+      const delay = 10
       wrapperMount(
-        <Portal trigger={trigger} defaultOpen closeOnTriggerMouseLeave mouseLeaveDelay={delay}><p>Hi</p></Portal>
+        <Portal trigger={<button />} defaultOpen closeOnTriggerMouseLeave mouseLeaveDelay={delay}><p /></Portal>
       )
 
       wrapper.find('button').simulate('mouseleave')
 
       // Fire a mouseEnter on the portal within the time limit
       setTimeout(() => {
-        domEvent.mouseEnter(wrapper.instance().node.firstElementChild)
+        domEvent.mouseEnter(wrapper.instance().rootNode.firstElementChild)
       }, delay - 1)
 
       // The portal should close because closeOnPortalMouseLeave not set
@@ -404,12 +367,17 @@ describe('Portal', () => {
       }, delay + 1)
     })
 
-    it('should not close portal on trigger mouseleave when portal receives mouseenter within limit', (done) => {
-      const trigger = <button>button</button>
-      const delay = 100
+    it('does not close the portal on trigger mouseleave when portal receives mouseenter within limit', (done) => {
+      const delay = 10
       wrapperMount(
-        <Portal trigger={trigger} defaultOpen closeOnTriggerMouseLeave closeOnPortalMouseLeave mouseLeaveDelay={delay}>
-          <p>Hi</p>
+        <Portal
+          trigger={<button />}
+          defaultOpen
+          closeOnTriggerMouseLeave
+          closeOnPortalMouseLeave
+          mouseLeaveDelay={delay}
+        >
+          <p />
         </Portal>
       )
 
@@ -417,145 +385,136 @@ describe('Portal', () => {
 
       // Fire a mouseEnter on the portal within the time limit
       setTimeout(() => {
-        domEvent.mouseEnter(wrapper.instance().node.firstElementChild)
+        domEvent.mouseEnter(wrapper.instance().rootNode.firstElementChild)
       }, delay - 1)
 
       // The portal should not have closed
       setTimeout(() => {
-        document.body.lastElementChild.should.equal(wrapper.instance().node)
+        document.body.lastElementChild.should.equal(wrapper.instance().rootNode)
         done()
       }, delay + 1)
     })
   })
 
   describe('openOnTriggerFocus', () => {
-    it('should not open portal on focus when not set', () => {
-      const spy = sandbox.spy()
-      const trigger = <button onFocus={spy}>button</button>
-      wrapperMount(<Portal trigger={trigger}><p>Hi</p></Portal>)
+    it('does not open the portal on focus when not set', () => {
+      wrapperMount(<Portal trigger={<button />}><p /></Portal>)
+        .find('button')
+        .simulate('focus')
 
-      wrapper.find('button').simulate('focus')
       document.body.childElementCount.should.equal(0)
-      spy.should.have.been.calledOnce()
     })
+    it('opens the portal on focus when set', () => {
+      wrapperMount(<Portal trigger={<button />} openOnTriggerFocus><p /></Portal>)
+        .find('button')
+        .simulate('focus')
 
-    it('should open portal on focus when set', () => {
-      const spy = sandbox.spy()
-      const trigger = <button onFocus={spy}>button</button>
-      wrapperMount(<Portal trigger={trigger} openOnTriggerFocus><p>Hi</p></Portal>)
-
-      wrapper.find('button').simulate('focus')
-      document.body.lastElementChild.should.equal(wrapper.instance().node)
-      spy.should.have.been.calledOnce()
+      document.body.lastElementChild.should.equal(wrapper.instance().rootNode)
     })
   })
 
   describe('closeOnTriggerBlur', () => {
-    it('should not close portal on blur when not set', () => {
-      const spy = sandbox.spy()
-      const trigger = <button onBlur={spy}>button</button>
-      wrapperMount(<Portal trigger={trigger} defaultOpen><p>Hi</p></Portal>)
+    it('does not close the portal on blur when not set', () => {
+      wrapperMount(<Portal trigger={<button />} defaultOpen><p /></Portal>)
+        .find('button')
+        .simulate('blur')
 
-      wrapper.find('button').simulate('blur')
-      document.body.lastElementChild.should.equal(wrapper.instance().node)
-      spy.should.have.been.calledOnce()
+      document.body.lastElementChild.should.equal(wrapper.instance().rootNode)
     })
 
-    it('should close portal on blur when set', () => {
-      const spy = sandbox.spy()
-      const trigger = <button onBlur={spy}>button</button>
-      wrapperMount(<Portal trigger={trigger} defaultOpen closeOnTriggerBlur><p>Hi</p></Portal>)
+    it('closes the portal on blur when set', () => {
+      wrapperMount(<Portal trigger={<button />} defaultOpen closeOnTriggerBlur><p /></Portal>)
+        .find('button')
+        .simulate('blur')
 
-      wrapper.find('button').simulate('blur')
       document.body.childElementCount.should.equal(0)
-      spy.should.have.been.calledOnce()
     })
   })
 
-  describe('close actions', () => {
-    it('closeOnEscape', () => {
-      wrapperMount(<Portal closeOnEscape defaultOpen><p>Hi</p></Portal>)
+  describe('closeOnEscape', () => {
+    it('closes the portal on escape', () => {
+      wrapperMount(<Portal closeOnEscape defaultOpen><p /></Portal>)
       document.body.childElementCount.should.equal(1)
-
       domEvent.keyDown(document, { key: 'Escape' })
       document.body.childElementCount.should.equal(0)
     })
 
-    it('closeOnDocumentClick', () => {
-      wrapperMount(<Portal closeOnDocumentClick defaultOpen><p>Hi</p></Portal>)
+    it('does not close the portal on escape when false', () => {
+      wrapperMount(<Portal closeOnEscape={false} defaultOpen><p /></Portal>)
       document.body.childElementCount.should.equal(1)
+      domEvent.keyDown(document, { key: 'Escape' })
+      document.body.childElementCount.should.equal(1)
+    })
+  })
 
-      // Should not close when click inside
-      domEvent.click(wrapper.instance().node.firstElementChild)
+  describe('closeOnDocumentClick', () => {
+    it('closes the portal on document click', () => {
+      wrapperMount(<Portal closeOnDocumentClick defaultOpen><p /></Portal>)
       document.body.childElementCount.should.equal(1)
 
       domEvent.click(document)
       document.body.childElementCount.should.equal(0)
     })
+    it('does not close on click inside', () => {
+      wrapperMount(<Portal closeOnDocumentClick defaultOpen><p /></Portal>)
 
-    it('closeOnRootNodeClick', () => {
-      wrapperMount(<Portal closeOnDocumentClick={false} closeOnRootNodeClick defaultOpen><p>Hi</p></Portal>)
+      domEvent.click(wrapper.instance().rootNode.firstElementChild)
       document.body.childElementCount.should.equal(1)
-
-      // Should not close when click inside
-      domEvent.click(wrapper.instance().node.firstElementChild)
-      document.body.childElementCount.should.equal(1)
-
-      // Should not close when click on body
-      domEvent.click(document.body)
-      document.body.childElementCount.should.equal(1)
-
-      domEvent.click(wrapper.instance().node.firstElementChild.parentNode)
-      document.body.childElementCount.should.equal(0)
     })
   })
 
   describe('focus', () => {
-    it('should take focus on first render', (done) => {
-      attachTo = document.createElement('div')
-      document.body.appendChild(attachTo)
-      const opts = { attachTo }
-      const portal = wrapperMount(<Portal defaultOpen><p>Hi</p></Portal>, opts)
+    it('takes focus on first render', (done) => {
+      wrapperMount(<Portal defaultOpen><p /></Portal>)
+
       setTimeout(() => {
-        const portalNode = portal.node.node.firstElementChild
-        expect(document.activeElement).to.equal(portalNode)
+        const { portalNode } = wrapper.instance()
+        document.activeElement.should.equal(portalNode)
         expect(portalNode.getAttribute('tabindex')).to.equal('-1')
         expect(portalNode.style.outline).to.equal('none')
         done()
-      })
+      }, 0)
     })
-    it('should not take focus when mounted on portals that closeOnTriggerBlur', (done) => {
-      attachTo = document.createElement('div')
-      document.body.appendChild(attachTo)
-      const opts = { attachTo }
-      const portal = wrapperMount(<Portal defaultOpen closeOnTriggerBlur><p>Hi</p></Portal>, opts)
+
+    it('does not take focus when mounted on portals that closeOnTriggerBlur', (done) => {
+      wrapperMount(<Portal defaultOpen closeOnTriggerBlur><p /></Portal>)
+
       setTimeout(() => {
-        const portalNode = portal.node.node.firstElementChild
-        expect(document.activeElement).to.not.equal(portalNode)
+        const { portalNode } = wrapper.instance()
+        document.activeElement.should.not.equal(portalNode)
         expect(portalNode.getAttribute('tabindex')).to.not.equal('-1')
         expect(portalNode.style.outline).to.not.equal('none')
         done()
-      })
+      }, 0)
     })
-    it('should not take focus on subsequent renders', (done) => {
-      attachTo = document.createElement('div')
-      document.body.appendChild(attachTo)
-      const opts = { attachTo }
-      const portal = wrapperMount(<Portal defaultOpen><input data-focus-me /></Portal>, opts)
+
+    it('does not take focus when mounted on portals that openOnTriggerFocus', (done) => {
+      wrapperMount(<Portal defaultOpen openOnTriggerFocus><p /></Portal>)
 
       setTimeout(() => {
-        const portalNode = portal.node.node.firstElementChild
-        expect(document.activeElement).to.equal(portalNode)
+        const { portalNode } = wrapper.instance()
+        document.activeElement.should.not.equal(portalNode)
+        expect(portalNode.getAttribute('tabindex')).to.not.equal('-1')
+        expect(portalNode.style.outline).to.not.equal('none')
+        done()
+      }, 0)
+    })
+
+    it('does not take focus on subsequent renders', (done) => {
+      wrapperMount(<Portal defaultOpen><input data-focus-me /></Portal>)
+
+      setTimeout(() => {
+        const { portalNode } = wrapper.instance()
+        document.activeElement.should.equal(portalNode)
 
         const input = document.querySelector('input[data-focus-me]')
         input.focus()
-        expect(document.activeElement).to.equal(input)
+        document.activeElement.should.equal(input)
 
-        portal.render()
-        expect(document.activeElement).to.equal(input)
-
+        wrapper.render()
+        document.activeElement.should.equal(input)
         done()
-      })
+      }, 0)
     })
   })
 })

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import React from 'react'
 
 import Modal from 'src/modules/Modal/Modal'
@@ -8,7 +7,6 @@ import ModalActions from 'src/modules/Modal/ModalActions'
 import ModalDescription from 'src/modules/Modal/ModalDescription'
 import Portal from 'src/addons/Portal/Portal'
 
-import { keyboardKey } from 'src/lib'
 import { assertNodeContains, assertBodyContains, domEvent, sandbox } from 'test/utils'
 import * as common from 'test/specs/commonTests'
 
@@ -35,8 +33,6 @@ const assertBodyClasses = (...rest) => {
     didFind.should.equal(hasClasses, message)
   })
 }
-
-const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }
 
 describe('Modal', () => {
   beforeEach(() => {
@@ -241,21 +237,20 @@ describe('Modal', () => {
   })
 
   describe('onOpen', () => {
-    let spy
-
-    beforeEach(() => {
-      spy = sandbox.spy()
-      wrapperMount(<Modal onOpen={spy} trigger={<div id='trigger' />} />)
-    })
-
     it('is called on trigger click', () => {
-      wrapper.find('#trigger').simulate('click', nativeEvent)
+      const spy = sandbox.spy()
+      wrapperMount(<Modal onOpen={spy} trigger={<div id='trigger' />} />)
+
+      wrapper.find('#trigger').simulate('click')
       spy.should.have.been.calledOnce()
     })
 
     it('is not called on body click', () => {
+      const spy = sandbox.spy()
+      wrapperMount(<Modal onOpen={spy} />)
+
       domEvent.click('body')
-      spy.should.not.have.been.calledOnce()
+      spy.should.not.have.been.called()
     })
   })
 
@@ -264,96 +259,115 @@ describe('Modal', () => {
 
     beforeEach(() => {
       spy = sandbox.spy()
-      wrapperMount(<Modal onClose={spy} defaultOpen />)
     })
 
     it('is called on dimmer click', () => {
+      wrapperMount(<Modal onClose={spy} defaultOpen />)
+
       domEvent.click('.ui.dimmer')
       spy.should.have.been.calledOnce()
     })
 
     it('is called on click outside of the modal', () => {
+      wrapperMount(<Modal onClose={spy} defaultOpen />)
+
       domEvent.click(document.querySelector('.ui.modal').parentNode)
       spy.should.have.been.calledOnce()
     })
 
     it('is not called on click inside of the modal', () => {
+      wrapperMount(<Modal onClose={spy} defaultOpen />)
+
       domEvent.click(document.querySelector('.ui.modal'))
-      spy.should.not.have.been.calledOnce()
+      spy.should.not.have.been.called()
     })
 
     it('is not called on body click', () => {
+      wrapperMount(<Modal onClose={spy} defaultOpen />)
+
       domEvent.click('body')
       spy.should.not.have.been.calledOnce()
     })
 
     it('is called when pressing escape', () => {
+      wrapperMount(<Modal onClose={spy} defaultOpen />)
+
       domEvent.keyDown(document, { key: 'Escape' })
       spy.should.have.been.calledOnce()
     })
 
-    it('is not called when pressing a key other than "Escape"', () => {
-      _.each(keyboardKey, (val, key) => {
-        // skip Escape key
-        if (val === keyboardKey.Escape) return
+    it('is not called when the open prop changes to false', () => {
+      wrapperMount(<Modal onClose={spy} defaultOpen />)
 
-        domEvent.keyDown(document, { key })
-        spy.should.not.have.been.called(`onClose was called when pressing "${key}"`)
-      })
+      wrapper.setProps({ open: false })
+      spy.should.not.have.been.called()
     })
 
-    it('is not called when the open prop changes to false', () => {
+    it('is not called when open changes to false programmatically', () => {
+      wrapperMount(<Modal onClose={spy} defaultOpen />)
+
       wrapper.setProps({ open: false })
+      spy.should.not.have.been.called()
+    })
+
+    it('is not called on dimmer click when closeOnDimmerClick is false', () => {
+      wrapperMount(<Modal onClose={spy} defaultOpen closeOnDimmerClick={false} />)
+
+      domEvent.click('.ui.dimmer')
+      spy.should.not.have.been.called()
+    })
+
+    it('is not called on body click when closeOnDocumentClick is false', () => {
+      wrapperMount(<Modal onClose={spy} defaultOpen closeOnDocumentClick={false} />)
+
+      domEvent.click(document.body)
       spy.should.not.have.been.called()
     })
   })
 
-  describe('with configurable close behaviours, onClose', () => {
-    let spy
+  describe('closeOnEscape', () => {
+    it('closes the modal when Escape is pressed by default', () => {
+      wrapperMount(<Modal defaultOpen closeOnEscape />)
 
-    beforeEach(() => {
-      spy = sandbox.spy()
-      wrapperMount(<Modal onClose={spy} open closeOnEscape={false} closeOnRootNodeClick={false} />)
-    })
-
-    it('is not called on dimmer click', () => {
-      domEvent.click('.ui.dimmer')
-      spy.should.not.have.been.calledOnce()
-    })
-
-    it('is not called on click outside of the modal', () => {
-      domEvent.click(document.querySelector('.ui.modal').parentNode)
-      spy.should.not.have.been.calledOnce()
-    })
-
-    it('is not called on click inside of the modal', () => {
-      domEvent.click(document.querySelector('.ui.modal'))
-      spy.should.not.have.been.calledOnce()
-    })
-
-    it('is not called on body click', () => {
-      domEvent.click('body')
-      spy.should.not.have.been.calledOnce()
-    })
-
-    it('is not called when pressing escape', () => {
+      document.body.childElementCount.should.equal(1)
       domEvent.keyDown(document, { key: 'Escape' })
-      spy.should.not.have.been.calledOnce()
+      document.body.childElementCount.should.equal(0)
     })
 
-    it('is not called when pressing a key other than "Escape"', () => {
-      _.each(keyboardKey, (val, key) => {
-        // skip Escape key
-        if (val === keyboardKey.Escape) return
+    it('closes the modal when true and Escape is pressed', () => {
+      wrapperMount(<Modal defaultOpen closeOnEscape />)
 
-        domEvent.keyDown(document, { key })
-        spy.should.not.have.been.called(`onClose was called when pressing "${key}"`)
-      })
+      document.body.childElementCount.should.equal(1)
+      domEvent.keyDown(document, { key: 'Escape' })
+      document.body.childElementCount.should.equal(0)
     })
 
-    it('is not called when the open prop changes to false', () => {
-      wrapper.setProps({ open: false })
-      spy.should.not.have.been.called()
+    it('does not close the modal when false and Escape is pressed', () => {
+      wrapperMount(<Modal defaultOpen closeOnEscape={false} />)
+
+      document.body.childElementCount.should.equal(1)
+      domEvent.keyDown(document, { key: 'Escape' })
+      document.body.childElementCount.should.equal(1)
+    })
+  })
+
+  describe('closeOnDocumentClick', () => {
+    it('is false by default', () => {
+      Modal.defaultProps.closeOnDocumentClick.should.equal(false)
+    })
+    it('closes the modal on document click when true', () => {
+      wrapperMount(<Modal defaultOpen closeOnDocumentClick />)
+
+      document.body.childElementCount.should.equal(1)
+      domEvent.click(document.body)
+      document.body.childElementCount.should.equal(0)
+    })
+    it('does not close the modal on document click when false', () => {
+      wrapperMount(<Modal defaultOpen closeOnDocumentClick={false} />)
+
+      document.body.childElementCount.should.equal(1)
+      domEvent.click(document.body)
+      document.body.childElementCount.should.equal(1)
     })
   })
 

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -6,7 +6,6 @@ import PopupHeader from 'src/modules/Popup/PopupHeader'
 import PopupContent from 'src/modules/Popup/PopupContent'
 import Portal from 'src/addons/Portal/Portal'
 
-import { keyboardKey } from 'src/lib'
 import { domEvent, sandbox } from 'test/utils'
 import * as common from 'test/specs/commonTests'
 
@@ -25,8 +24,6 @@ const assertIn = (node, selector, isPresent = true) => {
   didFind.should.equal(isPresent, `${didFind ? 'Found' : 'Did not find'} "${selector}" in the ${node}.`)
 }
 const assertInBody = (...args) => assertIn(document.body, ...args)
-
-const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }
 
 describe('Popup', () => {
   beforeEach(() => {
@@ -91,7 +88,7 @@ describe('Popup', () => {
         />
       )
 
-      wrapper.find('button').simulate('click', nativeEvent)
+      wrapper.find('button').simulate('click')
       assertInBody('.ui.popup.visible')
     })
     it('accepts an offest to the right', () => {
@@ -104,7 +101,7 @@ describe('Popup', () => {
         />
       )
 
-      wrapper.find('button').simulate('click', nativeEvent)
+      wrapper.find('button').simulate('click')
       assertInBody('.ui.popup.visible')
     })
   })
@@ -120,7 +117,7 @@ describe('Popup', () => {
             on='click'
           />
         )
-        wrapper.find('button').simulate('click', nativeEvent)
+        wrapper.find('button').simulate('click')
         const {
           top,
           right,
@@ -149,7 +146,7 @@ describe('Popup', () => {
       const trigger = <button>foo</button>
       wrapperMount(<Popup hideOnScroll content='foo' trigger={trigger} />)
 
-      wrapper.find('button').simulate('click', nativeEvent)
+      wrapper.find('button').simulate('click')
       assertInBody('.ui.popup.visible')
 
       document.body.scrollTop = 100
@@ -168,7 +165,7 @@ describe('Popup', () => {
       const trigger = <button>foo</button>
       wrapperMount(<Popup on='click' content='foo' header='bar' trigger={trigger} />)
 
-      wrapper.find('button').simulate('click', nativeEvent)
+      wrapper.find('button').simulate('click')
       assertInBody('.ui.popup.visible')
     })
 
@@ -176,7 +173,7 @@ describe('Popup', () => {
       const trigger = <button>foo</button>
       wrapperMount(<Popup content='foo' trigger={trigger} />)
 
-      wrapper.find('button').simulate('mouseenter', nativeEvent)
+      wrapper.find('button').simulate('mouseenter')
       setTimeout(() => {
         assertInBody('.ui.popup.visible')
         done()
@@ -187,7 +184,7 @@ describe('Popup', () => {
       const trigger = <input type='text' />
       wrapperMount(<Popup on='focus' content='foo' trigger={trigger} />)
 
-      wrapper.find('input').simulate('focus', nativeEvent)
+      wrapper.find('input').simulate('focus')
       assertInBody('.ui.popup.visible')
     })
   })
@@ -289,11 +286,6 @@ describe('Popup', () => {
       wrapperMount(<Popup onClose={spy} defaultOpen />)
     })
 
-    it('is called on background click', () => {
-      domEvent.click(document.querySelector('.ui.popup').parentNode)
-      spy.should.have.been.calledOnce()
-    })
-
     it('is not called on click inside of the popup', () => {
       domEvent.click(document.querySelector('.ui.popup'))
       spy.should.not.have.been.calledOnce()
@@ -307,16 +299,6 @@ describe('Popup', () => {
     it('is called when pressing escape', () => {
       domEvent.keyDown(document, { key: 'Escape' })
       spy.should.have.been.calledOnce()
-    })
-
-    it('is not called when pressing a key other than "Escape"', () => {
-      _.each(keyboardKey, (val, key) => {
-        // skip Escape key
-        if (val === keyboardKey.Escape) return
-
-        domEvent.keyDown(document, { key })
-        spy.should.not.have.been.called(`onClose was called when pressing "${key}"`)
-      })
     })
 
     it('is not called when the open prop changes to false', () => {


### PR DESCRIPTION
Fixes #1271 Do not steal focus on portal close
Fixes #1251 Do not stop propagation of events
Fixes #1076 Popups in Modals open in the correct position

This PR also:
- fixes the `mountNode=null` bug in for the Modal
- adds Modal prop `closeOnDimmerClick`
- keeps a Portal open when blurring the trigger and focusing the Portal