### PR TITLE
fix(Dimmer|Modal): fix compatibility with IE

### DIFF
--- a/src/modules/Dimmer/Dimmer.js
+++ b/src/modules/Dimmer/Dimmer.js
@@ -72,11 +72,19 @@ export default class Dimmer extends Component {
   static Dimmable = DimmerDimmable
 
   handlePortalMount = () => {
-    if (isBrowser) document.body.classList.add('dimmed', 'dimmable')
+    if (!isBrowser) return
+
+    // Heads up, IE doesn't support second argument in add()
+    document.body.classList.add('dimmed')
+    document.body.classList.add('dimmable')
   }
 
   handlePortalUnmount = () => {
-    if (isBrowser) document.body.classList.remove('dimmed', 'dimmable')
+    if (!isBrowser) return
+
+    // Heads up, IE doesn't support second argument in add()
+    document.body.classList.remove('dimmed')
+    document.body.classList.remove('dimmable')
   }
 
   handleClick = (e) => {

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -192,7 +192,8 @@ class Modal extends Component {
 
     if (dimmer) {
       debug('adding dimmer')
-      mountNode.classList.add('dimmable', 'dimmed')
+      mountNode.classList.add('dimmable')
+      mountNode.classList.add('dimmed')
 
       if (dimmer === 'blurring') {
         debug('adding blurred dimmer')
@@ -213,7 +214,12 @@ class Modal extends Component {
     // If the dimmer value changes while the modal is open, then removing its
     // current value could leave cruft classes previously added.
     const mountNode = this.getMountNode()
-    mountNode.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable')
+
+    // Heads up, IE doesn't support second argument in remove()
+    mountNode.classList.remove('blurring')
+    mountNode.classList.remove('dimmable')
+    mountNode.classList.remove('dimmed')
+    mountNode.classList.remove('scrollable')
 
     cancelAnimationFrame(this.animationRequestId)
 


### PR DESCRIPTION
Fixes #1759.

IE doesn't [support](https://developer.mozilla.org/en/docs/Web/API/Element/classList) second arguments on `add` and `remove`.
