### PR TITLE
Fix typings for Modal/Confirm to match their proptypes

### DIFF
--- a/src/modules/Modal/Modal.d.ts
+++ b/src/modules/Modal/Modal.d.ts
@@ -34,7 +34,7 @@ export interface ModalProps extends PortalProps {
   closeOnDocumentClick?: boolean;
 
   /** A Modal can be passed content via shorthand. */
-  content: any;
+  content?: any;
 
   /** Initial value of open. */
   defaultOpen?: boolean;
@@ -43,7 +43,7 @@ export interface ModalProps extends PortalProps {
   dimmer?: boolean | 'blurring' | 'inverted';
 
   /** A Modal can be passed header via shorthand. */
-  header: any;
+  header?: any;
 
   /** The node where the modal should mount. Defaults to document.body. */
   mountNode?: any;


### PR DESCRIPTION
Package: `semantic-ui-react`
Version: `0.68.1`

I was seeing the following two errors when packaging with webpack:

```bash
../semantic-ui-react/dist/commonjs/addons/Confirm/Confirm.d.ts
(4,18): error TS2430: Interface 'ConfirmProps' incorrectly extends interface 'ModalProps'.
  Property 'content' is optional in type 'ConfirmProps' but required in type 'ModalProps'.
```

and

```bash
../semantic-ui-react/dist/commonjs/addons/Confirm/Confirm.d.ts
(4,18): error TS2430: Interface 'ConfirmProps' incorrectly extends interface 'ModalProps'.
  Property 'header' is optional in type 'ConfirmProps' but required in type 'ModalProps'.
```

As far as I can tell the proptypes for content and headers aren't required for modal so I've removed that restriction so that the extends will match 

Note: `No linter errors added and passes tests.`