### PR TITLE
isEmpty for image module instead of isNil

### DIFF
--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -72,7 +72,7 @@ function Image(props) {
     if (!_.isNil(dimmer) || !_.isNil(label) || !_.isNil(wrapped) || !_.isNil(children)) return 'div'
   })
 
-  if (!_.isNil(children)) {
+  if (!_.isEmpty(children)) {
     return <ElementType {...rest} className={classes}>{children}</ElementType>
   }
 


### PR DESCRIPTION
it should skip creating img tag even if children are null or empty array. isNil returns false for empty array.