### PR TITLE
docs(Dropdown): fix examples and update messages

### DIFF
--- a/docs/app/Components/ComponentDoc/ContributionPrompt.js
+++ b/docs/app/Components/ComponentDoc/ContributionPrompt.js
@@ -5,16 +5,17 @@ import { Message, Icon } from 'src'
 
 const ContributionPrompt = ({ children }) => (
   <Message info icon>
-    <Icon name='search' />
+    <Icon name='bullhorn' />
     <Message.Content>
-      {children}<br />
-
-      If there's no{' '}
-      <a href={`${repoURL}/pulls` }>pull request</a>{' '}
-      open for this, you should{' '}
-      <a href={`${repoURL}/blob/master/.github/CONTRIBUTING.md` }>
-        contribute
-      </a>!
+      <p>{children}</p>
+      <p>
+        If there's no{' '}
+        <a href={`${repoURL}/pulls` }>pull request</a>{' '}
+        open for this, you should{' '}
+        <a href={`${repoURL}/blob/master/.github/CONTRIBUTING.md` }>
+          contribute
+        </a>!
+      </p>
     </Message.Content>
   </Message>
 )

--- a/docs/app/Examples/modules/Dropdown/Content/DropdownExampleDivider.js
+++ b/docs/app/Examples/modules/Dropdown/Content/DropdownExampleDivider.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Dropdown } from 'semantic-ui-react'
 
 const DropdownExampleDivider = () => (
-  <Dropdown text='Filter' floating labeled button className='icon'>
-    {/* <i class="filter icon"></i> */}
+  <Dropdown text='Filter' icon='filter' floating labeled button className='icon'>
     <Dropdown.Menu>
       <Dropdown.Header icon='tags' content='Filter by tag' />
       <Dropdown.Divider />

--- a/docs/app/Examples/modules/Dropdown/Content/DropdownExampleFloatedContent.js
+++ b/docs/app/Examples/modules/Dropdown/Content/DropdownExampleFloatedContent.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Dropdown, Icon } from 'semantic-ui-react'
 
 const DropdownExampleFloatedContent = () => (
-  <Dropdown text='Filter' floating labeled button className='icon'>
-    {/* <i class="filter icon"></i> */}
+  <Dropdown text='Filter' icon='filter' floating labeled button className='icon'>
     <Dropdown.Menu>
       <Dropdown.Header icon='tags' content='Filter by tag' />
       <Dropdown.Divider />

--- a/docs/app/Examples/modules/Dropdown/Content/DropdownExampleHeader.js
+++ b/docs/app/Examples/modules/Dropdown/Content/DropdownExampleHeader.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Dropdown } from 'semantic-ui-react'
 
 const DropdownExampleHeader = () => (
-  <Dropdown text='Filter' floating labeled button className='icon'>
-    {/* <i class="filter icon"></i> */}
+  <Dropdown text='Filter' icon='filter' floating labeled button className='icon'>
     <Dropdown.Menu>
       <Dropdown.Header icon='tags' content='Filter by tag' />
       <Dropdown.Item>Important</Dropdown.Item>

--- a/docs/app/Examples/modules/Dropdown/Content/DropdownExampleIcon.js
+++ b/docs/app/Examples/modules/Dropdown/Content/DropdownExampleIcon.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Dropdown } from 'semantic-ui-react'
 
 const DropdownExampleIcon = () => (
-  <Dropdown text='Filter' floating labeled button className='icon'>
-    {/* <i class="filter icon"></i> */}
+  <Dropdown text='Filter' icon='filter' floating labeled button className='icon'>
     <Dropdown.Menu>
       <Dropdown.Header icon='tags' content='Filter by tag' />
       <Dropdown.Divider />

--- a/docs/app/Examples/modules/Dropdown/Content/DropdownExampleImage.js
+++ b/docs/app/Examples/modules/Dropdown/Content/DropdownExampleImage.js
@@ -4,8 +4,7 @@ import { Dropdown } from 'semantic-ui-react'
 import { friendOptions } from '../common'
 
 const DropdownExampleImage = () => (
-  <Dropdown text='Add user' floating labeled button className='icon'>
-    {/* <i class="add user icon"></i> */}
+  <Dropdown text='Add user' icon='add user' floating labeled button className='icon'>
     <Dropdown.Menu>
       <Dropdown.Header content='People You Might Know' />
       {friendOptions.map((option) => <Dropdown.Item key={option.value} {...option} />)}

--- a/docs/app/Examples/modules/Dropdown/Content/DropdownExampleInput.js
+++ b/docs/app/Examples/modules/Dropdown/Content/DropdownExampleInput.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Dropdown, Input } from 'semantic-ui-react'
 
 const DropdownExampleInput = () => (
-  <Dropdown text='Filter' floating labeled button className='icon'>
-    {/* <i class="filter icon"></i> */}
+  <Dropdown text='Filter' icon='filter' floating labeled button className='icon'>
     <Dropdown.Menu>
       <Dropdown.Header content='Search Issues' />
       <Input icon='search' iconPosition='left' name='search' />

--- a/docs/app/Examples/modules/Dropdown/Content/DropdownExampleLabel.js
+++ b/docs/app/Examples/modules/Dropdown/Content/DropdownExampleLabel.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Dropdown } from 'semantic-ui-react'
 
 const DropdownExampleLabel = () => (
-  <Dropdown text='Filter' floating labeled button className='icon'>
-    {/* <i class="filter icon"></i> */}
+  <Dropdown text='Filter' icon='filter' floating labeled button className='icon'>
     <Dropdown.Menu>
       <Dropdown.Header icon='tags' content='Filter by tag' />
       <Dropdown.Divider />

--- a/docs/app/Examples/modules/Dropdown/Content/DropdownExampleMessage.js
+++ b/docs/app/Examples/modules/Dropdown/Content/DropdownExampleMessage.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Dropdown, Message } from 'semantic-ui-react'
 
 const DropdownExampleMessage = () => (
-  <Dropdown text='Login' floating labeled button className='icon'>
-    {/* <i class="filter icon"></i> */}
+  <Dropdown text='Login' icon='filter' floating labeled button className='icon'>
     <Dropdown.Menu>
       <Message error header='Error' content='You must log-in to see all categories' />
     </Dropdown.Menu>

--- a/docs/app/Examples/modules/Dropdown/Content/index.js
+++ b/docs/app/Examples/modules/Dropdown/Content/index.js
@@ -9,52 +9,92 @@ const DropdownContentExamples = () => (
       title='Header'
       description='A dropdown menu can contain a header.'
       examplePath='modules/Dropdown/Content/DropdownExampleHeader'
-    />
+    >
+      <ContributionPrompt>
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
+      </ContributionPrompt>
+    </ComponentExample>
     <ComponentExample
       title='Divider'
       description='A dropdown menu can contain dividers to separate related content.'
       examplePath='modules/Dropdown/Content/DropdownExampleDivider'
-    />
+    >
+      <ContributionPrompt>
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
+      </ContributionPrompt>
+    </ComponentExample>
     <ComponentExample
       title='Icon'
       description='A dropdown menu can contain an icon.'
       examplePath='modules/Dropdown/Content/DropdownExampleIcon'
-    />
+    >
+      <ContributionPrompt>
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
+      </ContributionPrompt>
+    </ComponentExample>
     <ComponentExample
       title='Description'
       description='A dropdown menu can contain a description.'
       examplePath='modules/Dropdown/Content/DropdownExampleDescription'
-    />
+    >
+      <ContributionPrompt>
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
+      </ContributionPrompt>
+    </ComponentExample>
     <ComponentExample
       title='Label'
       description='A dropdown menu can contain a label.'
       examplePath='modules/Dropdown/Content/DropdownExampleLabel'
-    />
+    >
+      <ContributionPrompt>
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
+      </ContributionPrompt>
+    </ComponentExample>
     <ComponentExample
       title='Message'
       description='A dropdown menu can contain a message.'
       examplePath='modules/Dropdown/Content/DropdownExampleMessage'
-    />
+    >
+      <ContributionPrompt>
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
+      </ContributionPrompt>
+    </ComponentExample>
     <ComponentExample
       title='Floated Content'
       description='A dropdown menu can contain floated content.'
       examplePath='modules/Dropdown/Content/DropdownExampleFloatedContent'
-    />
+    >
+      <ContributionPrompt>
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
+      </ContributionPrompt>
+    </ComponentExample>
     <ComponentExample
       title='Input'
       description='A dropdown menu can contain an input.'
       examplePath='modules/Dropdown/Content/DropdownExampleInput'
     >
       <ContributionPrompt>
-        The example below shows the desired markup but is not functional.
-        Needs to be defined via shorthand, which is not yet possible.
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
       </ContributionPrompt>
     </ComponentExample>
     <ComponentExample
       title='Image'
       description='A dropdown menu can contain an image.'
       examplePath='modules/Dropdown/Content/DropdownExampleImage'
-    />
+    >
+      <ContributionPrompt>
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
+      </ContributionPrompt>
+    </ComponentExample>
   </ExampleSection>
 )
 

--- a/docs/app/Examples/modules/Dropdown/States/DropdownExampleActive.js
+++ b/docs/app/Examples/modules/Dropdown/States/DropdownExampleActive.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import { Dropdown } from 'semantic-ui-react'
 
+const options = [
+  { key: 1, text: 'Choice 1', value: 1 },
+  { key: 2, text: 'Choice 2', value: 2 },
+]
+
 const DropdownExampleActive = () => (
-  <Dropdown text='Dropdown' open>
-    <Dropdown.Menu>
-      <Dropdown.Item>Choice 1</Dropdown.Item>
-      <Dropdown.Item>Choice 2</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+  <Dropdown text='Dropdown' options={options} open />
 )
 
 export default DropdownExampleActive

--- a/docs/app/Examples/modules/Dropdown/States/DropdownExampleDisabled.js
+++ b/docs/app/Examples/modules/Dropdown/States/DropdownExampleDisabled.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import { Dropdown } from 'semantic-ui-react'
 
+const options = [
+  { key: 1, text: 'Choice 1', value: 1 },
+  { key: 2, text: 'Choice 2', value: 2 },
+]
+
 const DropdownExampleDisabled = () => (
-  <Dropdown text='Dropdown' disabled>
-    <Dropdown.Menu>
-      <Dropdown.Item>Choice 1</Dropdown.Item>
-      <Dropdown.Item>Choice 2</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+  <Dropdown text='Dropdown' options={options} disabled />
 )
 
 export default DropdownExampleDisabled

--- a/docs/app/Examples/modules/Dropdown/States/DropdownExampleDisabledItem.js
+++ b/docs/app/Examples/modules/Dropdown/States/DropdownExampleDisabledItem.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import { Dropdown } from 'semantic-ui-react'
 
-const DropdownExampleActive = () => (
-  <Dropdown text='Dropdown'>
-    <Dropdown.Menu>
-      <Dropdown.Item>Choice 1</Dropdown.Item>
-      <Dropdown.Item disabled>Choice 2</Dropdown.Item>
-      <Dropdown.Item>Choice 3</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+const options = [
+  { key: 1, text: 'Choice 1', value: 1 },
+  { key: 2, text: 'Choice 2', value: 2, disabled: true },
+  { key: 3, text: 'Choice 3', value: 3 },
+]
+
+const DropdownExampleDisabledItem = () => (
+  <Dropdown text='Dropdown' options={options} open />
 )
 
-export default DropdownExampleActive
+export default DropdownExampleDisabledItem

--- a/docs/app/Examples/modules/Dropdown/States/DropdownExampleError.js
+++ b/docs/app/Examples/modules/Dropdown/States/DropdownExampleError.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import { Dropdown } from 'semantic-ui-react'
 
+const options = [
+  { key: 1, text: 'Choice 1', value: 1 },
+  { key: 2, text: 'Choice 2', value: 2 },
+]
+
 const DropdownExampleError = () => (
-  <Dropdown text='Dropdown' error>
-    <Dropdown.Menu>
-      <Dropdown.Item>Choice 1</Dropdown.Item>
-      <Dropdown.Item>Choice 2</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+  <Dropdown text='Dropdown' options={options} error />
 )
 
 export default DropdownExampleError

--- a/docs/app/Examples/modules/Dropdown/States/DropdownExampleLoading.js
+++ b/docs/app/Examples/modules/Dropdown/States/DropdownExampleLoading.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import { Dropdown } from 'semantic-ui-react'
 
+const options = [
+  { key: 1, text: 'Choice 1', value: 1 },
+  { key: 2, text: 'Choice 2', value: 2 },
+]
+
 const DropdownExampleLoading = () => (
-  <Dropdown text='Dropdown' loading>
-    <Dropdown.Menu>
-      <Dropdown.Item>Choice 1</Dropdown.Item>
-      <Dropdown.Item>Choice 2</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+  <Dropdown text='Dropdown' options={options} loading />
 )
 
 export default DropdownExampleLoading

--- a/docs/app/Examples/modules/Dropdown/Types/DropdownExampleDropdown.js
+++ b/docs/app/Examples/modules/Dropdown/Types/DropdownExampleDropdown.js
@@ -17,8 +17,7 @@ const DropdownExampleDropdown = () => (
       <Dropdown.Divider />
       <Dropdown.Item text='Download As...' />
       <Dropdown.Item text='Publish To Web' />
-      {/* item text can also be defined as children */}
-      <Dropdown.Item>E-mail Collaborators</Dropdown.Item>
+      <Dropdown.Item text='E-mail Collaborators' />
     </Dropdown.Menu>
   </Dropdown>
 )

--- a/docs/app/Examples/modules/Dropdown/Types/DropdownExampleFloating.js
+++ b/docs/app/Examples/modules/Dropdown/Types/DropdownExampleFloating.js
@@ -1,16 +1,16 @@
 import React from 'react'
 import { Button, Dropdown } from 'semantic-ui-react'
 
+const options = [
+  { key: 'edit', icon: 'edit', text: 'Edit Post', value: 'edit' },
+  { key: 'delete', icon: 'delete', text: 'Remove Post', value: 'delete' },
+  { key: 'hide', icon: 'hide', text: 'Hide Post', value: 'hide' },
+]
+
 const DropdownExampleFloating = () => (
   <Button.Group color='teal'>
     <Button>Save</Button>
-    <Dropdown floating button className='icon'>
-      <Dropdown.Menu>
-        <Dropdown.Item icon='edit' text='Edit Post' />
-        <Dropdown.Item icon='delete' text='Remove Post' />
-        <Dropdown.Item icon='hide' text='Hide Post' />
-      </Dropdown.Menu>
-    </Dropdown>
+    <Dropdown options={options} floating button className='icon' />
   </Button.Group>
 )
 

--- a/docs/app/Examples/modules/Dropdown/Types/DropdownExampleMultipleSearchInMenu.js
+++ b/docs/app/Examples/modules/Dropdown/Types/DropdownExampleMultipleSearchInMenu.js
@@ -13,8 +13,7 @@ import { tagOptions } from '../common'
 
 
 const DropdownExampleMultipleSearchInMenu = () => (
-  <Dropdown text='Filter Posts' multiple>
-    {/* <i class="filter icon"></i> */}
+  <Dropdown text='Filter Posts' multiple icon='filter'>
     <Dropdown.Menu>
       <Input icon='search' iconPosition='left' className='search' />
       <Dropdown.Divider />

--- a/docs/app/Examples/modules/Dropdown/Types/DropdownExamplePointing.js
+++ b/docs/app/Examples/modules/Dropdown/Types/DropdownExamplePointing.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Dropdown, Menu } from 'semantic-ui-react'
+import { Dropdown, Icon, Menu } from 'semantic-ui-react'
 
 const DropdownExamplePointing = () => (
   <Menu>
@@ -10,7 +10,7 @@ const DropdownExamplePointing = () => (
       <Dropdown.Menu>
         <Dropdown.Header>Categories</Dropdown.Header>
         <Dropdown.Item>
-          <i className='dropdown icon'></i>
+          <Icon name='dropdown' />
           <span className='text'>Clothing</span>
           <Dropdown.Menu>
             <Dropdown.Header>Mens</Dropdown.Header>

--- a/docs/app/Examples/modules/Dropdown/Types/DropdownExampleSearchInMenu.js
+++ b/docs/app/Examples/modules/Dropdown/Types/DropdownExampleSearchInMenu.js
@@ -12,8 +12,7 @@ import { tagOptions } from '../common'
 // ]
 
 const DropdownExampleSearchInMenu = () => (
-  <Dropdown text='Filter Posts' floating labeled button className='icon'>
-    {/* <i class="filter icon"></i> */}
+  <Dropdown text='Filter Posts' icon='filter' floating labeled button className='icon'>
     <Dropdown.Menu>
       <Input icon='search' iconPosition='left' className='search' />
       <Dropdown.Divider />

--- a/docs/app/Examples/modules/Dropdown/Types/DropdownExampleSimple.js
+++ b/docs/app/Examples/modules/Dropdown/Types/DropdownExampleSimple.js
@@ -1,15 +1,15 @@
 import React from 'react'
 import { Dropdown, Menu } from 'semantic-ui-react'
 
+const options = [
+  { key: 1, text: 'Choice 1', value: 1 },
+  { key: 2, text: 'Choice 2', value: 2 },
+  { key: 3, text: 'Choice 3', value: 3 },
+]
+
 const DropdownExampleSimple = () => (
   <Menu compact>
-    <Dropdown simple text='Dropdown' className='item'>
-      <Dropdown.Menu>
-        <Dropdown.Item>Choice 1</Dropdown.Item>
-        <Dropdown.Item>Choice 2</Dropdown.Item>
-        <Dropdown.Item>Choice 3</Dropdown.Item>
-      </Dropdown.Menu>
-    </Dropdown>
+    <Dropdown text='Dropdown' options={options} simple item />
   </Menu>
 )
 

--- a/docs/app/Examples/modules/Dropdown/Types/index.js
+++ b/docs/app/Examples/modules/Dropdown/Types/index.js
@@ -9,7 +9,12 @@ const DropdownTypesExamples = () => (
       title='Dropdown'
       description='A dropdown.'
       examplePath='modules/Dropdown/Types/DropdownExampleDropdown'
-    />
+    >
+      <ContributionPrompt>
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
+      </ContributionPrompt>
+    </ComponentExample>
     <ComponentExample
       title='Selection'
       description='A dropdown can be used to select between choices in a form.'
@@ -49,8 +54,8 @@ const DropdownTypesExamples = () => (
       examplePath='modules/Dropdown/Types/DropdownExampleSearchInMenu'
     >
       <ContributionPrompt>
-        The example below shows the desired markup but is not functional.
-        Needs to be defined via shorthand, which is not yet possible.
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
       </ContributionPrompt>
     </ComponentExample>
     <ComponentExample
@@ -58,8 +63,8 @@ const DropdownTypesExamples = () => (
       examplePath='modules/Dropdown/Types/DropdownExampleMultipleSearchInMenu'
     >
       <ContributionPrompt>
-        The example below shows the desired markup but is not functional.
-        Needs to be defined via shorthand, which is not yet possible.
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
       </ContributionPrompt>
     </ComponentExample>
     <ComponentExample

--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleTrigger.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleTrigger.js
@@ -3,28 +3,27 @@ import { Dropdown, Icon } from 'semantic-ui-react'
 
 const trigger = (
   <span>
-    <Icon name='user' />
-    Hello, Bob
+    <Icon name='user' /> Hello, Bob
   </span>
 )
 
+const options = [
+  {
+    key: 'user',
+    text: <span>Signed in as <strong>Bob Smith</strong></span>,
+    disabled: true,
+  },
+  { key: 'profile', text: 'Your Profile' },
+  { key: 'stars', text: 'Your Stars' },
+  { key: 'explore', text: 'Explore' },
+  { key: 'integrations', text: 'Integrations' },
+  { key: 'help', text: 'Help' },
+  { key: 'settings', text: 'Settings' },
+  { key: 'sign-out', text: 'Sign Out' },
+]
+
 const DropdownTriggerExample = () => (
-  <Dropdown trigger={trigger}>
-    <Dropdown.Menu>
-      <Dropdown.Item disabled>
-        Signed in as <strong>Bob Smith</strong>
-      </Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item>Your Profile</Dropdown.Item>
-      <Dropdown.Item>Your Stars</Dropdown.Item>
-      <Dropdown.Item>Explore</Dropdown.Item>
-      <Dropdown.Item>Integrations</Dropdown.Item>
-      <Dropdown.Item>Help</Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item>Settings</Dropdown.Item>
-      <Dropdown.Item>Sign Out</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+  <Dropdown trigger={trigger} options={options} />
 )
 
 export default DropdownTriggerExample

--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleTriggerImage.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleTriggerImage.js
@@ -4,19 +4,18 @@ import { Dropdown, Image } from 'semantic-ui-react'
 
 const trigger = (
   <span>
-    <Image avatar src={faker.internet.avatar()} />
-    {faker.name.findName()}
+    <Image avatar src={faker.internet.avatar()} /> {faker.name.findName()}
   </span>
 )
 
+const options = [
+  { key: 'user', text: 'Account', icon: 'user' },
+  { key: 'settings', text: 'Settings', icon: 'settings' },
+  { key: 'sign-out', text: 'Sign Out', icon: 'sign out' },
+]
+
 const DropdownImageTriggerExample = () => (
-  <Dropdown trigger={trigger} pointing='top left' icon={null}>
-    <Dropdown.Menu>
-      <Dropdown.Item text='Account' icon='user' />
-      <Dropdown.Item text='Settings' icon='settings' />
-      <Dropdown.Item text='Sign Out' icon='sign out' />
-    </Dropdown.Menu>
-  </Dropdown>
+  <Dropdown trigger={trigger} options={options} pointing='top left' icon={null} />
 )
 
 export default DropdownImageTriggerExample

--- a/docs/app/Examples/modules/Dropdown/Variations/DropdownExampleMenuDirection.js
+++ b/docs/app/Examples/modules/Dropdown/Variations/DropdownExampleMenuDirection.js
@@ -1,27 +1,26 @@
 import React from 'react'
-import { Dropdown } from 'semantic-ui-react'
+import { Dropdown, Icon } from 'semantic-ui-react'
 
 const DropdownExampleMenuDirection = () => (
   <Dropdown text='Menu' floating labeled button className='icon'>
-    {/* <i class="dropdown icon"></i> */}
     <Dropdown.Menu>
       <Dropdown.Item>
-        <i className='left dropdown icon'></i>
+        <Icon name='left dropdown' />
         <span className='text'>Left</span>
-        <div className='left menu'>
+        <Dropdown.Menu className='left'>
           <Dropdown.Item>1</Dropdown.Item>
           <Dropdown.Item>2</Dropdown.Item>
           <Dropdown.Item>3</Dropdown.Item>
-        </div>
+        </Dropdown.Menu>
       </Dropdown.Item>
       <Dropdown.Item>
-        <i className='dropdown icon'></i>
+        <Icon name='dropdown' />
         <span className='text'>Right</span>
-        <div className='right menu'>
+        <Dropdown.Menu className='right'>
           <Dropdown.Item>1</Dropdown.Item>
           <Dropdown.Item>2</Dropdown.Item>
           <Dropdown.Item>3</Dropdown.Item>
-        </div>
+        </Dropdown.Menu>
       </Dropdown.Item>
     </Dropdown.Menu>
   </Dropdown>

--- a/docs/app/Examples/modules/Dropdown/Variations/DropdownExampleMenuDirectionLeft.js
+++ b/docs/app/Examples/modules/Dropdown/Variations/DropdownExampleMenuDirectionLeft.js
@@ -1,35 +1,34 @@
 import React from 'react'
-import { Dropdown } from 'semantic-ui-react'
+import { Dropdown, Icon } from 'semantic-ui-react'
 
 const DropdownExampleMenuDirectionLeft = () => (
   <Dropdown text='Menu' floating labeled button className='icon'>
-    {/* <i class="dropdown icon"></i> */}
     <Dropdown.Menu className='left'>
       <Dropdown.Item>
-        <i className='dropdown icon'></i>
+        <Icon name='dropdown' />
         <span className='text'>Left</span>
-        <div className='menu'>
+        <Dropdown.Menu>
           <Dropdown.Item>
-            <i className='dropdown icon'></i>
+            <Icon name='dropdown' />
             <span className='text'>Still Left</span>
-            <div className='menu'>
+            <Dropdown.Menu>
               <Dropdown.Item>1</Dropdown.Item>
               <Dropdown.Item>2</Dropdown.Item>
               <Dropdown.Item>3</Dropdown.Item>
-            </div>
+            </Dropdown.Menu>
           </Dropdown.Item>
           <Dropdown.Item>2</Dropdown.Item>
           <Dropdown.Item>3</Dropdown.Item>
-        </div>
+        </Dropdown.Menu>
       </Dropdown.Item>
       <Dropdown.Item>
-        <i className='left dropdown icon'></i>
+        <Icon name='left dropdown' />
         <span className='text'>Left</span>
-        <div className='menu'>
+        <Dropdown.Menu>
           <Dropdown.Item>1</Dropdown.Item>
           <Dropdown.Item>2</Dropdown.Item>
           <Dropdown.Item>3</Dropdown.Item>
-        </div>
+        </Dropdown.Menu>
       </Dropdown.Item>
     </Dropdown.Menu>
   </Dropdown>

--- a/docs/app/Examples/modules/Dropdown/Variations/DropdownExampleSearchInMenuScrolling.js
+++ b/docs/app/Examples/modules/Dropdown/Variations/DropdownExampleSearchInMenuScrolling.js
@@ -4,8 +4,7 @@ import { Dropdown, Input } from 'semantic-ui-react'
 import { tagOptions } from '../common'
 
 const DropdownExampleSearchInMenuScrolling = () => (
-  <Dropdown text='Filter Posts'>
-    {/* <i class="filter icon"></i> */}
+  <Dropdown text='Filter Posts' icon='filter'>
     <Dropdown.Menu>
       <Input icon='search' iconPosition='left' className='search' />
       <Dropdown.Divider />

--- a/docs/app/Examples/modules/Dropdown/Variations/index.js
+++ b/docs/app/Examples/modules/Dropdown/Variations/index.js
@@ -15,8 +15,8 @@ const DropdownVariationsExamples = () => (
       examplePath='modules/Dropdown/Variations/DropdownExampleSearchInMenuScrolling'
     >
       <ContributionPrompt>
-        The example below shows the desired markup but is not functional.
-        Needs to be defined via shorthand, which is not yet possible.
+        Dropdown state is not fully managed when using the subcomponent API.
+        The shorthand props API fully manages state but needs to be extended to support the markup shown here.
       </ContributionPrompt>
     </ComponentExample>
     <ComponentExample

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -104,7 +104,7 @@ Icon.propTypes = {
   loading: PropTypes.bool,
 
   /** Name of the icon. */
-  name: customPropTypes.suggest(SUI.ICONS_AND_ALIASES),
+  name: customPropTypes.suggest(SUI.ALL_ICONS_IN_ALL_CONTEXTS),
 
   /** Icon can rotated. */
   rotated: PropTypes.oneOf(['clockwise', 'counterclockwise']),

--- a/src/lib/SUI.js
+++ b/src/lib/SUI.js
@@ -223,3 +223,15 @@ export const ICONS_AND_ALIASES = [
   ...ICONS,
   ...ICON_ALIASES,
 ]
+
+// Some icon names are not part of icons.css.
+// These are only valid as children of other components.
+// Their CSS rules are defined by a specific component's CSS.
+// We don't want to show name warnings for those usages so we add them as valid names here.
+export const COMPONENT_CONTEXT_SPECIFIC_ICONS = [
+  'left dropdown',      // nested dropdown menu direction icon
+]
+export const ALL_ICONS_IN_ALL_CONTEXTS = [
+  ...ICONS_AND_ALIASES,
+  ...COMPONENT_CONTEXT_SPECIFIC_ICONS,
+]


### PR DESCRIPTION
Fixes #1378.  The confusion in that issue has come up several times.  In response, this PR:

1. Updates old subcomponent API examples to use the shorthand props API where possible.
1. Updates the subcomponent API info message and adds it to all applicable examples.
1. Adds support for component context specific icon names, such as `left dropdown`.

### Background
The Dropdown does not manage its own state when using the subcomponent API.  Only the shorthand props API has access to the children (via a config object passed through props) to properly add event listeners and manage state.

Many of the doc site examples show the subcomponent API usage.  Some are required to do this as we do not yet support the shorthand to create the variation displayed.  Other examples use the subcomponent API simply because they are old.  In both cases, very few subcomponent API examples give the proper information regarding this.