### PR TITLE
refactor(dts): add white to the list of SemanticColors in typescript dts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -50,7 +50,7 @@ export type SemanticShorthandItem<T> = React.ReactNode | T;
 // ======================================================
 
 export type SemanticCOLORS = 'red' | 'orange' | 'yellow' | 'olive' | 'green' | 'teal' | 'blue' | 'violet' | 'purple' |
-  'pink' | 'brown' | 'grey' | 'black';
+  'pink' | 'brown' | 'grey' | 'black' | 'white' ;
 export type SemanticSIZES = 'mini' | 'tiny' | 'small' | 'medium' | 'large' | 'big' | 'huge' | 'massive';
 
 // ======================================================


### PR DESCRIPTION
Add white to the list of SemanticColors in the Typescript definition.