### PR TITLE
fix(AutoControlledComponent): use setState instead of an assign

### DIFF
--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -136,8 +136,6 @@ class Portal extends Component {
     type: META.TYPES.ADDON,
   }
 
-  state = {}
-
   componentDidMount() {
     debug('componentDidMount()')
     this.renderPortal()

--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -68,8 +68,11 @@ export const getAutoControlledStateValue = (propName, props, state, includeDefau
 }
 
 export default class AutoControlledComponent extends Component {
-  componentWillMount() {
+  constructor(...args) {
+    super(...args)
+
     const { autoControlledProps } = this.constructor
+    const state = _.invoke(this, 'initialState', this.props) || {}
 
     if (process.env.NODE_ENV !== 'production') {
       const { defaultProps, name, propTypes } = this.constructor
@@ -130,7 +133,7 @@ export default class AutoControlledComponent extends Component {
     // Also look for the default prop for any auto controlled props (foo => defaultFoo)
     // so we can set initial values from defaults.
     const initialAutoControlledState = autoControlledProps.reduce((acc, prop) => {
-      acc[prop] = getAutoControlledStateValue(prop, this.props, this.state, true)
+      acc[prop] = getAutoControlledStateValue(prop, this.props, state, true)
 
       if (process.env.NODE_ENV !== 'production') {
         const defaultPropName = getDefaultPropName(prop)
@@ -146,7 +149,7 @@ export default class AutoControlledComponent extends Component {
       return acc
     }, {})
 
-    this.state = { ...this.state, ...initialAutoControlledState }
+    this.state = { ...state, ...initialAutoControlledState }
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -72,7 +72,7 @@ export default class AutoControlledComponent extends Component {
     super(...args)
 
     const { autoControlledProps } = this.constructor
-    const state = _.invoke(this, 'initialState', this.props) || {}
+    const state = _.invoke(this, 'getInitialState', this.props) || {}
 
     if (process.env.NODE_ENV !== 'production') {
       const { defaultProps, name, propTypes } = this.constructor

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -95,13 +95,8 @@ export default class Accordion extends Component {
   static Content = AccordionContent
   static Title = AccordionTitle
 
-  state = {}
-
-  constructor(...args) {
-    super(...args)
-    this.state = {
-      activeIndex: this.props.exclusive ? -1 : [-1],
-    }
+  initialState({ exclusive }) {
+    return { activeIndex: exclusive ? -1 : [-1] }
   }
 
   handleTitleClick = (e, index) => {

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -95,7 +95,7 @@ export default class Accordion extends Component {
   static Content = AccordionContent
   static Title = AccordionTitle
 
-  initialState({ exclusive }) {
+  getInitialState({ exclusive }) {
     return { activeIndex: exclusive ? -1 : [-1] }
   }
 

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -128,8 +128,6 @@ export default class Checkbox extends Component {
     type: META.TYPES.MODULE,
   }
 
-  state = {}
-
   componentDidMount() {
     this.setIndeterminate()
   }

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -358,7 +358,6 @@ export default class Dropdown extends Component {
   static Menu = DropdownMenu
 
   componentWillMount() {
-    if (super.componentWillMount) super.componentWillMount()
     debug('componentWillMount()')
     const { open, value } = this.state
 

--- a/src/modules/Embed/Embed.js
+++ b/src/modules/Embed/Embed.js
@@ -106,8 +106,6 @@ export default class Embed extends Component {
     type: META.TYPES.MODULE,
   }
 
-  state = {}
-
   getSrc() {
     const {
       autoplay = true,

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -143,8 +143,6 @@ class Modal extends Component {
   static Description = ModalDescription
   static Actions = ModalActions
 
-  state = {}
-
   componentWillUnmount() {
     debug('componentWillUnmount()')
     this.handlePortalUnmount()

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -196,7 +196,6 @@ export default class Search extends Component {
   static Results = SearchResults
 
   componentWillMount() {
-    if (super.componentWillMount) super.componentWillMount()
     debug('componentWillMount()')
     const { open, value } = this.state
 

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -57,10 +57,7 @@ class Sidebar extends Component {
   }
 
   static Pushable = SidebarPushable
-
   static Pusher = SidebarPusher
-
-  state = {}
 
   startAnimating = (duration = 500) => {
     clearTimeout(this.stopAnimatingTimer)

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -74,8 +74,8 @@ class Tab extends Component {
 
   static Pane = TabPane
 
-  state = {
-    activeIndex: 0,
+  initialState() {
+    return { activeIndex: 0 }
   }
 
   handleItemClick = (e, { index }) => {

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -74,7 +74,7 @@ class Tab extends Component {
 
   static Pane = TabPane
 
-  initialState() {
+  getInitialState() {
     return { activeIndex: 0 }
   }
 

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -12,7 +12,7 @@ let TestClass
 const createTestClass = (options = {}) => class Test extends AutoControlledComponent {
   static autoControlledProps = options.autoControlledProps
   static defaultProps = options.defaultProps
-  initialState() {
+  getInitialState() {
     return options.state
   }
   render = () => <div />

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -12,7 +12,9 @@ let TestClass
 const createTestClass = (options = {}) => class Test extends AutoControlledComponent {
   static autoControlledProps = options.autoControlledProps
   static defaultProps = options.defaultProps
-  state = options.state
+  initialState() {
+    return options.state
+  }
   render = () => <div />
 }
 /* eslint-enable */


### PR DESCRIPTION
Fixes #1761.
Fixes #1682.

In #1770, I suggested that the problem is in that `setState` is an async, I was right. `AutoControlledComponent` component's children such as `Dropdown` and  `Search` had own logic inside the `componentWillMount` method that relied on the current state.

The `componentWillMount` method was renamed to `constructor` as it's a single place where `state` is assignable. However, we need to have ability to assign an initial state, so I added the `initialState` method that accepts `props` as an argument.

@apiv Thanks for you suggestions in #1770.