### PR TITLE
chore(es-modules): fix usage of require

### DIFF
--- a/build/preset-es2015.js
+++ b/build/preset-es2015.js
@@ -1,6 +1,13 @@
-const options = process.env.BABEL_ENV === 'es' ? { modules: false } : {}
+let options = {}
+let plugins = []
+
+if (process.env.BABEL_ENV === 'es') {
+  options = { modules: false }
+  plugins = [['transform-rename-import', { original: './debug.cjs', replacement: './debug.es' }]]
+}
 
 module.exports = {
+  plugins,
   presets: [
     ['es2015', options],
   ],

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-transform-react-handled-props": "^0.2.3",
     "babel-plugin-transform-react-remove-prop-types": "^0.3.2",
+    "babel-plugin-transform-rename-import": "^2.0.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.5.0",

--- a/src/lib/debug/debug.cjs.js
+++ b/src/lib/debug/debug.cjs.js
@@ -1,4 +1,4 @@
-import isBrowser from './isBrowser'
+import isBrowser from '../isBrowser'
 let _debug
 const noop = () => undefined
 
@@ -26,24 +26,4 @@ if (isBrowser && process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !
   _debug = () => noop
 }
 
-/**
- * Create a namespaced debug function.
- * @param {String} namespace Usually a component name.
- * @example
- * import { makeDebugger } from 'src/lib'
- * const debug = makeDebugger('namespace')
- *
- * debug('Some message')
- * @returns {Function}
- */
-export const makeDebugger = (namespace) => {
-  return _debug(`semanticUIReact:${namespace}`)
-}
-
-/**
- * Default debugger, simple log.
- * @example
- * import { debug } from 'src/lib'
- * debug('Some message')
- */
-export const debug = makeDebugger('log')
+export default _debug

--- a/src/lib/debug/debug.es.js
+++ b/src/lib/debug/debug.es.js
@@ -1,0 +1,31 @@
+import debug from 'debug'
+import isBrowser from '../isBrowser'
+
+let _debug
+const noop = () => undefined
+
+if (isBrowser && process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
+  // Heads Up!
+  // https://github.com/visionmedia/debug/pull/331
+  //
+  // debug now clears storage on load, grab the debug settings before require('debug').
+  // We try/catch here as Safari throws on localStorage access in private mode or with cookies disabled.
+  let DEBUG
+  try {
+    DEBUG = window.localStorage.debug
+  } catch (e) {
+    /* eslint-disable no-console */
+    console.error('Semantic-UI-React could not enable debug.')
+    console.error(e)
+   /* eslint-enable no-console */
+  }
+
+  _debug = debug
+
+  // enable what ever settings we got from storage
+  _debug.enable(DEBUG)
+} else {
+  _debug = () => noop
+}
+
+export default _debug

--- a/src/lib/debug/index.js
+++ b/src/lib/debug/index.js
@@ -1,0 +1,23 @@
+import _debug from './debug.cjs'
+
+/**
+ * Create a namespaced debug function.
+ * @param {String} namespace Usually a component name.
+ * @example
+ * import { makeDebugger } from 'src/lib'
+ * const debug = makeDebugger('namespace')
+ *
+ * debug('Some message')
+ * @returns {Function}
+ */
+export const makeDebugger = (namespace) => {
+  return _debug(`semanticUIReact:${namespace}`)
+}
+
+/**
+ * Default debugger, simple log.
+ * @example
+ * import { debug } from 'src/lib'
+ * debug('Some message')
+ */
+export const debug = makeDebugger('log')


### PR DESCRIPTION
Fixes #1238.
Replaces #1237.

----

### What it does?

Stipes our debug functionality to `debug.cjs` and `debug.es` files, who use `require` and `import` to fetch `debug` module. Plugin for `babel` replaces import of module when build is for ES modules. This will fix our ES build for rollup and will left everything as is.

@levithomason I will be glad to hear your opinion there.