### PR TITLE
fix(Dropdown): update text when item selected with keyboard

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -603,7 +603,7 @@ export default class Dropdown extends Component {
 
   selectItemOnEnter = (e) => {
     debug('selectItemOnEnter()', keyboardKey.getName(e))
-    const { search } = this.props
+    const { multiple, search } = this.props
 
     if (keyboardKey.getCode(e) !== keyboardKey.Enter) return
     e.preventDefault()
@@ -617,7 +617,7 @@ export default class Dropdown extends Component {
     this.makeSelectedItemActive(e)
     this.closeOnChange(e)
 
-    if (isAdditionItem || optionSize === 1) this.clearSearchQuery()
+    if (!multiple || isAdditionItem || optionSize === 1) this.clearSearchQuery()
     if (search && this.searchRef) this.searchRef.focus()
   }
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -603,7 +603,7 @@ export default class Dropdown extends Component {
 
   selectItemOnEnter = (e) => {
     debug('selectItemOnEnter()', keyboardKey.getName(e))
-    const { multiple, search } = this.props
+    const { search } = this.props
 
     if (keyboardKey.getCode(e) !== keyboardKey.Enter) return
     e.preventDefault()
@@ -611,13 +611,9 @@ export default class Dropdown extends Component {
     const optionSize = _.size(this.getMenuOptions())
     if (search && optionSize === 0) return
 
-    const item = this.getSelectedItem()
-    const isAdditionItem = item['data-additional']
-
     this.makeSelectedItemActive(e)
     this.closeOnChange(e)
-
-    if (!multiple || isAdditionItem || optionSize === 1) this.clearSearchQuery()
+    this.clearSearchQuery()
     if (search && this.searchRef) this.searchRef.focus()
   }
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -947,6 +947,30 @@ describe('Dropdown', () => {
         .find('div.text')
         .should.contain.text(item.text())
     })
+    it('is updated on item enter if multiple search results present', () => {
+      const searchOptions = [
+        { value: 0, text: 'foo' },
+        { value: 1, text: 'foe' },
+      ]
+      wrapperMount(<Dropdown options={searchOptions} selection />)
+
+      // open and simulate search
+      wrapper
+        .simulate('click')
+        .setState({ searchQuery: 'fo' })
+
+      // arrow down
+      domEvent.keyDown(document, { key: 'ArrowDown' })
+      domEvent.keyDown(document, { key: 'Enter' })
+
+      const item = wrapper
+        .find('.selected')
+
+      // text updated
+      wrapper
+        .find('div.text')
+        .should.contain.text(item.text())
+    })
     it('displays if value is 0', () => {
       const text = faker.hacker.noun()
 


### PR DESCRIPTION
Fixes #2161 
the text on dropdown wasn't updated when item is selected with keyboard after search because `searchQuery` wasn't cleared if there are multiple search results (it is cleared if there's only one search result). And if `searchQuery` is not cleared, we do not update text in [renderText](https://github.com/Semantic-Org/Semantic-UI-React/blob/master/src/modules/Dropdown/Dropdown.js#L1136)