### PR TITLE
docs(Button): remove redundant prop in Vertical Group example

### DIFF
--- a/docs/app/Examples/elements/Button/GroupVariations/ButtonExampleGroupVertical.js
+++ b/docs/app/Examples/elements/Button/GroupVariations/ButtonExampleGroupVertical.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button } from 'semantic-ui-react'
 
 const ButtonExampleGroupVertical = () => (
-  <Button.Group attached='top' vertical>
+  <Button.Group vertical>
     <Button>Feed</Button>
     <Button>Messages</Button>
     <Button>Events</Button>


### PR DESCRIPTION
Fixes #1697.