### PR TITLE
fix(Input): Allow "right" to be passed as `actionPosition`/`iconPosition` on Input element

### DIFF
--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -39,7 +39,7 @@ class Input extends Component {
     ]),
 
     /** An action can appear along side an Input on the left or right. */
-    actionPosition: PropTypes.oneOf(['left']),
+    actionPosition: PropTypes.oneOf(['left', 'right']),
 
     /** Primary content. */
     children: PropTypes.node,
@@ -66,7 +66,7 @@ class Input extends Component {
     ]),
 
     /** An Icon can appear inside an Input on the left or right. */
-    iconPosition: PropTypes.oneOf(['left']),
+    iconPosition: PropTypes.oneOf(['left', 'right']),
 
     /** Shorthand for creating the HTML Input. */
     input: customPropTypes.itemShorthand,


### PR DESCRIPTION
`actionPosition` and `iconPosition` both default to "right", but prop-types for both warn when "right" is passed in. Came up in the following case:

```jsx
<Form.Input label="Some label" actionPosition="right">
  <input />
  {flag && <Button content="Sometimes Visible" />}
  <Button content="Always Visible" />
</Form.Input>
```