### PR TITLE
docs(Views): add <meta name="viewport"> tags to docs

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Title</title>
   <script
     src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.14.0/babel.min.js"

--- a/docs/app/index.ejs
+++ b/docs/app/index.ejs
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" type="image/x-icon" href='/logo.png' />
   <link rel="stylesheet"
         href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/<%= htmlWebpackPlugin.options.versions.sui %>/semantic.min.css">


### PR DESCRIPTION
Fixes #2230.

Lack of tags prevents responsive examples from being responsive. See #2230 for more details.