### PR TITLE
fix(Dropdown): Adjusts search input join() to allow for hashed params compatibility

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1060,7 +1060,7 @@ export default class Dropdown extends Component {
         aria-autocomplete='list'
         onChange={this.handleSearchChange}
         className='search'
-        name={[name, 'search'].join('-')}
+        name={['search', name].join('-')}
         autoComplete='off'
         tabIndex={computedTabIndex}
         style={{ width: searchWidth }}

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1530,7 +1530,7 @@ describe('Dropdown Component', () => {
       wrapperShallow(<Dropdown name='foo' options={options} selection search />)
         .should.have.descendants('input.search')
 
-      wrapper.find('input.search').should.have.prop('name', 'foo-search')
+      wrapper.find('input.search').should.have.prop('name', 'search-foo')
     })
 
     it('sets focus to the search input on open', () => {


### PR DESCRIPTION
Dropdowns with search suffixed the name attribute creating an error with frameworks/servers that use hashed params like Ruby on Rails. This moves the suffix to a prefix for compatibility and updates the test to reflect this change.

```html
<!-- before / causes server errors -->
<input type="text" value="" aria-autocomplete="list" class="search" name="profile[city]-search" autocomplete="off" tabindex="0">

<!-- after / fixes errors -->
<input type="text" value="" aria-autocomplete="list" class="search" name="search-profile[city]" autocomplete="off" tabindex="0">
```