### PR TITLE
fix(Checkbox): fix `checked` value returned by `onClick`

### DIFF
--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -159,7 +159,7 @@ export default class Checkbox extends Component {
 
     if (!this.canToggle()) return
 
-    _.invoke(this.props, 'onClick', e, { ...this.props, checked: !!checked, indeterminate: !!indeterminate })
+    _.invoke(this.props, 'onClick', e, { ...this.props, checked: !checked, indeterminate: !!indeterminate })
     _.invoke(this.props, 'onChange', e, { ...this.props, checked: !checked, indeterminate: false })
 
     this.trySetState({ checked: !checked, indeterminate: false })

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -147,17 +147,13 @@ describe('Checkbox', () => {
 
   describe('onClick', () => {
     it('is called with (event { name, value, checked }) on label click', () => {
-      const spy = sandbox.spy()
-      const expectProps = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
-      mount(<Checkbox onClick={spy} {...expectProps} />)
+      const onClick = sandbox.spy()
+      const expectProps = { name: 'foo', value: 'bar', checked: true, indeterminate: true }
+      mount(<Checkbox onClick={onClick} {...expectProps} />)
         .simulate('click')
 
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, {
-        ...expectProps,
-        checked: expectProps.checked,
-        indeterminate: expectProps.indeterminate,
-      })
+      onClick.should.have.been.calledOnce()
+      onClick.should.have.been.calledWithMatch({}, { ...expectProps, checked: !expectProps.checked })
     })
     it('is not called when the checkbox has the disabled prop set', () => {
       const spy = sandbox.spy()


### PR DESCRIPTION
Fixes #1936.