### PR TITLE
Fix errors in TypeScript definitions

### DIFF
--- a/src/collections/Form/FormCheckbox.d.ts
+++ b/src/collections/Form/FormCheckbox.d.ts
@@ -11,6 +11,9 @@ export interface FormCheckboxProps extends FormFieldProps, CheckboxProps {
 
   /** A FormField control prop. */
   control?: any;
+
+  /** HTML input type, either checkbox or radio. */
+  type?: 'checkbox' | 'radio';
 }
 
 declare const FormCheckbox: React.StatelessComponent<FormCheckboxProps>;

--- a/src/collections/Form/FormRadio.d.ts
+++ b/src/collections/Form/FormRadio.d.ts
@@ -11,6 +11,9 @@ export interface FormRadioProps extends FormFieldProps, RadioProps {
 
   /** A FormField control prop. */
   control?: any;
+
+  /** HTML input type, either checkbox or radio. */
+  type?: 'checkbox' | 'radio';
 }
 
 declare const FormRadio: React.StatelessComponent<FormRadioProps>;

--- a/src/views/Statistic/StatisticGroup.d.ts
+++ b/src/views/Statistic/StatisticGroup.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { SemanticCOLORS, SemanticWIDTHS } from '../..';
-import { StatisticSizeProp } from './Statictic';
+import { StatisticSizeProp } from './Statistic';
 
 export interface StatisticGroupProps {
   [key: string]: any;


### PR DESCRIPTION
Fixes the following errors with TypeScript 2.3.2:

```
Failed to compile.

Error in [...]\node_modules\semantic-ui-react\dist\commonjs\views\Statistic\StatisticGroup.d.ts
(4,35): error TS2307: Cannot find module './Statictic'.

Error in [...]\node_modules\semantic-ui-react\dist\commonjs\collections\Form\FormCheckbox.d.ts
(6,18): error TS2320: Interface 'FormCheckboxProps' cannot simultaneously extend types 'FormFieldProps' and 'CheckboxProps'.
  Named property 'type' of types 'FormFieldProps' and 'CheckboxProps' are not identical.

Error in [...]\node_modules\semantic-ui-react\dist\commonjs\collections\Form\FormRadio.d.ts
(6,18): error TS2320: Interface 'FormRadioProps' cannot simultaneously extend types 'FormFieldProps' and 'RadioProps'.
  Named property 'type' of types 'FormFieldProps' and 'RadioProps' are not identical.
```