### PR TITLE
chore(package): update babel-plugin-transform-react-handled-props

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "babel-plugin-__coverage__": "^11.0.0",
     "babel-plugin-lodash": "^3.2.10",
     "babel-plugin-react-transform": "^2.0.2",
-    "babel-plugin-transform-react-handled-props": "^0.2.2",
+    "babel-plugin-transform-react-handled-props": "^0.2.3",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.10",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.18.0",


### PR DESCRIPTION
I've updated plugin (fix and test case) for #1169. Now, it ignores object's spread.

See [PR](https://github.com/layershifter/babel-plugin-transform-react-handled-props/pull/7) and [this comment ](https://github.com/Semantic-Org/Semantic-UI-React/issues/1169#issuecomment-283164599)for details.