### PR TITLE
fix(Visibility): fix behaviour of reverse calls

### DIFF
--- a/src/behaviors/Visibility/Visibility.js
+++ b/src/behaviors/Visibility/Visibility.js
@@ -199,7 +199,7 @@ export default class Visibility extends Component {
 
     const { context, fireOnMount } = this.props
 
-    context.addEventListener('scroll', this.handleUpdate)
+    context.addEventListener('scroll', this.handleScroll)
     if (fireOnMount) this.update()
   }
 
@@ -207,7 +207,7 @@ export default class Visibility extends Component {
     if (!isBrowser) return
 
     const { context } = this.props
-    context.removeEventListener('scroll', this.handleUpdate)
+    context.removeEventListener('scroll', this.handleScroll)
   }
 
   // ----------------------------------------
@@ -260,7 +260,7 @@ export default class Visibility extends Component {
     })
   }
 
-  handleUpdate = () => {
+  handleScroll = () => {
     if (this.ticking) return
 
     this.ticking = true

--- a/src/behaviors/Visibility/Visibility.js
+++ b/src/behaviors/Visibility/Visibility.js
@@ -181,7 +181,7 @@ export default class Visibility extends Component {
     topVisible: false,
   }
 
-  occurredCallbacks = []
+  firedCallbacks = []
 
   // ----------------------------------------
   // Lifecycle
@@ -191,7 +191,7 @@ export default class Visibility extends Component {
     const cleanHappened = continuous !== this.props.continuous || once !== this.props.once
 
     // Heads up! We should clean up array of happened callbacks, if values of these props are changed
-    if (cleanHappened) this.occurredCallbacks = []
+    if (cleanHappened) this.firedCallbacks = []
   }
 
   componentDidMount() {
@@ -219,10 +219,10 @@ export default class Visibility extends Component {
     if (!callback) return
 
     // Heads up! When `continuous` is true, callback will be fired always
-    if (!continuous && _.includes(this.occurredCallbacks, name)) return
+    if (!continuous && _.includes(this.firedCallbacks, name)) return
 
     callback(null, { ...this.props, calculations: this.calculations })
-    this.occurredCallbacks.push(name)
+    this.firedCallbacks.push(name)
   }
 
   fire = ({ callback, name }, value, reverse = false) => {
@@ -237,7 +237,7 @@ export default class Visibility extends Component {
     if (matchesDirection && executionPossible) this.execute(callback, name)
 
     // Heads up! We should remove callback from the happened when it's not `once`
-    if (!once) this.occurredCallbacks = _.without(this.occurredCallbacks, name)
+    if (!once) this.firedCallbacks = _.without(this.firedCallbacks, name)
   }
 
   fireOnPassed() {

--- a/src/behaviors/Visibility/Visibility.js
+++ b/src/behaviors/Visibility/Visibility.js
@@ -171,21 +171,27 @@ export default class Visibility extends Component {
   }
 
   calculations = {
-    topPassed: false,
     bottomPassed: false,
-    topVisible: false,
     bottomVisible: false,
     fits: false,
     passing: false,
-    onScreen: false,
     offScreen: false,
+    onScreen: false,
+    topPassed: false,
+    topVisible: false,
   }
 
-  firedCallbacks = []
+  occurredCallbacks = []
+
+  // ----------------------------------------
+  // Lifecycle
+  // ----------------------------------------
 
   componentWillReceiveProps({ continuous, once }) {
-    const cleanOut = continuous !== this.props.continuous || once !== this.props.once
-    if (cleanOut) this.firedCallbacks = []
+    const cleanHappened = continuous !== this.props.continuous || once !== this.props.once
+
+    // Heads up! We should clean up array of happened callbacks, if values of these props are changed
+    if (cleanHappened) this.occurredCallbacks = []
   }
 
   componentDidMount() {
@@ -193,86 +199,48 @@ export default class Visibility extends Component {
 
     const { context, fireOnMount } = this.props
 
-    context.addEventListener('scroll', this.handleScroll)
-    if (fireOnMount) this.handleUpdate()
+    context.addEventListener('scroll', this.handleUpdate)
+    if (fireOnMount) this.update()
   }
 
   componentWillUnmount() {
     if (!isBrowser) return
 
     const { context } = this.props
-    context.removeEventListener('scroll', this.handleScroll)
+    context.removeEventListener('scroll', this.handleUpdate)
   }
 
-  execute = (callback, name) => {
+  // ----------------------------------------
+  // Callback handling
+  // ----------------------------------------
+
+  execute(callback, name) {
+    const { continuous } = this.props
+    if (!callback) return
+
+    // Heads up! When `continuous` is true, callback will be fired always
+    if (!continuous && _.includes(this.occurredCallbacks, name)) return
+
+    callback(null, { ...this.props, calculations: this.calculations })
+    this.occurredCallbacks.push(name)
+  }
+
+  fire = ({ callback, name }, value, reverse = false) => {
     const { continuous, once } = this.props
 
-    if (!callback) return
-    // Reverse callbacks aren't fired continuously
-    if (this.calculations[name] === false) return
+    // Heads up! For the execution is required:
+    // - current value correspond to the fired direction
+    // - `continuous` is true or calculation values are different
+    const matchesDirection = this.calculations[value] !== reverse
+    const executionPossible = continuous || this.calculations[value] !== this.oldCalculations[value]
 
-    // Always fire callback if continuous = true
-    if (continuous) {
-      callback(null, { ...this.props, calculations: this.calculations })
-      return
-    }
+    if (matchesDirection && executionPossible) this.execute(callback, name)
 
-    // If once = true, fire callback only if it wasn't fired before
-    if (once) {
-      if (!_.includes(this.firedCallbacks, name)) {
-        this.firedCallbacks.push(name)
-        callback(null, { ...this.props, calculations: this.calculations })
-      }
-
-      return
-    }
-
-    // Fire callback only if the value changed
-    if (this.calculations[name] !== this.oldCalculations[name]) {
-      callback(null, { ...this.props, calculations: this.calculations })
-    }
+    // Heads up! We should remove callback from the happened when it's not `once`
+    if (!once) this.occurredCallbacks = _.without(this.occurredCallbacks, name)
   }
 
-  fireCallbacks() {
-    const {
-      onBottomPassed,
-      onBottomPassedReverse,
-      onBottomVisible,
-      onBottomVisibleReverse,
-      onPassing,
-      onPassingReverse,
-      onTopPassed,
-      onTopPassedReverse,
-      onTopVisible,
-      onTopVisibleReverse,
-      onOffScreen,
-      onOnScreen,
-    } = this.props
-    const callbacks = {
-      bottomPassed: onBottomPassed,
-      bottomVisible: onBottomVisible,
-      passing: onPassing,
-      offScreen: onOffScreen,
-      onScreen: onOnScreen,
-      topPassed: onTopPassed,
-      topVisible: onTopVisible,
-    }
-    const reverse = {
-      bottomPassed: onBottomPassedReverse,
-      bottomVisible: onBottomVisibleReverse,
-      passing: onPassingReverse,
-      topPassed: onTopPassedReverse,
-      topVisible: onTopVisibleReverse,
-    }
-
-    _.invoke(this.props, 'onUpdate', null, { ...this.props, calculations: this.calculations })
-    this.fireOnPassed()
-
-    _.forEach(callbacks, (callback, name) => this.execute(callback, name))
-    _.forEach(reverse, (callback, name) => this.execute(callback, name))
-  }
-
-  fireOnPassed = () => {
+  fireOnPassed() {
     const { percentagePassed, pixelsPassed } = this.calculations
     const { onPassed } = this.props
 
@@ -292,18 +260,64 @@ export default class Visibility extends Component {
     })
   }
 
-  handleScroll = () => {
+  handleUpdate = () => {
     if (this.ticking) return
 
     this.ticking = true
-    requestAnimationFrame(this.handleUpdate)
+    requestAnimationFrame(this.update)
   }
 
-  handleRef = c => (this.ref = c)
-
-  handleUpdate = () => {
+  update = () => {
     this.ticking = false
 
+    this.oldCalculations = this.calculations
+    this.calculations = this.computeCalculations()
+
+    const {
+      onBottomPassed,
+      onBottomPassedReverse,
+      onBottomVisible,
+      onBottomVisibleReverse,
+      onPassing,
+      onPassingReverse,
+      onTopPassed,
+      onTopPassedReverse,
+      onTopVisible,
+      onTopVisibleReverse,
+      onOffScreen,
+      onOnScreen,
+    } = this.props
+    const forward = {
+      bottomPassed: { callback: onBottomPassed, name: 'onBottomPassed' },
+      bottomVisible: { callback: onBottomVisible, name: 'onBottomVisible' },
+      passing: { callback: onPassing, name: 'onPassing' },
+      offScreen: { callback: onOffScreen, name: 'onOffScreen' },
+      onScreen: { callback: onOnScreen, name: 'onOnScreen' },
+      topPassed: { callback: onTopPassed, name: 'onTopPassed' },
+      topVisible: { callback: onTopVisible, name: 'onTopVisible' },
+    }
+
+    const reverse = {
+      bottomPassed: { callback: onBottomPassedReverse, name: 'onBottomPassedReverse' },
+      bottomVisible: { callback: onBottomVisibleReverse, name: 'onBottomVisibleReverse' },
+      passing: { callback: onPassingReverse, name: 'onPassingReverse' },
+      topPassed: { callback: onTopPassedReverse, name: 'onTopPassedReverse' },
+      topVisible: { callback: onTopVisibleReverse, name: 'onTopVisibleReverse' },
+    }
+
+    _.invoke(this.props, 'onUpdate', null, { ...this.props, calculations: this.calculations })
+    this.fireOnPassed()
+
+    // Heads up! Reverse callbacks should be fired first
+    _.forEach(reverse, (data, value) => this.fire(data, value, true))
+    _.forEach(forward, (data, value) => this.fire(data, value))
+  }
+
+  // ----------------------------------------
+  // Helpers
+  // ----------------------------------------
+
+  computeCalculations() {
     const { offset } = this.props
     const { bottom, height, top, width } = this.ref.getBoundingClientRect()
     const [topOffset, bottomOffset] = normalizeOffset(offset)
@@ -323,8 +337,7 @@ export default class Visibility extends Component {
     const onScreen = (topVisible || topPassed) && !bottomPassed
     const offScreen = !onScreen
 
-    this.oldCalculations = this.calculations
-    this.calculations = {
+    return {
       bottomPassed,
       bottomVisible,
       fits,
@@ -338,9 +351,17 @@ export default class Visibility extends Component {
       topVisible,
       width,
     }
-
-    this.fireCallbacks()
   }
+
+  // ----------------------------------------
+  // Refs
+  // ----------------------------------------
+
+  handleRef = c => (this.ref = c)
+
+  // ----------------------------------------
+  // Render
+  // ----------------------------------------
 
   render() {
     const { children } = this.props


### PR DESCRIPTION
I'm working on #2070, but it can't be finished without changes there. 

We have wrong behaviour for `*reverse` callbacks and it's easy to show, see GIFs. We fire them always, but in fact they should be called in the oppositite condition.

```js
// topPassed
if(calculations.topPassed) module.execute(callback, callbackName);

// topPassedReverse
if(!calculations.topPassed) module.execute(callback, callbackName);
```

#### SUI

<details>
  <summary>Click to expand</summary>
  <img src="https://user-images.githubusercontent.com/14183168/30584583-e257fb02-9d32-11e7-8154-d671c80badd2.gif">
</details>

#### SUIR

<details>
  <summary>Click to expand</summary>
  <img src="https://user-images.githubusercontent.com/14183168/30584597-ec2ba750-9d32-11e7-8fee-987e8dcce784.gif">
</details>

