### PR TITLE
fix(Tab): relax menuItem prop type

### DIFF
--- a/docs/app/Examples/modules/Tab/Usage/TabExampleCustomMenuItem.js
+++ b/docs/app/Examples/modules/Tab/Usage/TabExampleCustomMenuItem.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Label, Menu, Tab } from 'semantic-ui-react'
+
+const panes = [
+  {
+    menuItem: { key: 'users', icon: 'users', content: 'Users' },
+    render: () => <Tab.Pane>Tab 1 Content</Tab.Pane>,
+  },
+  {
+    menuItem: <Menu.Item key='messages'>Messages<Label>15</Label></Menu.Item>,
+    render: () => <Tab.Pane>Tab 2 Content</Tab.Pane>,
+  },
+]
+
+const TabExampleCustomMenuItem = () => (
+  <Tab panes={panes} />
+)
+
+export default TabExampleCustomMenuItem

--- a/docs/app/Examples/modules/Tab/Usage/index.js
+++ b/docs/app/Examples/modules/Tab/Usage/index.js
@@ -19,6 +19,11 @@ const TabUsageExamples = () => (
       description='You can capture the tab change event.'
       examplePath='modules/Tab/Usage/TabExampleOnTabChange'
     />
+    <ComponentExample
+      title='Custom Menu Items'
+      description='You can pass any shorthand value as a menu item.'
+      examplePath='modules/Tab/Usage/TabExampleCustomMenuItem'
+    />
   </ExampleSection>
 )
 

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -54,7 +54,7 @@ class Tab extends Component {
      * }
      */
     panes: PropTypes.arrayOf(PropTypes.shape({
-      menuItem: PropTypes.string.isRequired,
+      menuItem: customPropTypes.itemShorthand,
       render: PropTypes.func.isRequired,
     })),
   }


### PR DESCRIPTION
Fixes #1822 

The Tab was designed to allow any shorthand value to be passed as the `menuItem`.  The propType was limited to string.

This PR relaxes the propType and adds an example with shorthand `menuItem`s.