### PR TITLE
fix(Button): fix animated prop type definition

### DIFF
--- a/src/elements/Button/Button.d.ts
+++ b/src/elements/Button/Button.d.ts
@@ -22,7 +22,7 @@ export interface ButtonProps {
   active?: boolean;
 
   /** A button can animate to show hidden content. */
-  animated?: 'fade' | 'vertical';
+  animated?: boolean | 'fade' | 'vertical';
 
   /** A button can be attached to the top or bottom of other content. */
   attached?: 'left' | 'right' | 'top' | 'bottom';


### PR DESCRIPTION
The type definitions for the Button component were slightly off. The `animated` prop can be a boolean in addition to the `'fade'` and `'vertical'` values. This matches the propTypes definition as well.