### PR TITLE
[WIP/RFC] CSS-in-JS styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "babel-runtime": "^6.22.0",
     "classnames": "^2.1.5",
     "debug": "^2.6.3",
-    "lodash": "^4.17.2"
+    "glamor": "^2.20.24",
+    "lodash": "^4.17.2",
+    "semantic-ui-css-in-js": "0.0.1"
   },
   "devDependencies": {
     "@types/react": "^15.0.14",
@@ -67,8 +69,8 @@
     "babel-plugin-__coverage__": "^11.0.0",
     "babel-plugin-lodash": "^3.2.10",
     "babel-plugin-react-transform": "^2.0.2",
-    "babel-plugin-transform-react-remove-prop-types": "^0.3.2",
     "babel-plugin-transform-react-handled-props": "^0.2.3",
+    "babel-plugin-transform-react-remove-prop-types": "^0.3.2",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.5.0",

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -214,23 +214,28 @@ class Button extends Component {
       size,
       toggle,
     } = this.props
+    const buttonStyles = makeButtonStyles()
+    const sx = css(
+      buttonStyles.base,
+      active && buttonStyles.active,
+      basic && buttonStyles.basic,
+      circular && buttonStyles.circular,
+      compact && buttonStyles.compact,
+      fluid && buttonStyles.fluid,
+      (icon === true || icon && (labelPosition || !children && !content)) && buttonStyles.icon,
+      inverted && buttonStyles.inverted,
+      loading && buttonStyles.loading,
+      negative && buttonStyles.negative,
+      positive && buttonStyles.positive,
+      primary && buttonStyles.primary,
+      secondary && buttonStyles.secondary,
+      toggle && buttonStyles.toggle
+    )
+    const classes = cx(`${sx}`, className)
 
     const baseClasses = cx(
       color,
       size,
-      useKeyOnly(active, 'active'),
-      useKeyOnly(basic, 'basic'),
-      useKeyOnly(circular, 'circular'),
-      useKeyOnly(compact, 'compact'),
-      useKeyOnly(fluid, 'fluid'),
-      useKeyOnly(icon === true || icon && (labelPosition || !children && !content), 'icon'),
-      useKeyOnly(inverted, 'inverted'),
-      useKeyOnly(loading, 'loading'),
-      useKeyOnly(negative, 'negative'),
-      useKeyOnly(positive, 'positive'),
-      useKeyOnly(primary, 'primary'),
-      useKeyOnly(secondary, 'secondary'),
-      useKeyOnly(toggle, 'toggle'),
       useKeyOrValueAndKey(animated, 'animated'),
       useKeyOrValueAndKey(attached, 'attached'),
     )
@@ -247,10 +252,6 @@ class Button extends Component {
     const tabIndex = this.computeTabIndex(ElementType)
 
     if (!_.isNil(children)) {
-      const buttonStyles = makeButtonStyles()
-      const sx = css(buttonStyles.base)
-      const classes = cx(`${sx}`, className)
-      // const classes = cx('ui', baseClasses, wrapperClasses, labeledClasses, 'button', className)
       debug('render children:', { classes })
 
       return (
@@ -266,7 +267,6 @@ class Button extends Component {
     } })
 
     if (labelElement) {
-      const classes = cx('ui', baseClasses, 'button', className)
       const containerClasses = cx('ui', labeledClasses, 'button', className, wrapperClasses)
 
       debug('render label:', { classes, containerClasses }, this.props)
@@ -283,7 +283,6 @@ class Button extends Component {
     }
 
     if (!_.isNil(icon) && _.isNil(label)) {
-      const classes = cx('ui', labeledClasses, baseClasses, 'button', className, wrapperClasses)
       debug('render icon && !label:', { classes })
 
       return (
@@ -293,7 +292,6 @@ class Button extends Component {
       )
     }
 
-    const classes = cx('ui', labeledClasses, baseClasses, 'button', className, wrapperClasses)
     debug('render default:', { classes })
 
     return (

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -1,6 +1,8 @@
 import cx from 'classnames'
 import _ from 'lodash'
 import React, { Component, PropTypes } from 'react'
+import { css } from 'glamor';
+import { makeButtonStyles } from 'semantic-ui-css-in-js';
 
 import {
   customPropTypes,
@@ -245,7 +247,10 @@ class Button extends Component {
     const tabIndex = this.computeTabIndex(ElementType)
 
     if (!_.isNil(children)) {
-      const classes = cx('ui', baseClasses, wrapperClasses, labeledClasses, 'button', className)
+      const buttonStyles = makeButtonStyles();
+      const sx = css(buttonStyles.base);
+      const classes = cx(`${sx}`, className);
+      // const classes = cx('ui', baseClasses, wrapperClasses, labeledClasses, 'button', className)
       debug('render children:', { classes })
 
       return (

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -1,8 +1,8 @@
 import cx from 'classnames'
 import _ from 'lodash'
 import React, { Component, PropTypes } from 'react'
-import { css } from 'glamor';
-import { makeButtonStyles } from 'semantic-ui-css-in-js';
+import { css } from 'glamor'
+import { makeButtonStyles } from 'semantic-ui-css-in-js'
 
 import {
   customPropTypes,
@@ -247,9 +247,9 @@ class Button extends Component {
     const tabIndex = this.computeTabIndex(ElementType)
 
     if (!_.isNil(children)) {
-      const buttonStyles = makeButtonStyles();
-      const sx = css(buttonStyles.base);
-      const classes = cx(`${sx}`, className);
+      const buttonStyles = makeButtonStyles()
+      const sx = css(buttonStyles.base)
+      const classes = cx(`${sx}`, className)
       // const classes = cx('ui', baseClasses, wrapperClasses, labeledClasses, 'button', className)
       debug('render children:', { classes })
 


### PR DESCRIPTION
This is a very early stage PR which aims to get us moving in the direction of a CSS-in-JS solution for styling SUIR. I've read over #1009 and am taking @levithomason's thoughts into account with the implementation.

The current plan is to use [glamor](https://github.com/threepointone/glamor) as the CSS-in-JS solution for React. The full list of features can be found [here](https://github.com/threepointone/glamor#features), but some important highlights:
- Framework agnostic
- Supports all the pseudo :classes/::elements
- Support for `@media` / `@font-face` / `@keyframes`
- SSR support

The base styles themselves will be distributed in a separate package, and will not be tied to React. This will allow for implementations for other JS frameworks. The one caveat here is that while the base JS style objects are generally the same between CSS-in-JS implementations, they start to vary when you get down to the pseudo-selectors, `@media` queries, etc. This means that the raw styles themselves would probably need to be glamor-specific, or at least something that looks a lot like glamor (such as [cxs](https://github.com/jxnblk/cxs)). Given that glamor is not tied to a particular framework, I do not see this as being a show stopper.

Currently the styles are located at [maxdeviant/semantic-ui-css-in-js](https://github.com/maxdeviant/semantic-ui-css-in-js) and have a corresponding [npm package](https://www.npmjs.com/package/semantic-ui-css-in-js). The approach here is going to look very similar to the LESS files in the main Semantic UI library. The primary difference will be that instead of exposing the styles directly, the package will expose style creators that take in the theme to allow for dynamic theming at runtime.

In way of theming, the theme configuration will be passed down using context via some sort of `ThemeProvider` component.

Landing this PR will close #1009.

@levithomason Would love to hear your thoughts on this :smile: