### PR TITLE
fix(package): add babel-runtime for commonjs builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "homepage": "https://github.com/Semantic-Org/Semantic-UI-React#readme",
   "dependencies": {
+    "babel-runtime": "^6.22.0",
     "classnames": "^2.1.5",
     "debug": "^2.4.5",
     "lodash": "^4.17.2"


### PR DESCRIPTION
Fixes #1260 

This PR adds `babel-runtime` as a package dep.

I've opted for a regular dependency over a peer dependency here as I don't want users to have to install more modules to get up and running.  Also, our package only requires the necessary modules from runtime, so it is cherry picked, similar to how we handle lodash.