### PR TITLE
fix(Popup): change position(right/left) for small width components

### DIFF
--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -140,6 +140,20 @@ export default class Popup extends Component {
 
   state = {}
 
+  computePopupOffset(width) { // computing the left/right offset based on width
+    let offset = 0
+    if (width > 17 && width <= 25) {
+      offset = 5.8
+    } else if (width > 9 && width <= 17) {
+      offset = 13
+    } else if (width > 5 && width <= 9) {
+      offset = 15
+    } else if (width > 1 && width <= 5) {
+      offset = 18
+    }
+    return offset
+  }
+
   computePopupStyle(positions) {
     const style = { position: 'absolute' }
 
@@ -151,10 +165,20 @@ export default class Popup extends Component {
     const { clientWidth, clientHeight } = document.documentElement
 
     if (_.includes(positions, 'right')) {
-      style.right = Math.round(clientWidth - (this.coords.right + pageXOffset))
+      if (this.coords.width < 25) { // for the element having small width
+        style.right = Math.round(clientWidth - (this.coords.right + pageXOffset)
+         - this.computePopupOffset(this.coords.width))
+      } else {
+        style.right = Math.round(clientWidth - (this.coords.right + pageXOffset))
+      }
       style.left = 'auto'
     } else if (_.includes(positions, 'left')) {
-      style.left = Math.round(this.coords.left + pageXOffset)
+      if (this.coords.width < 25) { // for the element having small width
+        style.left = Math.round(this.coords.left + pageXOffset
+        - this.computePopupOffset(this.coords.width))
+      } else {
+        style.left = Math.round(this.coords.left + pageXOffset)
+      }
       style.right = 'auto'
     } else { // if not left nor right, we are horizontally centering the element
       const xOffset = (this.coords.width - this.popupCoords.width) / 2

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -141,17 +141,10 @@ export default class Popup extends Component {
   state = {}
 
   computePopupOffset(width) { // computing the left/right offset based on width
-    let offset = 0
-    if (width > 17 && width <= 25) {
-      offset = 5.8
-    } else if (width > 9 && width <= 17) {
-      offset = 13
-    } else if (width > 5 && width <= 9) {
-      offset = 15
-    } else if (width > 1 && width <= 5) {
-      offset = 18
-    }
-    return offset
+    if (width > 17 && width <= 25) return 5.8
+    else if (width > 9 && width <= 17) return 13
+    else if (width > 5 && width <= 9) return 15
+    else if (width > 1 && width <= 5) return 18
   }
 
   computePopupStyle(positions) {


### PR DESCRIPTION
The position of the Popup on elements with smaller width(<25px) not aligned.