### PR TITLE
fix(Dropdown): fix warning on PropTypes with React >= 15.5.0

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -65,7 +65,7 @@ export default class Dropdown extends Component {
       customPropTypes.disallow(['options', 'selection']),
       customPropTypes.givenProps(
         { children: PropTypes.any.isRequired },
-        React.PropTypes.element.isRequired,
+        PropTypes.element.isRequired,
       ),
     ]),
 


### PR DESCRIPTION
Fixes #1587

Seems that the commit 3a09c0fe7c1c5d6daab78304d1c4fc19f9aa022e missed a PropTypes, so it also has a warning when in developing.