### PR TITLE
feat(Table) add missing Table alignment props

### DIFF
--- a/docs/app/Examples/collections/Table/Variations/index.js
+++ b/docs/app/Examples/collections/Table/Variations/index.js
@@ -62,13 +62,13 @@ const Variations = () => {
 
       <ComponentExample
         title='Vertical Alignment'
-        description='A table header, row or cell can adjust its vertical alignment.'
+        description='A table, header, row or cell can adjust its vertical alignment.'
         examplePath='collections/Table/Variations/TableExampleVerticalAlign'
       />
 
       <ComponentExample
         title='Text Alignment'
-        description='A table header, row, or cell can adjust its text alignment.'
+        description='A table, header, row, or cell can adjust its text alignment.'
         examplePath='collections/Table/Variations/TableExampleTextAlign'
       />
 

--- a/src/collections/Table/Table.d.ts
+++ b/src/collections/Table/Table.d.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {
   SemanticCOLORS,
   SemanticVERTICALALIGNMENTS,
-  SemanticWIDTHS,
+  SemanticWIDTHS
 } from '../..';
 import { default as TableBody } from './TableBody';
 import { default as TableCell } from './TableCell';

--- a/src/collections/Table/Table.d.ts
+++ b/src/collections/Table/Table.d.ts
@@ -2,7 +2,8 @@ import * as React from 'react';
 
 import {
   SemanticCOLORS,
-  SemanticWIDTHS
+  SemanticVERTICALALIGNMENTS,
+  SemanticWIDTHS,
 } from '../..';
 import { default as TableBody } from './TableBody';
 import { default as TableCell } from './TableCell';
@@ -94,8 +95,14 @@ interface TableProps {
   /** Data to be passed to the renderBodyRow function. */
   tableData?: Array<any>;
 
+  /** A table can adjust its text alignment. */
+  textAlign?: 'center' | 'left' | 'right';
+
   /** A table can specify how it stacks table content responsively. */
   unstackable?: boolean;
+
+  /** A table can adjust its text alignment. */
+  verticalAlign?: SemanticVERTICALALIGNMENTS;
 }
 
 interface TableComponent extends React.StatelessComponent<TableProps> {

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -52,7 +52,7 @@ function Table(props) {
     tableData,
     textAlign,
     unstackable,
-    verticalAlign
+    verticalAlign,
   } = props
 
   const classes = cx(
@@ -216,7 +216,7 @@ Table.propTypes = {
   unstackable: PropTypes.bool,
 
   /** A table can adjust its text alignment. */
-  verticalAlign: PropTypes.oneOf(SUI.VERTICAL_ALIGNMENTS)
+  verticalAlign: PropTypes.oneOf(SUI.VERTICAL_ALIGNMENTS),
 }
 
 Table.Body = TableBody

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -10,6 +10,8 @@ import {
   SUI,
   useKeyOnly,
   useKeyOrValueAndKey,
+  useTextAlignProp,
+  useVerticalAlignProp,
   useWidthProp,
 } from '../../lib'
 import TableBody from './TableBody'
@@ -48,7 +50,9 @@ function Table(props) {
     striped,
     structured,
     tableData,
+    textAlign,
     unstackable,
+    verticalAlign
   } = props
 
   const classes = cx(
@@ -71,6 +75,8 @@ function Table(props) {
     useKeyOrValueAndKey(basic, 'basic'),
     useKeyOrValueAndKey(compact, 'compact'),
     useKeyOrValueAndKey(padded, 'padded'),
+    useTextAlignProp(textAlign),
+    useVerticalAlignProp(verticalAlign),
     useWidthProp(columns, 'column'),
     'table',
     className,
@@ -203,8 +209,14 @@ Table.propTypes = {
     PropTypes.array,
   ]),
 
+  /** A table can adjust its text alignment. */
+  textAlign: PropTypes.oneOf(_.without(SUI.TEXT_ALIGNMENTS, 'justified')),
+
   /** A table can specify how it stacks table content responsively. */
   unstackable: PropTypes.bool,
+
+  /** A table can adjust its text alignment. */
+  verticalAlign: PropTypes.oneOf(SUI.VERTICAL_ALIGNMENTS)
 }
 
 Table.Body = TableBody

--- a/test/specs/collections/Table/Table-test.js
+++ b/test/specs/collections/Table/Table-test.js
@@ -23,6 +23,9 @@ describe('Table', () => {
     widthClass: 'column',
   })
 
+  common.implementsTextAlignProp(Table, ['left', 'center', 'right'])
+  common.implementsVerticalAlignProp(Table)
+
   common.propKeyOnlyToClassName(Table, 'celled')
   common.propKeyOnlyToClassName(Table, 'collapsing')
   common.propKeyOnlyToClassName(Table, 'definition')


### PR DESCRIPTION
Add `textAlign` and `verticalAlign` props to the Table component.

Fixes #1389 