### PR TITLE
chore(view): update cdn for faker

### DIFF
--- a/docs/app/index.ejs
+++ b/docs/app/index.ejs
@@ -61,7 +61,7 @@
     src="//cdnjs.cloudflare.com/ajax/libs/babel-standalone/<%= htmlWebpackPlugin.options.versions.babel %>/babel.min.js"
     data-presets="es2015,react,stage1"
   ></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/Faker/<%= htmlWebpackPlugin.options.versions.faker %>/faker.min.js"></script>
+  <script src="//cdn.jsdelivr.net/faker.js/<%= htmlWebpackPlugin.options.versions.faker %>/faker.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/js-beautify/<%= htmlWebpackPlugin.options.versions.jsBeautify %>/beautify-html.min.js"></script>
   <!-- Use unminified React when not in production so we get errors and warnings -->
   <script src="//cdnjs.cloudflare.com/ajax/libs/react/<%= htmlWebpackPlugin.options.versions.react %>/react<%= __PROD__ ? '.min' : '' %>.js"></script>


### PR DESCRIPTION
We recently [performed](https://github.com/Semantic-Org/Semantic-UI-React/pull/1418/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L90) update of `faker` to `4.1.0`. However, cdnjs doesn't contains this version.

I've updated `index.ejs` to use jsdelivr.