### PR TITLE
feat(FormField): pass disabled prop to form control

### DIFF
--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -66,7 +66,7 @@ function FormField(props) {
   // ----------------------------------------
   // Checkbox/Radio Control
   // ----------------------------------------
-  const controlProps = { ...rest, children, required, type }
+  const controlProps = { ...rest, children, disabled, required, type }
 
   // wrap HTML checkboxes/radios in the label
   if (control === 'input' && (type === 'checkbox' || type === 'radio')) {

--- a/test/specs/collections/Form/FormField-test.js
+++ b/test/specs/collections/Form/FormField-test.js
@@ -80,7 +80,31 @@ describe('FormField', () => {
     })
   })
 
+  describe('disabled', () => {
+    it('is not set by default', () => {
+      const wrapper = shallow(<FormField control='input' />)
+      const input = wrapper.find('input')
+
+      wrapper.should.have.exactly(1).descendants('input')
+      input.should.not.have.prop('disabled')
+    })
+    it('is passed to the control', () => {
+      const wrapper = shallow(<FormField control='input' disabled />)
+      const input = wrapper.find('input')
+
+      wrapper.should.have.exactly(1).descendants('input')
+      input.should.have.prop('disabled', true)
+    })
+  })
+
   describe('required', () => {
+    it('is not set by default', () => {
+      const wrapper = shallow(<FormField control='input' />)
+      const input = wrapper.find('input')
+
+      wrapper.should.have.exactly(1).descendants('input')
+      input.should.not.have.prop('required')
+    })
     it('is passed to the control', () => {
       const wrapper = shallow(<FormField control='input' required />)
       const input = wrapper.find('input')


### PR DESCRIPTION
Fixes #1115

This PR updates the `FormField` to pass along the `disabled` prop to the underlying `control`.