### PR TITLE
Binding with context

### DIFF
--- a/docs/app/Examples/modules/Search/Types/SearchExampleCategory.js
+++ b/docs/app/Examples/modules/Search/Types/SearchExampleCategory.js
@@ -53,7 +53,7 @@ export default class SearchExampleCategory extends Component {
         isLoading: false,
         results: filteredResults,
       })
-    }, 500)
+    }, 500).bind(this)
   }
 
   render() {


### PR DESCRIPTION
It allows for inner functions (setTimeout in this case).

Removes error:
- 'setState' not found