### PR TITLE
fix(eventStack): correct handling of removed targets

### DIFF
--- a/test/specs/lib/eventStack/eventStack-test.js
+++ b/test/specs/lib/eventStack/eventStack-test.js
@@ -3,8 +3,7 @@ import { domEvent, sandbox } from 'test/utils'
 
 describe('eventStack', () => {
   afterEach(() => {
-    eventStack._eventTargets = {}
-    eventStack._targets = []
+    eventStack._targets = new Map()
   })
 
   describe('sub', () => {
@@ -67,6 +66,19 @@ describe('eventStack', () => {
 
       clickHandler.should.have.been.calledOnce()
       keyHandler.should.have.not.been.called()
+    })
+
+    it('unsubscribes from same event multiple times', () => {
+      const handler = sandbox.spy()
+
+      eventStack.sub('click', handler)
+      domEvent.click(document)
+
+      eventStack.unsub('click', handler)
+      eventStack.unsub('click', handler)
+      domEvent.click(document)
+
+      handler.should.have.been.calledOnce()
     })
   })
 })


### PR DESCRIPTION
Rel [#2075#comment](https://github.com/Semantic-Org/Semantic-UI-React/issues/2075#issuecomment-331749246).

Changes:
- `eventStack` now uses `Map`
- corrected behaviour of `unsub`