### PR TITLE
fix(Modal): scrolling disabled with multiple modals bug

### DIFF
--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -259,7 +259,12 @@ class Modal extends Component {
         if (scrolling) {
           mountNode.classList.add('scrolling')
         } else {
-          mountNode.classList.remove('scrolling')
+          // Check if another modal exists before removing the scolling
+          const anotherModal = document.getElementsByClassName('ui page modals').length
+          // Only remove scrolling class if there is no other modals active
+          if (anotherModal === 0) {
+            mountNode.classList.remove('scrolling')
+          }
         }
       }
 


### PR DESCRIPTION
Fixes #1157, fixes #2248

See the discussion at #1157 for more details, bug was reopened as #2248. The gist of it is that closing a modal removes the scrolling class from body, so if multiple scrollable modals are open the top one closing disables the bottom one's scroll.