### PR TITLE
fix(typings): fix definition for Accordion.Accordion

### DIFF
--- a/src/modules/Accordion/AccordionAccordion.d.ts
+++ b/src/modules/Accordion/AccordionAccordion.d.ts
@@ -42,6 +42,6 @@ export interface AccordionPanelProps {
   title: SemanticShorthandItem<AccordionTitleProps>;
 }
 
-declare const AccordionAccordion: AccordionAccordionProps;
+declare const AccordionAccordion: React.ComponentClass<AccordionAccordionProps>;
 
 export default AccordionAccordion;


### PR DESCRIPTION
Hey,
is my first PR, so if i forgot something... sorry :)! 

this commit fix the failure
> TS2604:JSX element type 'Accordion.Accordion' does not have any construct or call signatures.