### PR TITLE
docs(Progress): fix label/progress prop docs

### DIFF
--- a/docs/app/Examples/modules/Progress/Content/ProgressExampleLabelPercent.js
+++ b/docs/app/Examples/modules/Progress/Content/ProgressExampleLabelPercent.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Progress } from 'semantic-ui-react'
 
-const ProgressExampleLabelPercent = () => (
-  <Progress value='4' total='5' label='percent' />
+const ProgressExampleProgressPercent = () => (
+  <Progress value='4' total='5' progress='percent' />
 )
 
-export default ProgressExampleLabelPercent
+export default ProgressExampleProgressPercent

--- a/docs/app/Examples/modules/Progress/Content/ProgressExampleLabelProp.js
+++ b/docs/app/Examples/modules/Progress/Content/ProgressExampleLabelProp.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Progress } from 'semantic-ui-react'
+
+const ProgressExampleLabelProp = () => (
+  <Progress percent={55} label='Label' />
+)
+
+export default ProgressExampleLabelProp

--- a/docs/app/Examples/modules/Progress/Content/ProgressExampleLabelRatio.js
+++ b/docs/app/Examples/modules/Progress/Content/ProgressExampleLabelRatio.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Progress } from 'semantic-ui-react'
 
-const ProgressExampleLabelRatio = () => (
-  <Progress value='3' total='5' label='ratio' />
+const ProgressExampleProgressRatio = () => (
+  <Progress value='3' total='5' progress='ratio' />
 )
 
-export default ProgressExampleLabelRatio
+export default ProgressExampleProgressRatio

--- a/docs/app/Examples/modules/Progress/Content/index.js
+++ b/docs/app/Examples/modules/Progress/Content/index.js
@@ -20,12 +20,16 @@ const ProgressContentExamples = () => (
       examplePath='modules/Progress/Content/ProgressExampleLabel'
     />
     <ComponentExample
-      description='A progress element can contain a percent label.'
-      examplePath='modules/Progress/Content/ProgressExampleLabelPercent'
+      description='A progress label can also be defined via props.'
+      examplePath='modules/Progress/Content/ProgressExampleLabelProp'
     />
     <ComponentExample
-      description='A progress element can contain a ratio label.'
-      examplePath='modules/Progress/Content/ProgressExampleLabelRatio'
+      description='A progress element display progress as a percent.'
+      examplePath='modules/Progress/Content/ProgressExampleProgressPercent'
+    />
+    <ComponentExample
+      description='A progress element display progress as a ratio.'
+      examplePath='modules/Progress/Content/ProgressExampleProgressRatio'
     />
   </ExampleSection>
 )


### PR DESCRIPTION
#1355 was merged however some docs were not fully updated.  This PR updates the examples and adds a `label` prop example.