### PR TITLE
chore(coverage): remove docs from coverage reports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -18,7 +18,7 @@
   "env": {
     "test": {
       "plugins": [
-        ["__coverage__", { "ignore": "test/" }]
+        ["__coverage__", { "only": "src/" }]
       ]
     }
   }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
 coverage:
   ignore:
-    - src/factories.js
+    - docs/*
     - src/lib/*


### PR DESCRIPTION
It looks very strange to me that we include our docs to coverage reports. This PR fixes it.