### PR TITLE
fix(Dropdown): do not close on click when search is empty

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1008,8 +1008,8 @@ export default class Dropdown extends Component {
       e.preventDefault()
       return
     }
+
     this.close(e)
-    return
   }
 
   // ----------------------------------------

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -995,7 +995,18 @@ export default class Dropdown extends Component {
     this.setState({ focus: hasFocus })
   }
 
-  toggle = (e) => this.state.open ? this.close(e) : this.open(e)
+  toggle = (e) => {
+    if (this.state.open) {
+      const { search } = this.props
+      const options = this.getMenuOptions()
+      if (search && _.isEmpty(options)) {
+        e.preventDefault()
+      } else {
+        return this.close(e)
+      }
+    }
+    return this.open(e)
+  }
 
   // ----------------------------------------
   // Render

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -996,16 +996,20 @@ export default class Dropdown extends Component {
   }
 
   toggle = (e) => {
-    if (this.state.open) {
-      const { search } = this.props
-      const options = this.getMenuOptions()
-      if (search && _.isEmpty(options)) {
-        e.preventDefault()
-      } else {
-        return this.close(e)
-      }
+    if (!this.state.open) {
+      this.open(e)
+      return
     }
-    return this.open(e)
+
+    const { search } = this.props
+    const options = this.getMenuOptions()
+
+    if (search && _.isEmpty(options)) {
+      e.preventDefault()
+      return
+    }
+    this.close(e)
+    return
   }
 
   // ----------------------------------------

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -123,6 +123,17 @@ describe('Dropdown', () => {
       .should.have.been.calledOnce()
   })
 
+  it('does not close on click when search is true and options are empty', () => {
+    wrapperMount(<Dropdown options={{}} search selection defaultOpen />)
+
+    const instance = wrapper.instance()
+    sandbox.spy(instance.ref, 'blur')
+
+    dropdownMenuIsOpen()
+    wrapper.simulate('click')
+    dropdownMenuIsOpen()
+  })
+
   it('opens on focus', () => {
     wrapperMount(<Dropdown options={options} />)
 


### PR DESCRIPTION
Fixes #1451 . Mimics the behaviour of SUI core in similar scenario.