### PR TITLE
feat(Visibility): add `direction` for calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Any other issue labeled [`help wanted`][4] is ready for a PR.
 |-----------------|-----------------|-----------------|-----------------|--------------------|
 | ✓ Button        | ✓ Breadcrumb    | ✓ Advertisement | ✓ Accordion     |   Form Validation  |
 | ✓ Container     | ✓ Form          | ✓ Card          | ✓ Checkbox      | *API (NA)*         |
-| ✓ Divider       | ✓ Grid          | ✓ Comment       | ✓ Dimmer        | ✓ Visibility (NA)  |
+| ✓ Divider       | ✓ Grid          | ✓ Comment       | ✓ Dimmer        | ✓ Visibility       |
 | ✓ Flag          | ✓ Menu          | ✓ Feed          | ✓ Dropdown      |                    |
 | ✓ Header        | ✓ Message       | ✓ Item          | ✓ Embed         |                    |
 | ✓ Icon          | ✓ Table         | ✓ Statistic     | ✓ Modal         |                    |

--- a/docs/app/Examples/behaviors/Visibility/Settings/VisibilityExampleFireOnMount.js
+++ b/docs/app/Examples/behaviors/Visibility/Settings/VisibilityExampleFireOnMount.js
@@ -4,6 +4,7 @@ import { Divider, Grid, Image, Table, Segment, Visibility } from 'semantic-ui-re
 export default class VisibilityExampleFireOnMount extends Component {
   state = {
     calculations: {
+      direction: 'none',
       height: 0,
       width: 0,
       topPassed: false,
@@ -55,6 +56,10 @@ export default class VisibilityExampleFireOnMount extends Component {
               </Table.Row>
             </Table.Header>
             <Table.Body>
+              <Table.Row>
+                <Table.Cell>direction</Table.Cell>
+                <Table.Cell>{calculations.direction}</Table.Cell>
+              </Table.Row>
               <Table.Row>
                 <Table.Cell>pixelsPassed</Table.Cell>
                 <Table.Cell>{calculations.pixelsPassed.toFixed()}px</Table.Cell>

--- a/docs/app/Examples/behaviors/Visibility/Types/VisibilityExampleVisibility.js
+++ b/docs/app/Examples/behaviors/Visibility/Types/VisibilityExampleVisibility.js
@@ -6,6 +6,7 @@ import Wireframe from '../Wireframe'
 export default class VisibilityExampleVisibility extends Component {
   state = {
     calculations: {
+      direction: 'none',
       height: 0,
       width: 0,
       topPassed: false,
@@ -47,6 +48,10 @@ export default class VisibilityExampleVisibility extends Component {
                   </Table.Row>
                 </Table.Header>
                 <Table.Body>
+                  <Table.Row>
+                    <Table.Cell>direction</Table.Cell>
+                    <Table.Cell>{calculations.direction}</Table.Cell>
+                  </Table.Row>
                   <Table.Row>
                     <Table.Cell>pixelsPassed</Table.Cell>
                     <Table.Cell>{calculations.pixelsPassed.toFixed()}px</Table.Cell>

--- a/src/behaviors/Visibility/Visibility.d.ts
+++ b/src/behaviors/Visibility/Visibility.d.ts
@@ -141,6 +141,7 @@ export interface VisibilityProps {
 export interface VisibilityCalculations {
   bottomPassed: boolean;
   bottomVisible: boolean;
+  direction: 'down' | 'up';
   fits: boolean;
   height: number;
   passing: boolean;

--- a/src/behaviors/Visibility/Visibility.js
+++ b/src/behaviors/Visibility/Visibility.js
@@ -193,6 +193,7 @@ export default class Visibility extends Component {
 
     const { context, fireOnMount } = this.props
 
+    this.pageYOffset = window.pageYOffset
     context.addEventListener('scroll', this.handleScroll)
     if (fireOnMount) this.handleUpdate()
   }
@@ -308,6 +309,7 @@ export default class Visibility extends Component {
     const { bottom, height, top, width } = this.ref.getBoundingClientRect()
     const [topOffset, bottomOffset] = normalizeOffset(offset)
 
+    const direction = window.pageYOffset > this.pageYOffset ? 'down' : 'up'
     const topPassed = top < topOffset
     const bottomPassed = bottom < bottomOffset
 
@@ -327,6 +329,7 @@ export default class Visibility extends Component {
     this.calculations = {
       bottomPassed,
       bottomVisible,
+      direction,
       fits,
       height,
       passing,
@@ -338,6 +341,7 @@ export default class Visibility extends Component {
       topVisible,
       width,
     }
+    this.pageYOffset = window.pageYOffset
 
     this.fireCallbacks()
   }

--- a/test/specs/behaviors/Visibility/Visibility-test.js
+++ b/test/specs/behaviors/Visibility/Visibility-test.js
@@ -3,7 +3,7 @@ import React from 'react'
 
 import Visibility from 'src/behaviors/Visibility'
 import * as common from 'test/specs/commonTests'
-import { sandbox } from 'test/utils'
+import { domEvent, sandbox } from 'test/utils'
 
 let wrapper
 
@@ -177,6 +177,41 @@ describe('Visibility', () => {
           callback.should.have.been.calledTwice()
         })
       }
+    })
+
+    describe('direction', () => {
+      let pageYOffset
+
+      beforeEach(() => {
+        pageYOffset = window.pageYOffset
+      })
+
+      afterEach(() => {
+        window.pageYOffset = pageYOffset
+      })
+
+      it('returns up when scrolling down', () => {
+        const onUpdate = sandbox.spy()
+        mount(<Visibility onUpdate={onUpdate} />)
+
+        window.pageYOffset = 5
+        domEvent.scroll(window)
+        onUpdate.should.have.been.calledWithMatch(null, {
+          calculations: { direction: 'down' },
+        })
+      })
+
+      it('returns up when scrolling up', () => {
+        window.pageYOffset = 100
+        const onUpdate = sandbox.spy()
+        mount(<Visibility onUpdate={onUpdate} />)
+
+        window.pageYOffset = 50
+        domEvent.scroll(window)
+        onUpdate.should.have.been.calledWithMatch(null, {
+          calculations: { direction: 'up' },
+        })
+      })
     })
   })
 


### PR DESCRIPTION
Cut from #2088.

# What?

SUI has [`direction`](https://github.com/Semantic-Org/Semantic-UI/blob/master/src/definitions/behaviors/visibility.js#L869) value in `calculations`, this PR adds it into the component. I don't added `static` value because I don't know when it really can be.

