### PR TITLE
fix(Form): don't prevent form submission when action=''

### DIFF
--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -102,7 +102,7 @@ class Form extends Component {
 
     // Heads up! Third party libs can pass own data as first argument, we need to check that it has preventDefault()
     // method.
-    if (!action) _.invoke(e, 'preventDefault')
+    if (!action && action !== '') _.invoke(e, 'preventDefault')
     _.invoke(this.props, 'onSubmit', e, this.props, ...args)
   }
 

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -102,7 +102,7 @@ class Form extends Component {
 
     // Heads up! Third party libs can pass own data as first argument, we need to check that it has preventDefault()
     // method.
-    if (typeof action === 'string') _.invoke(e, 'preventDefault')
+    if (typeof action !== 'string') _.invoke(e, 'preventDefault')
     _.invoke(this.props, 'onSubmit', e, this.props, ...args)
   }
 

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -102,7 +102,7 @@ class Form extends Component {
 
     // Heads up! Third party libs can pass own data as first argument, we need to check that it has preventDefault()
     // method.
-    if (!action && action !== '') _.invoke(e, 'preventDefault')
+    if (typeof action === 'string') _.invoke(e, 'preventDefault')
     _.invoke(this.props, 'onSubmit', e, this.props, ...args)
   }
 

--- a/test/specs/collections/Form/Form-test.js
+++ b/test/specs/collections/Form/Form-test.js
@@ -67,13 +67,22 @@ describe('Form', () => {
       shallow(<Form />)
         .simulate('submit', event)
 
-      event.preventDefault.should.have.been.calledOnce()
+      shallow(<Form action={false} />)
+        .simulate('submit', event)
+
+      shallow(<Form action={null} />)
+        .simulate('submit', event)
+
+      event.preventDefault.should.have.been.calledThrice()
     })
 
     it('does not prevent default on the event when there is an action', () => {
       const event = { preventDefault: sandbox.spy() }
 
       shallow(<Form action='do not prevent default!' />)
+        .simulate('submit', event)
+
+      shallow(<Form action='' />)
         .simulate('submit', event)
 
       event.preventDefault.should.not.have.been.called()


### PR DESCRIPTION
When the action attribute is an empty string it means to submit to the current URL which is quite useful.