### PR TITLE
feat(typings): expose FormComponent in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export {
   BreadcrumbSectionProps
 } from './dist/commonjs/collections/Breadcrumb/BreadcrumbSection';
 
-export { default as Form, FormProps } from './dist/commonjs/collections/Form';
+export { default as Form, FormProps, FormComponent } from './dist/commonjs/collections/Form';
 export { default as FormButton, FormButtonProps } from './dist/commonjs/collections/Form/FormButton';
 export { default as FormCheckbox, FormCheckboxProps } from './dist/commonjs/collections/Form/FormCheckbox';
 export { default as FormDropdown, FormDropdownProps } from './dist/commonjs/collections/Form/FormDropdown';

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export {
   BreadcrumbSectionProps
 } from './dist/commonjs/collections/Breadcrumb/BreadcrumbSection';
 
-export { default as Form, FormProps, FormComponent } from './dist/commonjs/collections/Form';
+export { default as Form, FormComponent, FormProps } from './dist/commonjs/collections/Form';
 export { default as FormButton, FormButtonProps } from './dist/commonjs/collections/Form/FormButton';
 export { default as FormCheckbox, FormCheckboxProps } from './dist/commonjs/collections/Form/FormCheckbox';
 export { default as FormDropdown, FormDropdownProps } from './dist/commonjs/collections/Form/FormDropdown';

--- a/src/collections/Form/Form.d.ts
+++ b/src/collections/Form/Form.d.ts
@@ -47,7 +47,7 @@ export interface FormProps {
   widths?: 'equal';
 }
 
-interface FormComponent extends React.StatelessComponent<FormProps> {
+export interface FormComponent extends React.StatelessComponent<FormProps> {
   Field: typeof FormField;
   Button: typeof FormButton;
   Checkbox: typeof FormCheckbox;

--- a/src/collections/Form/index.d.ts
+++ b/src/collections/Form/index.d.ts
@@ -1,1 +1,1 @@
-export { default, FormProps, FormComponent } from './Form';
+export { default, FormComponent, FormProps } from './Form';

--- a/src/collections/Form/index.d.ts
+++ b/src/collections/Form/index.d.ts
@@ -1,1 +1,1 @@
-export { default, FormProps } from './Form';
+export { default, FormProps, FormComponent } from './Form';


### PR DESCRIPTION
In order to generate typings for custom controls based on your react controls a FormControl needs to be exposed. This is only a change to typings.
