### PR TITLE
breaking(Checkbox): callback with new checked value in onClick

### DIFF
--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -159,7 +159,7 @@ export default class Checkbox extends Component {
 
     if (!this.canToggle()) return
 
-    _.invoke(this.props, 'onClick', e, { ...this.props, checked: !!checked, indeterminate: !!indeterminate })
+    _.invoke(this.props, 'onClick', e, { ...this.props, checked: !checked, indeterminate: !!indeterminate })
     _.invoke(this.props, 'onChange', e, { ...this.props, checked: !checked, indeterminate: false })
 
     this.trySetState({ checked: !checked, indeterminate: false })

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -155,7 +155,7 @@ describe('Checkbox', () => {
       spy.should.have.been.calledOnce()
       spy.should.have.been.calledWithMatch({}, {
         ...expectProps,
-        checked: expectProps.checked,
+        checked: !expectProps.checked,
         indeterminate: expectProps.indeterminate,
       })
     })


### PR DESCRIPTION
## Breaking Change

Currently, it represented the previous checked state the `checked` value in a Checkbox's `onClick` callback represents the old state.  It now represents the new `checked` state.

### Before

You needed to negate the `checked` value to get the correct new value:

```jsx
handleClick = (e, data) => this.setState({ checked: !data.checked })

<Checkbox onClick={this.handleClick} />
```

### After

The `checked` value represents the correct new value.

```jsx
handleClick = (e, data) => this.setState({ checked: data.checked })

<Checkbox onClick={this.handleClick} />
```
>Note, this is analogous to a controlled `<Input />`'s `value`.


***

change onClick's checked value to be the new representation of the
checked state instead of the representation before the event was
triggered

BREAKING CHANGE: Checkbox.onClick has changed how the checked property
is defined.  To migrate update code that references checked property to
the opposite value currently assumed.
Closes Semantic-Org/Semantic-UI-React#1936