### PR TITLE
Modal, Portal and Popup

### DIFF
--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -57,6 +57,9 @@ class Portal extends Component {
     /** Initial value of open. */
     defaultOpen: PropTypes.bool,
 
+    /** Should portal focus on itself on render. Usefull if portal content sets it's own focus */
+    focusOnRender: PropTypes.bool,
+
     /** The node where the portal should mount. */
     mountNode: PropTypes.any,
 
@@ -121,6 +124,7 @@ class Portal extends Component {
     closeOnDocumentClick: true,
     closeOnEscape: true,
     openOnTriggerClick: true,
+    focusOnRender: true
   }
 
   static autoControlledProps = [
@@ -335,7 +339,7 @@ class Portal extends Component {
     if (!this.state.open) return
     debug('renderPortal()')
 
-    const { children, className, closeOnTriggerBlur, openOnTriggerFocus } = this.props
+    const { children, className, closeOnTriggerBlur, openOnTriggerFocus, focusOnRender } = this.props
 
     this.mountPortal()
 
@@ -369,9 +373,10 @@ class Portal extends Component {
       // Wait a tick for things like popups which need to calculate where the popup shows up.
       // Otherwise, the element is focused at its initial position, scrolling the browser, then
       // it is immediately repositioned at the proper location.
-      setTimeout(() => {
-        if (this.portalNode) this.portalNode.focus()
-      })
+      if(focusOnRender)
+        setTimeout(() => {
+          if (this.portalNode) this.portalNode.focus()
+        })
     }
 
     this.portalNode.addEventListener('mouseleave', this.handlePortalMouseLeave)

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -170,6 +170,8 @@ class Modal extends Component {
     const { dimmer } = this.props
     const mountNode = this.getMountNode()
 
+    this.setState({mountNodeOriginalClassList: mountNode.className})
+
     if (dimmer) {
       debug('adding dimmer')
       mountNode.classList.add('dimmable', 'dimmed')
@@ -193,7 +195,8 @@ class Modal extends Component {
     // If the dimmer value changes while the modal is open, then removing its
     // current value could leave cruft classes previously added.
     const mountNode = this.getMountNode()
-    mountNode.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
+    //mountNode.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
+    mountNode.classname = this.state.mountNodeOriginalClassList
 
     cancelAnimationFrame(this.animationRequestId)
 

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -151,9 +151,13 @@ class Modal extends Component {
     debug('close()')
 
     const { onClose } = this.props
-    if (onClose) onClose(e, this.props)
-
-    this.trySetState({ open: false })
+    if (onClose) {
+      const result = onClose(e, this.props)
+      if (result !== false)
+        this.trySetState({ open: false })
+    }
+    else
+      this.trySetState({ open: false })
   }
 
   handleOpen = (e) => {

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -73,6 +73,9 @@ export default class Popup extends Component {
     /** Hide the Popup when scrolling the window. */
     hideOnScroll: PropTypes.bool,
 
+    /** Should portal focus on itself on render. Usefull if portal content sets it's own focus */
+    focusOnRender: PropTypes.bool,
+
     /** Horizontal offset in pixels to be applied to the Popup. */
     offset: PropTypes.number,
 
@@ -242,7 +245,7 @@ export default class Popup extends Component {
   getPortalProps() {
     const portalProps = {}
 
-    const { on, hoverable } = this.props
+    const { on, hoverable, focusOnRender } = this.props
 
     if (hoverable) {
       portalProps.closeOnPortalMouseLeave = true
@@ -263,6 +266,8 @@ export default class Popup extends Component {
       portalProps.mouseLeaveDelay = 70
       portalProps.mouseEnterDelay = 50
     }
+
+    portalProps.focusOnRender = focusOnRender
 
     return portalProps
   }


### PR DESCRIPTION
1) This addresses the problem of portal stealing the focus
https://github.com/Semantic-Org/Semantic-UI-React/issues/1324
**Popup**: added prop focusOnRender (bool)
**Portal**: added prop focusOnRender (bool, default true)


2) This addresses the issue, which allows user to close modal (by clicking outside or hitting esc) and we should be able to check if closing the modal is possible (for example changes inside the modal haven't been saved)
**Modal**: onClose callback allows to cancel closing modal if false is returned


3) This solves the problem of opening a modal with a scroller inside a modal with a scroller. When the upper modal is closed it reverts the original modal's scroller function back (otherwise lower modal loses a scrollbar)
**Modal**: mountNode original classnames are saved in modal state and reverted when modal is unmounted

Please let me know if this goes inline with the concept of SUI-React, than I could polish this changes or something..

Thanks, with respect, Dan