### PR TITLE
fix(MenuExampleText): activeItem logic

### DIFF
--- a/docs/app/Examples/collections/Menu/Types/MenuExampleText.js
+++ b/docs/app/Examples/collections/Menu/Types/MenuExampleText.js
@@ -13,8 +13,8 @@ export default class MenuExampleText extends Component {
       <Menu text>
         <Menu.Item header>Sort By</Menu.Item>
         <Menu.Item name='closest' active={activeItem === 'closest'} onClick={this.handleItemClick} />
-        <Menu.Item name='mostComments' active={activeItem === 'comments'} onClick={this.handleItemClick} />
-        <Menu.Item name='mostPopular' active={activeItem === 'popular'} onClick={this.handleItemClick} />
+        <Menu.Item name='mostComments' active={activeItem === 'mostComments'} onClick={this.handleItemClick} />
+        <Menu.Item name='mostPopular' active={activeItem === 'mostPopular'} onClick={this.handleItemClick} />
       </Menu>
     )
   }


### PR DESCRIPTION
Fixes [#1640](https://github.com/Semantic-Org/Semantic-UI-React/issues/1640)

BEFORE:
When selected the "Closest" Menu item:
![normal](https://cloud.githubusercontent.com/assets/26656420/25514425/d84b9b72-2b91-11e7-9e63-447733308912.PNG)
When selected the "Most Comments" Menu item:
![error](https://cloud.githubusercontent.com/assets/26656420/25514377/920a8a42-2b91-11e7-8361-604ca1d2d987.PNG)
When selected the "Most Popular" Menu item:
![error](https://cloud.githubusercontent.com/assets/26656420/25514378/9335f10e-2b91-11e7-8fc3-0eba3aaa25d7.PNG)


AFTER:
When selected the "Closest" Menu item:
![normal](https://cloud.githubusercontent.com/assets/26656420/25514425/d84b9b72-2b91-11e7-9e63-447733308912.PNG)
When selected the "Most Comments" Menu item:
![fix most](https://cloud.githubusercontent.com/assets/26656420/25514284/b4c014b8-2b90-11e7-8031-0a88a169042e.PNG)
When selected the "Most Popular" Menu item:
![fixed popular](https://cloud.githubusercontent.com/assets/26656420/25514286/b4c24972-2b90-11e7-9ff7-5bc499dbf1d2.PNG)