### PR TITLE
docs(Form): add required and width examples

### DIFF
--- a/docs/app/Examples/collections/Form/FieldVariations/FormExampleRequiredField.js
+++ b/docs/app/Examples/collections/Form/FieldVariations/FormExampleRequiredField.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Form, Input } from 'semantic-ui-react'
+
+const FormExampleRequiredField = () => (
+  <Form>
+    <Form.Field required>
+      <label>Last name</label>
+      <Input placeholder='Full name' />
+    </Form.Field>
+    <Form.Checkbox
+      inline
+      label='I agree to the terms and conditions'
+      required
+    />
+  </Form>
+)
+
+export default FormExampleRequiredField

--- a/docs/app/Examples/collections/Form/FieldVariations/FormExampleRequiredField.js
+++ b/docs/app/Examples/collections/Form/FieldVariations/FormExampleRequiredField.js
@@ -7,11 +7,6 @@ const FormExampleRequiredField = () => (
       <label>Last name</label>
       <Input placeholder='Full name' />
     </Form.Field>
-    <Form.Checkbox
-      inline
-      label='I agree to the terms and conditions'
-      required
-    />
   </Form>
 )
 

--- a/docs/app/Examples/collections/Form/FieldVariations/FormExampleRequiredFieldShorthand.js
+++ b/docs/app/Examples/collections/Form/FieldVariations/FormExampleRequiredFieldShorthand.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Form } from 'semantic-ui-react'
+
+const FormExampleRequiredFieldShorthand = () => (
+  <Form>
+    <Form.Checkbox
+      inline
+      label='I agree to the terms and conditions'
+      required
+    />
+  </Form>
+)
+
+export default FormExampleRequiredFieldShorthand

--- a/docs/app/Examples/collections/Form/FieldVariations/FormExampleWidthField.js
+++ b/docs/app/Examples/collections/Form/FieldVariations/FormExampleWidthField.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Form, Input } from 'semantic-ui-react'
+
+const FormExampleWidthField = () => (
+  <Form>
+    <Form.Group>
+      <Form.Input label='First name' placeholder='First Name' width={6} />
+      <Form.Input label='Middle Name' placeholder='Middle Name' width={4} />
+      <Form.Input label='Last Name' placeholder='Last Name' width={6} />
+    </Form.Group>
+    <Form.Group>
+      <Form.Input placeholder='2 Wide' width={2} />
+      <Form.Input placeholder='12 Wide' width={12} />
+      <Form.Input placeholder='2 Wide' width={2} />
+    </Form.Group>
+    <Form.Group>
+      <Form.Input placeholder='8 Wide' width={8} />
+      <Form.Input placeholder='6 Wide' width={6} />
+      <Form.Input placeholder='2 Wide' width={2} />
+    </Form.Group>
+  </Form>
+)
+
+export default FormExampleWidthField

--- a/docs/app/Examples/collections/Form/FieldVariations/index.js
+++ b/docs/app/Examples/collections/Form/FieldVariations/index.js
@@ -20,6 +20,10 @@ const FormFieldVariationsExamples = () => (
       description='A field can show that input is mandatory.'
       examplePath='collections/Form/FieldVariations/FormExampleRequiredField'
     />
+    <ComponentExample
+      description='Form.Field shorthand can also be required.'
+      examplePath='collections/Form/FieldVariations/FormExampleRequiredFieldShorthand'
+    />
   </ExampleSection>
 )
 

--- a/docs/app/Examples/collections/Form/FieldVariations/index.js
+++ b/docs/app/Examples/collections/Form/FieldVariations/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
 import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
 
@@ -8,6 +9,16 @@ const FormFieldVariationsExamples = () => (
       title='Inline'
       description='A field can have its label next to instead of above it.'
       examplePath='collections/Form/FieldVariations/FormExampleInlineField'
+    />
+    <ComponentExample
+      title='Width'
+      description='A field can specify its width in grid columns.'
+      examplePath='collections/Form/FieldVariations/FormExampleWidthField'
+    />
+    <ComponentExample
+      title='Required'
+      description='A field can show that input is mandatory.'
+      examplePath='collections/Form/FieldVariations/FormExampleRequiredField'
     />
   </ExampleSection>
 )


### PR DESCRIPTION
Fixes #1444. Also adds example with withds.