### PR TITLE
fix(Input): add missing minLength prop

### DIFF
--- a/src/lib/htmlInputPropsUtils.js
+++ b/src/lib/htmlInputPropsUtils.js
@@ -6,7 +6,7 @@ export const htmlInputAttrs = [
 
   // LIMITED HTML PROPS
   'autoCapitalize', 'autoComplete', 'autoCorrect', 'autoFocus', 'checked', 'disabled', 'form', 'id', 'max', 'maxLength',
-  'min', 'multiple', 'name', 'pattern', 'placeholder', 'readOnly', 'required', 'step', 'type', 'value',
+  'min', 'minLength', 'multiple', 'name', 'pattern', 'placeholder', 'readOnly', 'required', 'step', 'type', 'value',
 ]
 
 export const htmlInputEvents = [


### PR DESCRIPTION
Fixes `minLength` not being passed down to input elements by adding it to `htmlInputAttrs`.