### PR TITLE
HomepageLayout.js is not compatible in webpack: "^2.1.0-beta.21"

### DIFF
--- a/docs/app/Layouts/HomepageLayout.js
+++ b/docs/app/Layouts/HomepageLayout.js
@@ -34,18 +34,17 @@ const FixedMenu = () => (
 
 export default class HomepageLayout extends Component {
   constructor(props) {
-    super(props);
+    super(props)
     this.state = {}
-    
     this.hideFixedMenu = this.hideFixedMenu.bind(this)
     this.showFixedMenu = this.showFixedMenu.bind(this)
   }
 
-  hideFixedMenu(){
+  hideFixedMenu() {
     this.setState({ visible: false })
   }
 
-  showFixedMenu(){
+  showFixedMenu() {
     this.setState({ visible: true })
   }
 

--- a/docs/app/Layouts/HomepageLayout.js
+++ b/docs/app/Layouts/HomepageLayout.js
@@ -33,10 +33,21 @@ const FixedMenu = () => (
 )
 
 export default class HomepageLayout extends Component {
-  state = {}
+  constructor(props) {
+    super(props);
+    this.state = {}
+    
+    this.hideFixedMenu = this.hideFixedMenu.bind(this)
+    this.showFixedMenu = this.showFixedMenu.bind(this)
+  }
 
-  hideFixedMenu = () => this.setState({ visible: false })
-  showFixedMenu = () => this.setState({ visible: true })
+  hideFixedMenu(){
+    this.setState({ visible: false })
+  }
+
+  showFixedMenu(){
+    this.setState({ visible: true })
+  }
 
   render() {
     const { visible } = this.state
@@ -107,7 +118,6 @@ export default class HomepageLayout extends Component {
               <Grid.Column floated='right' width={6}>
                 <Image
                   bordered
-                  rounded
                   size='large'
                   src='/assets/images/wireframe/white-image.png'
                 />


### PR DESCRIPTION
I update react syntax to make it compatible to new webpack version
My version is "^2.1.0-beta.21"
i get this error

```
ERROR in ./assets/js/semantic_layout.jsx
Module build failed: SyntaxError: Unexpected token (36:8)

  34 | 
  35 | export default class HomepageLayout extends Component {
> 36 |   state = {}
     |         ^
  37 | 
  38 |   hideFixedMenu = () => this.setState({ visible: false })
  39 |   showFixedMenu = () => this.setState({ visible: true })

 @ ./assets/js/index.jsx 3:0-51
```

hope my code work on others webpack too haha.