### PR TITLE
docs(Form): fix typo

### DIFF
--- a/docs/app/Examples/collections/Form/Shorthand/index.js
+++ b/docs/app/Examples/collections/Form/Shorthand/index.js
@@ -84,7 +84,7 @@ const FormTypesExamples = () => (
     </ComponentExample>
 
     <ComponentExample
-      title='Accessible lables'
+      title='Accessible Labels'
       description='Adding an id to a shorthand Form.Field adds a matching htmlFor prop to the label.'
       examplePath='collections/Form/Shorthand/FormExampleFieldControlId'
     />


### PR DESCRIPTION
* Correct the spelling of a word
* Capitalize the first letter of the word