### PR TITLE
fix(AutoControlledComponent): rename state method

### DIFF
--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -72,7 +72,7 @@ export default class AutoControlledComponent extends Component {
     super(...args)
 
     const { autoControlledProps } = this.constructor
-    const state = _.invoke(this, 'getInitialState', this.props) || {}
+    const state = _.invoke(this, 'getInitialAutoControlledState', this.props) || {}
 
     if (process.env.NODE_ENV !== 'production') {
       const { defaultProps, name, propTypes } = this.constructor

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -95,7 +95,7 @@ export default class Accordion extends Component {
   static Content = AccordionContent
   static Title = AccordionTitle
 
-  getInitialState({ exclusive }) {
+  getInitialAutoControlledState({ exclusive }) {
     return { activeIndex: exclusive ? -1 : [-1] }
   }
 

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -74,7 +74,7 @@ class Tab extends Component {
 
   static Pane = TabPane
 
-  getInitialState() {
+  getInitialAutoControlledState() {
     return { activeIndex: 0 }
   }
 

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -12,7 +12,7 @@ let TestClass
 const createTestClass = (options = {}) => class Test extends AutoControlledComponent {
   static autoControlledProps = options.autoControlledProps
   static defaultProps = options.defaultProps
-  getInitialState() {
+  getInitialAutoControlledState() {
     return options.state
   }
   render = () => <div />


### PR DESCRIPTION
Fixes #1863.

In #1799 we improved compatibility with React 16, that PR introcuced `getInitialState` method as was [suggested](https://github.com/Semantic-Org/Semantic-UI-React/pull/1799#discussion_r124040515). However, this name is reserved and [produces](https://github.com/facebook/react/blob/b840229286ac2a82fa49553ce793cf7b953d1845/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js#L256) warnings even in [Fiber](https://github.com/facebook/react/blob/f9af9aacd3c14288cd5869ff23cc71cdfb54d447/src/renderers/shared/fiber/ReactFiberClassComponent.js#L171).