### PR TITLE
docs(Item): cleanup Item's floated example

### DIFF
--- a/docs/app/Examples/views/Item/Variations/ItemExampleFloated.js
+++ b/docs/app/Examples/views/Item/Variations/ItemExampleFloated.js
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Button, Image as ImageComponent, Item } from 'semantic-ui-react'
+import { Button, Image, Item } from 'semantic-ui-react'
 
-const paragraph = <ImageComponent src='/assets/images/wireframe/short-paragraph.png' />
+const paragraph = <Image src='/assets/images/wireframe/short-paragraph.png' />
 
 const ItemExampleFloated = () => (
   <Item.Group relaxed>


### PR DESCRIPTION
Fixes error in docs. "AS" is not being recognized.