### PR TITLE
docs(Search): add example of input shorthand 

### DIFF
--- a/docs/app/Examples/modules/Search/Variations/SearchExampleInput.js
+++ b/docs/app/Examples/modules/Search/Variations/SearchExampleInput.js
@@ -1,5 +1,4 @@
 import React from 'react'
-
 import SearchExampleStandard from '../Types/SearchExampleStandard'
 
 const SearchExampleInput = () => (

--- a/docs/app/Examples/modules/Search/Variations/SearchExampleInput.js
+++ b/docs/app/Examples/modules/Search/Variations/SearchExampleInput.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+import SearchExampleStandard from '../Types/SearchExampleStandard'
+
+const SearchExampleInput = () => (
+  <SearchExampleStandard input={{ icon: 'search', iconPosition: 'left' }} />
+)
+
+export default SearchExampleInput

--- a/docs/app/Examples/modules/Search/Variations/index.js
+++ b/docs/app/Examples/modules/Search/Variations/index.js
@@ -14,6 +14,11 @@ const SearchVariationsExamples = () => (
       description='A search can have its results aligned to its left or right container edge.'
       examplePath='modules/Search/Variations/SearchExampleAligned'
     />
+    <ComponentExample
+      title='Input'
+      description='A search can be passed an input via shorthand props.'
+      examplePath='modules/Search/Variations/SearchExampleInput'
+    />
   </ExampleSection>
 )
 

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "through2": "^2.0.2",
     "tslint": "^5.0.0",
     "tslint-config-typings": "^0.3.1",
-    "typescript": "^2.3.1",
+    "typescript": "^2.3.2",
     "webpack": "^2.3.2",
     "webpack-dev-middleware": "^1.10.1",
     "webpack-hot-middleware": "^2.17.1"

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "through2": "^2.0.2",
     "tslint": "^5.0.0",
     "tslint-config-typings": "^0.3.1",
-    "typescript": "^2.3.2",
+    "typescript": "^2.3.1",
     "webpack": "^2.3.2",
     "webpack-dev-middleware": "^1.10.1",
     "webpack-hot-middleware": "^2.17.1"


### PR DESCRIPTION
Adding a simple example of passing input shorthand prop to ```Search``` mentioned in [#1628](https://github.com/Semantic-Org/Semantic-UI-React/issues/1628).

Fixes #1628