### PR TITLE
feat(TextArea): add focus() method

### DIFF
--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -54,6 +54,8 @@ class TextArea extends Component {
     }
   }
 
+  focus = () => (this.ref.focus())
+
   handleChange = (e) => {
     const { onChange } = this.props
     if (onChange) onChange(e, { ...this.props, value: e.target && e.target.value })

--- a/test/specs/addons/TextArea/TextArea-test.js
+++ b/test/specs/addons/TextArea/TextArea-test.js
@@ -42,32 +42,11 @@ describe('TextArea', () => {
 
   describe('focus', () => {
     it('can be set via a ref', () => {
-      const mountNode = document.createElement('div')
-      document.body.appendChild(mountNode)
-
-      const wrapper = mount(<TextArea />, { attachTo: mountNode })
-      wrapper.instance().focus()
-
+      wrapperMount(<TextArea />)
       const element = document.querySelector('textarea')
+
+      wrapper.instance().focus()
       document.activeElement.should.equal(element)
-
-      wrapper.detach()
-      document.body.removeChild(mountNode)
-    })
-  })
-
-  describe('onChange', () => {
-    it('is called with (e, data) on change', () => {
-      const spy = sandbox.spy()
-      const e = { target: { value: 'name' } }
-      const props = { 'data-foo': 'bar', onChange: spy }
-
-      wrapperShallow(<TextArea {...props} />)
-
-      wrapper.find('textarea').simulate('change', e)
-
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(e, { ...props, value: e.target.value })
     })
   })
 
@@ -137,6 +116,21 @@ describe('TextArea', () => {
       wrapper.setProps({ autoHeight: false })
 
       assertHeight('') // no height
+    })
+  })
+
+  describe('onChange', () => {
+    it('is called with (e, data) on change', () => {
+      const spy = sandbox.spy()
+      const e = { target: { value: 'name' } }
+      const props = { 'data-foo': 'bar', onChange: spy }
+
+      wrapperShallow(<TextArea {...props} />)
+
+      wrapper.find('textarea').simulate('change', e)
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(e, { ...props, value: e.target.value })
     })
   })
 })

--- a/test/specs/addons/TextArea/TextArea-test.js
+++ b/test/specs/addons/TextArea/TextArea-test.js
@@ -40,6 +40,22 @@ describe('TextArea', () => {
     },
   })
 
+  describe('focus', () => {
+    it('can be set via a ref', () => {
+      const mountNode = document.createElement('div')
+      document.body.appendChild(mountNode)
+
+      const wrapper = mount(<TextArea />, { attachTo: mountNode })
+      wrapper.instance().focus()
+
+      const element = document.querySelector('textarea')
+      document.activeElement.should.equal(element)
+
+      wrapper.detach()
+      document.body.removeChild(mountNode)
+    })
+  })
+
   describe('onChange', () => {
     it('is called with (e, data) on change', () => {
       const spy = sandbox.spy()


### PR DESCRIPTION
I want to focus a `TextArea` element with a `ref`, but the `ref` refers to a component instance rather than a DOM element. We already solved this problem for `Input` by adding a `focus()` method, which will relay the method invocation to the underlying DOM element. So, in this PR, I'd like to add the same `focus()` method to the `TextArea` component.