### PR TITLE
breaking(Modal): update shorthand functionality

### DIFF
--- a/docs/app/Examples/modules/Modal/Types/ModalExampleShorthand.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalExampleShorthand.js
@@ -4,11 +4,11 @@ import { Button, Modal } from 'semantic-ui-react'
 const ModalShorthandExample = () => (
   <Modal
     trigger={<Button>Show Modal</Button>}
-    header='Delete Your Account'
-    content='Are you sure you want to delete your account'
+    header='Reminder!'
+    content='Call Benjamin regarding the reports.'
     actions={[
-      { key: 'no', content: 'No', color: 'red', triggerClose: true },
-      { key: 'yes', content: 'Yes', color: 'green', triggerClose: true },
+      'Snooze',
+      { key: 'done', content: 'Done', positive: true },
     ]}
   />
 )

--- a/docs/app/Examples/modules/Modal/Types/ModalExampleShorthand.js
+++ b/docs/app/Examples/modules/Modal/Types/ModalExampleShorthand.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button, Modal } from 'semantic-ui-react'
 
-const ModalShorthandExample = () => (
+const ModalExampleShorthand = () => (
   <Modal
     trigger={<Button>Show Modal</Button>}
     header='Reminder!'
@@ -13,4 +13,4 @@ const ModalShorthandExample = () => (
   />
 )
 
-export default ModalShorthandExample
+export default ModalExampleShorthand

--- a/docs/app/Examples/modules/Modal/Variations/ModalExampleCloseIcon.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalExampleCloseIcon.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button, Header, Icon, Modal } from 'semantic-ui-react'
 
 const ModalExampleCloseIcon = () => (
-  <Modal trigger={<Button>Show Modal</Button>} closeIcon='close'>
+  <Modal trigger={<Button>Show Modal</Button>} closeIcon>
     <Header icon='archive' content='Archive Old Messages' />
     <Modal.Content>
       <p>Your inbox is getting full, would you like us to enable automatic archiving of old messages?</p>

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -270,6 +270,12 @@ export const itemShorthand = (...args) => every([
   PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.object,
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.object,
+      ]),
+    ),
   ]),
 ])(...args)
 

--- a/src/modules/Modal/Modal.d.ts
+++ b/src/modules/Modal/Modal.d.ts
@@ -14,7 +14,7 @@ export interface ModalProps extends PortalProps {
   as?: any;
 
   /** A Modal can be passed action buttons via shorthand. */
-  actions?: Array<any>;
+  actions?: any;
 
   /** A Modal can reduce its complexity */
   basic?: boolean;

--- a/src/modules/Modal/Modal.d.ts
+++ b/src/modules/Modal/Modal.d.ts
@@ -14,7 +14,7 @@ export interface ModalProps extends PortalProps {
   as?: any;
 
   /** A Modal can be passed action buttons via shorthand. */
-  actions?: any;
+  actions?: Array<any>;
 
   /** A Modal can reduce its complexity */
   basic?: boolean;
@@ -48,6 +48,14 @@ export interface ModalProps extends PortalProps {
 
   /** The node where the modal should mount. Defaults to document.body. */
   mountNode?: any;
+
+  /**
+   * Action onClick handler when using shorthand `actions`.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
+   */
+  onActionClick?: (event: React.MouseEvent<HTMLElement>, data: ModalProps) => void;
 
   /**
    * Called when a close event happens.

--- a/src/modules/Modal/Modal.d.ts
+++ b/src/modules/Modal/Modal.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { SemanticShorthandItem } from '../..';
 import { PortalProps } from '../../addons/Portal';
-import { default as ModalActions } from './ModalActions';
+import { default as ModalActions, ModalActionsProps } from './ModalActions';
 import { default as ModalContent, ModalContentProps } from './ModalContent';
 import { default as ModalDescription } from './ModalDescription';
 import { default as ModalHeader, ModalHeaderProps } from './ModalHeader';
@@ -13,8 +13,8 @@ export interface ModalProps extends PortalProps {
   /** An element type to render as (string or function). */
   as?: any;
 
-  /** A Modal can be passed action buttons via shorthand. */
-  actions?: Array<any>;
+  /** Shorthand for Modal.Actions. Typically an array of button shorthand. */
+  actions?: SemanticShorthandItem<ModalActionsProps>;
 
   /** A Modal can reduce its complexity */
   basic?: boolean;

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -14,7 +14,6 @@ import {
   META,
   useKeyOnly,
 } from '../../lib'
-import Button from '../../elements/Button'
 import Icon from '../../elements/Icon'
 import Portal from '../../addons/Portal'
 import ModalHeader from './ModalHeader'
@@ -35,7 +34,7 @@ class Modal extends Component {
     as: customPropTypes.as,
 
     /** Shorthand for Modal.Actions. Typically an array of button shorthand. */
-    actions: customPropTypes.itemShorthand,
+    actions: customPropTypes.collectionShorthand,
 
     /** A modal can reduce its complexity */
     basic: PropTypes.bool,
@@ -72,6 +71,14 @@ class Modal extends Component {
 
     /** The node where the modal should mount. Defaults to document.body. */
     mountNode: PropTypes.any,
+
+    /**
+     * Action onClick handler when using shorthand `actions`.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onActionClick: PropTypes.func,
 
     /**
      * Called when a close event happens.
@@ -151,6 +158,8 @@ class Modal extends Component {
   handleActionsOverrides = predefinedProps => ({
     onActionClick: (e, actionProps) => {
       _.invoke(predefinedProps, 'onActionClick', e, actionProps)
+      _.invoke(this.props, 'onActionClick', e, this.props)
+
       this.handleClose(e)
     },
   })

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -34,7 +34,7 @@ class Modal extends Component {
     as: customPropTypes.as,
 
     /** Shorthand for Modal.Actions. Typically an array of button shorthand. */
-    actions: customPropTypes.collectionShorthand,
+    actions: customPropTypes.itemShorthand,
 
     /** A modal can reduce its complexity */
     basic: PropTypes.bool,

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -34,7 +34,7 @@ class Modal extends Component {
     as: customPropTypes.as,
 
     /** Elements to render as Modal action buttons. */
-    actions: PropTypes.arrayOf(customPropTypes.itemShorthand),
+    actions: customPropTypes.itemShorthand,
 
     /** A modal can reduce its complexity */
     basic: PropTypes.bool,

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -46,7 +46,11 @@ class Modal extends Component {
     className: PropTypes.string,
 
     /** Shorthand for the close icon. Closes the modal on click. */
-    closeIcon: customPropTypes.itemShorthand,
+    closeIcon: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.object,
+      PropTypes.bool,
+    ]),
 
     /** Whether or not the Modal should close when the dimmer is clicked. */
     closeOnDimmerClick: PropTypes.bool,

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -45,12 +45,8 @@ class Modal extends Component {
     /** Additional classes. */
     className: PropTypes.string,
 
-    /** Icon. */
-    closeIcon: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.object,
-      PropTypes.bool,
-    ]),
+    /** Shorthand for the close icon. Closes the modal on click. */
+    closeIcon: customPropTypes.itemShorthand,
 
     /** Whether or not the Modal should close when the dimmer is clicked. */
     closeOnDimmerClick: PropTypes.bool,

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -14,6 +14,7 @@ import {
   META,
   useKeyOnly,
 } from '../../lib'
+import Button from '../../elements/Button'
 import Icon from '../../elements/Icon'
 import Portal from '../../addons/Portal'
 import ModalHeader from './ModalHeader'
@@ -33,7 +34,7 @@ class Modal extends Component {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
 
-    /** Elements to render as Modal action buttons. */
+    /** Shorthand for Modal.Actions. Typically an array of button shorthand. */
     actions: customPropTypes.itemShorthand,
 
     /** A modal can reduce its complexity */
@@ -149,10 +150,8 @@ class Modal extends Component {
 
   handleActionsOverrides = predefinedProps => ({
     onActionClick: (e, actionProps) => {
-      const { triggerClose } = actionProps
-
       _.invoke(predefinedProps, 'onActionClick', e, actionProps)
-      if (triggerClose) this.handleClose(e)
+      this.handleClose(e)
     },
   })
 

--- a/src/modules/Modal/ModalActions.d.ts
+++ b/src/modules/Modal/ModalActions.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ButtonProps } from '../../elements/Button';
+import { SemanticShorthandCollection } from '../..'
 
 export interface ModalActionsProps {
   [key: string]: any;
@@ -7,8 +8,8 @@ export interface ModalActionsProps {
   /** An element type to render as (string or function). */
   as?: any;
 
-  /** An element type to render as (string or function). */
-  actions?: Array<any>;
+  /** Array of shorthand buttons. */
+  actions?: SemanticShorthandCollection<ButtonProps>;
 
   /** Primary content. */
   children?: React.ReactNode;

--- a/src/modules/Modal/ModalActions.d.ts
+++ b/src/modules/Modal/ModalActions.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ButtonProps } from '../../elements/Button';
-import { SemanticShorthandCollection } from '../..'
+import { SemanticShorthandCollection } from '../..';
 
 export interface ModalActionsProps {
   [key: string]: any;

--- a/src/modules/Modal/ModalActions.js
+++ b/src/modules/Modal/ModalActions.js
@@ -21,11 +21,8 @@ export default class ModalActions extends Component {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,
 
-    /** Elements to render as Modal action buttons. */
-    actions: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.arrayOf(customPropTypes.itemShorthand),
-    ]),
+    /** Array of shorthand buttons. */
+    actions: customPropTypes.collectionShorthand,
 
     /** Primary content. */
     children: PropTypes.node,
@@ -34,10 +31,10 @@ export default class ModalActions extends Component {
     className: PropTypes.string,
 
     /**
-     * onClick handler for an action. Mutually exclusive with children.
+     * Action onClick handler when using shorthand `actions`.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All item props.
+     * @param {object} data - All props from the clicked action.
      */
     onActionClick: customPropTypes.every([
       customPropTypes.disallow(['children']),

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -105,10 +105,10 @@ describe('Modal', () => {
 
   describe('actions', () => {
     it('closes the modal on action click', () => {
-      wrapperMount(<Modal defaultOpen actions={['OK']} />)
+      wrapperMount(<Modal actions={['OK']} defaultOpen />)
 
       assertBodyContains('.ui.modal')
-      domEvent.click('.ui.modal.actions .button')
+      domEvent.click('.ui.modal .actions .button')
       assertBodyContains('.ui.modal', false)
     })
   })
@@ -117,16 +117,13 @@ describe('Modal', () => {
     it('is called when an action is clicked', () => {
       const onActionClick = sandbox.spy()
       const event = { target: null }
+      const props = { actions: ['OK'], defaultOpen: true, onActionClick }
 
-      wrapperMount(
-        <Modal defaultOpen>
-          <Modal.Actions></Modal.Actions>
-        </Modal>
-      )
+      wrapperMount(<Modal {...props} />)
+      domEvent.click('.ui.modal .actions .button')
 
-      domEvent.click('.button:last-child')
       onActionClick.should.have.been.calledOnce()
-      onActionClick.should.have.been.calledWithMatch(event, { content: 'OK' })
+      onActionClick.should.have.been.calledWithMatch(event, props)
     })
   })
 

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -111,6 +111,16 @@ describe('Modal', () => {
       domEvent.click('.ui.modal .actions .button')
       assertBodyContains('.ui.modal', false)
     })
+
+    it('calls shorthand onActionClick callback', () => {
+      const onActionClick = sandbox.spy()
+      const modalActions = { onActionClick, actions: [{ key: 'ok', content: 'OK' }] }
+      wrapperMount(<Modal actions={modalActions} defaultOpen />)
+
+      onActionClick.should.not.have.been.called()
+      domEvent.click('.ui.modal .actions .button')
+      onActionClick.should.have.been.calledOnce()
+    })
   })
 
   describe('onActionClick', () => {

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -104,29 +104,29 @@ describe('Modal', () => {
   })
 
   describe('actions', () => {
-    const actions = [
-      { key: 'cancel', content: 'Cancel' },
-      { key: 'ok', content: 'OK', triggerClose: true },
-    ]
+    it('closes the modal on action click', () => {
+      wrapperMount(<Modal defaultOpen actions={['OK']} />)
 
-    it('handles onItemClick', () => {
+      assertBodyContains('.ui.modal')
+      domEvent.click('.ui.modal.actions .button')
+      assertBodyContains('.ui.modal', false)
+    })
+  })
+
+  describe('onActionClick', () => {
+    it('is called when an action is clicked', () => {
       const onActionClick = sandbox.spy()
       const event = { target: null }
 
-      wrapperMount(<Modal defaultOpen actions={{ actions, onActionClick }} />)
+      wrapperMount(
+        <Modal defaultOpen>
+          <Modal.Actions></Modal.Actions>
+        </Modal>
+      )
 
       domEvent.click('.button:last-child')
       onActionClick.should.have.been.calledOnce()
       onActionClick.should.have.been.calledWithMatch(event, { content: 'OK' })
-    })
-
-    it('handles triggerClose prop on an action', () => {
-      wrapperMount(<Modal defaultOpen actions={actions} />)
-
-      domEvent.click('.button:first-child')
-      assertBodyContains('.ui.modal')
-      domEvent.click('.button:last-child')
-      assertBodyContains('.ui.modal', false)
     })
   })
 

--- a/test/specs/modules/Modal/ModalActions-test.js
+++ b/test/specs/modules/Modal/ModalActions-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import ModalActions from 'src/modules/Modal/ModalActions'
 
+import ModalActions from 'src/modules/Modal/ModalActions'
 import * as common from 'test/specs/commonTests'
 import { sandbox } from 'test/utils'
 


### PR DESCRIPTION
# Breaking Changes

Previously, shorthand Modal `actions` required passing button props objects with `triggerClose: true` on buttons that should close the Modal.

Now, all shorthand Modal `actions` buttons close the Modal automatically.  The `triggerClose` property has been removed.

## Before

```jsx
<Modal
  header='Reminder!'
  content='Call Benjamin.'
  actions={[
    { key: 'snooze', content: 'Snooze', triggerClose: true },
    { key: 'done', content: 'Done', positive: true, triggerClose: true },
  ]}
/>
```

## After

```jsx
<Modal
  header='Reminder!'
  content='Call Benjamin.'
  actions={[
    'Snooze',
    { key: 'done', content: 'Done', positive: true },
  ]}
/>
```

***

Blocking #1542 

This PR:

- [x] removes the `triggerClose` shorthand Modal `actions` property
- [x] makes all shorthand actions close the Modal
- [x] fix prop types / typings