### PR TITLE
docs(examples): add dependency for babel-plugin-lodash

### DIFF
--- a/examples/webpack1/package.json
+++ b/examples/webpack1/package.json
@@ -4,24 +4,27 @@
   "description": "Get started with Semantic UI React and Webpack 1",
   "main": "index.js",
   "scripts": {
+    "analize": "cross-env ANALIZE_ENV=true npm run build",
+    "analize:production": "cross-env ANALIZE_ENV=true npm run build:production",
     "build": "webpack",
     "build:production": "cross-env NODE_ENV=production npm run build"
   },
   "author": "Alexander Fedyashov <a@fedyashov.com>",
   "license": "MIT",
   "dependencies": {
-    "babel-core": "^6.24.0",
-    "babel-loader": "^6.4.0",
-    "babel-preset-es2015": "^6.24.0",
-    "babel-preset-react": "^6.23.0",
-    "babel-preset-stage-1": "^6.22.0",
-    "cross-env": "^3.2.3",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "semantic-ui-react": "^0.68.3",
-    "webpack": "^1.12.14"
+    "babel-core": "^6.24.1",
+    "babel-loader": "^6.4.1",
+    "babel-plugin-lodash": "^3.2.11",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-1": "^6.24.1",
+    "cross-env": "^5.0.0",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "semantic-ui-react": "^0.68.4",
+    "webpack": "^1.15.0"
   },
   "devDependencies": {
-    "webpack-bundle-analyzer": "^2.3.1"
+    "webpack-bundle-analyzer": "^2.8.2"
   }
 }

--- a/examples/webpack1/package.json
+++ b/examples/webpack1/package.json
@@ -4,8 +4,8 @@
   "description": "Get started with Semantic UI React and Webpack 1",
   "main": "index.js",
   "scripts": {
-    "analize": "cross-env ANALIZE_ENV=true npm run build",
-    "analize:production": "cross-env ANALIZE_ENV=true npm run build:production",
+    "analyze": "cross-env ANALYZE_ENV=true npm run build",
+    "analyze:production": "cross-env ANALYZE_ENV=true npm run build:production",
     "build": "webpack",
     "build:production": "cross-env NODE_ENV=production npm run build"
   },

--- a/examples/webpack1/webpack.config.js
+++ b/examples/webpack1/webpack.config.js
@@ -2,6 +2,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const path = require('path')
 const webpack = require('webpack')
 
+const analize = !!process.env.ANALIZE_ENV
 const env = process.env.NODE_ENV || 'development'
 
 const webpackConfig = {
@@ -26,7 +27,6 @@ const webpackConfig = {
         NODE_ENV: JSON.stringify(env),
       },
     }),
-    new BundleAnalyzerPlugin(),
   ],
 
   output: {
@@ -39,6 +39,10 @@ const webpackConfig = {
     root: path.resolve('src'),
     extensions: ['', '.js', '.jsx'],
   },
+}
+
+if (analize) {
+  webpackConfig.plugins.push(new BundleAnalyzerPlugin())
 }
 
 if (env === 'production') {

--- a/examples/webpack1/webpack.config.js
+++ b/examples/webpack1/webpack.config.js
@@ -2,7 +2,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const path = require('path')
 const webpack = require('webpack')
 
-const analize = !!process.env.ANALIZE_ENV
+const analyze = !!process.env.ANALYZE_ENV
 const env = process.env.NODE_ENV || 'development'
 
 const webpackConfig = {
@@ -41,7 +41,7 @@ const webpackConfig = {
   },
 }
 
-if (analize) {
+if (analyze) {
   webpackConfig.plugins.push(new BundleAnalyzerPlugin())
 }
 

--- a/examples/webpack2/package.json
+++ b/examples/webpack2/package.json
@@ -4,8 +4,8 @@
   "description": "Get started with Semantic UI React and Webpack 2",
   "main": "index.js",
   "scripts": {
-    "analize": "cross-env ANALIZE_ENV=true npm run build",
-    "analize:production": "cross-env ANALIZE_ENV=true npm run build:production",
+    "analyze": "cross-env ANALYZE_ENV=true npm run build",
+    "analyze:production": "cross-env ANALYZE_ENV=true npm run build:production",
     "build": "webpack",
     "build:production": "cross-env NODE_ENV=production npm run build"
   },

--- a/examples/webpack2/package.json
+++ b/examples/webpack2/package.json
@@ -4,24 +4,27 @@
   "description": "Get started with Semantic UI React and Webpack 2",
   "main": "index.js",
   "scripts": {
+    "analize": "cross-env ANALIZE_ENV=true npm run build",
+    "analize:production": "cross-env ANALIZE_ENV=true npm run build:production",
     "build": "webpack",
     "build:production": "cross-env NODE_ENV=production npm run build"
   },
   "author": "Alexander Fedyashov <a@fedyashov.com>",
   "license": "MIT",
   "dependencies": {
-    "babel-core": "^6.24.0",
-    "babel-loader": "^6.4.0",
-    "babel-preset-es2015": "^6.24.0",
-    "babel-preset-react": "^6.23.0",
-    "babel-preset-stage-1": "^6.22.0",
-    "cross-env": "^3.2.3",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "semantic-ui-react": "^0.68.3",
-    "webpack": "^2.3.0"
+    "babel-core": "^6.24.1",
+    "babel-loader": "^7.0.0",
+    "babel-plugin-lodash": "^3.2.11",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-1": "^6.24.1",
+    "cross-env": "^5.0.0",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "semantic-ui-react": "^0.68.4",
+    "webpack": "^2.6.1"
   },
   "devDependencies": {
-    "webpack-bundle-analyzer": "^2.3.1"
+    "webpack-bundle-analyzer": "^2.8.2"
   }
 }

--- a/examples/webpack2/webpack.config.js
+++ b/examples/webpack2/webpack.config.js
@@ -2,7 +2,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const path = require('path')
 const webpack = require('webpack')
 
-const analize = !!process.env.ANALIZE_ENV
+const analyze = !!process.env.ANALYZE_ENV
 const env = process.env.NODE_ENV || 'development'
 
 const webpackConfig = {
@@ -44,7 +44,7 @@ const webpackConfig = {
   },
 }
 
-if (analize) {
+if (analyze) {
   webpackConfig.plugins.push(new BundleAnalyzerPlugin())
 }
 

--- a/examples/webpack2/webpack.config.js
+++ b/examples/webpack2/webpack.config.js
@@ -2,6 +2,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const path = require('path')
 const webpack = require('webpack')
 
+const analize = !!process.env.ANALIZE_ENV
 const env = process.env.NODE_ENV || 'development'
 
 const webpackConfig = {
@@ -26,7 +27,6 @@ const webpackConfig = {
         NODE_ENV: JSON.stringify(env),
       },
     }),
-    new BundleAnalyzerPlugin(),
   ],
 
   output: {
@@ -42,6 +42,10 @@ const webpackConfig = {
     ],
     extensions: ['.js', '.jsx'],
   },
+}
+
+if (analize) {
+  webpackConfig.plugins.push(new BundleAnalyzerPlugin())
 }
 
 if (env === 'production') {


### PR DESCRIPTION
Fixes #1701.

- adds `babel-plugin-lodash` to deps;
- updates all deps;
- splits `analize` to dedicated scripts.