### PR TITLE
fix(TextArea): simplify propTypes

### DIFF
--- a/src/addons/TextArea/TextArea.d.ts
+++ b/src/addons/TextArea/TextArea.d.ts
@@ -18,13 +18,13 @@ export interface TextAreaProps {
   onChange?: (event: React.FormEvent<HTMLTextAreaElement>, data: TextAreaOnChangeData) => void;
 
   /** Indicates row count for a TextArea. */
-  rows?: number;
+  rows?: number | string;
 
   /** Custom TextArea style. */
   style?: Object;
 
   /** The value of the textarea. */
-  value?: string;
+  value?: number | string;
 }
 
 export interface TextAreaOnChangeData extends TextAreaProps {

--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -36,13 +36,19 @@ class TextArea extends Component {
     onChange: PropTypes.func,
 
     /** Indicates row count for a TextArea. */
-    rows: PropTypes.number,
+    rows: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
 
     /** Custom TextArea style. */
     style: PropTypes.object,
 
     /** The value of the textarea. */
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
   }
 
   static defaultProps = {


### PR DESCRIPTION
Fixes #1814.

I'm sure that `rows` and `value` can be `number`, too.