### PR TITLE
fix(Dropdown): fix touch event issue on mobile devices

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -453,6 +453,7 @@ export default class Dropdown extends Component {
       document.addEventListener('keydown', this.selectItemOnEnter)
       document.addEventListener('keydown', this.removeItemOnBackspace)
       document.addEventListener('click', this.closeOnDocumentClick)
+      document.addEventListener('touchend', this.closeOnDocumentClick)
       document.removeEventListener('keydown', this.openOnArrow)
       document.removeEventListener('keydown', this.openOnSpace)
       this.scrollSelectedItemIntoView()
@@ -463,6 +464,7 @@ export default class Dropdown extends Component {
       document.removeEventListener('keydown', this.moveSelectionOnKeyDown)
       document.removeEventListener('keydown', this.selectItemOnEnter)
       document.removeEventListener('click', this.closeOnDocumentClick)
+      document.removeEventListener('touchend', this.closeOnDocumentClick)
       if (!this.state.focus) {
         document.removeEventListener('keydown', this.removeItemOnBackspace)
       }
@@ -482,6 +484,7 @@ export default class Dropdown extends Component {
     document.removeEventListener('keydown', this.removeItemOnBackspace)
     document.removeEventListener('keydown', this.closeOnEscape)
     document.removeEventListener('click', this.closeOnDocumentClick)
+    document.removeEventListener('touchend', this.closeOnDocumentClick)
   }
 
   // ----------------------------------------


### PR DESCRIPTION
Fixes #1832.

When the dropdown component is used with mobile touch events the dropdown items list is not closed when touching the outer layer of the component (e.g.: "touchend" event on document or body). This is due to the fact that "touchend" event is not added/listed on componentDidUpdate lifecycle.

The fix was tested on iOS device & Chrome.