### PR TITLE
style(Confirm): refactor, update typings and propTypes usage

### DIFF
--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -1,68 +1,105 @@
 import _ from 'lodash'
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 
-import { getUnhandledProps, META } from '../../lib'
+import {
+  customPropTypes,
+  getUnhandledProps,
+  META,
+} from '../../lib'
 import Button from '../../elements/Button'
 import Modal from '../../modules/Modal'
 
 /**
- * A Confirm modal gives the user a choice to confirm or cancel an action
+ * A Confirm modal gives the user a choice to confirm or cancel an action/
  * @see Modal
  */
-function Confirm(props) {
-  const { open, cancelButton, confirmButton, header, content, onConfirm, onCancel } = props
-  const rest = getUnhandledProps(Confirm, props)
+class Confirm extends Component {
+  static propTypes = {
+    /** The cancel button text. */
+    cancelButton: customPropTypes.itemShorthand,
 
-  // `open` is auto controlled by the Modal
-  // It cannot be present (even undefined) with `defaultOpen`
-  // only apply it if the user provided an open prop
-  const openProp = {}
-  if (_.has(props, 'open')) openProp.open = open
+    /** The OK button text. */
+    confirmButton: customPropTypes.itemShorthand,
 
-  return (
-    <Modal {...openProp} size='small' onClose={onCancel} {...rest}>
-      {header && <Modal.Header>{header}</Modal.Header>}
-      {content && <Modal.Content>{content}</Modal.Content>}
-      <Modal.Actions>
-        <Button onClick={onCancel}>{cancelButton}</Button>
-        <Button primary onClick={onConfirm}>{confirmButton}</Button>
-      </Modal.Actions>
-    </Modal>
-  )
-}
+    /** The ModalContent text. */
+    content: customPropTypes.itemShorthand,
 
-Confirm._meta = {
-  name: 'Confirm',
-  type: META.TYPES.ADDON,
-}
+    /** The ModalHeader text. */
+    header: customPropTypes.itemShorthand,
 
-Confirm.propTypes = {
-  /** Whether or not the modal is visible */
-  open: PropTypes.bool,
+    /**
+     * Called when the Modal is closed without clicking confirm.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onCancel: PropTypes.func,
 
-  /** The cancel button text */
-  cancelButton: PropTypes.string,
+    /**
+     * Called when the OK button is clicked.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onConfirm: PropTypes.func,
 
-  /** The OK button text */
-  confirmButton: PropTypes.string,
+    /** Whether or not the modal is visible. */
+    open: PropTypes.bool,
+  }
 
-  /** The ModalHeader text */
-  header: PropTypes.string,
+  static defaultProps = {
+    cancelButton: 'Cancel',
+    confirmButton: 'OK',
+    content: 'Are you sure?',
+  }
 
-  /** The ModalContent text. */
-  content: PropTypes.string,
+  static _meta = {
+    name: 'Confirm',
+    type: META.TYPES.ADDON,
+  }
 
-  /** Called when the OK button is clicked */
-  onConfirm: PropTypes.func,
+  handleCancel = e => {
+    const { onCancel } = this.props
 
-  /** Called when the Cancel button is clicked */
-  onCancel: PropTypes.func,
-}
+    if (onCancel) onCancel(e, this.props)
+  }
 
-Confirm.defaultProps = {
-  cancelButton: 'Cancel',
-  confirmButton: 'OK',
-  content: 'Are you sure?',
+  handleConfirm = e => {
+    const { onConfirm } = this.props
+
+    if (onConfirm) onConfirm(e, this.props)
+  }
+
+  render() {
+    const {
+      cancelButton,
+      confirmButton,
+      content,
+      header,
+      open,
+    } = this.props
+    const rest = getUnhandledProps(Confirm, this.props)
+
+    // `open` is auto controlled by the Modal
+    // It cannot be present (even undefined) with `defaultOpen`
+    // only apply it if the user provided an open prop
+    const openProp = {}
+    if (_.has(this.props, 'open')) openProp.open = open
+
+    return (
+      <Modal {...rest} {...openProp} size='small' onClose={this.handleCancel}>
+        {Modal.Header.create(header)}
+        {Modal.Content.create(content)}
+        <Modal.Actions>
+          {Button.create(cancelButton, { onClick: this.handleCancel })}
+          {Button.create(confirmButton, {
+            onClick: this.handleConfirm,
+            primary: true,
+          })}
+        </Modal.Actions>
+      </Modal>
+    )
+  }
 }
 
 export default Confirm

--- a/src/addons/Confirm/index.d.ts
+++ b/src/addons/Confirm/index.d.ts
@@ -1,26 +1,35 @@
 import * as React from 'react';
 
 interface ConfirmProps {
+  /** The cancel button text. */
+  cancelButton?: any;
 
-  /** The cancel button text */
-  cancelButton?: string;
-
-  /** The OK button text */
-  confirmButton?: string;
+  /** The OK button text. */
+  confirmButton?: any;
 
   /** The ModalContent text. */
-  content?: string;
+  content?: any;
 
-  /** The ModalHeader text */
-  header?: string;
+  /** The ModalHeader text. */
+  header?: any;
 
-  /** Called when the Cancel button is clicked */
-  onCancel?: () => void;
+  /**
+   * Called when the Modal is closed without clicking confirm.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
+   */
+  onCancel?: (event: React.MouseEvent<HTMLAnchorElement>, data: ConfirmProps) => void;
 
-  /** Called when the OK button is clicked */
-  onConfirm?: () => void;
+  /**
+   * Called when the OK button is clicked.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
+   */
+  onConfirm?: (event: React.MouseEvent<HTMLAnchorElement>, data: ConfirmProps) => void;
 
-  /** Whether or not the modal is visible */
+  /** Whether or not the modal is visible. */
   open?: boolean;
 }
 

--- a/src/modules/Modal/ModalContent.js
+++ b/src/modules/Modal/ModalContent.js
@@ -1,7 +1,9 @@
-import React, { PropTypes } from 'react'
 import cx from 'classnames'
+import _ from 'lodash'
+import React, { PropTypes } from 'react'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -10,7 +12,13 @@ import {
 } from '../../lib'
 
 function ModalContent(props) {
-  const { children, image, className } = props
+  const {
+    children,
+    className,
+    content,
+    image,
+  } = props
+
   const classes = cx(
     className,
     useKeyOnly(image, 'image'),
@@ -19,7 +27,11 @@ function ModalContent(props) {
   const rest = getUnhandledProps(ModalContent, props)
   const ElementType = getElementType(ModalContent, props)
 
-  return <ElementType {...rest} className={classes}>{children}</ElementType>
+  return (
+    <ElementType {...rest} className={classes}>
+      {_.isNil(children) ? content : children}
+    </ElementType>
+  )
 }
 
 ModalContent._meta = {
@@ -38,8 +50,13 @@ ModalContent.propTypes = {
   /** Additional classes. */
   className: PropTypes.string,
 
+  /** Shorthand for primary content. */
+  content: customPropTypes.contentShorthand,
+
   /** A modal can contain image content */
   image: PropTypes.bool,
 }
+
+ModalContent.create = createShorthandFactory(ModalContent, content => ({ content }))
 
 export default ModalContent

--- a/src/modules/Modal/ModalHeader.js
+++ b/src/modules/Modal/ModalHeader.js
@@ -1,7 +1,9 @@
-import React, { PropTypes } from 'react'
 import cx from 'classnames'
+import _ from 'lodash'
+import React, { PropTypes } from 'react'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -9,12 +11,16 @@ import {
 } from '../../lib'
 
 function ModalHeader(props) {
-  const { children, className } = props
+  const { children, className, content } = props
   const classes = cx(className, 'header')
   const rest = getUnhandledProps(ModalHeader, props)
   const ElementType = getElementType(ModalHeader, props)
 
-  return <ElementType {...rest} className={classes}>{children}</ElementType>
+  return (
+    <ElementType {...rest} className={classes}>
+      {_.isNil(children) ? content : children}
+    </ElementType>
+  )
 }
 
 ModalHeader._meta = {
@@ -32,6 +38,11 @@ ModalHeader.propTypes = {
 
   /** Additional classes. */
   className: PropTypes.string,
+
+  /** Shorthand for primary content. */
+  content: customPropTypes.contentShorthand,
 }
+
+ModalHeader.create = createShorthandFactory(ModalHeader, content => ({ content }))
 
 export default ModalHeader

--- a/test/specs/addons/Confirm/Confirm-test.js
+++ b/test/specs/addons/Confirm/Confirm-test.js
@@ -4,7 +4,7 @@ import React from 'react'
 import Confirm from 'src/addons/Confirm/Confirm'
 import Modal from 'src/modules/Modal/Modal'
 import { keyboardKey } from 'src/lib'
-import { sandbox, domEvent, assertBodyContains } from 'test/utils'
+import { assertBodyContains, domEvent, sandbox } from 'test/utils'
 import * as common from 'test/specs/commonTests'
 
 // ----------------------------------------
@@ -28,6 +28,17 @@ describe('Confirm', () => {
   })
 
   common.isConformant(Confirm)
+
+  common.implementsShorthandProp(Confirm, {
+    propKey: 'header',
+    ShorthandComponent: Modal.Header,
+    mapValueToProps: content => ({ content }),
+  })
+  common.implementsShorthandProp(Confirm, {
+    propKey: 'content',
+    ShorthandComponent: Modal.Content,
+    mapValueToProps: content => ({ content }),
+  })
 
   it('renders a small Modal', () => {
     wrapperShallow(<Confirm />)
@@ -65,46 +76,21 @@ describe('Confirm', () => {
     })
   })
 
-  describe('header', () => {
-    it('is not present by default', () => {
-      shallow(<Confirm />)
-        .should.not.have.descendants('ModalHeader')
-    })
-    it('sets the header text', () => {
-      wrapperShallow(<Confirm header='foo' />)
-        .should.have.descendants('ModalHeader')
-      wrapper
-        .find('ModalHeader')
-        .shallow()
-        .should.have.text('foo')
-    })
-  })
-
-  describe('content', () => {
-    it('is "Are you sure?" by default', () => {
-      wrapperShallow(<Confirm />)
-        .should.have.descendants('ModalContent')
-      wrapper
-        .find('ModalContent')
-        .shallow()
-        .should.have.text('Are you sure?')
-    })
-    it('sets the content text', () => {
-      wrapperShallow(<Confirm content='foo' />)
-        .should.have.descendants('ModalContent')
-      wrapper
-        .find('ModalContent')
-        .shallow()
-        .should.have.text('foo')
-    })
-  })
-
   describe('onCancel', () => {
     let spy
 
     beforeEach(() => {
       spy = sandbox.spy()
       wrapperMount(<Confirm onCancel={spy} defaultOpen />)
+    })
+
+    it('omitted when not defined', () => {
+      const click = () => shallow(<Confirm />)
+        .find('Button')
+        .first()
+        .simulate('click')
+
+      expect(click).to.not.throw()
     })
 
     it('is called on Cancel button click', () => {
@@ -166,6 +152,14 @@ describe('Confirm', () => {
   })
 
   describe('onConfirm', () => {
+    it('omitted when not defined', () => {
+      const click = () => shallow(<Confirm />)
+        .find('Button[primary]')
+        .simulate('click')
+
+      expect(click).to.not.throw()
+    })
+
     it('is called on OK button click', () => {
       const spy = sandbox.spy()
       shallow(<Confirm onConfirm={spy} />)
@@ -197,7 +191,6 @@ describe('Confirm', () => {
       assertBodyContains('.ui.modal', false)
 
       wrapper.setProps({ open: true })
-
       assertBodyContains('.ui.modal')
     })
 
@@ -206,7 +199,6 @@ describe('Confirm', () => {
       assertBodyContains('.ui.modal')
 
       wrapper.setProps({ open: false })
-
       assertBodyContains('.ui.modal', false)
     })
   })

--- a/test/specs/addons/TextArea/TextArea-test.js
+++ b/test/specs/addons/TextArea/TextArea-test.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import TextArea from 'src/addons/TextArea/TextArea'
 import { sandbox } from 'test/utils'
-import * as common from '../commonTests'
+import * as common from 'test/specs/commonTests'
 
 // ----------------------------------------
 // Wrapper


### PR DESCRIPTION
This PR is part of work for removing propTypes in production bundle (#524, #731).
Also, cleanups and updates typings for #1072.
Fixes #1290.

---

**Warning**. This PR updates behavior of `onCancel` and `onConfirm`, now it handled inside `Confirm` component.

@levithomason I think we need to mark this change as _breaking_.  Before `data` was `Button`'s props while after this PR it will `Confirm`s props.