### PR TITLE
test(common): support isConformant for portals

### DIFF
--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -8,6 +8,9 @@ import { default as PopupHeader, PopupHeaderProps } from './PopupHeader';
 export interface PopupProps extends PortalProps {
   [key: string]: any;
 
+  /** An element type to render as (string or function). */
+  as?: any;
+
   /** Display the popup without the pointing arrow */
   basic?: boolean;
 

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -38,6 +38,9 @@ export const POSITIONS = [
  */
 export default class Popup extends Component {
   static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
+
     /** Display the popup without the pointing arrow. */
     basic: PropTypes.bool,
 

--- a/test/specs/commonTests/hasValidTypings.js
+++ b/test/specs/commonTests/hasValidTypings.js
@@ -75,7 +75,19 @@ export default (Component, extractedInfo, options = {}) => {
         const componentProps = _.keys(componentPropTypes)
         const interfaceProps = _.without(_.map(props, 'name'), ...ignoredTypingsProps)
 
-        componentProps.should.to.deep.equal(interfaceProps)
+        componentProps.forEach((propName) => {
+          interfaceProps.should.include(
+            propName,
+            `propTypes define "${propName}" but it is missing in typings`,
+          )
+        })
+
+        interfaceProps.forEach((propName) => {
+          componentProps.should.include(
+            propName,
+            `Typings define prop "${propName}" but it is missing in propTypes`,
+          )
+        })
       })
 
       it('only necessary are required', () => {

--- a/test/specs/commonTests/hasValidTypings.js
+++ b/test/specs/commonTests/hasValidTypings.js
@@ -80,9 +80,21 @@ export default (Component, extractedInfo, options = {}) => {
 
       it('only necessary are required', () => {
         const componentRequired = _.keys(requiredProps)
-        const interfaceRequired = _.filter(props, ['required', true])
+        const interfaceRequired = _.map(_.filter(props, ['required', true]), 'name')
 
-        componentRequired.should.to.deep.equal(_.map(interfaceRequired, 'name'))
+        componentRequired.forEach((propName) => {
+          interfaceRequired.should.include(
+            propName,
+            `Tests require prop "${propName}" but it is optional in typings`,
+          )
+        })
+
+        interfaceRequired.forEach((propName) => {
+          componentRequired.should.include(
+            propName,
+            `Typings require "${propName}" but it is optional in tests`,
+          )
+        })
       })
     })
 

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -44,6 +44,7 @@ describe('Modal', () => {
     if (wrapper && wrapper.unmount) wrapper.unmount()
   })
 
+  common.isConformant(Modal, { rendersPortal: true })
   common.hasSubComponents(Modal, [ModalHeader, ModalContent, ModalActions, ModalDescription])
   common.hasValidTypings(Modal)
 

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -35,6 +35,7 @@ describe('Popup', () => {
     if (wrapper && wrapper.unmount) wrapper.unmount()
   })
 
+  common.isConformant(Popup, { rendersPortal: true })
   common.hasSubComponents(Popup, [PopupHeader, PopupContent])
   common.hasValidTypings(Popup)
 

--- a/test/utils/assertNodeContains.js
+++ b/test/utils/assertNodeContains.js
@@ -14,6 +14,6 @@ export const assertNodeContains = (parentNode, childSelector, isPresent = true) 
  * Assert whether node is or is not a child of the document.body.
  *
  * @param {string} selector A DOM selector for the parent node
- * @param {boolean} isPresent Indicating whether to assert is present or is not present
+ * @param {boolean} [isPresent=true] Indicating whether to assert is present or is not present
  */
 export const assertBodyContains = (selector, isPresent) => assertNodeContains(document.body, selector, isPresent)


### PR DESCRIPTION
These commits were cherry picked from Datetime #1240.  We need to be able to test conformance for components that render portals.

- Add a `rendersPortal` isConformant option.
- Skip `as` prop conformance tests, not idea but better than skipping all conformance tests as we do now.  Portals render other components, which handle the `as` prop anyway.
- Look for the user's className in the `document.body` if rendering a portal.