### PR TITLE
feat(Message): add `top` to possible values of `attached`

### DIFF
--- a/docs/app/Layouts/AttachedContentLayout.js
+++ b/docs/app/Layouts/AttachedContentLayout.js
@@ -48,7 +48,7 @@ const AttachedContentLayout = () => (
         </Grid.Column>
 
         <Grid.Column>
-          <Table attached='top' basic verticalAllign='top'>
+          <Table attached='top' basic verticalAlign='top'>
             <Table.Header>
               <Table.HeaderCell>Header</Table.HeaderCell>
               <Table.HeaderCell>Header</Table.HeaderCell>

--- a/src/collections/Message/Message.d.ts
+++ b/src/collections/Message/Message.d.ts
@@ -18,7 +18,7 @@ export interface MessageProps {
   as?: any;
 
   /** A message can be formatted to attach itself to other content. */
-  attached?: boolean | 'bottom';
+  attached?: boolean | 'bottom' | 'top';
 
   /** Primary content. */
   children?: React.ReactNode;

--- a/src/collections/Message/Message.js
+++ b/src/collections/Message/Message.js
@@ -32,7 +32,7 @@ export default class Message extends Component {
     /** A message can be formatted to attach itself to other content. */
     attached: PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.oneOf(['bottom']),
+      PropTypes.oneOf(['bottom', 'top']),
     ]),
 
     /** Primary content. */

--- a/test/specs/collections/Message/Message-test.js
+++ b/test/specs/collections/Message/Message-test.js
@@ -44,7 +44,7 @@ describe('Message', () => {
   common.propKeyOnlyToClassName(Message, 'visible')
   common.propKeyOnlyToClassName(Message, 'warning')
 
-  common.propKeyOrValueAndKeyToClassName(Message, 'attached', ['bottom'])
+  common.propKeyOrValueAndKeyToClassName(Message, 'attached', ['bottom', 'top'])
 
   common.propValueOnlyToClassName(Message, 'color', SUI.COLORS)
   common.propValueOnlyToClassName(Message, 'size', _.without(SUI.SIZES, 'medium'))


### PR DESCRIPTION
Fixes #2154.

This PR:
- adds `top` to possible values of `attached`
- fixed misspelled `verticalAllign` in the example