### PR TITLE
feat(Menu): add `left` value to the position prop

### DIFF
--- a/src/collections/Menu/MenuItem.d.ts
+++ b/src/collections/Menu/MenuItem.d.ts
@@ -52,8 +52,8 @@ export interface MenuItemProps {
    */
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>, data: MenuItemProps) => void;
 
-  /** A menu item can take right position. */
-  position?: 'right';
+  /** A menu item can take left or right position. */
+  position?: 'left' | 'right';
 }
 
 declare const MenuItem: React.ComponentClass<MenuItemProps>;

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -75,8 +75,8 @@ export default class MenuItem extends Component {
      */
     onClick: PropTypes.func,
 
-    /** A menu item can take right position. */
-    position: PropTypes.oneOf(['right']),
+    /** A menu item can take left or right position. */
+    position: PropTypes.oneOf(['left', 'right']),
   }
 
   static _meta = {

--- a/src/collections/Menu/MenuMenu.d.ts
+++ b/src/collections/Menu/MenuMenu.d.ts
@@ -12,8 +12,8 @@ export interface MenuMenuProps {
   /** Additional classes. */
   className?: string;
 
-  /** A sub menu can take right position. */
-  position?: 'right';
+  /** A sub menu can take left or right position. */
+  position?: 'left' | 'right';
 }
 
 declare const MenuMenu: React.StatelessComponent<MenuMenuProps>;

--- a/src/collections/Menu/MenuMenu.js
+++ b/src/collections/Menu/MenuMenu.js
@@ -42,8 +42,8 @@ MenuMenu.propTypes = {
   /** Additional classes. */
   className: PropTypes.string,
 
-  /** A sub menu can take right position. */
-  position: PropTypes.oneOf(['right']),
+  /** A sub menu can take left or right position. */
+  position: PropTypes.oneOf(['left', 'right']),
 }
 
 export default MenuMenu

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -22,7 +22,7 @@ describe('MenuItem', () => {
   common.propKeyOrValueAndKeyToClassName(MenuItem, 'fitted', ['horizontally', 'vertically'])
 
   common.propValueOnlyToClassName(MenuItem, 'color', SUI.COLORS)
-  common.propValueOnlyToClassName(MenuItem, 'position', ['right'])
+  common.propValueOnlyToClassName(MenuItem, 'position', ['left', 'right'])
 
   it('renders a `div` by default', () => {
     shallow(<MenuItem />)

--- a/test/specs/collections/Menu/MenuMenu-test.js
+++ b/test/specs/collections/Menu/MenuMenu-test.js
@@ -5,5 +5,5 @@ describe('MenuMenu', () => {
   common.isConformant(MenuMenu)
   common.rendersChildren(MenuMenu)
 
-  common.propValueOnlyToClassName(MenuMenu, 'position', ['right'])
+  common.propValueOnlyToClassName(MenuMenu, 'position', ['left', 'right'])
 })


### PR DESCRIPTION
Rel #1851.

A `MenuMenu` and a `MenuItem` [should](https://github.com/Semantic-Org/Semantic-UI/blob/2.2.10/src/definitions/collections/menu.less#L463) also accept `left` value on the `position` prop.
