### PR TITLE
docs(TableExampleSortable): pass in null when that column isn't sorted

### DIFF
--- a/docs/app/Examples/collections/Table/Variations/TableExampleSortable.js
+++ b/docs/app/Examples/collections/Table/Variations/TableExampleSortable.js
@@ -42,13 +42,13 @@ export default class TableExampleSortable extends Component {
       <Table sortable celled fixed>
         <Table.Header>
           <Table.Row>
-            <Table.HeaderCell sorted={column === 'name' && direction} onClick={this.handleSort('name')}>
+            <Table.HeaderCell sorted={column === 'name' ? direction : null} onClick={this.handleSort('name')}>
               Name
             </Table.HeaderCell>
-            <Table.HeaderCell sorted={column === 'age' && direction} onClick={this.handleSort('age')}>
+            <Table.HeaderCell sorted={column === 'age' ? direction : null} onClick={this.handleSort('age')}>
               Age
             </Table.HeaderCell>
-            <Table.HeaderCell sorted={column === 'gender' && direction} onClick={this.handleSort('gender')}>
+            <Table.HeaderCell sorted={column === 'gender' ? direction : null} onClick={this.handleSort('gender')}>
               Gender
             </Table.HeaderCell>
           </Table.Row>


### PR DESCRIPTION
Docs demo were incorrect, this PR fixes them
```jsx
// before
<Table.HeaderCell sorted={column === 'name' && direction} />
// after
<Table.HeaderCell sorted={column === 'name' ? direction : null} />
```

***

# BELOW IS THE ORIGINAL POST WHICH IS NO LONGER APPLICABLE

Right now the `<Table sortable />` [demo in the docs](https://react.semantic-ui.com/collections/table#table-example-sortable) uses this JSX logic:

```jsx
<Table.HeaderCell sorted={column === 'name' && direction} />
```
This provides the value `false` when that column is not selected, however it actually causes a PropTypes validation error in React dev mode. It wasn't noticed because the demo site runs in production mode, where PropTypes are not checked.

https://jsfiddle.net/cq3tfzmf/

![image](https://cloud.githubusercontent.com/assets/762949/26806397/7cf7da96-4a05-11e7-9eb1-768f1305d1a7.png)

***

Because this pattern is indeed very useful, this PR adjusts the proptypes and TS to accept `false` as a valid option. `useValueAndKey(false, 'sorted')` seemingly correctly handles this case by ignoring it and **not** rendering `false sorted`, however the tests currently fail because it's not clear to me how to safely amend them.

I've tracked down the offending helper, [`classNamePropValueBeforePropName`](https://github.com/Semantic-Org/Semantic-UI-React/blob/master/test/specs/commonTests/classNameHelpers.js#L6) but I'm hesitant to change it ignore false values without knowing the reprecusions. Will need maintainer guidance, if this PR is otherwise acceptable.

***

### Alternatives

The alternative I can think of is returning `null|undefined` which appears to work around it. We would then need to amend the docs to use this.

```jsx
<Table.HeaderCell sorted={(column === 'name' && direction) || null} />
```

***
Commit message marked as a feature since the API docs themselves didn't ever claim this was supported, only the demo implied it was. If your interpretation is that this was a "bug", obv lmk and I'll change.