### PR TITLE
breaking(Dropdown): correct onSearchChange signature

### DIFF
--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -174,9 +174,9 @@ export interface DropdownProps {
    * Called on search input change.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {string} value - Current value of search input.
+   * @param {object} data - All props, includes current value of searchQuery.
    */
-  onSearchChange?: (event: React.SyntheticEvent<HTMLElement>, value: string) => void;
+  onSearchChange?: (event: React.SyntheticEvent<HTMLElement>, data: DropdownOnSearchChangeData) => void;
 
   /** Controls whether or not the dropdown menu is displayed. */
   open?: boolean;
@@ -242,6 +242,13 @@ export interface DropdownProps {
 
   /** A dropdown can open upward. */
   upward?: boolean;
+}
+
+/* TODO: replace with DropdownProps when #1829 will be fixed:
+ * https://github.com/Semantic-Org/Semantic-UI-React/issues/1829
+ */
+interface DropdownOnSearchChangeData extends DropdownProps {
+  searchQuery: string;
 }
 
 interface DropdownComponent extends React.ComponentClass<DropdownProps> {

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -229,7 +229,7 @@ export default class Dropdown extends Component {
      * Called on search input change.
      *
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {string} value - Current value of search input.
+     * @param {object} data - All props, includes current value of searchQuery.
      */
     onSearchChange: PropTypes.func,
 
@@ -755,7 +755,7 @@ export default class Dropdown extends Component {
     const { open } = this.state
     const newQuery = value
 
-    _.invoke(this.props, 'onSearchChange', e, newQuery)
+    _.invoke(this.props, 'onSearchChange', e, { ...this.props, searchQuery: newQuery })
     this.setState({
       selectedIndex: 0,
       searchQuery: newQuery,

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1575,7 +1575,10 @@ describe('Dropdown', () => {
         .simulate('change', { target: { value: 'a' }, stopPropagation: _.noop })
 
       spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({ target: { value: 'a' } }, 'a')
+      spy.should.have.been.calledWithMatch({ target: { value: 'a' } }, {
+        search: true,
+        searchQuery: 'a',
+      })
     })
 
     it("don't open the menu on change if query's length is less than minCharacters", () => {


### PR DESCRIPTION
# BREAKING

Fixes #2052.
Rel #1828.

Handler | Previous Signature | Current Signature
------- | ------------------ | -----------------
onSearchChange | (e, value) | (e, { ...props, searchQuery })

### Before

```jsx
<Dropdown onSearchChange={(e, value) => console.log(e, value)} />
```

### After

```jsx
<Dropdown onSearchChange={(e, data) => console.log(e, data.searchQuery)} />
```