### PR TITLE
fix(Progress): use floor for data-percent attribute

### DIFF
--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -193,7 +193,7 @@ class Progress extends Component {
     const percent = this.getPercent()
 
     return (
-      <ElementType {...rest} className={classes} data-percent={percent}>
+      <ElementType {...rest} className={classes} data-percent={Math.floor(percent)}>
         <div className='bar' style={{ width: `${percent}%` }}>
           {this.renderProgress(percent)}
         </div>

--- a/test/specs/modules/Progress/Progress-test.js
+++ b/test/specs/modules/Progress/Progress-test.js
@@ -98,6 +98,16 @@ describe('Progress', () => {
       shallow(<Progress percent={10} />)
         .should.have.prop('data-percent', 10)
     })
+
+    it('floors the value of percent prop', () => {
+      shallow(<Progress percent={8.28} />)
+        .should.have.prop('data-percent', 8)
+    })
+
+    it('floors the results value and total props', () => {
+      shallow(<Progress value={828} total={10000} />)
+        .should.have.prop('data-percent', 8)
+    })
   })
 
   describe('indicating', () => {


### PR DESCRIPTION
Floor the data-percent attribute so Semantic UI CSS works as expected.

Fixes #1671