### PR TITLE
fix(FormField): pass content prop through

### DIFF
--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -74,7 +74,7 @@ function FormField(props) {
   // ----------------------------------------
   // Checkbox/Radio Control
   // ----------------------------------------
-  const controlProps = { ...rest, children, disabled, required, type }
+  const controlProps = { ...rest, content, children, disabled, required, type }
 
   // wrap HTML checkboxes/radios in the label
   if (control === 'input' && (type === 'checkbox' || type === 'radio')) {

--- a/test/specs/collections/Form/FormField-test.js
+++ b/test/specs/collections/Form/FormField-test.js
@@ -4,6 +4,7 @@ import React from 'react'
 import Radio from 'src/addons/Radio/Radio'
 import FormField from 'src/collections/Form/FormField'
 import { SUI } from 'src/lib'
+import Button from 'src/elements/Button/Button'
 import Checkbox from 'src/modules/Checkbox/Checkbox'
 import * as common from 'test/specs/commonTests'
 
@@ -111,6 +112,23 @@ describe('FormField', () => {
 
       wrapper.should.have.exactly(1).descendants('input')
       input.should.have.prop('required', true)
+    })
+  })
+
+  describe('content', () => {
+    it('is not set by default', () => {
+      const wrapper = shallow(<FormField control={Button} />)
+      const button = wrapper.find('Button')
+
+      wrapper.should.have.exactly(1).descendants('Button')
+      button.should.not.have.prop('content')
+    })
+    it('is passed to the control', () => {
+      const wrapper = shallow(<FormField control={Button} content='Click Me' />)
+      const button = wrapper.find('Button')
+
+      wrapper.should.have.exactly(1).descendants('Button')
+      button.should.have.prop('content', 'Click Me')
     })
   })
 })


### PR DESCRIPTION
Fixes #2211 

`Form.Button` was updated to handle the `content` prop, however, only unhandled props are passed to underlying components.  This resulted in the `content` prop no longer being passed through to the underlying `component`.

This PR explicitly passes it through as it is explicitly handled.  Tests have also been added.  Can be merged once tests pass.