### PR TITLE
fix(Step): fixed typo in Step.Group className

### DIFF
--- a/src/elements/Step/StepGroup.js
+++ b/src/elements/Step/StepGroup.js
@@ -35,7 +35,7 @@ function StepGroup(props) {
     size,
     useKeyOnly(fluid, 'fluid'),
     useKeyOnly(ordered, 'ordered'),
-    useKeyOnly(unstackable, 'unstackable,'),
+    useKeyOnly(unstackable, 'unstackable'),
     useKeyOnly(vertical, 'vertical'),
     useValueAndKey(stackable, 'stackable'),
     'steps',


### PR DESCRIPTION
Fixes #1942.
fixed typo of invalid comma for the generated class unstackable