### PR TITLE
chore(webpack): switch rawgit to github

### DIFF
--- a/config.js
+++ b/config.js
@@ -67,7 +67,7 @@ config = Object.assign({}, config, {
   compiler_hash_type: __PROD__ ? 'chunkhash' : 'hash',
   compiler_fail_on_warning: __TEST__ || __PROD__,
   compiler_output_path: paths.base(config.dir_docs_dist),
-  compiler_public_path: __PROD__ ? '//cdn.rawgit.com/Semantic-Org/Semantic-UI-React/gh-pages/' : '/',
+  compiler_public_path: __PROD__ ? '//raw.github.com/Semantic-Org/Semantic-UI-React/gh-pages/' : '/',
   compiler_stats: {
     hash: false,            // the hash of the compilation
     version: false,         // webpack version info


### PR DESCRIPTION
Fixes #1870 

Rawgit is failing us so we're switching back to gh-pages for the bundle host.