### PR TITLE
fix(Modal|Popup|Portal): fix usage of eventStack sub/unsub

### DIFF
--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -42,6 +42,9 @@ export interface PortalProps {
   /** Initial value of open. */
   defaultOpen?: boolean;
 
+  /** Event pool namespace that is used to handle component events. */
+  eventPool?: string;
+
   /** The node where the portal should mount. */
   mountNode?: any;
 
@@ -94,9 +97,6 @@ export interface PortalProps {
 
   /** Controls whether or not the portal should open when mousing over the trigger. */
   openOnTriggerMouseEnter?: boolean;
-
-  /** Event pool namespace that is used to handle component events. */
-  eventPool?: string;
 
   /** Controls whether the portal should be prepended to the mountNode instead of appended. */
   prepend?: boolean;

--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -95,6 +95,9 @@ export interface PortalProps {
   /** Controls whether or not the portal should open when mousing over the trigger. */
   openOnTriggerMouseEnter?: boolean;
 
+  /** Event pool namespace that is used to handle component events. */
+  eventPool?: string;
+
   /** Controls whether the portal should be prepended to the mountNode instead of appended. */
   prepend?: boolean;
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -62,6 +62,9 @@ class Portal extends Component {
     /** Initial value of open. */
     defaultOpen: PropTypes.bool,
 
+    /** Event pool namespace that is used to handle component events */
+    eventPool: PropTypes.string,
+
     /** The node where the portal should mount. */
     mountNode: PropTypes.any,
 
@@ -115,9 +118,6 @@ class Portal extends Component {
     /** Controls whether or not the portal should open when mousing over the trigger. */
     openOnTriggerMouseEnter: PropTypes.bool,
 
-    /** Event pool namespace that is used to handle component events */
-    eventPool: PropTypes.string,
-
     /** Controls whether the portal should be prepended to the mountNode instead of appended. */
     prepend: PropTypes.bool,
 
@@ -128,8 +128,8 @@ class Portal extends Component {
   static defaultProps = {
     closeOnDocumentClick: true,
     closeOnEscape: true,
-    openOnTriggerClick: true,
     eventPool: 'default',
+    openOnTriggerClick: true,
   }
 
   static autoControlledProps = [
@@ -376,9 +376,9 @@ class Portal extends Component {
     debug('mountPortal()')
 
     const {
+      eventPool,
       mountNode = isBrowser ? document.body : null,
       prepend,
-      eventPool,
     } = this.props
 
     this.rootNode = document.createElement('div')
@@ -398,7 +398,6 @@ class Portal extends Component {
     if (!isBrowser || !this.rootNode) return
 
     debug('unmountPortal()')
-
     const { eventPool } = this.props
 
     ReactDOM.unmountComponentAtNode(this.rootNode)

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -139,6 +139,7 @@ class Portal extends Component {
 
   componentDidMount() {
     debug('componentDidMount()')
+    this.uniqueId = _.uniqueId()
     this.renderPortal()
   }
 
@@ -384,8 +385,8 @@ class Portal extends Component {
       mountNode.appendChild(this.rootNode)
     }
 
-    eventStack.sub('click', this.handleDocumentClick, 'Portal')
-    eventStack.sub('keydown', this.handleEscape, 'Portal')
+    eventStack.sub('click', this.handleDocumentClick, `Portal${this.uniqueId}`)
+    eventStack.sub('keydown', this.handleEscape, `Portal${this.uniqueId}`)
     _.invoke(this.props, 'onMount', null, this.props)
   }
 
@@ -403,8 +404,8 @@ class Portal extends Component {
     this.rootNode = null
     this.portalNode = null
 
-    eventStack.unsub('click', this.handleDocumentClick, 'Portal')
-    eventStack.unsub('keydown', this.handleEscape, 'Portal')
+    eventStack.unsub('click', this.handleDocumentClick, `Portal${this.uniqueId}`)
+    eventStack.unsub('keydown', this.handleEscape, `Portal${this.uniqueId}`)
     _.invoke(this.props, 'onUnmount', null, this.props)
   }
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -115,6 +115,9 @@ class Portal extends Component {
     /** Controls whether or not the portal should open when mousing over the trigger. */
     openOnTriggerMouseEnter: PropTypes.bool,
 
+    /** Event pool namespace that is used to handle component events */
+    eventPool: PropTypes.string,
+
     /** Controls whether the portal should be prepended to the mountNode instead of appended. */
     prepend: PropTypes.bool,
 
@@ -126,6 +129,7 @@ class Portal extends Component {
     closeOnDocumentClick: true,
     closeOnEscape: true,
     openOnTriggerClick: true,
+    eventPool: 'default'
   }
 
   static autoControlledProps = [
@@ -139,7 +143,6 @@ class Portal extends Component {
 
   componentDidMount() {
     debug('componentDidMount()')
-    this.uniqueId = _.uniqueId()
     this.renderPortal()
   }
 
@@ -375,6 +378,7 @@ class Portal extends Component {
     const {
       mountNode = isBrowser ? document.body : null,
       prepend,
+      eventPool
     } = this.props
 
     this.rootNode = document.createElement('div')
@@ -385,8 +389,8 @@ class Portal extends Component {
       mountNode.appendChild(this.rootNode)
     }
 
-    eventStack.sub('click', this.handleDocumentClick, `Portal${this.uniqueId}`)
-    eventStack.sub('keydown', this.handleEscape, `Portal${this.uniqueId}`)
+    eventStack.sub('click', this.handleDocumentClick, eventPool)
+    eventStack.sub('keydown', this.handleEscape, eventPool)
     _.invoke(this.props, 'onMount', null, this.props)
   }
 
@@ -394,6 +398,8 @@ class Portal extends Component {
     if (!isBrowser || !this.rootNode) return
 
     debug('unmountPortal()')
+
+    const { eventPool } = this.props
 
     ReactDOM.unmountComponentAtNode(this.rootNode)
     this.rootNode.parentNode.removeChild(this.rootNode)
@@ -404,8 +410,8 @@ class Portal extends Component {
     this.rootNode = null
     this.portalNode = null
 
-    eventStack.unsub('click', this.handleDocumentClick, `Portal${this.uniqueId}`)
-    eventStack.unsub('keydown', this.handleEscape, `Portal${this.uniqueId}`)
+    eventStack.unsub('click', this.handleDocumentClick, eventPool)
+    eventStack.unsub('keydown', this.handleEscape, eventPool)
     _.invoke(this.props, 'onUnmount', null, this.props)
   }
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -129,7 +129,7 @@ class Portal extends Component {
     closeOnDocumentClick: true,
     closeOnEscape: true,
     openOnTriggerClick: true,
-    eventPool: 'default'
+    eventPool: 'default',
   }
 
   static autoControlledProps = [
@@ -378,7 +378,7 @@ class Portal extends Component {
     const {
       mountNode = isBrowser ? document.body : null,
       prepend,
-      eventPool
+      eventPool,
     } = this.props
 
     this.rootNode = document.createElement('div')

--- a/src/modules/Modal/Modal.d.ts
+++ b/src/modules/Modal/Modal.d.ts
@@ -34,6 +34,9 @@ export interface ModalProps extends PortalProps {
   /** Whether or not the Modal should close when the document is clicked. */
   closeOnDocumentClick?: boolean;
 
+  /** Event pool namespace that is used to handle component events */
+  eventPool?: string;
+
   /** A Modal can be passed content via shorthand. */
   content?: SemanticShorthandItem<ModalContentProps>;
 

--- a/src/modules/Modal/Modal.d.ts
+++ b/src/modules/Modal/Modal.d.ts
@@ -34,9 +34,6 @@ export interface ModalProps extends PortalProps {
   /** Whether or not the Modal should close when the document is clicked. */
   closeOnDocumentClick?: boolean;
 
-  /** Event pool namespace that is used to handle component events */
-  eventPool?: string;
-
   /** A Modal can be passed content via shorthand. */
   content?: SemanticShorthandItem<ModalContentProps>;
 
@@ -45,6 +42,9 @@ export interface ModalProps extends PortalProps {
 
   /** A modal can appear in a dimmer. */
   dimmer?: boolean | 'blurring' | 'inverted';
+
+  /** Event pool namespace that is used to handle component events */
+  eventPool?: string;
 
   /** A Modal can be passed header via shorthand. */
   header?: SemanticShorthandItem<ModalHeaderProps>;

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -58,9 +58,6 @@ class Modal extends Component {
     /** Whether or not the Modal should close when the document is clicked. */
     closeOnDocumentClick: PropTypes.bool,
 
-    /** Event pool namespace that is used to handle component events */
-    eventPool: PropTypes.string,
-
     /** Simple text content for the Modal. */
     content: customPropTypes.itemShorthand,
 
@@ -72,6 +69,9 @@ class Modal extends Component {
       PropTypes.bool,
       PropTypes.oneOf(['inverted', 'blurring']),
     ]),
+
+    /** Event pool namespace that is used to handle component events */
+    eventPool: PropTypes.string,
 
     /** Modal displayed above the content in bold. */
     header: customPropTypes.itemShorthand,
@@ -357,13 +357,13 @@ class Modal extends Component {
         closeOnRootNodeClick={closeOnDimmerClick}
         {...portalProps}
         className={dimmerClasses}
+        eventPool={eventPool}
         mountNode={mountNode}
         open={open}
         onClose={this.handleClose}
         onMount={this.handlePortalMount}
         onOpen={this.handleOpen}
         onUnmount={this.handlePortalUnmount}
-        eventPool={eventPool}
       >
         {this.renderContent(rest)}
       </Portal>

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -138,7 +138,7 @@ class Modal extends Component {
     dimmer: true,
     closeOnDimmerClick: true,
     closeOnDocumentClick: false,
-    eventPool: 'Modal'
+    eventPool: 'Modal',
   }
 
   static autoControlledProps = [

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -58,6 +58,9 @@ class Modal extends Component {
     /** Whether or not the Modal should close when the document is clicked. */
     closeOnDocumentClick: PropTypes.bool,
 
+    /** Event pool namespace that is used to handle component events */
+    eventPool: PropTypes.string,
+
     /** Simple text content for the Modal. */
     content: customPropTypes.itemShorthand,
 
@@ -135,6 +138,7 @@ class Modal extends Component {
     dimmer: true,
     closeOnDimmerClick: true,
     closeOnDocumentClick: false,
+    eventPool: 'Modal'
   }
 
   static autoControlledProps = [
@@ -315,7 +319,7 @@ class Modal extends Component {
 
   render() {
     const { open } = this.state
-    const { closeOnDimmerClick, closeOnDocumentClick, dimmer } = this.props
+    const { closeOnDimmerClick, closeOnDocumentClick, dimmer, eventPool } = this.props
     const mountNode = this.getMountNode()
 
     // Short circuit when server side rendering
@@ -359,6 +363,7 @@ class Modal extends Component {
         onMount={this.handlePortalMount}
         onOpen={this.handleOpen}
         onUnmount={this.handlePortalUnmount}
+        eventPool={eventPool}
       >
         {this.renderContent(rest)}
       </Portal>


### PR DESCRIPTION
fixes #2075

Without this change, any event handlers added to EventStack under the 'Portal' namespace will be appended to an array. If another Portal is then mounted, new event handlers will be added to the EventStack and take precedence over the original portal's event handlers.

This change allows each portal to store its event handlers under its own namespace in EventStack, so when you click from one portal to another, the first one is appropriately closed.