### PR TITLE
fix(Dropdown): isEqual over shallowEqual for props

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -427,7 +427,7 @@ export default class Dropdown extends Component {
       this.setSelectedIndex(nextProps.value)
     }
 
-    if (!shallowEqual(nextProps.options, this.props.options)) {
+    if (!_.isEqual(nextProps.options, this.props.options)) {
       this.setSelectedIndex(undefined, nextProps.options)
     }
   }

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -452,6 +452,30 @@ describe('Dropdown', () => {
     })
   })
 
+  describe('setSelectedIndex', () => {
+    it('will call setSelectedIndex if options change', () => {
+      wrapperMount(<Dropdown options={options} />)
+
+      const instance = wrapper.instance()
+      sandbox.spy(instance, 'setSelectedIndex')
+
+      wrapper.setProps({ options: [] })
+
+      instance.setSelectedIndex.should.have.been.calledOnce()
+    })
+
+    it('will not call setSelectedIndex if options have not changed', () => {
+      wrapperMount(<Dropdown options={options} />)
+
+      const instance = wrapper.instance()
+      sandbox.spy(instance, 'setSelectedIndex')
+
+      wrapper.setProps({ options })
+
+      instance.setSelectedIndex.should.not.have.been.calledOnce()
+    })
+  })
+
   describe('isMouseDown', () => {
     it('tracks when the mouse is down', () => {
       wrapperShallow(<Dropdown />)


### PR DESCRIPTION
fixes #2243

Component on `componentWillReceiveProps` will always run `setSelectedIndex` because shallowEqual on two objects internally runs `object.is(a, b)` to compare objects which will always be false because `nextProps.options` and `this.props.options` are not the same object