### PR TITLE
feat(Dropdown): add support for `forceSelection` prop

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleForceSelection.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleForceSelection.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Dropdown } from 'semantic-ui-react'
+
+import { getOptions } from '../common'
+
+const DropdownExampleForceSelection = () => (
+  <Dropdown
+    forceSelection={false}
+    options={getOptions(5)}
+    placeholder='I will not select any value on open'
+    selection
+  />
+)
+
+export default DropdownExampleForceSelection

--- a/docs/app/Examples/modules/Dropdown/Usage/index.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/index.js
@@ -15,7 +15,7 @@ const DropdownUsageExamples = () => (
 
     <ComponentExample
       title='Close On Blur'
-      description='A dropdown that closes when it blurs'
+      description='A dropdown that closes when it blurs.'
       examplePath='modules/Dropdown/Usage/DropdownExampleCloseOnBlur'
     />
 
@@ -23,6 +23,11 @@ const DropdownUsageExamples = () => (
       title='Close On Change'
       description='A multiple selection dropdown can close when the user changes its value.'
       examplePath='modules/Dropdown/Usage/DropdownExampleCloseOnChange'
+    />
+    <ComponentExample
+      title='Force Selection'
+      description='Whether search selection will force currently selected choice when element is blurred.'
+      examplePath='modules/Dropdown/Usage/DropdownExampleForceSelection'
     />
 
     <ComponentExample

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -77,7 +77,7 @@ export interface DropdownProps {
   /** A dropdown can take the full width of its parent */
   fluid?: boolean;
 
-  /** Detemine if a selection is auto selected if an item isn't directly selected */
+  /** 	Whether search selection will force currently selected choice when element is blurred. */
   forceSelection?: boolean;
 
   /** A dropdown menu can contain a header. */

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -77,6 +77,9 @@ export interface DropdownProps {
   /** A dropdown can take the full width of its parent */
   fluid?: boolean;
 
+  /** Detemine if a selection is auto selected if an item isn't directly selected */
+  forceSelection?: boolean,
+  
   /** A dropdown menu can contain a header. */
   header?: React.ReactNode;
 

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -78,8 +78,8 @@ export interface DropdownProps {
   fluid?: boolean;
 
   /** Detemine if a selection is auto selected if an item isn't directly selected */
-  forceSelection?: boolean,
-  
+  forceSelection?: boolean;
+
   /** A dropdown menu can contain a header. */
   header?: React.ReactNode;
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -130,7 +130,7 @@ export default class Dropdown extends Component {
     /** A dropdown can take the full width of its parent */
     fluid: PropTypes.bool,
 
-    /** Detemine if a selection is auto selected if an item isn't directly selected */
+    /** Whether search selection will force currently selected choice when element is blurred. */
     forceSelection: PropTypes.bool,
 
     /** A dropdown menu can contain a header. */
@@ -920,7 +920,6 @@ export default class Dropdown extends Component {
     const enabledIndicies = this.getEnabledIndices(options)
 
     let newSelectedIndex
-
     const firstIndex = enabledIndicies[0]
 
     // update the selected index
@@ -946,8 +945,7 @@ export default class Dropdown extends Component {
       newSelectedIndex = _.includes(enabledIndicies, activeIndex) ? activeIndex : undefined
     }
 
-    // if no selection is made and forceSelection is true, default to the first
-    // element
+    // if no selection is made and forceSelection is true, default to the first element
     if (forceSelection && (!newSelectedIndex || newSelectedIndex < 0)) {
       newSelectedIndex = firstIndex
     }

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -361,7 +361,7 @@ export default class Dropdown extends Component {
     additionPosition: 'top',
     closeOnBlur: true,
     deburr: false,
-    forceSelection: false,
+    forceSelection: true,
     icon: 'dropdown',
     minCharacters: 1,
     noResultsMessage: 'No results found.',

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -130,6 +130,9 @@ export default class Dropdown extends Component {
     /** A dropdown can take the full width of its parent */
     fluid: PropTypes.bool,
 
+    /** Detemine if a selection is auto selected if an item isn't directly selected */
+    forceSelection: PropTypes.bool,
+
     /** A dropdown menu can contain a header. */
     header: PropTypes.node,
 
@@ -358,6 +361,7 @@ export default class Dropdown extends Component {
     additionPosition: 'top',
     closeOnBlur: true,
     deburr: false,
+    forceSelection: false,
     icon: 'dropdown',
     minCharacters: 1,
     noResultsMessage: 'No results found.',
@@ -910,17 +914,20 @@ export default class Dropdown extends Component {
   }
 
   setSelectedIndex = (value = this.state.value, optionsProps = this.props.options) => {
-    const { multiple } = this.props
+    const { forceSelection, multiple } = this.props
     const { selectedIndex } = this.state
     const options = this.getMenuOptions(value, optionsProps)
     const enabledIndicies = this.getEnabledIndices(options)
 
     let newSelectedIndex
 
-    // update the selected index
-    if (!selectedIndex || selectedIndex < 0) {
-      const firstIndex = enabledIndicies[0]
+    const firstIndex = enabledIndicies[0];
 
+    // update the selected index
+    
+    // if no selection is made, will default to the first element if
+    if ( (!selectedIndex || selectedIndex < 0) && forceSelection) {
+      
       // Select the currently active item, if none, use the first item.
       // Multiple selects remove active items from the list,
       // their initial selected index should be 0.
@@ -941,8 +948,10 @@ export default class Dropdown extends Component {
       newSelectedIndex = _.includes(enabledIndicies, activeIndex) ? activeIndex : undefined
     }
 
-    if (!newSelectedIndex || newSelectedIndex < 0) {
-      newSelectedIndex = enabledIndicies[0]
+    // if no selection is made and forceSelection is true, default to the first
+    // element
+    if (forceSelection && (!newSelectedIndex || newSelectedIndex < 0)) {
+      newSelectedIndex = firstIndex
     }
 
     this.setState({ selectedIndex: newSelectedIndex })

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -921,13 +921,11 @@ export default class Dropdown extends Component {
 
     let newSelectedIndex
 
-    const firstIndex = enabledIndicies[0];
+    const firstIndex = enabledIndicies[0]
 
     // update the selected index
-    
     // if no selection is made, will default to the first element if
-    if ( (!selectedIndex || selectedIndex < 0) && forceSelection) {
-      
+    if ((!selectedIndex || selectedIndex < 0) && forceSelection) {
       // Select the currently active item, if none, use the first item.
       // Multiple selects remove active items from the list,
       // their initial selected index should be 0.

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -190,6 +190,22 @@ describe('Dropdown', () => {
     })
   })
 
+  describe('forceSelection', () => {
+    it('will set selectedIndex to the first element when is true', () => {
+      wrapperMount(<Dropdown options={[]} selection />)
+
+      wrapper.setProps({ options: getOptions() })
+      wrapper.should.have.state('selectedIndex', 0)
+    })
+
+    it('will not set the selectedIndex if forceSelection is false', () => {
+      wrapperMount(<Dropdown forceSelection={false} options={[]} selection />)
+
+      wrapper.setProps({ options: getOptions() })
+      wrapper.should.have.not.state('selectedIndex')
+    })
+  })
+
   describe('tabIndex', () => {
     it('defaults to 0', () => {
       shallow(<Dropdown options={options} />)
@@ -473,24 +489,6 @@ describe('Dropdown', () => {
       wrapper.setProps({ options })
 
       instance.setSelectedIndex.should.not.have.been.calledOnce()
-    })
-
-    it('will only set the selectedIndex to the first element if forceSelection is set to true (default)', () => {
-      wrapperMount(<Dropdown options={options} />)
-      wrapper.setState({ selectedIndex: undefined })
-      wrapper.setProps({ options: [] })
-
-      wrapper.should.have.state('selectedIndex', 0)
-    })
-
-    it('will only not set the selectedIndex to the first element if forceSelection is set to false', () => {
-      wrapperMount(<Dropdown options={options} forceSelection={false} />)
-      wrapper.setProps({
-        options: [],
-      })
-
-      wrapper.setState({ selectedIndex: undefined })
-      wrapper.should.have.state('selectedIndex', undefined)
     })
   })
 

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -474,6 +474,28 @@ describe('Dropdown', () => {
 
       instance.setSelectedIndex.should.not.have.been.calledOnce()
     })
+
+    it('will only set the selectedIndex to the first element if forceSelection is set to true (default)', () => {
+      wrapperMount(<Dropdown options={options} />)
+      
+      const instance = wrapper.instance()
+      wrapper.setState({ selectedIndex: undefined })
+      wrapper.setProps({ options: [] })
+      
+      wrapper.should.have.state("selectedIndex",0)
+    })
+
+    it('will only not set the selectedIndex to the first element if forceSelection is set to false', () => {
+      wrapperMount(<Dropdown options={options} forceSelection={false} />)
+
+      const instance = wrapper.instance()
+      wrapper.setProps({
+         options:[],
+      })
+      
+      wrapper.setState({ selectedIndex: undefined })
+      wrapper.should.have.state("selectedIndex",undefined)
+    })
   })
 
   describe('isMouseDown', () => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -477,24 +477,20 @@ describe('Dropdown', () => {
 
     it('will only set the selectedIndex to the first element if forceSelection is set to true (default)', () => {
       wrapperMount(<Dropdown options={options} />)
-      
-      const instance = wrapper.instance()
       wrapper.setState({ selectedIndex: undefined })
       wrapper.setProps({ options: [] })
-      
-      wrapper.should.have.state("selectedIndex",0)
+
+      wrapper.should.have.state('selectedIndex', 0)
     })
 
     it('will only not set the selectedIndex to the first element if forceSelection is set to false', () => {
       wrapperMount(<Dropdown options={options} forceSelection={false} />)
-
-      const instance = wrapper.instance()
       wrapper.setProps({
-         options:[],
+        options: [],
       })
-      
+
       wrapper.setState({ selectedIndex: undefined })
-      wrapper.should.have.state("selectedIndex",undefined)
+      wrapper.should.have.state('selectedIndex', undefined)
     })
   })
 


### PR DESCRIPTION
Fixes #2299.

Add support for forceSeletion for dropdown.

Still need to update unit test for this.  