### PR TITLE
breaking(Image): Inconsistent prop usage between Image and Icon for circular shape

### DIFF
--- a/docs/app/Examples/collections/Table/Types/TableExampleCollapsing.js
+++ b/docs/app/Examples/collections/Table/Types/TableExampleCollapsing.js
@@ -14,7 +14,7 @@ const TableExampleCollapsing = () => (
       <Table.Row>
         <Table.Cell>
           <Header as='h4' image>
-            <Image src='/assets/images/avatar/small/lena.png' shape='rounded' size='mini' />
+            <Image src='/assets/images/avatar/small/lena.png' rounded size='mini' />
             <Header.Content>
                 Lena
               <Header.Subheader>Human Resources</Header.Subheader>
@@ -28,7 +28,7 @@ const TableExampleCollapsing = () => (
       <Table.Row>
         <Table.Cell>
           <Header as='h4' image>
-            <Image src='/assets/images/avatar/small/matthew.png' shape='rounded' size='mini' />
+            <Image src='/assets/images/avatar/small/matthew.png' rounded size='mini' />
             <Header.Content>
                 Matthew
               <Header.Subheader>Fabric Design</Header.Subheader>
@@ -42,7 +42,7 @@ const TableExampleCollapsing = () => (
       <Table.Row>
         <Table.Cell>
           <Header as='h4' image>
-            <Image src='/assets/images/avatar/small/lindsay.png' shape='rounded' size='mini' />
+            <Image src='/assets/images/avatar/small/lindsay.png' rounded size='mini' />
             <Header.Content>
                 Lindsay
               <Header.Subheader>Entertainment</Header.Subheader>
@@ -56,7 +56,7 @@ const TableExampleCollapsing = () => (
       <Table.Row>
         <Table.Cell>
           <Header as='h4' image>
-            <Image src='/assets/images/avatar/small/mark.png' shape='rounded' size='mini' />
+            <Image src='/assets/images/avatar/small/mark.png' rounded size='mini' />
             <Header.Content>
                 Mark
               <Header.Subheader>Executive</Header.Subheader>

--- a/docs/app/Examples/elements/Header/Content/HeaderExampleImage.js
+++ b/docs/app/Examples/elements/Header/Content/HeaderExampleImage.js
@@ -3,7 +3,7 @@ import { Header, Image } from 'semantic-ui-react'
 
 const HeaderExampleImage = () => (
   <Header as='h2'>
-    <Image shape='circular' src='/assets/images/avatar/large/patrick.png' />
+    <Image circular src='/assets/images/avatar/large/patrick.png' />
     {' '}Patrick
   </Header>
 )

--- a/docs/app/Examples/elements/Image/Variations/ImageExampleCircular.js
+++ b/docs/app/Examples/elements/Image/Variations/ImageExampleCircular.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Image } from 'semantic-ui-react'
 
 const ImageExampleCircular = () => (
-  <Image src='/assets/images/wireframe/square-image.png' size='medium' shape='circular' />
+  <Image src='/assets/images/wireframe/square-image.png' size='medium' circular />
 )
 
 export default ImageExampleCircular

--- a/docs/app/Examples/elements/Image/Variations/ImageExampleRounded.js
+++ b/docs/app/Examples/elements/Image/Variations/ImageExampleRounded.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Image } from 'semantic-ui-react'
 
 const ImageExampleRounded = () => (
-  <Image src='/assets/images/wireframe/square-image.png' size='medium' shape='rounded' />
+  <Image src='/assets/images/wireframe/square-image.png' size='medium' rounded />
 )
 
 export default ImageExampleRounded

--- a/docs/app/Examples/elements/Reveal/Types/RevealExampleRotate.js
+++ b/docs/app/Examples/elements/Reveal/Types/RevealExampleRotate.js
@@ -4,10 +4,10 @@ import { Image, Reveal } from 'semantic-ui-react'
 const RevealExampleRotate = () => (
   <Reveal animated='rotate'>
     <Reveal.Content visible>
-      <Image shape='circular' size='small' src='/assets/images/wireframe/square-image.png' />
+      <Image circular size='small' src='/assets/images/wireframe/square-image.png' />
     </Reveal.Content>
     <Reveal.Content hidden>
-      <Image shape='circular' size='small' src='/assets/images/avatar/large/stevie.jpg' />
+      <Image circular size='small' src='/assets/images/avatar/large/stevie.jpg' />
     </Reveal.Content>
   </Reveal>
 )

--- a/docs/app/Examples/elements/Reveal/Types/RevealExampleRotateLeft.js
+++ b/docs/app/Examples/elements/Reveal/Types/RevealExampleRotateLeft.js
@@ -4,10 +4,10 @@ import { Image, Reveal } from 'semantic-ui-react'
 const RevealExampleRotateLeft = () => (
   <Reveal animated='rotate left'>
     <Reveal.Content visible>
-      <Image shape='circular' size='small' src='/assets/images/wireframe/square-image.png' />
+      <Image circular size='small' src='/assets/images/wireframe/square-image.png' />
     </Reveal.Content>
     <Reveal.Content hidden>
-      <Image shape='circular' size='small' src='/assets/images/avatar/large/veronika.jpg' />
+      <Image circular size='small' src='/assets/images/avatar/large/veronika.jpg' />
     </Reveal.Content>
   </Reveal>
 )

--- a/docs/app/Examples/views/Statistic/Content/StatisticExampleValue.js
+++ b/docs/app/Examples/views/Statistic/Content/StatisticExampleValue.js
@@ -26,7 +26,7 @@ const StatisticExampleValue = () => (
 
     <Statistic>
       <Statistic.Value>
-        <Image src='/assets/images/avatar/small/joe.jpg' inline shape='circular' />
+        <Image src='/assets/images/avatar/small/joe.jpg' inline circular />
         42
       </Statistic.Value>
       <Statistic.Label>Team Members</Statistic.Label>

--- a/docs/app/Layouts/ResponsiveLayout.js
+++ b/docs/app/Layouts/ResponsiveLayout.js
@@ -572,7 +572,7 @@ const ResponsiveLayout = () => (
             <Table.Cell>
               <Header as='h4' image>
                 <Image
-                  shape='rounded'
+                  rounded
                   size='mini'
                   src='/assets/images/wireframe/square-image.png'
                 />
@@ -590,7 +590,7 @@ const ResponsiveLayout = () => (
             <Table.Cell>
               <Header as='h4' image>
                 <Image
-                  shape='rounded'
+                  rounded
                   size='mini'
                   src='/assets/images/wireframe/square-image.png'
                 />
@@ -608,7 +608,7 @@ const ResponsiveLayout = () => (
             <Table.Cell>
               <Header as='h4' image>
                 <Image
-                  shape='rounded'
+                  rounded
                   size='mini'
                   src='/assets/images/wireframe/square-image.png'
                 />
@@ -626,7 +626,7 @@ const ResponsiveLayout = () => (
             <Table.Cell>
               <Header as='h4' image>
                 <Image
-                  shape='rounded'
+                  rounded
                   size='mini'
                   src='/assets/images/wireframe/square-image.png'
                 />

--- a/src/elements/Image/Image.d.ts
+++ b/src/elements/Image/Image.d.ts
@@ -33,6 +33,9 @@ export interface ImageProps {
   /** Primary content. */
   children?: React.ReactNode;
 
+  /** An image may appear circular. */
+  circular?: boolean;
+
   /** Additional classes. */
   className?: string;
 
@@ -66,8 +69,8 @@ export interface ImageProps {
   /** Shorthand for Label. */
   label?: SemanticShorthandItem<LabelProps>;
 
-  /** An image may appear rounded or circular. */
-  shape?: 'rounded'|'circular';
+  /** An image may appear rounded. */
+  rounded?: boolean;
 
   /** An image may appear at different sizes. */
   size?: SemanticSIZES;

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -123,7 +123,7 @@ Image.propTypes = {
 
   /** Primary content. */
   children: PropTypes.node,
-  
+
   /** An image may appear circular. */
   circular: PropTypes.bool,
 
@@ -135,7 +135,7 @@ Image.propTypes = {
 
   /** An image can show that it is disabled and cannot be selected. */
   disabled: PropTypes.bool,
-  
+
   /** Shorthand for Dimmer. */
   dimmer: customPropTypes.itemShorthand,
 

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -32,6 +32,7 @@ function Image(props) {
     bordered,
     centered,
     children,
+    circular,
     className,
     content,
     dimmer,
@@ -43,7 +44,7 @@ function Image(props) {
     href,
     inline,
     label,
-    shape,
+    rounded,
     size,
     spaced,
     src,
@@ -56,14 +57,15 @@ function Image(props) {
   const classes = cx(
     useKeyOnly(ui, 'ui'),
     size,
-    shape,
     useKeyOnly(avatar, 'avatar'),
     useKeyOnly(bordered, 'bordered'),
+    useKeyOnly(circular, 'circular'),
     useKeyOnly(centered, 'centered'),
     useKeyOnly(disabled, 'disabled'),
     useKeyOnly(fluid, 'fluid'),
     useKeyOnly(hidden, 'hidden'),
     useKeyOnly(inline, 'inline'),
+    useKeyOnly(rounded, 'rounded'),
     useKeyOrValueAndKey(spaced, 'spaced'),
     useValueAndKey(floated, 'floated'),
     useVerticalAlignProp(verticalAlign, 'aligned'),
@@ -121,6 +123,9 @@ Image.propTypes = {
 
   /** Primary content. */
   children: PropTypes.node,
+  
+  /** An image may appear circular. */
+  circular: PropTypes.bool,
 
   /** Additional classes. */
   className: PropTypes.string,
@@ -130,7 +135,7 @@ Image.propTypes = {
 
   /** An image can show that it is disabled and cannot be selected. */
   disabled: PropTypes.bool,
-
+  
   /** Shorthand for Dimmer. */
   dimmer: customPropTypes.itemShorthand,
 
@@ -161,9 +166,9 @@ Image.propTypes = {
   /** Shorthand for Label. */
   label: customPropTypes.itemShorthand,
 
-  /** An image may appear rounded or circular. */
-  shape: PropTypes.oneOf(['rounded', 'circular']),
-
+  /** An image may appear rounded. */
+  rounded: PropTypes.bool,
+  
   /** An image may appear at different sizes. */
   size: PropTypes.oneOf(SUI.SIZES),
 

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -168,7 +168,7 @@ Image.propTypes = {
 
   /** An image may appear rounded. */
   rounded: PropTypes.bool,
-  
+
   /** An image may appear at different sizes. */
   size: PropTypes.oneOf(SUI.SIZES),
 

--- a/test/specs/elements/Image/Image-test.js
+++ b/test/specs/elements/Image/Image-test.js
@@ -27,14 +27,15 @@ describe('Image', () => {
   common.propKeyOnlyToClassName(Image, 'avatar')
   common.propKeyOnlyToClassName(Image, 'bordered')
   common.propKeyOnlyToClassName(Image, 'centered')
+  common.propKeyOnlyToClassName(Image, 'circular')
   common.propKeyOnlyToClassName(Image, 'disabled')
   common.propKeyOnlyToClassName(Image, 'fluid')
   common.propKeyOnlyToClassName(Image, 'hidden')
   common.propKeyOnlyToClassName(Image, 'inline')
+  common.propKeyOnlyToClassName(Image, 'rounded')
 
   common.propKeyOrValueAndKeyToClassName(Image, 'spaced', ['left', 'right'])
 
-  common.propValueOnlyToClassName(Image, 'shape', ['rounded', 'circular'])
   common.propValueOnlyToClassName(Image, 'size', SUI.SIZES)
 
   it('renders an img tag', () => {


### PR DESCRIPTION
Fixes #2217.

# Why?
Make properties more concistent with other elements. See #2217 for more details.

---

## `Image`
Before|After
:---:|:---:
`<Image shape="rounded" />`|`<Image rounded />`
`<Image shape="circular" />`|`<Image circular />`