### PR TITLE
fix(TextArea): invalid TypeScript class declaration

### DIFF
--- a/src/addons/TextArea/TextArea.d.ts
+++ b/src/addons/TextArea/TextArea.d.ts
@@ -31,7 +31,7 @@ export interface TextAreaOnChangeData extends TextAreaProps {
   value?: string;
 }
 
-declare class TextArea extends React.Component<TextArea, {}> {
+declare class TextArea extends React.Component<TextAreaProps, {}> {
   focus: () => void;
 }
 


### PR DESCRIPTION
This fixes issues introduced by #1972 described in [my comment](https://github.com/Semantic-Org/Semantic-UI-React/pull/1972#issuecomment-324662971) on the original pull request.