### PR TITLE
feat(docs): use https url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <!-- Logo -->
 <p align="center">
-  <a href="http://react.semantic-ui.com">
+  <a href="https://react.semantic-ui.com">
     <img height="128" width="128" src="https://github.com/Semantic-Org/Semantic-UI-React/raw/master/docs/app/logo.png">
   </a>
 </p>
 
 <!-- Name -->
 <h1 align="center">
-  <a href="http://react.semantic-ui.com/">Semantic UI React</a>
+  <a href="https://react.semantic-ui.com/">Semantic UI React</a>
 </h1>
 
 <!-- Badges -->
@@ -176,7 +176,7 @@ Big thanks to our [contributors][20], especially:
 - @layershifter for bringing momentum and continual support
 
 [1]: https://github.com/Semantic-Org/Semantic-UI-React/blob/master/.github/CONTRIBUTING.md
-[2]: http://react.semantic-ui.com/
+[2]: https://react.semantic-ui.com/
 [3]: https://facebook.github.io/react/
 [4]: https://github.com/Semantic-Org/Semantic-UI-React/labels/help%20wanted
 [5]: https://semantic-ui.com/
@@ -197,7 +197,7 @@ Big thanks to our [contributors][20], especially:
 [20]: https://github.com/Semantic-Org/Semantic-UI-React/graphs/contributors
 [21]: https://github.com/Semantic-Org/Semantic-UI-React/labels/good%20first%20contribution
 [22]: https://github.com/Semantic-Org/Semantic-UI-React/edit/master/README.md
-[23]: http://react.semantic-ui.com/usage#css
+[23]: https://react.semantic-ui.com/usage#css
 [24]: https://github.com/Semantic-Org/Semantic-UI-React/issues/802#issuecomment-258990274
 [25]: http://learnsemantic.com/themes/creating.html
 [26]: https://github.com/Semantic-Org/Semantic-UI-Meteor

--- a/docs/app/404.html
+++ b/docs/app/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <!-- Hack to redirect SPA routes back to the index.html -->
-  <meta http-equiv="refresh" content="0;URL='http://react.semantic-ui.com'" />
+  <meta http-equiv="refresh" content="0;URL='https://react.semantic-ui.com'" />
   <script>sessionStorage.redirect = location.href</script>
 </head>
 <body></body>

--- a/docs/app/Components/ComponentDoc/ComponentExample.js
+++ b/docs/app/Components/ComponentDoc/ComponentExample.js
@@ -103,7 +103,7 @@ class ComponentExample extends Component {
     e.preventDefault()
     this.setHashAndScroll()
 
-    copyToClipboard(this.anchorName)
+    copyToClipboard(location.href)
     this.setState({ copiedDirectLink: true })
 
     setTimeout(() => this.setState({ copiedDirectLink: false }), 1000)

--- a/examples/webpack1/src/main.js
+++ b/examples/webpack1/src/main.js
@@ -10,7 +10,7 @@ const App = () => (
 
     <Button
       content='Discover docs'
-      href='http://react.semantic-ui.com'
+      href='https://react.semantic-ui.com'
       icon='github'
       labelPosition='left'
     />


### PR DESCRIPTION
The doc site now supports HTTPS.  Many users are linking to HTTPS, however, our SPA redirects for handling soft routes are using HTTP.  This means direct links to HTTPS urls are lost and the user is redirected to the default route.

This PR moves all links to the HTTPS url.

I also fixed the `Direct Link` copy functionality, it was only copying the slug, now it copies the href.