### PR TITLE
fix(MenuExampleNameProp): fix activeItem logic

### DIFF
--- a/docs/app/Examples/collections/Menu/Types/MenuExampleNameProp.js
+++ b/docs/app/Examples/collections/Menu/Types/MenuExampleNameProp.js
@@ -13,12 +13,12 @@ export default class MenuExampleNameProp extends Component {
       <Menu>
         <Menu.Item
           name='editorials'
-          active={activeItem === 'Editorials'}
+          active={activeItem === 'editorials'}
           onClick={this.handleItemClick}
         />
         <Menu.Item
           name='reviews'
-          active={activeItem === 'Reviews'}
+          active={activeItem === 'reviews'}
           onClick={this.handleItemClick}
         />
         <Menu.Item


### PR DESCRIPTION
Fixes #1583

The `activeItem` comparison logic is using the wrong casing.