### PR TITLE
breaking(Dropdown): remove hidden select

### DIFF
--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -94,9 +94,6 @@ export interface DropdownProps {
   /** A selection dropdown can allow multiple selections. */
   multiple?: boolean;
 
-  /** Name of the hidden input which holds the value. */
-  name?: string;
-
   /** Message to display when there are no results. */
   noResultsMessage?: string;
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -148,9 +148,6 @@ export default class Dropdown extends Component {
     /** A selection dropdown can allow multiple selections. */
     multiple: PropTypes.bool,
 
-    /** Name of the hidden input which holds the value. */
-    name: PropTypes.string,
-
     /** Message to display when there are no results. */
     noResultsMessage: PropTypes.string,
 
@@ -1060,28 +1057,8 @@ export default class Dropdown extends Component {
     return <div className={classes}>{_text}</div>
   }
 
-  renderHiddenInput = () => {
-    debug('renderHiddenInput()')
-    const { value } = this.state
-    const { multiple, name, options, selection } = this.props
-    debug(`name:      ${name}`)
-    debug(`selection: ${selection}`)
-    debug(`value:     ${value}`)
-    if (!selection) return null
-
-    // a dropdown without an active item will have an empty string value
-    return (
-      <select type='hidden' aria-hidden='true' name={name} value={value} multiple={multiple}>
-        <option value='' />
-        {_.map(options, (option, i) => (
-          <option key={getKeyOrValue(option.key, option.value)} value={option.value}>{option.text}</option>
-        ))}
-      </select>
-    )
-  }
-
   renderSearchInput = () => {
-    const { disabled, search, name, tabIndex } = this.props
+    const { disabled, search, tabIndex } = this.props
     const { searchQuery } = this.state
 
     if (!search) return null
@@ -1107,7 +1084,6 @@ export default class Dropdown extends Component {
         aria-autocomplete='list'
         onChange={this.handleSearchChange}
         className='search'
-        name={[name, 'search'].join('-')}
         autoComplete='off'
         tabIndex={computedTabIndex}
         style={{ width: searchWidth }}
@@ -1285,7 +1261,6 @@ export default class Dropdown extends Component {
         tabIndex={computedTabIndex}
         ref={this.handleRef}
       >
-        {this.renderHiddenInput()}
         {this.renderLabels()}
         {this.renderSearchInput()}
         {this.renderSearchSizer()}

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1247,13 +1247,12 @@ describe('Dropdown', () => {
     })
     describe('removing items', () => {
       it('calls onChange without the clicked value', () => {
-        const name = 'my-dropdown'
         const value = _.map(options, 'value')
         const randomIndex = _.random(options.length - 1)
         const randomValue = value[randomIndex]
         const expected = _.without(value, randomValue)
         const spy = sandbox.spy()
-        wrapperMount(<Dropdown options={options} selection name={name} value={value} multiple onChange={spy} />)
+        wrapperMount(<Dropdown options={options} selection value={value} multiple onChange={spy} />)
 
         wrapper
           .find('.delete.icon')
@@ -1261,7 +1260,7 @@ describe('Dropdown', () => {
           .simulate('click')
 
         spy.should.have.been.calledOnce()
-        spy.should.have.been.calledWithMatch({}, { name, value: expected })
+        spy.should.have.been.calledWithMatch({}, { value: expected })
       })
     })
   })
@@ -1283,10 +1282,9 @@ describe('Dropdown', () => {
       spy.should.not.have.been.called()
     })
     it('removes the last item when there is no search query', () => {
-      const name = 'my-dropdown'
       const value = _.map(options, 'value')
       const expected = _.dropRight(value)
-      wrapperMount(<Dropdown options={options} selection name={name} value={value} multiple search onChange={spy} />)
+      wrapperMount(<Dropdown options={options} selection value={value} multiple search onChange={spy} />)
 
       // open
       wrapper.simulate('click')
@@ -1294,14 +1292,13 @@ describe('Dropdown', () => {
       domEvent.keyDown(document, { key: 'Backspace' })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, { name, value: expected })
+      spy.should.have.been.calledWithMatch({}, { value: expected })
     })
     it('removes the last item when there is no search query when uncontrolled', () => {
-      const name = 'my-dropdown'
       const value = _.map(options, 'value')
       const expected = _.dropRight(value)
       wrapperMount(
-        <Dropdown options={options} selection name={name} defaultValue={value} multiple search onChange={spy} />
+        <Dropdown options={options} selection defaultValue={value} multiple search onChange={spy} />
       )
 
       // open
@@ -1310,7 +1307,7 @@ describe('Dropdown', () => {
       domEvent.keyDown(document, { key: 'Backspace' })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, { name, value: expected })
+      spy.should.have.been.calledWithMatch({}, { value: expected })
 
       wrapper
         .state('value')
@@ -1351,38 +1348,35 @@ describe('Dropdown', () => {
     })
 
     it('is called with event and value on item click', () => {
-      const name = 'my-dropdown'
       const randomIndex = _.random(options.length - 1)
       const randomValue = options[randomIndex].value
-      wrapperMount(<Dropdown options={options} selection onChange={spy} name={name} />)
+      wrapperMount(<Dropdown options={options} selection onChange={spy} />)
         .simulate('click')
         .find('DropdownItem')
         .at(randomIndex)
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, { name, value: randomValue })
+      spy.should.have.been.calledWithMatch({}, { value: randomValue })
     })
     it('is called with event and value when pressing enter on a selected item', () => {
-      const name = 'my-dropdown'
       const firstValue = options[0].value
-      wrapperMount(<Dropdown options={options} selection onChange={spy} name={name} />)
+      wrapperMount(<Dropdown options={options} selection onChange={spy} />)
         .simulate('click')
 
       domEvent.keyDown(document, { key: 'Enter' })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, { name, value: firstValue })
+      spy.should.have.been.calledWithMatch({}, { value: firstValue })
     })
     it('is called with event and value when blurring', () => {
-      const name = 'my-dropdown'
       const firstValue = options[0].value
-      wrapperMount(<Dropdown options={options} selection onChange={spy} name={name} />)
+      wrapperMount(<Dropdown options={options} selection onChange={spy} />)
         .simulate('focus')  // open, highlights first item
         .simulate('blur')   // blur should activate selected item
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, { name, value: firstValue })
+      spy.should.have.been.calledWithMatch({}, { value: firstValue })
     })
     it('is not called on blur when closed', () => {
       wrapperMount(<Dropdown options={options} selection open={false} onChange={spy} />)
@@ -1513,48 +1507,6 @@ describe('Dropdown', () => {
     })
   })
 
-  describe('selection', () => {
-    it('does not add a hidden select by default', () => {
-      wrapperMount(<Dropdown />)
-        .should.not.have.descendants('select[type="hidden"]')
-    })
-    it('adds a hidden select', () => {
-      wrapperShallow(<Dropdown options={options} selection />)
-        .should.have.exactly(1).descendants('select[type="hidden"]')
-    })
-    it('passes the name prop to the hidden select', () => {
-      wrapperShallow(<Dropdown name='foo' options={options} selection />)
-        .find('select[type="hidden"]').should.have.prop('name', 'foo')
-    })
-    it('passes the value prop to the hidden select', () => {
-      const value = _.values(options)
-
-      wrapperShallow(<Dropdown name='foo' value={value} options={options} selection />)
-        .find('select[type="hidden"][name="foo"]').should.have.prop('value', value)
-    })
-    it('passes the multiple prop to the hidden select', () => {
-      const selector = 'select[type="hidden"][name="foo"]'
-
-      wrapperShallow(<Dropdown name='foo' multiple options={options} selection />)
-        .find(selector).should.have.prop('multiple', true)
-
-      wrapperShallow(<Dropdown name='foo' multiple={false} options={options} selection />)
-        .find(selector).should.have.prop('multiple', false)
-    })
-    it('adds options to the hidden select', () => {
-      wrapperShallow(<Dropdown options={options} selection />)
-        .should.have.exactly(options.length + 1).descendants('option')
-
-      options.forEach((opt, i) => {
-        // index is incremented to exclude the empty option value
-        const optionElement = wrapper.find('option').at(i + 1)
-
-        optionElement.should.have.prop('value', opt.value)
-        optionElement.should.have.text(opt.text)
-      })
-    })
-  })
-
   describe('search', () => {
     it('does not add a search input when not defined', () => {
       wrapperShallow(<Dropdown options={options} selection />)
@@ -1564,13 +1516,6 @@ describe('Dropdown', () => {
     it('adds a search input when present', () => {
       wrapperShallow(<Dropdown options={options} selection search />)
         .should.have.exactly(1).descendants('input.search')
-    })
-
-    it('adds the name prop to the search input', () => {
-      wrapperShallow(<Dropdown name='foo' options={options} selection search />)
-        .should.have.descendants('input.search')
-
-      wrapper.find('input.search').should.have.prop('name', 'foo-search')
     })
 
     it('sets focus to the search input on open', () => {
@@ -2122,9 +2067,8 @@ describe('Dropdown', () => {
 
     it('calls onAddItem prop when clicking new value', () => {
       const spy = sandbox.spy()
-      const name = 'my-dropdown'
       const search = wrapperMount(
-        <Dropdown options={customOptions} selection search allowAdditions onAddItem={spy} name={name} />
+        <Dropdown options={customOptions} selection search allowAdditions onAddItem={spy} />
       )
         .find('input.search')
 
@@ -2136,14 +2080,13 @@ describe('Dropdown', () => {
         .simulate('click')
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, { name, value: 'boo' })
+      spy.should.have.been.calledWithMatch({}, { value: 'boo' })
     })
 
     it('calls onAddItem prop when pressing enter on new value', () => {
       const spy = sandbox.spy()
-      const name = 'my-dropdown'
       const search = wrapperMount(
-        <Dropdown options={customOptions} selection search allowAdditions onAddItem={spy} name={name} />
+        <Dropdown options={customOptions} selection search allowAdditions onAddItem={spy} />
       )
         .find('input.search')
 
@@ -2151,7 +2094,7 @@ describe('Dropdown', () => {
       domEvent.keyDown(document, { key: 'Enter' })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, { name, value: 'boo' })
+      spy.should.have.been.calledWithMatch({}, { value: 'boo' })
     })
   })
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -211,10 +211,6 @@ describe('Dropdown', () => {
       wrapperMount(<Dropdown />)
       wrapper.find('div').at(0).should.have.prop('role', 'listbox')
     })
-    it('should label selection dropdown with aria-hidden=true', () => {
-      wrapperMount(<Dropdown selection />)
-      wrapper.find('select').at(0).should.have.prop('aria-hidden', 'true')
-    })
     it('should label search dropdown as a combobox', () => {
       wrapperMount(<Dropdown search />)
       wrapper.find('div').at(0).should.have.prop('role', 'combobox')


### PR DESCRIPTION
# BREAKING

The hidden `select` element has been removed from the rendered Dropdown component.  A React application should never read nor write to the DOM, so you'll likely never know this was removed.

This was a unadvertised and nonsupported API, but we're marking it as a breaking change in case users were relying on it.  If you relied on it to "get the value" of a Dropdown, you should instead capture the value from the `data` argument in the `onChange(e, data)` handler and persist it for later access.  See the [docs](https://react.semantic-ui.com).

You can persist data in component state somewhere higher in the render tree.  You might also consider using something like redux.js.org as an app state solution.

***

Falsy factory keys were fixed in #1729, including the Dropdown's handling of keys on the hidden `option` elements. That fix will go out to 0.68.x to fix that release for users.

This PR removes the hidden `select` altogether.  It is an artifact from long ago. It will be released in `0.69.x` as **breaking** as there may be some users reading the values from the DOM, unfortunately.