### PR TITLE
fix(Form): call preventDefault in onSubmit only when it exists

### DIFF
--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -94,10 +94,13 @@ class Form extends Component {
   static Select = FormSelect
   static TextArea = FormTextArea
 
-  handleSubmit = e => {
-    const { action, onSubmit } = this.props
-    if (!action) e.preventDefault()
-    if (onSubmit) onSubmit(e, { ...this.props })
+  handleSubmit = (e, ...args) => {
+    const { action } = this.props
+
+    // Heads up! Third party libs can pass own data as first argument, we need to check that it has preventDefault()
+    // method.
+    if (!action) _.invoke(e, 'preventDefault')
+    _.invoke(this.props, 'onSubmit', e, this.props, ...args)
   }
 
   render() {
@@ -130,7 +133,7 @@ class Form extends Component {
     const rest = getUnhandledProps(Form, this.props)
     const ElementType = getElementType(Form, this.props)
 
-    return <ElementType {...rest} onSubmit={this.handleSubmit} className={classes}>{children}</ElementType>
+    return <ElementType {...rest} className={classes} onSubmit={this.handleSubmit}>{children}</ElementType>
   }
 }
 

--- a/test/specs/collections/Form/Form-test.js
+++ b/test/specs/collections/Form/Form-test.js
@@ -44,42 +44,46 @@ describe('Form', () => {
 
   describe('onSubmit', () => {
     it('prevents default on the event when there is no action', () => {
-      const preventDefault = sandbox.spy()
+      const event = { preventDefault: sandbox.spy() }
 
-      shallow(<Form onSubmit={_.noop} />)
-        .simulate('submit', { preventDefault })
-      preventDefault.should.have.been.calledOnce()
+      shallow(<Form />)
+        .simulate('submit', event)
+
+      event.preventDefault.should.have.been.calledOnce()
     })
 
     it('does not prevent default on the event when there is an action', () => {
-      const preventDefault = sandbox.spy()
+      const event = { preventDefault: sandbox.spy() }
 
-      shallow(<Form action='do not prevent default!' onSubmit={_.noop} />)
+      shallow(<Form action='do not prevent default!' />)
         .simulate('submit', event)
-      preventDefault.should.not.have.been.called()
+
+      event.preventDefault.should.not.have.been.called()
     })
 
     it('is called with (e, props) on submit', () => {
       const onSubmit = sandbox.spy()
-      const e = { name: 'foo' }
+      const event = { name: 'foo' }
       const props = { 'data-bar': 'baz' }
 
       shallow(<Form {...props} onSubmit={onSubmit} />)
-        .simulate('submit', e)
+        .simulate('submit', event)
 
       onSubmit.should.have.been.calledOnce()
-      onSubmit.should.have.been.calledWithMatch(e, props)
+      onSubmit.should.have.been.calledWithMatch(event, props)
     })
 
     it('passes all args to onSubmit', () => {
       const onSubmit = sandbox.spy()
       const props = { 'data-baz': 'baz' }
+      const event = { fake: 'event' }
+      const args = ['some', 'extra', 'args']
 
       shallow(<Form {...props} onSubmit={onSubmit} />)
-        .simulate('submit', { name: 'foo' }, { name: 'bar' })
+        .simulate('submit', event, ...args)
 
       onSubmit.should.have.been.calledOnce()
-      onSubmit.should.have.been.calledWithMatch({ name: 'foo' }, props, { name: 'bar' })
+      onSubmit.should.have.been.calledWithMatch(event, props, ...args)
     })
   })
 })

--- a/test/specs/collections/Form/Form-test.js
+++ b/test/specs/collections/Form/Form-test.js
@@ -44,21 +44,42 @@ describe('Form', () => {
 
   describe('onSubmit', () => {
     it('prevents default on the event when there is no action', () => {
-      const event = { preventDefault: sandbox.spy() }
+      const preventDefault = sandbox.spy()
 
-      shallow(<Form onSubmit={sandbox.spy()} />)
-        .simulate('submit', event)
-
-      event.preventDefault.should.have.been.calledOnce()
+      shallow(<Form onSubmit={_.noop} />)
+        .simulate('submit', { preventDefault })
+      preventDefault.should.have.been.calledOnce()
     })
 
     it('does not prevent default on the event when there is an action', () => {
-      const event = { preventDefault: sandbox.spy() }
+      const preventDefault = sandbox.spy()
 
-      shallow(<Form action='do not prevent default!' onSubmit={sandbox.spy()} />)
+      shallow(<Form action='do not prevent default!' onSubmit={_.noop} />)
         .simulate('submit', event)
+      preventDefault.should.not.have.been.called()
+    })
 
-      event.preventDefault.should.not.have.been.called()
+    it('is called with (e, props) on submit', () => {
+      const onSubmit = sandbox.spy()
+      const e = { name: 'foo' }
+      const props = { 'data-bar': 'baz' }
+
+      shallow(<Form {...props} onSubmit={onSubmit} />)
+        .simulate('submit', e)
+
+      onSubmit.should.have.been.calledOnce()
+      onSubmit.should.have.been.calledWithMatch(e, props)
+    })
+
+    it('passes all args to onSubmit', () => {
+      const onSubmit = sandbox.spy()
+      const props = { 'data-baz': 'baz' }
+
+      shallow(<Form {...props} onSubmit={onSubmit} />)
+        .simulate('submit', { name: 'foo' }, { name: 'bar' })
+
+      onSubmit.should.have.been.calledOnce()
+      onSubmit.should.have.been.calledWithMatch({ name: 'foo' }, props, { name: 'bar' })
     })
   })
 })


### PR DESCRIPTION
Fixes #1790.

In #1786 we implimented a small, but cool enhancement, but as our user [reports ](https://github.com/Semantic-Org/Semantic-UI-React/issues/1769#issuecomment-310516466) it's not fully compatible with third-party libraries. This PR fixes this.