### PR TITLE
test(ACC): use deterministic test props

### DIFF
--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -19,9 +19,11 @@ const createTestClass = (options = {}) => class Test extends AutoControlledCompo
 
 const toDefaultName = (prop) => `default${prop.slice(0, 1).toUpperCase() + prop.slice(1)}`
 
-const makeProps = () => _.transform(_.times(_.random(3, 10)), (res) => {
-  res[_.camelCase(faker.hacker.noun())] = faker.hacker.verb()
-}, {})
+const makeProps = () => ({
+  computer: 'hardware',
+  flux: 'capacitor',
+  ion: 'belt',
+})
 
 const makeDefaultProps = (props) => _.transform(props, (res, val, key) => {
   res[toDefaultName(key)] = val


### PR DESCRIPTION
The random prop generator sometimes generated duplicate props.  There are tests that assert certain props were not present.  Since there are sometimes duplicates, the check for not present would fail since only one copy of the prop was removed while its duplicate remained.

This PR replaces `makeProps` with a static props object.