### PR TITLE
fix(Card): add link prop to typings

### DIFF
--- a/src/views/Card/index.d.ts
+++ b/src/views/Card/index.d.ts
@@ -37,6 +37,9 @@ interface CardProps {
   /** A card can contain an Image component. */
   image?: any;
 
+  /** A card can be formatted to link to other content. */
+  link?: boolean;
+
   /** Shorthand for CardMeta. */
   meta?: any;
 


### PR DESCRIPTION
We've merged #1359, but forgot to add prop to typings.