### PR TITLE
fix(Input|Button|TextArea): add `focus` method to typings

### DIFF
--- a/src/addons/TextArea/TextArea.d.ts
+++ b/src/addons/TextArea/TextArea.d.ts
@@ -31,6 +31,8 @@ export interface TextAreaOnChangeData extends TextAreaProps {
   value?: string;
 }
 
-declare const TextArea: React.ComponentClass<TextAreaProps>;
+declare class TextArea extends React.Component<TextArea, {}> {
+  focus: () => void;
+}
 
 export default TextArea;

--- a/src/elements/Button/Button.d.ts
+++ b/src/elements/Button/Button.d.ts
@@ -101,12 +101,12 @@ export interface ButtonProps {
   toggle?: boolean;
 }
 
-interface ButtonComponent extends React.ComponentClass<ButtonProps> {
-  Content: typeof ButtonContent;
-  Group: typeof ButtonGroup;
-  Or: typeof ButtonOr;
-}
+declare class Button extends React.Component<ButtonProps, {}> {
+  static Content: typeof ButtonContent;
+  static Group: typeof ButtonGroup;
+  static Or: typeof ButtonOr;
 
-declare const Button: ButtonComponent;
+  focus: () => void;
+}
 
 export default Button;

--- a/src/elements/Input/Input.d.ts
+++ b/src/elements/Input/Input.d.ts
@@ -83,6 +83,8 @@ export interface InputOnChangeData extends InputProps {
   value: string;
 }
 
-declare const Input: React.ComponentClass<InputProps>;
+declare class Input extends React.Component<InputProps, {}> {
+  focus: () => void;
+}
 
 export default Input;


### PR DESCRIPTION
Fixes #1970.