### PR TITLE
docs(Icon): fix selector for input

### DIFF
--- a/docs/app/Components/IconSearch/IconSearch.js
+++ b/docs/app/Components/IconSearch/IconSearch.js
@@ -57,7 +57,7 @@ export default class IconSearch extends Component {
   state = { search: '', includeSimilar: true }
 
   componentDidMount() {
-    const input = document.querySelector('#docs-icon-set-input input')
+    const input = document.querySelector('#docs-icon-set-input')
     input.focus()
   }
 


### PR DESCRIPTION
Fixes #1709.

After #1517 `id` is passing to `input` element, so the selector became incorrect.