### PR TITLE
fix(Dropdown): keep dropdown open when closeOnChange is set to false

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1098,7 +1098,7 @@ export default class Dropdown extends Component {
     this.setState({ focus: hasFocus })
   }
 
-  toggle = e => (this.state.open ? this.close(e) : this.open(e))
+  toggle = e => (this.state.open ? this.closeOnChange(e) : this.open(e))
 
   // ----------------------------------------
   // Render


### PR DESCRIPTION
Root cause: When `options` prop is used, clicking on the dropdown item will trigger `handleItemClick` which will utilize `closeOnChange` properly.
When `options` prop is undefined(using `children`), clicking on the dropdown item will trigger `handleClick` instead which will use `toggle`(if `search` prop is falsy) instead of `closeOnChange`.

Fix: Replaced `this.close(e)` in `toggle` with `this.closeOnChange(e)` to keep dropdown open when `closeOnChange` is set to `false`.

issue: Dropdown: ignores closeOnChange if it has children and isn't a search #2041