### PR TITLE
BREAKING(Tab): allow right/left without `tabular`

### DIFF
--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -73,7 +73,7 @@ class Tab extends Component {
 
   static defaultProps = {
     grid: { paneWidth: 12, tabWidth: 4 },
-    menu: { attached: true, tabular: true },
+    menu: { attached: true, tabular: true, alignment: 'left' },
     renderActiveOnly: true,
   }
 
@@ -124,13 +124,13 @@ class Tab extends Component {
 
     return (
       <Grid {...gridProps}>
-        {menu.props.tabular !== 'right' && GridColumn.create({ width: tabWidth, children: menu })}
+        {menu.props.alignment !== 'right' && GridColumn.create({ width: tabWidth, children: menu })}
         {GridColumn.create({
           width: paneWidth,
           children: this.renderItems(),
           stretched: true,
         })}
-        {menu.props.tabular === 'right' && GridColumn.create({ width: tabWidth, children: menu })}
+        {menu.props.alignment === 'right' && GridColumn.create({ width: tabWidth, children: menu })}
       </Grid>
     )
   }

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -73,7 +73,7 @@ class Tab extends Component {
 
   static defaultProps = {
     grid: { paneWidth: 12, tabWidth: 4 },
-    menu: { attached: true, tabular: true, alignment: 'left' },
+    menu: { attached: true, tabular: true, aligned: 'left' },
     renderActiveOnly: true,
   }
 
@@ -124,13 +124,13 @@ class Tab extends Component {
 
     return (
       <Grid {...gridProps}>
-        {menu.props.alignment !== 'right' && GridColumn.create({ width: tabWidth, children: menu })}
+        {menu.props.aligned !== 'right' && GridColumn.create({ width: tabWidth, children: menu })}
         {GridColumn.create({
           width: paneWidth,
           children: this.renderItems(),
           stretched: true,
         })}
-        {menu.props.alignment === 'right' && GridColumn.create({ width: tabWidth, children: menu })}
+        {menu.props.aligned === 'right' && GridColumn.create({ width: tabWidth, children: menu })}
       </Grid>
     )
   }

--- a/test/specs/modules/Tab/Tab-test.js
+++ b/test/specs/modules/Tab/Tab-test.js
@@ -16,10 +16,10 @@ describe('Tab', () => {
   ]
 
   describe('menu', () => {
-    it('defaults to an attached tabular menu', () => {
+    it('defaults to an attached left aligned tabular menu', () => {
       Tab.defaultProps
         .should.have.property('menu')
-        .which.deep.equals({ attached: true, tabular: true })
+        .which.deep.equals({ attached: true, tabular: true, aligned: 'left' })
     })
 
     it('passes the props to the Menu', () => {
@@ -54,8 +54,8 @@ describe('Tab', () => {
       wrapper.childAt(1).should.match('Menu')
     })
 
-    it("renders right of the pane when tabular='right'", () => {
-      const wrapper = shallow(<Tab menu={{ fluid: true, vertical: true, tabular: 'right' }} panes={panes} />)
+    it("renders right of the pane when aligned='right'", () => {
+      const wrapper = shallow(<Tab menu={{ fluid: true, vertical: true, aligned: 'right' }} panes={panes} />)
 
       wrapper.childAt(0).should.match('Grid')
       wrapper.childAt(0).shallow().childAt(0).should.match('GridColumn')


### PR DESCRIPTION
# BREAKING CHANGE

It is currently not possible to align vertical tabs to the left or right unless you use the `tabular` prop.  This PR allows left/right vertical tab alignment without requiring the `tabular` menu variation.

### Before

Right aligned tabs required the `tabular` prop and therefore the tabular menu variation.

```jsx
const panes = [ ...{} ]
const menu = {
  fluid: true,
  vertical: true,
  tabular: 'right',
 }

<Tab menu={menu} panes={panes} />
```
![image](https://user-images.githubusercontent.com/5067638/33232687-266bd51e-d1bf-11e7-9ba4-6f6f3617bf2c.png)

### After

Right aligned tabs no longer require the `tabular` prop and can be used with any menu variation.

```jsx
const panes = [ ...{} ]
const menu = {
  fluid: true,
  vertical: true,
  secondary: true,
  aligned: 'right'
}

<Tab menu={menu} panes={panes} />
```
![image](https://user-images.githubusercontent.com/5067638/33232692-2e4c228e-d1bf-11e7-999f-cc0df91d1680.png)

***

This allows tab menus to be right aligned without having the tabular styles set.

Resolves #2264 