### PR TITLE
fix(childMapping): correct argument order for getValue()

### DIFF
--- a/src/lib/childMapping.js
+++ b/src/lib/childMapping.js
@@ -46,15 +46,15 @@ export const mergeChildMappings = (prev = {}, next = {}) => {
   _.forEach(_.keys(next), (nextKey) => {
     if (_.has(nextKeysPending, nextKey)) {
       _.forEach(nextKeysPending[nextKey], (pendingKey) => {
-        childMapping[pendingKey] = getValue(pendingKey, next, prev)
+        childMapping[pendingKey] = getValue(pendingKey, prev, next)
       })
     }
 
-    childMapping[nextKey] = getValue(nextKey, next, prev)
+    childMapping[nextKey] = getValue(nextKey, prev, next)
   })
 
   _.forEach(pendingKeys, (pendingKey) => {
-    childMapping[pendingKey] = getValue(pendingKey, next, prev)
+    childMapping[pendingKey] = getValue(pendingKey, prev, next)
   })
 
   return childMapping

--- a/test/specs/lib/childMapping-test.js
+++ b/test/specs/lib/childMapping-test.js
@@ -94,5 +94,12 @@ describe('childMapping', () => {
         four: true,
       })
     })
+
+    it('should prefer next value of key over prev', () => {
+      const prev = { one: true }
+      const next = { one: false }
+
+      mergeChildMappings(prev, next).should.deep.equal({ one: false })
+    })
   })
 })


### PR DESCRIPTION
Fixes #2040. Corrects param order for `getValue()`.

```js
const getValue = (key, prev, next) => (_.has(next, key) ? next[key] : prev[key])
```