### PR TITLE
docs(Introduction): fix declarative example

### DIFF
--- a/docs/app/Views/Introduction.js
+++ b/docs/app/Views/Introduction.js
@@ -110,7 +110,7 @@ const MenuItemLinkAugmentationJSX = `import { Link } from 'react-router-dom'
   </Menu.Item>
 </Menu>`
 const MenuItemLinkAugmentationHTML = `<div class="ui menu">
-  <a class="item">
+  <a class="item" href="/home">
     Home
   </a>
 </div>`


### PR DESCRIPTION
There is a missing href to "/home" in the HTML version for the . [This is the link](https://react.semantic-ui.com/introduction#augmentation)
![pr_home](https://user-images.githubusercontent.com/26656420/27202144-3d03186a-51d5-11e7-9b5e-494cd3a328e0.png)


This PR changes `<a class="item">` to `<a class="item" href="/home">`