### PR TITLE
docs(Table): add sortable table example

### DIFF
--- a/docs/app/Examples/collections/Table/Variations/TableExampleSortable.js
+++ b/docs/app/Examples/collections/Table/Variations/TableExampleSortable.js
@@ -39,7 +39,7 @@ export default class TableExampleSortable extends Component {
     const { column, data, direction } = this.state
 
     return (
-      <Table sortable celled>
+      <Table sortable celled fixed>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell sorted={column === 'name' && direction} onClick={this.handleSort('name')}>

--- a/docs/app/Examples/collections/Table/Variations/TableExampleSortable.js
+++ b/docs/app/Examples/collections/Table/Variations/TableExampleSortable.js
@@ -9,59 +9,56 @@ const tableData = [
   { name: 'Ben', age: 70, gender: 'Male' },
 ]
 
-class TableExampleSortable extends Component {
+export default class TableExampleSortable extends Component {
   state = {
-    sortProp: null,
-    sortDirection: null,
+    column: null,
     data: tableData,
+    direction: null,
   }
 
-  handleSort = (prop) => () => {
-    const { data, sortDirection, sortProp } = this.state
+  handleSort = clickedColumn => () => {
+    const { column, data, direction } = this.state
 
-    if (sortProp !== prop) {
-      const sortedData = _.sortBy(data, [prop])
-      this.setState({ data: sortedData, sortDirection: 'ascending', sortProp: prop })
-    } else {
-      const sortedData = data.slice(0).reverse()
-      const direction = sortDirection === 'ascending' ? 'descending' : 'ascending'
-      this.setState({ data: sortedData, sortDirection: direction })
+    if (column !== clickedColumn) {
+      this.setState({
+        column: clickedColumn,
+        data: _.sortBy(data, [clickedColumn]),
+        direction: 'ascending',
+      })
+
+      return
     }
+
+    this.setState({
+      data: data.reverse(),
+      direction: direction === 'ascending' ? 'descending' : 'ascending',
+    })
   }
 
   render() {
-    const { data, sortDirection, sortProp } = this.state
+    const { column, data, direction } = this.state
 
     return (
       <Table sortable celled>
         <Table.Header>
           <Table.Row>
-            <Table.HeaderCell
-              sorted={sortProp === 'name' ? sortDirection : null}
-              onClick={this.handleSort('name')}
-            >
+            <Table.HeaderCell sorted={column === 'name' && direction} onClick={this.handleSort('name')}>
               Name
             </Table.HeaderCell>
-            <Table.HeaderCell
-              sorted={sortProp === 'age' ? sortDirection : null}
-              onClick={this.handleSort('age')}
-            >
+            <Table.HeaderCell sorted={column === 'age' && direction} onClick={this.handleSort('age')}>
               Age
             </Table.HeaderCell>
-            <Table.HeaderCell
-              sorted={sortProp === 'gender' ? sortDirection : null}
-              onClick={this.handleSort('gender')}
-            >
+            <Table.HeaderCell sorted={column === 'gender' && direction} onClick={this.handleSort('gender')}>
               Gender
             </Table.HeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>
-          {_.map(data, (item) => (
-            <Table.Row key={item.name}>
-              <Table.Cell>{item.name}</Table.Cell>
-              <Table.Cell>{item.age}</Table.Cell>
-              <Table.Cell>{item.gender}</Table.Cell>
+          {_.map(data, ({ age, gender, name }) => (
+            <Table.Row key={name}>
+              <Table.Cell>{name}</Table.Cell>
+              <Table.Cell>{age}</Table.Cell>
+              <Table.Cell>{gender}</Table.Cell>
             </Table.Row>
           ))}
         </Table.Body>
@@ -69,5 +66,3 @@ class TableExampleSortable extends Component {
     )
   }
 }
-
-export default TableExampleSortable

--- a/docs/app/Examples/collections/Table/Variations/TableExampleSortable.js
+++ b/docs/app/Examples/collections/Table/Variations/TableExampleSortable.js
@@ -1,0 +1,73 @@
+import _ from 'lodash'
+import React, { Component } from 'react'
+import { Table } from 'semantic-ui-react'
+
+const tableData = [
+  { name: 'John', age: 15, gender: 'Male' },
+  { name: 'Amber', age: 40, gender: 'Female' },
+  { name: 'Leslie', age: 25, gender: 'Female' },
+  { name: 'Ben', age: 70, gender: 'Male' },
+]
+
+class TableExampleSortable extends Component {
+  state = {
+    sortProp: null,
+    sortDirection: null,
+    data: tableData,
+  }
+
+  handleSort = (prop) => () => {
+    const { data, sortDirection, sortProp } = this.state
+
+    if (sortProp !== prop) {
+      const sortedData = _.sortBy(data, [prop])
+      this.setState({ data: sortedData, sortDirection: 'ascending', sortProp: prop })
+    } else {
+      const sortedData = data.slice(0).reverse()
+      const direction = sortDirection === 'ascending' ? 'descending' : 'ascending'
+      this.setState({ data: sortedData, sortDirection: direction })
+    }
+  }
+
+  render() {
+    const { data, sortDirection, sortProp } = this.state
+
+    return (
+      <Table sortable celled>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell
+              sorted={sortProp === 'name' ? sortDirection : null}
+              onClick={this.handleSort('name')}
+            >
+              Name
+            </Table.HeaderCell>
+            <Table.HeaderCell
+              sorted={sortProp === 'age' ? sortDirection : null}
+              onClick={this.handleSort('age')}
+            >
+              Age
+            </Table.HeaderCell>
+            <Table.HeaderCell
+              sorted={sortProp === 'gender' ? sortDirection : null}
+              onClick={this.handleSort('gender')}
+            >
+              Gender
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {_.map(data, (item) => (
+            <Table.Row key={item.name}>
+              <Table.Cell>{item.name}</Table.Cell>
+              <Table.Cell>{item.age}</Table.Cell>
+              <Table.Cell>{item.gender}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    )
+  }
+}
+
+export default TableExampleSortable

--- a/docs/app/Examples/collections/Table/Variations/index.js
+++ b/docs/app/Examples/collections/Table/Variations/index.js
@@ -61,6 +61,12 @@ const Variations = () => {
       </ComponentExample>
 
       <ComponentExample
+        title='Sortable Columns'
+        description='A table can appear to sort its data by column in ascending or descending order.'
+        examplePath='collections/Table/Variations/TableExampleSortable'
+      />
+
+      <ComponentExample
         title='Vertical Alignment'
         description='A table, header, row or cell can adjust its vertical alignment.'
         examplePath='collections/Table/Variations/TableExampleVerticalAlign'

--- a/docs/app/Examples/collections/Table/Variations/index.js
+++ b/docs/app/Examples/collections/Table/Variations/index.js
@@ -61,12 +61,6 @@ const Variations = () => {
       </ComponentExample>
 
       <ComponentExample
-        title='Sortable Columns'
-        description='A table can appear to sort its data by column in ascending or descending order.'
-        examplePath='collections/Table/Variations/TableExampleSortable'
-      />
-
-      <ComponentExample
         title='Vertical Alignment'
         description='A table, header, row or cell can adjust its vertical alignment.'
         examplePath='collections/Table/Variations/TableExampleVerticalAlign'
@@ -133,6 +127,12 @@ const Variations = () => {
         examplePath='collections/Table/Variations/TableExampleInverted'
       />
       <ComponentExample examplePath='collections/Table/Variations/TableExampleInvertedColors' />
+
+      <ComponentExample
+        title='Sortable'
+        description='A table can appear to sort its data by column in ascending or descending order.'
+        examplePath='collections/Table/Variations/TableExampleSortable'
+      />
 
       <ComponentExample
         title='Full-Width Header / Footer'


### PR DESCRIPTION
Add an example using ```sortable``` and ```sorted``` props to sort a Table's data. Fixes [#1195](https://github.com/Semantic-Org/Semantic-UI-React/issues/1195)