### PR TITLE
docs(props): fix uniqueness

### DIFF
--- a/gulp/plugins/util/parseType.js
+++ b/gulp/plugins/util/parseType.js
@@ -2,7 +2,9 @@ require('babel-register')
 const _ = require('lodash')
 const SUI = require('../../../src/lib/SUI') // eslint-disable-line no-unused-vars
 
-const evalValue = value => _.uniq(eval(value)) // eslint-disable-line no-eval
+const evalValue = value => eval(value) // eslint-disable-line no-eval
+
+const uniqValues = values => _.uniqWith(values, (val, other) => val == other) // eslint-disable-line eqeqeq
 
 const transformEnumValues = values => _.flatMap(values, ({ value }) => {
   if (_.startsWith(value, '...SUI')) return evalValue(value.substring(3))
@@ -13,10 +15,10 @@ const parseEnum = type => {
   const { value } = type
 
   if (typeof value === 'string' && value.includes('SUI')) {
-    return Object.assign(type, { value: evalValue(value) })
+    return Object.assign(type, { value: uniqValues(evalValue(value)) })
   }
 
-  return Object.assign(type, { value: transformEnumValues(value) })
+  return Object.assign(type, { value: uniqValues(transformEnumValues(value)) })
 }
 
 const parseUnion = union => {

--- a/gulp/plugins/util/parseType.js
+++ b/gulp/plugins/util/parseType.js
@@ -4,7 +4,7 @@ const SUI = require('../../../src/lib/SUI') // eslint-disable-line no-unused-var
 
 const evalValue = value => eval(value) // eslint-disable-line no-eval
 
-const uniqValues = values => _.uniqWith(values, (val, other) => `${val}` == `${other}`)
+const uniqValues = values => _.uniqWith(values, (val, other) => `${val}` === `${other}`)
 
 const transformEnumValues = values => _.flatMap(values, ({ value }) => {
   if (_.startsWith(value, '...SUI')) return evalValue(value.substring(3))

--- a/gulp/plugins/util/parseType.js
+++ b/gulp/plugins/util/parseType.js
@@ -4,7 +4,7 @@ const SUI = require('../../../src/lib/SUI') // eslint-disable-line no-unused-var
 
 const evalValue = value => eval(value) // eslint-disable-line no-eval
 
-const uniqValues = values => _.uniqWith(values, (val, other) => val == other) // eslint-disable-line eqeqeq
+const uniqValues = values => _.uniqWith(values, (val, other) => `${val}` == `${other}`)
 
 const transformEnumValues = values => _.flatMap(values, ({ value }) => {
   if (_.startsWith(value, '...SUI')) return evalValue(value.substring(3))


### PR DESCRIPTION
### Before

![_899](https://user-images.githubusercontent.com/14183168/27274855-a3d769fa-54dd-11e7-8b59-900458b79b3a.png)
![_900](https://user-images.githubusercontent.com/14183168/27274863-ab827a3c-54dd-11e7-91be-1b661e9845f5.png)

### After

![_899](https://user-images.githubusercontent.com/14183168/27274859-a76812ae-54dd-11e7-8ca0-15e77703b6ab.png)
![_901](https://user-images.githubusercontent.com/14183168/27274869-b13c5bb4-54dd-11e7-8505-b597752c02e6.png)

### Why?

`SUI.WIDTHS` contains both numbers and strings (example: `1` and `'1'`), but it does not matter for the docs. Also, as we use `value` as `key` and React converts `key` to string, we have duplicate, but invisible elements.