### PR TITLE
feat(Dropdown): Add minCharacters prop

### DIFF
--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -88,6 +88,9 @@ export interface DropdownProps {
   /** A dropdown can show that it is currently loading data. */
   loading?: boolean;
 
+  /** The minimum characters for a search to begin showing results. */
+  minCharacters?: number;
+
   /** A selection dropdown can allow multiple selections. */
   multiple?: boolean;
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -712,13 +712,13 @@ export default class Dropdown extends Component {
     debug(e.target.value)
     // prevent propagating to this.props.onChange()
     e.stopPropagation()
-    const { search, onSearchChange } = this.props
+    const { search, onSearchChange, minCharacters } = this.props
     const { open } = this.state
     const newQuery = e.target.value
 
     if (onSearchChange) onSearchChange(e, newQuery)
 
-    if (newQuery.length >= this.props.minCharacters) {
+    if (newQuery.length >= minCharacters) {
       // open search dropdown on search query
       if (search && newQuery && !open) this.open()
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -140,6 +140,9 @@ export default class Dropdown extends Component {
     /** A dropdown can show that it is currently loading data. */
     loading: PropTypes.bool,
 
+    /** The minimum characters for a search to begin showing results. */
+    minCharacters: PropTypes.number,
+
     /** A selection dropdown can allow multiple selections. */
     multiple: PropTypes.bool,
 
@@ -335,6 +338,7 @@ export default class Dropdown extends Component {
     selectOnBlur: true,
     openOnFocus: true,
     closeOnBlur: true,
+    minCharacters: 1,
   }
 
   static autoControlledProps = [
@@ -714,13 +718,15 @@ export default class Dropdown extends Component {
 
     if (onSearchChange) onSearchChange(e, newQuery)
 
-    // open search dropdown on search query
-    if (search && newQuery && !open) this.open()
+    if (newQuery.length >= this.props.minCharacters) {
+      // open search dropdown on search query
+      if (search && newQuery && !open) this.open()
 
-    this.setState({
-      selectedIndex: 0,
-      searchQuery: newQuery,
-    })
+      this.setState({
+        selectedIndex: 0,
+        searchQuery: newQuery,
+      })
+    }
   }
 
   // ----------------------------------------

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1604,6 +1604,19 @@ describe('Dropdown', () => {
       dropdownMenuIsOpen()
     })
 
+    it('Don\'t open the menu on change if query\'s length is less than minCharacters', () => {
+      wrapperMount(<Dropdown options={options} selection search minCharacters={4} />)
+
+      dropdownMenuIsClosed()
+
+      // simulate search with query's length is less than minCharacters
+      wrapper
+        .find('input.search')
+        .simulate('change', { target: { value: faker.hacker.noun().substring(0, 1) } })
+
+      dropdownMenuIsClosed()
+    })
+
     it('does not call onChange on query change', () => {
       const onChangeSpy = sandbox.spy()
       wrapperMount(<Dropdown options={options} selection search onChange={onChangeSpy} />)

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1604,7 +1604,7 @@ describe('Dropdown', () => {
       dropdownMenuIsOpen()
     })
 
-    it('Don\'t open the menu on change if query\'s length is less than minCharacters', () => {
+    it("Don't open the menu on change if query's length is less than minCharacters", () => {
       wrapperMount(<Dropdown options={options} selection search minCharacters={4} />)
 
       dropdownMenuIsClosed()


### PR DESCRIPTION
I've added minCharacters props in Dropdown as requested in #1124. Now we can set the minimum characters for a search to begin showing results.

I also would like to add saveRemoteData but I'm wondered if it's not useless. Because someone will use Flux' store and someone else the Redux' store and the other the locale storage. 

So should I use locale storage to implement saveRemoteData?