### PR TITLE
fix(Modal): set scrolling body class on re-open

### DIFF
--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -178,7 +178,7 @@ class Modal extends Component {
     const { onClose } = this.props
     if (onClose) onClose(e, this.props)
 
-    this.trySetState({ open: false })
+    this.trySetState({ open: false }, { scrolling: false })
   }
 
   handleIconOverrides = predefinedProps => ({

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -503,6 +503,26 @@ describe('Modal', () => {
       })
     })
 
+    it('adds the scrolling class to the body after re-open', (done) => {
+      assertBodyClasses('scrolling', false)
+
+      window.innerHeight = 10
+      wrapperMount(<Modal defaultOpen>foo</Modal>)
+
+      requestAnimationFrame(() => {
+        assertBodyClasses('scrolling')
+        domEvent.click('.ui.dimmer')
+
+        assertBodyClasses('scrolling', false)
+
+        wrapper.setProps({ open: true })
+        requestAnimationFrame(() => {
+          assertBodyClasses('scrolling')
+          done()
+        })
+      })
+    })
+
     it('removes the scrolling class from the body on unmount', (done) => {
       assertBodyClasses('scrolling', false)
 


### PR DESCRIPTION
Fixes #2150 by unsetting `scrolling` state prop when modal is closed.