### PR TITLE
feat(typings): export generic types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,9 @@ export { default as StepDescription, StepDescriptionProps } from './dist/commonj
 export { default as StepGroup, StepGroupProps } from './dist/commonjs/elements/Step/StepGroup';
 export { default as StepTitle, StepTitleProps } from './dist/commonjs/elements/Step/StepTitle';
 
+// Generics
+export * from './dist/commonjs';
+
 // Modules
 export { default as Accordion, AccordionProps } from './dist/commonjs/modules/Accordion/Accordion';
 export { default as AccordionContent, AccordionContentProps } from './dist/commonjs/modules/Accordion/AccordionContent';


### PR DESCRIPTION
For now, if I want to refer to Semantic generic types, I need to do:

```typescript
// actual
import { SemanticCOLORS } from "../../node_modules/semantic-ui-react/dist/commonjs";

// proposed
import { SemanticCOLORS } from "semantic-ui-react"
```

I don't know if "Generics" comment is good, if someone have a better proposition, I take it!