### PR TITLE
docs(examples): direct links, maximize, better props

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentProps.js
+++ b/docs/app/Components/ComponentDoc/ComponentProps.js
@@ -1,12 +1,28 @@
 import _ from 'lodash'
 import React, { Component, PropTypes } from 'react'
 
-import { Icon, Popup, Table } from 'src'
+import { Header, Icon, Popup, Table } from 'src'
 import { SUI } from 'src/lib'
 
-const descriptionExtraStyle = {
-  fontSize: '0.95em',
-  color: '#777',
+const extraDescriptionStyle = {
+  color: '#666',
+}
+const extraDescriptionContentStyle = {
+  marginLeft: '0.5em',
+}
+
+const Extra = ({ title, children, inline, ...rest }) => (
+  <div {...rest} style={extraDescriptionStyle}>
+    <strong>{title}</strong>
+    <div style={{ ...extraDescriptionContentStyle, display: inline ? 'inline' : 'block' }}>
+      {children}
+    </div>
+  </div>
+)
+Extra.propTypes = {
+  children: PropTypes.node,
+  inline: PropTypes.bool,
+  title: PropTypes.node,
 }
 
 const getTagType = tag => tag.type.type === 'AllLiteral' ? 'any' : tag.type.name
@@ -71,24 +87,28 @@ export default class ComponentProps extends Component {
 
     const paramSignature = params
       .map(param => `${param.name}: ${getTagType(param)}`)
+      // prevent object properties from showing as individual params
+      .filter(p => !p.includes('.'))
       .join(', ')
 
-    const tagDescriptions = _.compact([...params, returns]).map(tag => (
-      <div style={{ color: '#888' }} key={tag.name}>
-        <strong>{tag.name || tag.title}</strong> - {tag.description}
-      </div>
-    ))
-
-    const signature = (
-      <pre><code>{item.name}({paramSignature}){returns ? `: ${getTagType(returns)}` : ''}</code></pre>
-    )
+    const tagDescriptionRows = _.compact([...params, returns]).map(tag => {
+      const name = tag.name || tag.title
+      return (
+        <div key={name} style={{ display: 'flex', flexDirection: 'row' }}>
+          <div style={{ flex: '2 2 0', padding: '0.1em 0' }}>
+            <code>{name}</code>
+          </div>
+          <div style={{ flex: '5 5 0', padding: '0.1em 0' }}>
+            {tag.description}
+          </div>
+        </div>
+      )
+    })
 
     return (
-      <div>
-        <strong>Signature:</strong>
-        {signature}
-        {tagDescriptions}
-      </div>
+      <Extra title={<pre>{item.name}({paramSignature}){returns ? `: ${getTagType(returns)}` : ''}</pre>}>
+        {tagDescriptionRows}
+      </Extra>
     )
   }
 
@@ -104,7 +124,7 @@ export default class ComponentProps extends Component {
     if (item.type !== '{enum}') return
 
     const { showEnumsFor } = this.state
-    const truncateAt = 30
+    const truncateAt = 10
 
     if (!item.value) return null
 
@@ -112,37 +132,37 @@ export default class ComponentProps extends Component {
       return accumulator.concat(this.expandEnums(_.trim(v.value || v, '.\'')))
     }, [])
 
+    const valueElements = _.map(values, val => <span key={val}><code>{val}</code> </span>)
+
     // show all if there are few
     if (values.length < truncateAt) {
       return (
-        <p style={descriptionExtraStyle}>
-          <strong>Enums: </strong> {values.join(', ')}
-        </p>
+        <Extra title='Enums:' inline>
+          {valueElements}
+        </Extra>
       )
     }
 
     // add button to show more when there are many values and it is not toggled
     if (!showEnumsFor[item.name]) {
       return (
-        <p style={descriptionExtraStyle}>
-          <strong>Enums: </strong>
+        <Extra title='Enums:' inline>
           <a style={{ cursor: 'pointer' }} onClick={this.toggleEnumsFor(item.name)}>
             Show all {values.length}
           </a>
-          <div>{values.slice(0, truncateAt - 1).join(', ')}...</div>
-        </p>
+          <div>{valueElements.slice(0, truncateAt - 1)}...</div>
+        </Extra>
       )
     }
 
     // add "show more" button when there are many
     return (
-      <p style={descriptionExtraStyle}>
-        <strong>Enums: </strong>
+      <Extra title='Enums:' inline>
         <a style={{ cursor: 'pointer' }} onClick={this.toggleEnumsFor(item.name)}>
           Show less
         </a>
-        <div>{values.join(', ')}</div>
-      </p>
+        <div>{valueElements}</div>
+      </Extra>
     )
   }
 
@@ -153,9 +173,7 @@ export default class ComponentProps extends Component {
         <Table.Cell>{this.renderDefaultValue(item)}</Table.Cell>
         <Table.Cell>{item.type}</Table.Cell>
         <Table.Cell>
-          {item.description && (
-            <p>{item.description}</p>
-          )}
+          {item.description && <p>{item.description}</p>}
           {this.renderFunctionSignature(item)}
           {this.renderEnums(item)}
         </Table.Cell>
@@ -188,7 +206,7 @@ export default class ComponentProps extends Component {
     }), 'name')
 
     return (
-      <Table compact basic='very'>
+      <Table compact='very' basic='very'>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>Name</Table.HeaderCell>

--- a/docs/app/Components/ExternalExampleLayout.js
+++ b/docs/app/Components/ExternalExampleLayout.js
@@ -1,0 +1,33 @@
+import 'semantic-ui-css/semantic.css'
+import _ from 'lodash/fp'
+import React, { Component, PropTypes } from 'react'
+
+// import ComponentExample from '../Components/ComponentDoc/ComponentExample'
+import PageNotFound from '../Views/PageNotFound'
+import { exampleContext } from 'docs/app/utils'
+
+const exampleKeys = exampleContext.keys()
+
+export default class ExternalExampleLayout extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    history: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        kebabCaseName: PropTypes.string.isRequired,
+      }),
+    }).isRequired,
+  }
+
+  render() {
+    const { kebabCaseName } = this.props.match.params
+    const componentName = _.startCase(kebabCaseName).replace(/ /g, '')
+    const componentKey = _.find(_.endsWith(`${componentName}.js`), exampleKeys)
+    const ExampleComponent = exampleContext(componentKey).default
+
+    if (!ExampleComponent) return <PageNotFound />
+
+    return <ExampleComponent />
+  }
+}

--- a/docs/app/Components/ExternalExampleLayout.js
+++ b/docs/app/Components/ExternalExampleLayout.js
@@ -2,7 +2,6 @@ import 'semantic-ui-css/semantic.css'
 import _ from 'lodash/fp'
 import React, { Component, PropTypes } from 'react'
 
-// import ComponentExample from '../Components/ComponentDoc/ComponentExample'
 import PageNotFound from '../Views/PageNotFound'
 import { exampleContext } from 'docs/app/utils'
 
@@ -23,9 +22,11 @@ export default class ExternalExampleLayout extends Component {
   render() {
     const { kebabCaseName } = this.props.match.params
     const componentName = _.startCase(kebabCaseName).replace(/ /g, '')
-    const componentKey = _.find(_.endsWith(`${componentName}.js`), exampleKeys)
-    const ExampleComponent = exampleContext(componentKey).default
 
+    const componentKey = _.find(_.endsWith(`${componentName}.js`), exampleKeys)
+    if (!componentKey) return <PageNotFound />
+
+    const ExampleComponent = exampleContext(componentKey).default
     if (!ExampleComponent) return <PageNotFound />
 
     return <ExampleComponent />

--- a/docs/app/Components/Layout.js
+++ b/docs/app/Components/Layout.js
@@ -5,6 +5,7 @@ import React, { Component, PropTypes } from 'react'
 import Sidebar from 'docs/app/Components/Sidebar/Sidebar'
 import style from 'docs/app/Style'
 import TAAttribution from 'docs/app/Components/TAAttribution/TAAttribution'
+import { scrollToAnchor } from 'docs/app/utils'
 
 const anchors = new AnchorJS({
   icon: '#',
@@ -28,6 +29,9 @@ export default class Layout extends Component {
   }
 
   resetPage = () => {
+    // only reset the page when changing routes
+    if (this.pathname === location.pathname) return
+
     clearTimeout(this.scrollStartTimeout)
 
     scrollTo(0, 0)
@@ -36,30 +40,8 @@ export default class Layout extends Component {
     anchors.remove([1, 2, 3, 4, 5, 6].map(n => `.rendered-example h${n}`).join(', '))
     anchors.remove('.no-anchor')
 
-    this.scrollStartTimeout = setTimeout(this.scrollToAnchor, 500)
-  }
-
-  scrollToAnchor = () => {
-    const anchor = location.hash && document.querySelector(location.hash)
-
-    // no scroll to target, stop
-    if (!anchor) return
-
-    const elementTop = Math.round(anchor.getBoundingClientRect().top)
-
-    // scrolled to element, stop
-    if (elementTop === 0) return
-
-    // hit max scroll boundaries, stop
-    const isScrolledToTop = scrollY === 0
-    const isScrolledToBottom = scrollY + document.body.clientHeight === document.body.scrollHeight
-    const scrollStep = Math.ceil((Math.abs(elementTop / 8))) * Math.sign(elementTop)
-
-    if (isScrolledToBottom && scrollStep > 0 || isScrolledToTop && scrollStep < 0) return
-
-    // more scrolling to do!
-    scrollBy(0, scrollStep)
-    requestAnimationFrame(this.scrollToAnchor)
+    this.scrollStartTimeout = setTimeout(scrollToAnchor, 500)
+    this.pathname = location.pathname
   }
 
   render() {

--- a/docs/app/routes.js
+++ b/docs/app/routes.js
@@ -3,9 +3,11 @@ import {
   BrowserRouter,
   Route,
   Redirect,
+  Switch,
 } from 'react-router-dom'
 import Root from './Components/Root'
 import Layout from './Components/Layout'
+import ExternalExampleLayout from './Components/ExternalExampleLayout'
 import Introduction from './Views/Introduction'
 import Usage from './Views/Usage'
 import PageNotFound from './Views/PageNotFound'
@@ -14,13 +16,18 @@ const RedirectToIntro = () => <Redirect to='introduction' />
 
 const Router = () => (
   <BrowserRouter>
-    <Layout>
-      <Route exact path='/' render={RedirectToIntro} />
-      <Route exact path='/introduction' component={Introduction} />
-      <Route exact path='/usage' component={Usage} />
-      <Route exact path='/:type/:name' component={Root} />
-      <Route exact path='/*' component={PageNotFound} />
-    </Layout>
+    <Switch>
+      <Route exact path='/maximize/:kebabCaseName' component={ExternalExampleLayout} />
+      <Layout>
+        <Switch>
+          <Route exact path='/' render={RedirectToIntro} />
+          <Route exact path='/introduction' component={Introduction} />
+          <Route exact path='/usage' component={Usage} />
+          <Route exact path='/:type/:name' component={Root} />
+          <Route exact path='/*' component={PageNotFound} />
+        </Switch>
+      </Layout>
+    </Switch>
   </BrowserRouter>
 )
 

--- a/docs/app/utils.js
+++ b/docs/app/utils.js
@@ -24,3 +24,26 @@ export const repoURL = 'https://github.com/Semantic-Org/Semantic-UI-React'
 export const semanticUIDocsURL = 'https://semantic-ui.com/'
 export const semanticUIRepoURL = 'https://github.com/Semantic-Org/Semantic-UI'
 export const semanticUICSSRepoURL = 'https://github.com/Semantic-Org/Semantic-UI-CSS'
+
+export const scrollToAnchor = () => {
+  const anchor = location.hash && document.querySelector(location.hash)
+
+  // no scroll to target, stop
+  if (!anchor) return
+
+  const elementTop = Math.round(anchor.getBoundingClientRect().top)
+
+  // scrolled to element, stop
+  if (elementTop === 0) return
+
+  // hit max scroll boundaries, stop
+  const isScrolledToTop = scrollY === 0
+  const isScrolledToBottom = scrollY + document.body.clientHeight === document.body.scrollHeight
+  const scrollStep = Math.ceil((Math.abs(elementTop / 8))) * Math.sign(elementTop)
+
+  if (isScrolledToBottom && scrollStep > 0 || isScrolledToTop && scrollStep < 0) return
+
+  // more scrolling to do!
+  scrollBy(0, scrollStep)
+  requestAnimationFrame(scrollToAnchor)
+}

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -15,6 +15,9 @@ const debug = makeDebugger('portal')
 /**
  * A component that allows you to render children outside their parent.
  * @see Modal
+ * @see Popup
+ * @see Dimmer
+ * @see Confirm
  */
 class Portal extends Component {
   static propTypes = {

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -66,7 +66,7 @@ class Menu extends Component {
     /** A vertical menu may take the size of its container. */
     fluid: PropTypes.bool,
 
-    /** A menu may have labeled icons. */
+    /** A menu may have just icons (bool) or labeled icons. */
     icon: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.oneOf(['labeled']),


### PR DESCRIPTION
# Direct links to _every_ example
You can now link to every example file, regardless of whether or not it has a title.  Clicking the link icon gives the example the "focused" style shadow, scrolls it into view, and copies the link to your clipboard.

![http://g.recordit.co/f441YlgsJK.gif](http://g.recordit.co/f441YlgsJK.gif)

# Maximize an example
You can now launch any example in a maximized window.  This is super helpful for large examples, like Grids:

![http://g.recordit.co/Ywx2w6GplV.gif](http://g.recordit.co/Ywx2w6GplV.gif)

# Edit Code
Toggling the code editor now scrolls the example into view and updates the url with the direct link:

![http://g.recordit.co/NqYu4o2uYc.gif](http://g.recordit.co/NqYu4o2uYc.gif)

# @see Portal Components

I've added links to portal powered components.

![image](https://cloud.githubusercontent.com/assets/5067638/23844497/b812e4c2-077f-11e7-894b-ebc01e05d384.png)

# Cleaner Callback Docs
I recently added return types to callback signatures.  We also now support object property param definitions (needed in Tab PR #430).  I've now cleaned up the callback signature layout as well:

![image](https://cloud.githubusercontent.com/assets/5067638/23844521/e3da8196-077f-11e7-9909-c12e34186be1.png)