### PR TITLE
feat(Icon|Flag): PureComponent for Icon/Flag

### DIFF
--- a/src/elements/Flag/Flag.d.ts
+++ b/src/elements/Flag/Flag.d.ts
@@ -59,7 +59,7 @@ export interface FlagProps {
     'zambia' | 'zw' | 'zimbabwe';
 }
 
-declare class Flag extends React.Component<FlagProps, {}> {
+declare class Flag extends React.PureComponent<FlagProps, {}> {
 }
 
 export default Flag;

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 
 import {
   createShorthandFactory,
@@ -58,7 +58,7 @@ const names = [
 /**
  * A flag is is used to represent a political state.
  */
-class Flag extends Component {
+class Flag extends PureComponent {
   static propTypes = {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,

--- a/src/elements/Icon/Icon.d.ts
+++ b/src/elements/Icon/Icon.d.ts
@@ -54,7 +54,7 @@ export interface IconProps {
   size?: IconSizeProp;
 }
 
-declare class Icon extends React.Component<IconProps, {}> {
+declare class Icon extends React.PureComponent<IconProps, {}> {
   Group: typeof IconGroup;
 }
 

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -1,7 +1,7 @@
 import cx from 'classnames'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 
 import {
   createShorthandFactory,
@@ -20,7 +20,7 @@ import IconGroup from './IconGroup'
  * An icon is a glyph used to represent something else.
  * @see Image
  */
-class Icon extends Component {
+class Icon extends PureComponent {
   static propTypes = {
     /** An element type to render as (string or function). */
     as: customPropTypes.as,


### PR DESCRIPTION
Per [comments here](https://github.com/Semantic-Org/Semantic-UI-React/issues/1020#issuecomment-304082926), I have added in support for `PureComponent` in `Icon` and `Flag`. It looks like since that discussion happened last, someone has already added support for SCU and `shallowEqual` so adding `PureComponent` was the last piece for this.