### PR TITLE
fix(Dropdown): Sizer rendering incorrectly; Fixes #1298

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1073,7 +1073,7 @@ export default class Dropdown extends Component {
       this.sizerRef.style.display = 'inline'
       this.sizerRef.textContent = searchQuery
       searchWidth = Math.ceil(this.sizerRef.getBoundingClientRect().width)
-      this.sizerRef.style.removeProperty('display')
+      this.sizerRef.style.display = 'none'
     }
 
     return (


### PR DESCRIPTION
Setting the attribute to 'none' instead of using removeProperty.