### PR TITLE
fix(Dropdown): display all provided values, even if they aren't in the options

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -860,7 +860,9 @@ export default class Dropdown extends Component {
   getItemByValue = (value) => {
     const { options } = this.props
 
-    return _.find(options, { value })
+    // The added item might not be in the provided options
+    // in which case we just assume the value/text are the same
+    return _.find(options, { value }) || { text: value, value }
   }
 
   getMenuItemIndexByValue = (value, givenOptions) => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1361,6 +1361,22 @@ describe('Dropdown', () => {
         .find('Label')
         .should.have.prop('content', activeItem.text)
     })
+    it('displays a label for active items that are not in options', () => {
+      // select a random item, expect a label with the item's text
+      const activeItem = _.sample(options)
+      wrapperShallow(<Dropdown options={options} selection value={[activeItem.value, 'not-in-options']} multiple />)
+        .should.have.descendants('Label')
+
+      wrapper
+        .find('Label')
+        .at(0)
+        .should.have.prop('content', activeItem.text)
+
+      wrapper
+        .find('Label')
+        .at(1)
+        .should.have.prop('content', 'not-in-options')
+    })
     it('keeps the selection within the range of remaining options', () => {
       // items are removed as they are made active
       // the selection should move if the last item is made active


### PR DESCRIPTION
If you provide active values that aren't in the options you provide they're currently ignored. This PR changes that behavior so that `values` is the source of truth.

This is a "fix" to us because this is how the jQuery variant works, but this could also be seen as a feature and also potentially a breaking change if someone was relying on this. Lmk if you'd like this changed of course. 😄 

This allows the dev to not need to maintain two separate options in state; the original, and the modified one with additions. Instead they can think of options as immutable to the user. This prolly comes down to a difference in perception of what "options" is and whether a controlled component should blindly render the provided values or selectively choose.