### PR TITLE
docs(Introduction): fix declarative example

### DIFF
--- a/docs/app/Views/Introduction.js
+++ b/docs/app/Views/Introduction.js
@@ -59,7 +59,7 @@ const RatingJSX = '<Rating rating={1} maxRating={5} />'
 const RatingHTML = `<div
   class="ui rating"
   data-rating="1"
-  data-max-rating="3"
+  data-max-rating="5"
 ></div>`
 
 const MessageIconJSX = `<Message


### PR DESCRIPTION
There is a difference between a code translated from JSX to HTML in https://react.semantic-ui.com/introduction where the max value is 5 in JSX version and 3 in HTML version

![introduction declarative](https://cloud.githubusercontent.com/assets/26656420/26438820/082128d2-40da-11e7-8346-8aa9fe365ce5.PNG)

This PR sets the max value in HTML version to 5