### PR TITLE
docs(Transition): enhancements

### DIFF
--- a/docs/app/Examples/modules/Transition/Types/TransitionExampleGroup.js
+++ b/docs/app/Examples/modules/Transition/Types/TransitionExampleGroup.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import React, { Component } from 'react'
 import { Button, Image, List, Transition } from 'semantic-ui-react'
 
+/* Note how the username is used both in constructing the URL and as the key prop */
 const users = ['ade', 'chris', 'christian', 'daniel', 'elliot', 'helen']
 
 export default class TransitionExampleGroup extends Component {

--- a/docs/app/Examples/modules/Transition/Types/index.js
+++ b/docs/app/Examples/modules/Transition/Types/index.js
@@ -6,23 +6,30 @@ import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
 
 const TransitionTypesExamples = () => (
   <ExampleSection title='Types'>
+
     <ComponentExample
       title='Transition'
       description='A Transition animates a single child by toggling the the visible prop.'
       examplePath='modules/Transition/Types/TransitionExampleTransition'
     >
       <Message warning>
-        <p>Do not unmount a Transition child or else it cannot be animated.</p>
+        <p>An animated component must not unmount unexpectedly or the transition will not run as intended.</p>
         <Message.List>
           <Message.Item>
-            Use the <code>unmountOnHide</code> prop to unmount the child after the animation exits.
+            If you need to animate children as they mount and unmount, use a <code>Transition.Group</code>. 
           </Message.Item>
           <Message.Item>
-            Use a <code>Transition.Group</code> to animate children as they mount and unmount.
+            It is paramount that each child of a <code>Transition.Group</code>
+            has an unique <code>key</code> prop that stays constant through rerenders.
+            In particular, it is likely that <code>keys</code> based on pseudo-random identifiers or simple loop increment variables will lead to unexpected behavior.
+          </Message.Item>
+          <Message.Item>
+            When using the <code>Transition</code> component, you may unmount the animated child when the transition completes by setting the <code>unmountOnHide</code> prop.
           </Message.Item>
         </Message.List>
       </Message>
     </ComponentExample>
+
     <ComponentExample
       title='Transition Group'
       description='A Transition Group animates children as they mount and unmount.'


### PR DESCRIPTION
Here are my 2 cents. I had some issues with the `Transition.Group` component resulting from poorly picked `key` props on the child components. As I suspect this is a common blunder, I thought I'd make a note about it in the docs. Cheers!