### PR TITLE
breaking(Search): update onResultSelect and onSearchChange signature

### DIFF
--- a/src/modules/Search/Search.d.ts
+++ b/src/modules/Search/Search.d.ts
@@ -105,15 +105,15 @@ export interface SearchProps {
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
    * @param {object} data - All props.
    */
-  onResultSelect?: (event: React.MouseEvent<HTMLDivElement>, data: SearchResultProps) => void;
+  onResultSelect?: (event: React.MouseEvent<HTMLDivElement>, data: SearchProps) => void;
 
   /**
    * Called on search input change.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {string} value - Current value of search input.
+   * @param {object} data - All props, includes current value of search input.
    */
-  onSearchChange?: (event: React.MouseEvent<HTMLElement>, value: string) => void;
+  onSearchChange?: (event: React.MouseEvent<HTMLElement>, data: SearchProps) => void;
 
   // ------------------------------------
   // Style

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -141,7 +141,7 @@ export default class Search extends Component {
      * Called on search input change.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {string} value - Current value of search input.
+     * @param {object} data - All props, includes current value of search input.
      */
     onSearchChange: PropTypes.func,
 
@@ -285,8 +285,8 @@ export default class Search extends Component {
   handleResultSelect = (e, result) => {
     debug('handleResultSelect()')
     debug(result)
-    const { onResultSelect } = this.props
-    if (onResultSelect) onResultSelect(e, result)
+
+    _.invoke(this.props, 'onResultSelect', e, { ...this.props, result })
   }
 
   closeOnEscape = (e) => {
@@ -400,11 +400,11 @@ export default class Search extends Component {
     debug(e.target.value)
     // prevent propagating to this.props.onChange()
     e.stopPropagation()
-    const { onSearchChange, minCharacters } = this.props
+    const { minCharacters } = this.props
     const { open } = this.state
     const newQuery = e.target.value
 
-    if (onSearchChange) onSearchChange(e, newQuery)
+    _.invoke(this.props, 'onSearchChange', e, { ...this.props, value: newQuery })
 
     // open search dropdown on search query
     if (newQuery.length < minCharacters) {

--- a/test/specs/modules/Search/Search-test.js
+++ b/test/specs/modules/Search/Search-test.js
@@ -546,7 +546,11 @@ describe('Search', () => {
         .simulate('click', nativeEvent)
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, randomResult)
+      spy.should.have.been.calledWithMatch({}, {
+        minCharacters: 0,
+        result: randomResult,
+        results: options,
+      })
     })
     it('is called with event and value when pressing enter on a selected item', () => {
       const firstResult = options[0]
@@ -559,7 +563,7 @@ describe('Search', () => {
       domEvent.keyDown(document, { key: 'Enter' })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, firstResult)
+      spy.should.have.been.calledWithMatch({}, { result: firstResult })
     })
     it('is not called when updating the value prop', () => {
       const value = _.sample(options).title
@@ -591,7 +595,11 @@ describe('Search', () => {
         .simulate('change', { target: { value: 'a' }, stopPropagation: _.noop })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({ target: { value: 'a' } }, 'a')
+      spy.should.have.been.calledWithMatch({ target: { value: 'a' } }, {
+        minCharacters: 0,
+        results: options,
+        value: 'a',
+      })
     })
   })
 


### PR DESCRIPTION
# BREAKING

This wasn't done in #951 and there were arguments for that reason, however I think that all our callbacks should be consistent.

Handler | Previous Signature | Current Signature
------- | ------------------ | -----------------
onResultSelect | (e, result) | (e, { ...props, result })
onSearchChange | (e, value) | (e, { ...props, value })

### Before

```jsx
<Search onResultSelect={(e, result) => console.log(e, result)} />
<Search onSearchChange={(e, value) => console.log(e, value)} />
```

### After

```jsx
<Search onResultSelect={(e, data) => console.log(e, data.result)} />
<Search onSearchChange={(e, data) => console.log(e, data.value)} />
```