### PR TITLE
fix(Image): relax `wrapped` propType

### DIFF
--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -182,11 +182,7 @@ Image.propTypes = {
   ]),
 
   /** An image can render wrapped in a `div.ui.image` as alternative HTML markup. */
-  wrapped: customPropTypes.every([
-    PropTypes.bool,
-    // these props wrap the image in an a tag already
-    customPropTypes.disallow(['href']),
-  ]),
+  wrapped: PropTypes.bool,
 }
 
 Image.defaultProps = {


### PR DESCRIPTION
This PR relaxes `wrapped` propType. It makes a sence, but it will throw warning when it will be used with `Item.Image` because it always passes `wrapped={true}`:

```jsx
<Item.Image
  as='a'
  href='http://example.com'
  src={src}
  size='tiny'
/>
```