### PR TITLE
breaking(Progress): control progress solely with progress

### DIFF
--- a/docs/app/Examples/modules/Progress/Variations/ProgressExampleInverted.js
+++ b/docs/app/Examples/modules/Progress/Variations/ProgressExampleInverted.js
@@ -3,16 +3,16 @@ import { Progress, Segment } from 'semantic-ui-react'
 
 const ProgressExampleInverted = () => (
   <Segment inverted>
-    <Progress percent={21} inverted label>
+    <Progress percent={21} inverted progress>
       Uploading Files
     </Progress>
-    <Progress percent={100} inverted label success>
+    <Progress percent={100} inverted progress success>
       success
     </Progress>
-    <Progress percent={100} inverted label warning>
+    <Progress percent={100} inverted progress warning>
       warning
     </Progress>
-    <Progress percent={100} inverted label error>
+    <Progress percent={100} inverted progress error>
       error
     </Progress>
   </Segment>

--- a/docs/app/Examples/modules/Progress/Variations/ProgressExampleInvertedColor.js
+++ b/docs/app/Examples/modules/Progress/Variations/ProgressExampleInvertedColor.js
@@ -3,19 +3,19 @@ import { Progress, Segment } from 'semantic-ui-react'
 
 const ProgressExampleInvertedColor = () => (
   <Segment inverted>
-    <Progress percent={32} inverted color='red' label />
-    <Progress percent={59} inverted color='orange' label />
-    <Progress percent={13} inverted color='yellow' label />
-    <Progress percent={37} inverted color='olive' label />
-    <Progress percent={83} inverted color='green' label />
-    <Progress percent={23} inverted color='teal' label />
-    <Progress percent={85} inverted color='blue' label />
-    <Progress percent={38} inverted color='violet' label />
-    <Progress percent={47} inverted color='purple' label />
-    <Progress percent={29} inverted color='pink' label />
-    <Progress percent={68} inverted color='brown' label />
-    <Progress percent={36} inverted color='grey' label />
-    <Progress percent={72} inverted color='black' label />
+    <Progress percent={32} inverted color='red' progress />
+    <Progress percent={59} inverted color='orange' progress />
+    <Progress percent={13} inverted color='yellow' progress />
+    <Progress percent={37} inverted color='olive' progress />
+    <Progress percent={83} inverted color='green' progress />
+    <Progress percent={23} inverted color='teal' progress />
+    <Progress percent={85} inverted color='blue' progress />
+    <Progress percent={38} inverted color='violet' progress />
+    <Progress percent={47} inverted color='purple' progress />
+    <Progress percent={29} inverted color='pink' progress />
+    <Progress percent={68} inverted color='brown' progress />
+    <Progress percent={36} inverted color='grey' progress />
+    <Progress percent={72} inverted color='black' progress />
   </Segment>
 )
 

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -142,7 +142,7 @@ class Progress extends Component {
   }
 
   renderProgress = percent => {
-    const { 
+    const {
       precision,
       progress,
       total,

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -69,7 +69,7 @@ class Progress extends Component {
     /** A progress bar can contain a text value indicating current progress. */
     progress: PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.oneOf(['ratio', 'percent']),
+      PropTypes.oneOf(['percent', 'ratio']),
     ]),
 
     /** A progress bar can vary in size. */
@@ -134,26 +134,26 @@ class Progress extends Component {
     return autoSuccess && (percent >= 100 || value >= total)
   }
 
-  renderProgress = (percent) => {
-    const { precision, progress, value, total } = this.props
+  renderLabel = () => {
+    const { children, label } = this.props
+
+    if (!_.isNil(children)) return <div className='label'>{children}</div>
+    return createShorthand('div', val => ({ children: val }), label, { className: 'label' })
+  }
+
+  renderProgress = percent => {
+    const { 
+      precision,
+      progress,
+      total,
+      value,
+    } = this.props
 
     if (!progress && _.isUndefined(precision)) return
     return (
       <div className='progress'>
         { progress !== 'ratio' ? `${percent}%` : `${value}/${total}` }
       </div>
-    )
-  }
-
-  renderLabel = () => {
-    const { children, label } = this.props
-
-    if (!_.isNil(children)) return <div className='label'>{children}</div>
-    return createShorthand(
-      'div',
-      val => ({ children: val }),
-      label,
-      { className: 'label' }
     )
   }
 
@@ -189,7 +189,6 @@ class Progress extends Component {
     )
     const rest = getUnhandledProps(Progress, this.props)
     const ElementType = getElementType(Progress, this.props)
-
     const percent = this.getPercent()
 
     return (

--- a/src/modules/Progress/index.d.ts
+++ b/src/modules/Progress/index.d.ts
@@ -38,7 +38,7 @@ interface ProgressProps {
   inverted?: string;
 
   /** Can be set to either to display progress as percent or ratio. */
-  label?: boolean | 'ratio' | 'percent';
+  label?: any;
 
   /** Current percent complete. */
   percent?: number | string;
@@ -47,7 +47,7 @@ interface ProgressProps {
   precision?: number;
 
   /** A progress bar can contain a text value indicating current progress. */
-  progress?: boolean;
+  progress?: boolean | 'percent' | 'ratio';
 
   /** A progress bar can vary in size. */
   size?: 'tiny' | 'small' | 'medium' | 'large' | 'big';

--- a/test/specs/modules/Progress/Progress-test.js
+++ b/test/specs/modules/Progress/Progress-test.js
@@ -96,22 +96,11 @@ describe('Progress', () => {
   })
 
   describe('label', () => {
-    it('displays the progress as a percentage by default', () => {
-      shallow(<Progress percent={20} label />)
-        .should.have.descendants('.progress')
-        .and.contain.text('20%')
-    })
-    it('displays the progress as a ratio when set to "ratio"', () => {
-      shallow(<Progress label='ratio' value={1} total={2} />)
+    it('shows the label text when provided', () => {
+      shallow(<Progress label='some-label' />)
         .children()
-        .find('.progress')
-        .should.contain.text('1/2')
-    })
-    it('displays the progress as a percentage when set to "percent"', () => {
-      shallow(<Progress label='percent' value={1} total={2} />)
-        .children()
-        .find('.progress')
-        .should.contain.text('50%')
+        .find('.label')
+        .should.contain.text('some-label')
     })
   })
 
@@ -130,6 +119,23 @@ describe('Progress', () => {
       shallow(<Progress progress={false} />)
         .find('.bar')
         .should.not.have.descendants('.progress')
+    })
+    it('displays the progress as a percentage by default', () => {
+      shallow(<Progress percent={20} progress />)
+        .should.have.descendants('.progress')
+        .and.contain.text('20%')
+    })
+    it('displays the progress as a ratio when set to "ratio"', () => {
+      shallow(<Progress progress='ratio' value={1} total={2} />)
+        .children()
+        .find('.progress')
+        .should.contain.text('1/2')
+    })
+    it('displays the progress as a percentage when set to "percent"', () => {
+      shallow(<Progress progress='percent' value={1} total={2} />)
+        .children()
+        .find('.progress')
+        .should.contain.text('50%')
     })
     it('shows the percent complete', () => {
       shallow(<Progress percent={72} progress />)
@@ -191,7 +197,7 @@ describe('Progress', () => {
 
   describe('total/value', () => {
     it('calculates the percent complete', () => {
-      shallow(<Progress value={1} total={2} />)
+      shallow(<Progress value={1} total={2} progress />)
         .children()
         .find('.progress')
         .should.contain.text('50%')


### PR DESCRIPTION
## Breaking Changes!
The `label` prop no longer accepts `ratio|percent` as a means to control the progress readout on the bar. It now refers to the text label applied to the element. The `children` prop takes precedence however.
The `progress` prop now handles this by either accepting a `boolean` which defaults to `percent` or a string with either `ratio` or `percent`. 

### Before 
```jsx
<Progress total={2} value={1} label='ratio' />
<Progress total={2} value={1} label='percent' />
```

### After
```jsx
<Progress total={2} value={1} progress='ratio' />
<Progress total={2} value={1} progress='percent' />
<Progress total={2} value={2} label='Dragon ISS Berthing' />
```

### Unchanged
```jsx
<Progress total={2} value={2}>Dragon ISS Berthing</Progress>
```

Fixes #1352 