### PR TITLE
docs(Button): add missing props to example

### DIFF
--- a/docs/app/Examples/elements/Button/GroupVariations/ButtonExampleGroupLabeledIcon.js
+++ b/docs/app/Examples/elements/Button/GroupVariations/ButtonExampleGroupLabeledIcon.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button } from 'semantic-ui-react'
 
 const ButtonExampleGroupLabeledIcon = () => (
-  <Button.Group labeled>
+  <Button.Group vertical labeled icon>
     <Button icon='play' content='Play' />
     <Button icon='pause' content='Pause' />
     <Button icon='shuffle' content='Shuffle' />


### PR DESCRIPTION
Fixes #2190.

Updates the documentation according to https://github.com/Semantic-Org/Semantic-UI-React/issues/2190.