### PR TITLE
feat(UniversalInput): add component

### DIFF
--- a/docs/app/Examples/addons/UniversalInput/Types/UniversalInputExampleInput.js
+++ b/docs/app/Examples/addons/UniversalInput/Types/UniversalInputExampleInput.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+import { Form, Grid, Header, UniversalInput } from 'semantic-ui-react'
+
+export default class UniversalInputExampleInput extends Component {
+  state = {
+    finalValue: null,
+    value: null,
+  }
+
+  handleChange = (e, { finalValue, value }) => this.setState({ finalValue, value })
+
+  render() {
+    return (
+      <Grid>
+        <Grid.Column width={8}>
+          <Form>
+            <Form.Field>
+              <UniversalInput onChange={this.handleChange} placeholder='Try to type something...' />
+            </Form.Field>
+          </Form>
+        </Grid.Column>
+        <Grid.Column width={8}>
+          <Header>State</Header>
+          <pre>{JSON.stringify(this.state, null, 2)}</pre>
+        </Grid.Column>
+      </Grid>
+    )
+  }
+}

--- a/docs/app/Examples/addons/UniversalInput/Types/UniversalInputExampleTextArea.js
+++ b/docs/app/Examples/addons/UniversalInput/Types/UniversalInputExampleTextArea.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react'
+import { Form, Grid, Header, UniversalInput } from 'semantic-ui-react'
+
+export default class UniversalInputExampleTextArea extends Component {
+  state = {
+    finalValue: null,
+    value: null,
+  }
+
+  handleChange = (e, { finalValue, value }) => this.setState({ finalValue, value })
+
+  render() {
+    return (
+      <Grid>
+        <Grid.Column width={8}>
+          <Form>
+            <Form.Field>
+              <UniversalInput
+                as='textarea'
+                onChange={this.handleChange}
+                placeholder='Try to type something...'
+              />
+            </Form.Field>
+          </Form>
+        </Grid.Column>
+        <Grid.Column width={8}>
+          <Header>State</Header>
+          <pre>{JSON.stringify(this.state, null, 2)}</pre>
+        </Grid.Column>
+      </Grid>
+    )
+  }
+}

--- a/docs/app/Examples/addons/UniversalInput/Types/index.js
+++ b/docs/app/Examples/addons/UniversalInput/Types/index.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const UniversalInputTypesExamples = () => (
+  <ExampleSection title='Types'>
+    <ComponentExample
+      title='Universal Input'
+      description='An input.'
+      examplePath='addons/UniversalInput/Types/UniversalInputExampleInput'
+    />
+    <ComponentExample
+      title='Textarea'
+      description='A textarea.'
+      examplePath='addons/UniversalInput/Types/UniversalInputExampleTextArea'
+    />
+  </ExampleSection>
+)
+
+export default UniversalInputTypesExamples

--- a/docs/app/Examples/addons/UniversalInput/Usage/UniversalInputExampleControlled.js
+++ b/docs/app/Examples/addons/UniversalInput/Usage/UniversalInputExampleControlled.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react'
+import { Button, Form, Grid, Header, UniversalInput } from 'semantic-ui-react'
+
+export default class UniversalInputExampleControlled extends Component {
+  state = {
+    finalValue: null,
+    value: null,
+  }
+
+  handleChange = (e, { finalValue, value }) => this.setState({ finalValue, value })
+
+  setValue = value => () => this.setState({ value })
+
+  render() {
+    const { value } = this.state
+
+    return (
+      <Grid>
+        <Grid.Column width={8}>
+          <Form>
+            <Form.Field>
+              <UniversalInput onChange={this.handleChange} value={value} />
+            </Form.Field>
+          </Form>
+        </Grid.Column>
+        <Grid.Column width={8}>
+          <Button content='Set "foo"' onClick={this.setValue('foo')} />
+          <Button content='Set "bar"' onClick={this.setValue('bar')} />
+
+          <Header>State</Header>
+          <pre>{JSON.stringify(this.state, null, 2)}</pre>
+        </Grid.Column>
+      </Grid>
+    )
+  }
+}

--- a/docs/app/Examples/addons/UniversalInput/Usage/UniversalInputExampleOnCompose.js
+++ b/docs/app/Examples/addons/UniversalInput/Usage/UniversalInputExampleOnCompose.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+import { Form, Grid, Header, UniversalInput } from 'semantic-ui-react'
+
+export default class UniversalInputExampleOnCompose extends Component {
+  state = {
+    finalValue: null,
+    value: null,
+  }
+
+  handleCompose = (e, { finalValue, value }) => this.setState({ finalValue, value })
+
+  render() {
+    return (
+      <Grid>
+        <Grid.Column width={8}>
+          <Form>
+            <Form.Field>
+              <UniversalInput onCompose={this.handleCompose} />
+            </Form.Field>
+          </Form>
+        </Grid.Column>
+        <Grid.Column width={8}>
+          <Header>State</Header>
+          <pre>{JSON.stringify(this.state, null, 2)}</pre>
+        </Grid.Column>
+      </Grid>
+    )
+  }
+}

--- a/docs/app/Examples/addons/UniversalInput/Usage/index.js
+++ b/docs/app/Examples/addons/UniversalInput/Usage/index.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
+import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
+
+const UniversalInputUsage = () => (
+  <ExampleSection title='Usage'>
+    <ComponentExample
+      title='Controlled'
+      description='An input can be controlled.'
+      examplePath='addons/UniversalInput/Usage/UniversalInputExampleControlled'
+    />
+    <ComponentExample
+      title='onComposed'
+      description='A component provides an onCompose event.'
+      examplePath='addons/UniversalInput/Usage/UniversalInputExampleOnCompose'
+    />
+  </ExampleSection>
+)
+
+export default UniversalInputUsage

--- a/docs/app/Examples/addons/UniversalInput/index.js
+++ b/docs/app/Examples/addons/UniversalInput/index.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import Types from './Types'
+import Usage from './Usage'
+
+const UniversalInputExamples = () => (
+  <div>
+    <Types />
+    <Usage />
+  </div>
+)
+
+export default UniversalInputExamples

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ export { default as Portal, PortalProps } from './dist/commonjs/addons/Portal';
 export { default as Radio, RadioProps } from './dist/commonjs/addons/Radio';
 export { default as Select, SelectProps } from './dist/commonjs/addons/Select';
 export { default as TextArea, TextAreaProps, TextAreaOnChangeData } from './dist/commonjs/addons/TextArea';
+export { default as UniversalInput, UniversalInputProps } from './dist/commonjs/addons/UniversalInput';
 
 // Behaviors
 export {

--- a/src/addons/UniversalInput/UniversalInput.d.ts
+++ b/src/addons/UniversalInput/UniversalInput.d.ts
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+export interface UniversalInputProps {
+  [key: string]: any;
+
+  /** An element type to render as (string or function). */
+  as?: any;
+
+  /** The value of the input. */
+  defaultValue?: number | string;
+
+  /**
+   * Called on change.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props and proposed value.
+   */
+  onChange?: (event: React.FormEvent<HTMLTextAreaElement>, data: UniversalInputOnData) => void;
+
+  /**
+   * Called on change and when the composition is ended.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props and proposed value.
+   */
+  onCompose?: (event: React.FormEvent<HTMLTextAreaElement>, data: UniversalInputOnData) => void;
+
+  /** The HTML input type. */
+  type?: string;
+
+  /** The value of the input. */
+  value?: number | string;
+}
+
+export interface UniversalInputOnData extends UniversalInputProps {
+  finalValue?: string;
+}
+
+declare const UniversalInput: React.ComponentClass<UniversalInputProps>;
+
+export default UniversalInput;

--- a/src/addons/UniversalInput/UniversalInput.js
+++ b/src/addons/UniversalInput/UniversalInput.js
@@ -1,0 +1,115 @@
+import _ from 'lodash'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import {
+  AutoControlledComponent as Component,
+  createShorthandFactory,
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
+
+/**
+ * An input that correctly handles `onChange` event with IME (Chinese Input Method Editor).
+ * @see https://github.com/facebook/react/issues/3926
+ */
+class UniversalInput extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
+
+    /** The default value of the input. */
+    defaultValue: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
+
+    /**
+     * Called on change.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props and proposed value.
+     */
+    onChange: PropTypes.func,
+
+    /**
+     * Called on change and when the composition is ended.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props and proposed value.
+     */
+    onComposed: PropTypes.func,
+
+    /** The HTML input type. */
+    type: PropTypes.string,
+
+    /** The value of the input. */
+    value: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
+  }
+
+  static defaultProps = {
+    as: 'input',
+    type: 'text',
+  }
+
+  static autoControlledProps = [
+    'value',
+  ]
+
+  static _meta = {
+    name: 'UniversalInput',
+    type: META.TYPES.ADDON,
+  }
+
+  handleComposition = e => {
+    if (e.type !== 'compositionend') {
+      this.compositioning = true
+      return
+    }
+
+    this.compositioning = false
+    // Heads up! Fire change method to update for Chrome v53
+    // https://chromium.googlesource.com/chromium/src/+/afce9d93e76f2ff81baaa088a4ea25f67d1a76b3%5E%21/
+    this.handleChange(e)
+  }
+
+  handleChange = e => {
+    const { finalValue: currentValue } = this.state
+    const value = _.get(e, 'target.value')
+    const finalValue = this.compositioning ? currentValue : value
+
+    this.trySetState({ value }, { finalValue })
+    _.invoke(this, 'props.onChange', e, { ...this.props, finalValue, value })
+    if (!this.compositioning) _.invoke(this, 'props.onCompose', e, { ...this.props, finalValue, value })
+  }
+
+  handleRef = c => (_.invoke(this, 'props.inputRef', c))
+
+  render() {
+    const rest = getUnhandledProps(UniversalInput, this.props)
+    const ElementType = getElementType(UniversalInput, this.props)
+    const { as, type, value } = this.state
+
+    return (
+      <ElementType
+        {...rest}
+        onChange={this.handleChange}
+        onCompositionStart={this.handleComposition}
+        onCompositionUpdate={this.handleComposition}
+        onCompositionEnd={this.handleComposition}
+        ref={this.handleRef}
+        type={as === 'input' ? type : null}
+        value={value}
+      />
+    )
+  }
+}
+
+UniversalInput.create = createShorthandFactory(UniversalInput, type => ({ type }))
+
+export default UniversalInput

--- a/src/addons/UniversalInput/index.d.ts
+++ b/src/addons/UniversalInput/index.d.ts
@@ -1,0 +1,1 @@
+export { default, UniversalInputProps } from './UniversalInput';

--- a/src/addons/UniversalInput/index.js
+++ b/src/addons/UniversalInput/index.js
@@ -1,0 +1,1 @@
+export default from './UniversalInput'

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export { default as Portal } from './addons/Portal'
 export { default as Radio } from './addons/Radio'
 export { default as Select } from './addons/Select'
 export { default as TextArea } from './addons/TextArea'
+export { default as UniversalInput } from './addons/UniversalInput'
 
 // Behaviors
 export { default as Visibility } from './behaviors/Visibility'


### PR DESCRIPTION
# WIP

Fixes #1744.

### Proposed changes

This PR adds the `Universal Input` (a quite strange name, open for ideas) component, that correctly handles composition events. This component will replace an `input` usages. I grabbed ideas from facebook/react#3926.

#### Adds `finalValue` param to `onChange` handler

`finalValue` contains value after the composition was completed.

![peek 2017-06-12 13-49](https://user-images.githubusercontent.com/14183168/27030873-92a7d604-4f76-11e7-8f09-a64f176e8a49.gif)

#### Adds param to `onCompose` handler

It fires only after the composition was completed.

![peek 2017-06-12 13-50](https://user-images.githubusercontent.com/14183168/27030888-9cd30888-4f76-11e7-8ca7-451d149106e9.gif)


### TODO
- [ ] tests

This PR provides an input component that can be used by our other components. It correctly supports the handling of `onChange` with IME.