### PR TITLE
feat(Dropdown): add `direction` prop

### DIFF
--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -62,6 +62,9 @@ export interface DropdownProps {
   /** Initial value or value array if multiple. */
   defaultValue?: string | number | Array<number | string>;
 
+  /** A dropdown can be positioned to the left */
+  direction?: 'left';
+
   /** A disabled dropdown menu or item does not allow user interaction. */
   disabled?: boolean;
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -115,6 +115,9 @@ export default class Dropdown extends Component {
       ])),
     ]),
 
+    /** A dropdown can be positioned to the left */
+    direction: PropTypes.oneOf(['left']),
+
     /** A disabled dropdown menu or item does not allow user interaction. */
     disabled: PropTypes.bool,
 
@@ -1249,6 +1252,7 @@ export default class Dropdown extends Component {
       className,
       compact,
       disabled,
+      direction,
       error,
       fluid,
       floating,
@@ -1279,20 +1283,21 @@ export default class Dropdown extends Component {
       useKeyOnly(basic, 'basic'),
       useKeyOnly(button, 'button'),
       useKeyOnly(compact, 'compact'),
-      useKeyOnly(fluid, 'fluid'),
+      useKeyOnly(direction, 'left'),
       useKeyOnly(floating, 'floating'),
+      useKeyOnly(fluid, 'fluid'),
       useKeyOnly(inline, 'inline'),
       // TODO: consider augmentation to render Dropdowns as Button/Menu, solves icon/link item issues
       // https://github.com/Semantic-Org/Semantic-UI-React/issues/401#issuecomment-240487229
       // TODO: the icon class is only required when a dropdown is a button
       // useKeyOnly(icon, 'icon'),
-      useKeyOnly(labeled, 'labeled'),
       useKeyOnly(item, 'item'),
+      useKeyOnly(labeled, 'labeled'),
       useKeyOnly(multiple, 'multiple'),
       useKeyOnly(search, 'search'),
+      useKeyOnly(scrolling, 'scrolling'),
       useKeyOnly(selection, 'selection'),
       useKeyOnly(simple, 'simple'),
-      useKeyOnly(scrolling, 'scrolling'),
       useKeyOnly(upward, 'upward'),
 
       useKeyOrValueAndKey(pointing, 'pointing'),

--- a/src/modules/Dropdown/DropdownMenu.d.ts
+++ b/src/modules/Dropdown/DropdownMenu.d.ts
@@ -18,6 +18,9 @@ export interface DropdownMenuProps {
 
   /** A dropdown menu can scroll. */
   scrolling?: boolean;
+
+  /** A dropdown can be positioned to the left */
+  direction?: 'left';
 }
 
 declare const DropdownMenu: React.StatelessComponent<DropdownMenuProps>;

--- a/src/modules/Dropdown/DropdownMenu.js
+++ b/src/modules/Dropdown/DropdownMenu.js
@@ -15,8 +15,9 @@ import {
  * A dropdown menu can contain a menu.
  */
 function DropdownMenu(props) {
-  const { children, className, content, scrolling } = props
+  const { children, className, content, direction, scrolling } = props
   const classes = cx(
+    useKeyOnly(direction, 'left'),
     useKeyOnly(scrolling, 'scrolling'),
     'menu transition',
     className,
@@ -43,6 +44,9 @@ DropdownMenu.propTypes = {
 
   /** Primary content. */
   children: PropTypes.node,
+
+  /** A dropdown can be positioned to the left */
+  direction: PropTypes.oneOf(['left']),
 
   /** Additional classes. */
   className: PropTypes.string,


### PR DESCRIPTION
This PR adds left directioning support to DropdownMenu.

Closes issue #1897

