### PR TITLE
breaking(Dropdown): clean searchQuery after selection in multiple search Dropdown

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleSearchQuery.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleSearchQuery.js
@@ -7,10 +7,7 @@ import { stateOptions } from '../common'
 export default class DropdownExampleSearchQuery extends Component {
   state = { searchQuery: '' }
 
-  handleChange = (e, { value }) => this.setState({
-    value,
-    searchQuery: '',
-  })
+  handleChange = (e, { searchQuery, value }) => this.setState({ searchQuery, value })
 
   handleSearchChange = (e, { searchQuery }) => this.setState({ searchQuery })
 

--- a/docs/app/Examples/modules/Dropdown/Usage/index.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/index.js
@@ -96,8 +96,8 @@ const DropdownUsageExamples = () => (
       examplePath='modules/Dropdown/Usage/DropdownExampleSearchQuery'
     >
       <Message info>
-        This example also shows how to override default bevahiour of the search query which keeps
-        entered value after selection.
+        This example also shows how to override default bevahiour of the search query and keep entered value after
+        selection.
       </Message>
     </ComponentExample>
     <ComponentExample

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -602,7 +602,7 @@ export default class Dropdown extends Component {
 
   selectItemOnEnter = (e) => {
     debug('selectItemOnEnter()', keyboardKey.getName(e))
-    const { multiple, onAddItem, search } = this.props
+    const { onAddItem, search } = this.props
 
     if (keyboardKey.getCode(e) !== keyboardKey.Enter) return
     e.preventDefault()
@@ -616,7 +616,7 @@ export default class Dropdown extends Component {
     this.makeSelectedItemActive(e)
     this.closeOnChange(e)
 
-    if (!multiple || isAdditionItem || optionSize === 1) this.clearSearchQuery()
+    if (isAdditionItem || optionSize === 1) this.clearSearchQuery()
     if (search && this.searchRef) this.searchRef.focus()
   }
 


### PR DESCRIPTION
Fixes #1829.
Rel #1795.
Rel #2048.
Rel #2109.

```jsx
<Dropdown search multiple />
```

| Type  | Behaviour |
| ------------- | ------------- |
| **Before** | Search query was kept after item selection |
| **After** | Search query will be cleared after selection, if you want to keep previous behaviour, use [controlled components](https://facebook.github.io/react/docs/forms.html#controlled-components) and handle `searchQuery` manually |

In #1795 we changed the behaviour of `searchQuery`, we don't clear it after selection in `multiple search` `Dropdown`. This PR reverts this change because:
- this behaviour isn't intuitive for users and we got claims about it
- #2109 added ability to control `searchQuery`