### PR TITLE
docs(ComponentProps): fix compatibility with IE

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentProps.js
+++ b/docs/app/Components/ComponentDoc/ComponentProps.js
@@ -88,7 +88,7 @@ export default class ComponentProps extends Component {
     const paramSignature = params
       .map(param => `${param.name}: ${getTagType(param)}`)
       // prevent object properties from showing as individual params
-      .filter(p => !p.includes('.'))
+      .filter(p => !_.includes(p, '.'))
       .join(', ')
 
     const tagDescriptionRows = _.compact([...params, returns]).map(tag => {


### PR DESCRIPTION
IE doesn't support [`includes`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/includes).