### PR TITLE
fix(Search): only call onBlur & onFocus event handler once

### DIFF
--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -539,10 +539,8 @@ export default class Search extends Component {
       ...rest,
       icon,
       input: { className: 'prompt', tabIndex: '0', autoComplete: 'off' },
-      onBlur: this.handleBlur,
       onChange: this.handleSearchChange,
       onClick: this.handleInputClick,
-      onFocus: this.handleFocus,
       value,
     } })
   }

--- a/test/specs/modules/Search/Search-test.js
+++ b/test/specs/modules/Search/Search-test.js
@@ -525,6 +525,28 @@ describe('Search', () => {
     })
   })
 
+  describe('onBlur', () => {
+    it('is called with (event, data) on search input blur', () => {
+      const spy = sandbox.spy()
+      wrapperMount(<Search onBlur={spy} />)
+        .simulate('blur', nativeEvent)
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(nativeEvent)
+    })
+  })
+
+  describe('onFocus', () => {
+    it('is called with (event, data) on search input focus', () => {
+      const spy = sandbox.spy()
+      wrapperMount(<Search onFocus={spy} />)
+        .simulate('focus', nativeEvent)
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(nativeEvent)
+    })
+  })
+
   describe('onResultSelect', () => {
     let spy
     beforeEach(() => {

--- a/test/specs/modules/Search/Search-test.js
+++ b/test/specs/modules/Search/Search-test.js
@@ -526,7 +526,7 @@ describe('Search', () => {
   })
 
   describe('onBlur', () => {
-    it('is called with (event, data) on search input blur', () => {
+    it('is called with (event) on search input blur', () => {
       const spy = sandbox.spy()
       wrapperMount(<Search onBlur={spy} />)
         .simulate('blur', nativeEvent)
@@ -537,7 +537,7 @@ describe('Search', () => {
   })
 
   describe('onFocus', () => {
-    it('is called with (event, data) on search input focus', () => {
+    it('is called with (event) on search input focus', () => {
       const spy = sandbox.spy()
       wrapperMount(<Search onFocus={spy} />)
         .simulate('focus', nativeEvent)

--- a/test/specs/modules/Search/Search-test.js
+++ b/test/specs/modules/Search/Search-test.js
@@ -526,24 +526,24 @@ describe('Search', () => {
   })
 
   describe('onBlur', () => {
-    it('is called with (event) on search input blur', () => {
-      const spy = sandbox.spy()
-      wrapperMount(<Search onBlur={spy} />)
+    it('is called with (event, data) on search input blur', () => {
+      const onBlur = sandbox.spy()
+      wrapperMount(<Search results={options} onBlur={onBlur} />)
         .simulate('blur', nativeEvent)
 
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(nativeEvent)
+      onBlur.should.have.been.calledOnce()
+      onBlur.should.have.been.calledWithMatch(nativeEvent, { onBlur, results: options })
     })
   })
 
   describe('onFocus', () => {
-    it('is called with (event) on search input focus', () => {
-      const spy = sandbox.spy()
-      wrapperMount(<Search onFocus={spy} />)
+    it('is called with (event, data) on search input focus', () => {
+      const onFocus = sandbox.spy()
+      wrapperMount(<Search results={options} onFocus={onFocus} />)
         .simulate('focus', nativeEvent)
 
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(nativeEvent)
+      onFocus.should.have.been.calledOnce()
+      onFocus.should.have.been.calledWithMatch(nativeEvent, { onFocus, results: options })
     })
   })
 


### PR DESCRIPTION
Fixes #1962 

Search component onBlur and onFocus event handers should not be called twice.