### PR TITLE
docs(Dropdown): fix searchQuery example

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleSearchQuery.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleSearchQuery.js
@@ -12,7 +12,7 @@ export default class DropdownExampleSearchQuery extends Component {
     searchQuery: '',
   })
 
-  handleSearchChange = (e, searchQuery) => this.setState({ searchQuery })
+  handleSearchChange = (e, { searchQuery }) => this.setState({ searchQuery })
 
   render() {
     const { searchQuery, value } = this.state


### PR DESCRIPTION
It's strange, but the change of example wasn't included in #2109. This PR fixes it.