### PR TITLE
Backspace should delete items in multiselect dropdowns

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -584,10 +584,10 @@ export default class Dropdown extends Component {
     debug(keyboardKey.getName(e))
     if (keyboardKey.getCode(e) !== keyboardKey.Backspace) return
 
-    const { multiple, search } = this.props
+    const { multiple } = this.props
     const { searchQuery, value } = this.state
 
-    if (searchQuery || !search || !multiple || _.isEmpty(value)) return
+    if (searchQuery || !multiple || _.isEmpty(value)) return
 
     e.preventDefault()
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1330,16 +1330,23 @@ describe('Dropdown', () => {
 
       spy.should.not.have.been.called()
     })
-    it('does not remove items for multiple dropdowns without search', () => {
+    it('does remove items for multiple dropdowns without search', () => {
+      const name = 'my-dropdown'
       const value = _.map(options, 'value')
-      wrapperMount(<Dropdown options={options} selection value={value} multiple onChange={spy} />)
+      const expected = _.dropRight(value)
+      wrapperMount(<Dropdown options={options} selection name={name} defaultValue={value} multiple onChange={spy} />)
 
       // open
       wrapper.simulate('click')
 
       domEvent.keyDown(document, { key: 'Backspace' })
 
-      spy.should.not.have.been.called()
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch({}, { name, value: expected })
+
+      wrapper
+        .state('value')
+        .should.deep.equal(expected)
     })
   })
 


### PR DESCRIPTION
Fixes #1547 

Not sure why there was an if statement to prevent deletion of multiple items when not searching, but it means the component is not accessible to keyboard users. This removes that restriction.