### PR TITLE
fix(Search): Allow default action if there is no selected result

### DIFF
--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -317,12 +317,13 @@ export default class Search extends Component {
     debug('selectItemOnEnter()')
     debug(keyboardKey.getName(e))
     if (keyboardKey.getCode(e) !== keyboardKey.Enter) return
-    e.preventDefault()
 
     const result = this.getSelectedResult()
 
     // prevent selecting null if there was no selected item value
     if (!result) return
+
+    e.preventDefault()
 
     // notify the onResultSelect prop that the user is trying to change value
     this.setValue(result.title)


### PR DESCRIPTION
Currently, in the Search component, when there is no selected result, users cannot use the Enter key due to a misplaced call to "e.preventDefault()".

We should not stop the default action unless we actually do something.
This tiny PR will allow users to specify a custom onKeyPress action when there is no selected result.