### PR TITLE
fix(Checkbox): fix value prop types

### DIFF
--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -109,8 +109,8 @@ export default class Checkbox extends Component {
     /** The HTML input value. */
     value: PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.number
-    ])
+      PropTypes.number,
+    ]),
   }
 
   static defaultProps = {

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -107,7 +107,10 @@ export default class Checkbox extends Component {
     type: PropTypes.oneOf(['checkbox', 'radio']),
 
     /** The HTML input value. */
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ])
   }
 
   static defaultProps = {


### PR DESCRIPTION
Just a little fix, `PropTypes` doesn't match typescript definition into Checkbox.js.

```typescript
// Checkbox.d.ts:79

/** The HTML input value. */
  value?: number|string;
```