### PR TITLE
Fix Popup's PropTypes to use array.

### DIFF
--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -117,10 +117,10 @@ export default class Popup extends Component {
     trigger: PropTypes.node,
 
     /** Popup width. */
-    wide: PropTypes.oneOfType(
+    wide: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.oneOf(['very']),
-    ),
+    ]),
   }
 
   static defaultProps = {


### PR DESCRIPTION
The invalid definition is showing the warning `Warning: Invalid argument supplied to oneOfType, expected an instance of array.` on developer console.
