### PR TITLE
fix(TextArea): fix autoHeight calculate wrong value on long text

### DIFF
--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -115,7 +115,9 @@ class TextArea extends Component {
 
     // Measure the scrollHeight and update the height to match.
     this.ref.style.height = 'auto'
+    this.ref.style.overflowY = 'hidden'
     this.ref.style.height = `${Math.max(parseFloat(minHeight), Math.ceil(this.ref.scrollHeight + borderHeight))}px`
+    this.ref.style.overflowY = ''
   }
 
   render() {


### PR DESCRIPTION
Calculate content height without taking a vertical scroll bar into account.

fixes #2173