### PR TITLE
fix(Rating): make `defaultProps` static on `RatingIcon`

### DIFF
--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -56,7 +56,7 @@ export default class RatingIcon extends Component {
     selected: PropTypes.bool,
   }
 
-  defaultProps = {
+  static defaultProps = {
     as: 'i',
   }
 


### PR DESCRIPTION
Fixes #2057.