### PR TITLE
fix(Accordion): typings inverted to boolean

### DIFF
--- a/src/modules/Accordion/Accordion.d.ts
+++ b/src/modules/Accordion/Accordion.d.ts
@@ -28,7 +28,7 @@ export interface AccordionProps {
   fluid?: boolean;
 
   /** Format for dark backgrounds. */
-  inverted?: string;
+  inverted?: boolean;
 
   /**
    * Called when a panel title is clicked.


### PR DESCRIPTION
Tiny fix for typings, inverted type incorrectly set to string.