### PR TITLE
fix(Dropdown): closeOnBlur={false} does not work

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -630,6 +630,8 @@ export default class Dropdown extends Component {
     debug('closeOnDocumentClick()')
     debug(e)
 
+    if (!this.props.closeOnBlur) return
+
     // If event happened in the dropdown, ignore it
     if (this.ref && _.isFunction(this.ref.contains) && this.ref.contains(e.target)) return
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -115,6 +115,15 @@ describe('Dropdown', () => {
     dropdownMenuIsClosed()
   })
 
+  it('does not close on blur with closeOnBlur set to false', () => {
+    wrapperMount(<Dropdown options={options} closeOnBlur={false} />)
+      .simulate('click')
+
+    dropdownMenuIsOpen()
+    wrapper.simulate('blur')
+    dropdownMenuIsOpen()
+  })
+
   it('blurs the Dropdown node on close', () => {
     wrapperMount(<Dropdown options={options} selection defaultOpen />)
 


### PR DESCRIPTION
fix(Dropdown): Don't add an event listener for document clicks if closeOnBlur is falsey
test(Dropdown): add a test for closeOnBlur={false}

fixes https://github.com/Semantic-Org/Semantic-UI-React/issues/1995