### PR TITLE
fix(Modal): fix typo in className

### DIFF
--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -219,7 +219,7 @@ class Modal extends Component {
     mountNode.classList.remove('blurring')
     mountNode.classList.remove('dimmable')
     mountNode.classList.remove('dimmed')
-    mountNode.classList.remove('scrollable')
+    mountNode.classList.remove('scrolling')
 
     cancelAnimationFrame(this.animationRequestId)
 

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -474,8 +474,14 @@ describe('Modal', () => {
   })
 
   describe('scrolling', () => {
+    const innerHeight = window.innerHeight
+
     afterEach(() => {
       document.body.classList.remove('scrolling')
+    })
+
+    after(() => {
+      window.innerHeight = innerHeight
     })
 
     it('does not add the scrolling class to the body by default', () => {

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -233,9 +233,14 @@ describe('Modal', () => {
     })
 
     describe('true', () => {
-      it('adds classes "dimmable dimmed" to the body', () => {
+      it('adds/removes body classes "dimmable dimmed" on mount/unmount', () => {
+        assertBodyClasses('dimmable', 'dimmed', false)
+
         wrapperMount(<Modal open dimmer />)
         assertBodyClasses('dimmable', 'dimmed')
+
+        wrapper.unmount()
+        assertBodyClasses('dimmable', 'dimmed', false)
       })
 
       it('adds a dimmer to the body', () => {
@@ -257,9 +262,14 @@ describe('Modal', () => {
     })
 
     describe('blurring', () => {
-      it('adds class "dimmable dimmed blurring" to the body', () => {
+      it('adds/removes body classes "dimmable dimmed blurring" on mount/unmount', () => {
+        assertBodyClasses('dimmable', 'dimmed', 'blurring', false)
+
         wrapperMount(<Modal open dimmer='blurring' />)
         assertBodyClasses('dimmable', 'dimmed', 'blurring')
+
+        wrapper.unmount()
+        assertBodyClasses('dimmable', 'dimmed', 'blurring', false)
       })
 
       it('adds a dimmer to the body', () => {
@@ -269,10 +279,14 @@ describe('Modal', () => {
     })
 
     describe('inverted', () => {
-      it('adds class "dimmable dimmed" to the body', () => {
-        wrapperMount(<Modal open dimmer='inverted' />)
+      it('adds/removes body classes "dimmable dimmed" on mount/unmount', () => {
+        assertBodyClasses('dimmable', 'dimmed', false)
+
+        wrapperMount(<Modal open dimmer />)
         assertBodyClasses('dimmable', 'dimmed')
-        assertBodyClasses('inverted', false)
+
+        wrapper.unmount()
+        assertBodyClasses('dimmable', 'dimmed', false)
       })
 
       it('adds an inverted dimmer to the body', () => {
@@ -463,9 +477,8 @@ describe('Modal', () => {
     })
 
     it('adds the scrolling class to the body when taller than the window', (done) => {
-      wrapperMount(<Modal open>foo</Modal>)
-
       window.innerHeight = 10
+      wrapperMount(<Modal open>foo</Modal>)
 
       requestAnimationFrame(() => {
         assertBodyClasses('scrolling')
@@ -473,7 +486,7 @@ describe('Modal', () => {
       })
     })
 
-    it('removes the scrolling class from the body when the window grows taller', (done) => {
+    it('adds/removes the scrolling class to the body when the window grows/shrinks', (done) => {
       assertBodyClasses('scrolling', false)
 
       wrapperMount(<Modal open>foo</Modal>)
@@ -487,6 +500,21 @@ describe('Modal', () => {
           assertBodyClasses('scrolling', false)
           done()
         })
+      })
+    })
+
+    it('removes the scrolling class from the body on unmount', (done) => {
+      assertBodyClasses('scrolling', false)
+
+      window.innerHeight = 10
+      wrapperMount(<Modal open>foo</Modal>)
+
+      requestAnimationFrame(() => {
+        assertBodyClasses('scrolling')
+        wrapper.unmount()
+
+        assertBodyClasses('scrolling', false)
+        done()
       })
     })
   })


### PR DESCRIPTION
We have the awesome [codepen](https://codepen.io/anon/pen/Ljerpm) in #1979. It show that `scrolling` className isn't removed from `body` after `Portal`'s unmount. In fact, there was a typo and this PR fixes it.

Fixes #1979.