### PR TITLE
fix(TabPane): remove extra loading prop

### DIFF
--- a/src/modules/Tab/TabPane.js
+++ b/src/modules/Tab/TabPane.js
@@ -32,7 +32,7 @@ function TabPane(props) {
   }
 
   return (
-    <ElementType {...calculatedDefaultProps} {...rest} className={classes} loading={loading}>
+    <ElementType {...calculatedDefaultProps} {...rest} className={classes}>
       {children}
     </ElementType>
   )


### PR DESCRIPTION
Fixes #1941

The `loading` prop was an artifact from a previous design which relied strictly on the Segment as the Tab Pane component.  The Segment does accept a loading prop.

We no longer need this as the `tab` class can accept an associated `loading` class, which is slightly different from the Segment's `loading` prop.  We already have this in place as well.

