### PR TITLE
fix(TextArea): use onInput for updating height for IE compatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ export { default as Confirm, ConfirmProps } from './dist/commonjs/addons/Confirm
 export { default as Portal, PortalProps } from './dist/commonjs/addons/Portal';
 export { default as Radio, RadioProps } from './dist/commonjs/addons/Radio';
 export { default as Select, SelectProps } from './dist/commonjs/addons/Select';
-export { default as TextArea, TextAreaProps, TextAreaOnChangeData } from './dist/commonjs/addons/TextArea';
+export { default as TextArea, TextAreaProps } from './dist/commonjs/addons/TextArea';
 
 // Behaviors
 export {

--- a/src/addons/TextArea/TextArea.d.ts
+++ b/src/addons/TextArea/TextArea.d.ts
@@ -15,7 +15,7 @@ export interface TextAreaProps {
    * @param {SyntheticEvent} event - The React SyntheticEvent object
    * @param {object} data - All props and the event value.
    */
-  onChange?: (event: React.FormEvent<HTMLTextAreaElement>, data: TextAreaOnChangeData) => void;
+  onChange?: (event: React.FormEvent<HTMLTextAreaElement>, data: TextAreaProps) => void;
 
   /**
    * Called on input.
@@ -23,7 +23,7 @@ export interface TextAreaProps {
    * @param {SyntheticEvent} event - The React SyntheticEvent object
    * @param {object} data - All props and the event value.
    */
-  onInput?: (event: React.FormEvent<HTMLTextAreaElement>, data: TextAreaOnInputData) => void;
+  onInput?: (event: React.FormEvent<HTMLTextAreaElement>, data: TextAreaProps) => void;
 
   /** Indicates row count for a TextArea. */
   rows?: number | string;
@@ -33,14 +33,6 @@ export interface TextAreaProps {
 
   /** The value of the textarea. */
   value?: number | string;
-}
-
-export interface TextAreaOnChangeData extends TextAreaProps {
-  value?: string;
-}
-
-export interface TextAreaOnInputData extends TextAreaProps {
-  value?: string;
 }
 
 declare class TextArea extends React.Component<TextAreaProps, {}> {

--- a/src/addons/TextArea/TextArea.d.ts
+++ b/src/addons/TextArea/TextArea.d.ts
@@ -17,6 +17,14 @@ export interface TextAreaProps {
    */
   onChange?: (event: React.FormEvent<HTMLTextAreaElement>, data: TextAreaOnChangeData) => void;
 
+  /**
+   * Called on input.
+   *
+   * @param {SyntheticEvent} event - The React SyntheticEvent object
+   * @param {object} data - All props and the event value.
+   */
+  onInput?: (event: React.FormEvent<HTMLTextAreaElement>, data: TextAreaOnInputData) => void;
+
   /** Indicates row count for a TextArea. */
   rows?: number | string;
 
@@ -28,6 +36,10 @@ export interface TextAreaProps {
 }
 
 export interface TextAreaOnChangeData extends TextAreaProps {
+  value?: string;
+}
+
+export interface TextAreaOnInputData extends TextAreaProps {
   value?: string;
 }
 

--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -33,6 +33,13 @@ class TextArea extends Component {
      */
     onChange: PropTypes.func,
 
+    /**
+     * Called on input.
+     * @param {SyntheticEvent} event - The React SyntheticEvent object
+     * @param {object} data - All props and the event value.
+     */
+    onInput: PropTypes.func,
+
     /** Indicates row count for a TextArea. */
     rows: PropTypes.oneOfType([
       PropTypes.number,
@@ -75,6 +82,12 @@ class TextArea extends Component {
     const value = _.get(e, 'target.value')
 
     _.invoke(this.props, 'onChange', e, { ...this.props, value })
+  }
+
+  handleInput = (e) => {
+    const value = _.get(e, 'target.value')
+
+    _.invoke(this.props, 'onInput', e, { ...this.props, value })
     this.updateHeight()
   }
 
@@ -116,6 +129,7 @@ class TextArea extends Component {
       <ElementType
         {...rest}
         onChange={this.handleChange}
+        onInput={this.handleInput}
         ref={this.handleRef}
         rows={rows}
         style={{ resize, ...style }}

--- a/src/addons/TextArea/index.d.ts
+++ b/src/addons/TextArea/index.d.ts
@@ -1,1 +1,1 @@
-export { default, TextAreaProps, TextAreaOnChangeData } from './TextArea';
+export { default, TextAreaProps, TextAreaOnChangeData, TextAreaOnInputData } from './TextArea';

--- a/src/addons/TextArea/index.d.ts
+++ b/src/addons/TextArea/index.d.ts
@@ -1,1 +1,1 @@
-export { default, TextAreaProps, TextAreaOnChangeData, TextAreaOnInputData } from './TextArea';
+export { default, TextAreaProps } from './TextArea';

--- a/test/specs/addons/TextArea/TextArea-test.js
+++ b/test/specs/addons/TextArea/TextArea-test.js
@@ -142,6 +142,20 @@ describe('TextArea', () => {
     })
   })
 
+  describe('onInput', () => {
+    it('is called with (e, data) on input', () => {
+      const spy = sandbox.spy()
+      const e = { target: { value: 'name' } }
+      const props = { 'data-foo': 'bar', onInput: spy }
+
+      wrapperShallow(<TextArea {...props} />)
+      wrapper.find('textarea').simulate('input', e)
+
+      spy.should.have.been.calledOnce()
+      spy.should.have.been.calledWithMatch(e, { ...props, value: e.target.value })
+    })
+  })
+
   describe('rows', () => {
     it('has default value', () => {
       shallow(<TextArea />)


### PR DESCRIPTION
Fixes #1925 

This is my first PR, apologies if there are any mistakes.
Added an onInput method to the TextArea component, copying the onChange pattern. Added a test for the onInput method.

Tested in IE11 and the requested behaviour (cutting and pasting) correctly resizes the TextArea.