### PR TITLE
feat(Dropdown): add support for 'maxSelections'

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleMaxSelections.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleMaxSelections.js
@@ -22,8 +22,15 @@ const options = [
   { key: 'ux', text: 'User Experience', value: 'ux' },
 ]
 
-const DropdownExampleMultipleSelection = () => (
-  <Dropdown fluid multiple selection search options={options} maxSelections={3} />
+const DropdownExampleMaxSelections = () => (
+  <Dropdown
+    fluid
+    maxSelections={3}
+    multiple
+    search
+    selection
+    options={options}
+  />
 )
 
-export default DropdownExampleMultipleSelection
+export default DropdownExampleMaxSelections

--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleMaxSelections.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleMaxSelections.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Dropdown } from 'semantic-ui-react'
+
+const options = [
+  { key: 'angular', text: 'Angular', value: 'angular' },
+  { key: 'css', text: 'CSS', value: 'css' },
+  { key: 'design', text: 'Graphic Design', value: 'design' },
+  { key: 'ember', text: 'Ember', value: 'ember' },
+  { key: 'html', text: 'HTML', value: 'html' },
+  { key: 'ia', text: 'Information Architecture', value: 'ia' },
+  { key: 'javascript', text: 'Javascript', value: 'javascript' },
+  { key: 'mech', text: 'Mechanical Engineering', value: 'mech' },
+  { key: 'meteor', text: 'Meteor', value: 'meteor' },
+  { key: 'node', text: 'NodeJS', value: 'node' },
+  { key: 'plumbing', text: 'Plumbing', value: 'plumbing' },
+  { key: 'python', text: 'Python', value: 'python' },
+  { key: 'rails', text: 'Rails', value: 'rails' },
+  { key: 'react', text: 'React', value: 'react' },
+  { key: 'repair', text: 'Kitchen Repair', value: 'repair' },
+  { key: 'ruby', text: 'Ruby', value: 'ruby' },
+  { key: 'ui', text: 'UI Design', value: 'ui' },
+  { key: 'ux', text: 'User Experience', value: 'ux' },
+]
+
+const DropdownExampleMultipleSelection = () => (
+  <Dropdown fluid multiple selection search options={options} maxSelections={3} />
+)
+
+export default DropdownExampleMultipleSelection

--- a/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleMaxSelectionsLocalized.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/DropdownExampleMaxSelectionsLocalized.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Dropdown } from 'semantic-ui-react'
+
+const options = [
+  { key: 'volvo', text: 'Volvo', value: 'volvo' },
+  { key: 'audi', text: 'Audi', value: 'audi' },
+  { key: 'bmw', text: 'BMW', value: 'bmw' },
+]
+
+
+const DropdownExampleMaxSelectionsLocalized = () => {
+  const maxSelections = 2
+
+  const LocalizedMessage = <span>Du får inte välja fler än {maxSelections} bilar</span>
+
+  return (
+    <Dropdown
+      fluid
+      maxSelections={maxSelections}
+      maxSelectionsMessage={LocalizedMessage}
+      multiple
+      search
+      selection
+      options={options}
+    />
+  )
+}
+
+export default DropdownExampleMaxSelectionsLocalized

--- a/docs/app/Examples/modules/Dropdown/Usage/index.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/index.js
@@ -139,7 +139,10 @@ const DropdownUsageExamples = () => (
     />
     <ComponentExample
       title='Max Selections Localized'
-      description='A dropdown allows the search to set the maximum number of allowed selections, with support for localization.'
+      description={
+        `A dropdown allows the search to set the maximum number
+        of allowed selections, with support for localization.`
+      }
       examplePath='modules/Dropdown/Usage/DropdownExampleMaxSelectionsLocalized'
     />
 

--- a/docs/app/Examples/modules/Dropdown/Usage/index.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/index.js
@@ -137,6 +137,11 @@ const DropdownUsageExamples = () => (
       description='A dropdown allows the search to set the maximum number of allowed selections.'
       examplePath='modules/Dropdown/Usage/DropdownExampleMaxSelections'
     />
+    <ComponentExample
+      title='Max Selections Localized'
+      description='A dropdown allows the search to set the maximum number of allowed selections, with support for localization.'
+      examplePath='modules/Dropdown/Usage/DropdownExampleMaxSelectionsLocalized'
+    />
 
   </ExampleSection>
 )

--- a/docs/app/Examples/modules/Dropdown/Usage/index.js
+++ b/docs/app/Examples/modules/Dropdown/Usage/index.js
@@ -132,6 +132,11 @@ const DropdownUsageExamples = () => (
     <ComponentExample
       examplePath='modules/Dropdown/Usage/DropdownExampleUpward'
     />
+    <ComponentExample
+      title='Max Selections'
+      description='A dropdown allows the search to set the maximum number of allowed selections.'
+      examplePath='modules/Dropdown/Usage/DropdownExampleMaxSelections'
+    />
 
   </ExampleSection>
 )

--- a/index.d.ts
+++ b/index.d.ts
@@ -148,6 +148,7 @@ export { default as DropdownDivider, DropdownDividerProps } from './dist/commonj
 export { default as DropdownHeader, DropdownHeaderProps } from './dist/commonjs/modules/Dropdown/DropdownHeader';
 export { default as DropdownItem, DropdownItemProps } from './dist/commonjs/modules/Dropdown/DropdownItem';
 export { default as DropdownMenu, DropdownMenuProps } from './dist/commonjs/modules/Dropdown/DropdownMenu';
+export { default as DropdownMessage, DropdownMessageProps } from './dist/commonjs/modules/Dropdown/DropdownMessage';
 export {
   default as DropdownSearchInput,
   DropdownSearchInputProps

--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,7 @@ export { default as DropdownDivider } from './modules/Dropdown/DropdownDivider'
 export { default as DropdownHeader } from './modules/Dropdown/DropdownHeader'
 export { default as DropdownItem } from './modules/Dropdown/DropdownItem'
 export { default as DropdownMenu } from './modules/Dropdown/DropdownMenu'
+export { default as DropdownMessage } from './modules/Dropdown/DropdownMessage'
 export { default as DropdownSearchInput } from './modules/Dropdown/DropdownSearchInput'
 
 export { default as Embed } from './modules/Embed'

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -5,6 +5,7 @@ import { default as DropdownDivider } from './DropdownDivider';
 import { default as DropdownHeader } from './DropdownHeader';
 import { default as DropdownItem, DropdownItemProps } from './DropdownItem';
 import { default as DropdownMenu } from './DropdownMenu';
+import { default as DropdownMessage } from './DropdownMessage';
 import { default as DropdownSearchInput } from './DropdownSearchInput';
 
 export interface DropdownProps {
@@ -280,6 +281,7 @@ interface DropdownComponent extends React.ComponentClass<DropdownProps> {
   Header: typeof DropdownHeader;
   Item: typeof DropdownItem;
   Menu: typeof DropdownMenu;
+  Message: typeof DropdownMessage;
   SearchInput: typeof DropdownSearchInput;
 }
 

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -98,6 +98,9 @@ export interface DropdownProps {
   /** A dropdown can show that it is currently loading data. */
   loading?: boolean;
 
+  /** A dropdown can allow a maximum number of selections. */
+  maxSelections?: number;
+
   /** The minimum characters for a search to begin showing results. */
   minCharacters?: number;
 

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -102,6 +102,9 @@ export interface DropdownProps {
   /** A dropdown can allow a maximum number of selections. */
   maxSelections?: number;
 
+  /** A dropdown can have a localized maxSelections message. */
+  maxSelectionsMessage?: React.ReactNode;
+
   /** The minimum characters for a search to begin showing results. */
   minCharacters?: number;
 
@@ -109,7 +112,7 @@ export interface DropdownProps {
   multiple?: boolean;
 
   /** Message to display when there are no results. */
-  noResultsMessage?: string;
+  noResultsMessage?: React.ReactNode;
 
   /**
    * Called when a user adds a new item. Use this to update the options list.

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -26,6 +26,7 @@ import DropdownItem from './DropdownItem'
 import DropdownHeader from './DropdownHeader'
 import DropdownMenu from './DropdownMenu'
 import DropdownSearchInput from './DropdownSearchInput'
+import DropdownMessage from './DropdownMessage'
 
 const debug = makeDebugger('dropdown')
 
@@ -403,6 +404,7 @@ export default class Dropdown extends Component {
   static Header = DropdownHeader
   static Item = DropdownItem
   static Menu = DropdownMenu
+  static Message = DropdownMessage
   static SearchInput = DropdownSearchInput
 
   getInitialAutoControlledState() {
@@ -1244,11 +1246,11 @@ export default class Dropdown extends Component {
     const options = this.getMenuOptions()
 
     if (!_.isNil(maxSelections) && value.length >= maxSelections) {
-      return <div className='message'>Max {maxSelections} selection{maxSelections > 1 && 's'}</div>
+      return <DropdownMessage type={'maxSelections'} value={maxSelections} />
     }
 
     if (noResultsMessage !== null && search && _.isEmpty(options)) {
-      return <div className='message'>{noResultsMessage}</div>
+      return <DropdownMessage type={'noResultsMessage'} noResultsMessage={noResultsMessage} />
     }
 
     const isActive = multiple

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1253,7 +1253,6 @@ export default class Dropdown extends Component {
     const options = this.getMenuOptions()
 
     if (!_.isNil(maxSelections) && value.length >= maxSelections) {
-
       return DropdownMessage.create('maxSelectionsMessage', {
         defaultProps: {
           value: maxSelections,

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -162,6 +162,12 @@ export default class Dropdown extends Component {
       PropTypes.number,
     ]),
 
+    /** A dropdown can have a localized maxSelections message. */
+    maxSelectionsMessage: customPropTypes.every([
+      customPropTypes.demand(['maxSelections']),
+      PropTypes.node,
+    ]),
+
     /** The minimum characters for a search to begin showing results. */
     minCharacters: PropTypes.number,
 
@@ -169,7 +175,7 @@ export default class Dropdown extends Component {
     multiple: PropTypes.bool,
 
     /** Message to display when there are no results. */
-    noResultsMessage: PropTypes.string,
+    noResultsMessage: PropTypes.node,
 
     /**
      * Called when a user adds a new item. Use this to update the options list.
@@ -378,8 +384,9 @@ export default class Dropdown extends Component {
     closeOnBlur: true,
     deburr: false,
     icon: 'dropdown',
+    maxSelectionsMessage: undefined,
     minCharacters: 1,
-    noResultsMessage: 'No results found.',
+    noResultsMessage: undefined,
     openOnFocus: true,
     renderLabel: ({ text }) => text,
     searchInput: 'text',
@@ -1241,16 +1248,26 @@ export default class Dropdown extends Component {
   }
 
   renderOptions = () => {
-    const { maxSelections, multiple, search, noResultsMessage } = this.props
+    const { maxSelections, maxSelectionsMessage, multiple, search, noResultsMessage } = this.props
     const { selectedIndex, value } = this.state
     const options = this.getMenuOptions()
 
     if (!_.isNil(maxSelections) && value.length >= maxSelections) {
-      return <DropdownMessage type={'maxSelections'} value={maxSelections} />
+
+      return DropdownMessage.create('maxSelectionsMessage', {
+        defaultProps: {
+          value: maxSelections,
+          maxSelectionsMessage,
+        },
+      })
     }
 
     if (noResultsMessage !== null && search && _.isEmpty(options)) {
-      return <DropdownMessage type={'noResultsMessage'} noResultsMessage={noResultsMessage} />
+      return DropdownMessage.create('noResultsMessage', {
+        defaultProps: {
+          noResultsMessage,
+        },
+      })
     }
 
     const isActive = multiple

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -156,7 +156,10 @@ export default class Dropdown extends Component {
     loading: PropTypes.bool,
 
     /** A dropdown can allow a maximum number of selections. */
-    maxSelections: PropTypes.number,
+    maxSelections: customPropTypes.every([
+      customPropTypes.demand(['multiple', 'selection']),
+      PropTypes.number,
+    ]),
 
     /** The minimum characters for a search to begin showing results. */
     minCharacters: PropTypes.number,

--- a/src/modules/Dropdown/DropdownMessage.d.ts
+++ b/src/modules/Dropdown/DropdownMessage.d.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+export interface DropdownMessageProps {
+  [key: string]: any;
+
+  /** An element type to render as (string or function). */
+  as?: any;
+
+  /** Additional classes. */
+  className?: string;
+
+  /** Message to display when rendering the noResultsMessage type. */
+  noResultsMessage?: string;
+
+  /** The message type. */
+  type?: 'noResultsMessage' | 'maxSelections';
+
+  /** The maxSelections value. */
+  value?: number | string;
+}
+
+declare const DropdownMessage: React.StatelessComponent<DropdownMessageProps>;
+
+export default DropdownMessage;

--- a/src/modules/Dropdown/DropdownMessage.d.ts
+++ b/src/modules/Dropdown/DropdownMessage.d.ts
@@ -9,16 +9,19 @@ export interface DropdownMessageProps {
   /** Additional classes. */
   className?: string;
 
+  /** Message to display when the maxSelections cap has been reached. */
+  maxSelectionsMessage?: React.ReactNode;
+
   /** Message to display when rendering the noResultsMessage type. */
-  noResultsMessage?: string;
+  noResultsMessage?: React.ReactNode;
 
   /** The message type. */
-  type: 'noResultsMessage' | 'maxSelections';
+  type: 'noResultsMessage' | 'maxSelectionsMessage';
 
   /** The maxSelections value. */
   value?: number | string;
 }
 
-declare const DropdownMessage: React.StatelessComponent<DropdownMessageProps>;
+declare const DropdownMessage: React.ComponentClass<DropdownMessageProps>;
 
 export default DropdownMessage;

--- a/src/modules/Dropdown/DropdownMessage.d.ts
+++ b/src/modules/Dropdown/DropdownMessage.d.ts
@@ -13,7 +13,7 @@ export interface DropdownMessageProps {
   noResultsMessage?: string;
 
   /** The message type. */
-  type?: 'noResultsMessage' | 'maxSelections';
+  type: 'noResultsMessage' | 'maxSelections';
 
   /** The maxSelections value. */
   value?: number | string;

--- a/src/modules/Dropdown/DropdownMessage.d.ts
+++ b/src/modules/Dropdown/DropdownMessage.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { SemanticShorthandContent } from '../..';
 
 export interface DropdownMessageProps {
   [key: string]: any;
@@ -10,16 +11,16 @@ export interface DropdownMessageProps {
   className?: string;
 
   /** Message to display when the maxSelections cap has been reached. */
-  maxSelectionsMessage?: React.ReactNode;
+  maxSelectionsMessage?: SemanticShorthandContent;
 
   /** Message to display when rendering the noResultsMessage type. */
-  noResultsMessage?: React.ReactNode;
+  noResultsMessage?: SemanticShorthandContent;
 
   /** The message type. */
   type: 'noResultsMessage' | 'maxSelectionsMessage';
 
   /** The maxSelections value. */
-  value?: number | string;
+  value?: number;
 }
 
 declare const DropdownMessage: React.ComponentClass<DropdownMessageProps>;

--- a/src/modules/Dropdown/DropdownMessage.js
+++ b/src/modules/Dropdown/DropdownMessage.js
@@ -1,0 +1,61 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import {
+  customPropTypes,
+  getElementType,
+  getUnhandledProps,
+  META,
+} from '../../lib'
+
+/**
+ * A message sub-component for Dropdown component.
+ */
+function DropdownMessage(props) {
+  const { className, noResultsMessage, type, value } = props
+
+  const classes = cx('message', className)
+
+  let message = ''
+  if (type === 'noResultsMessage') {
+    message = noResultsMessage
+  } else {
+    message = `Max ${value} selection${value > 1 ? 's' : ''}`
+  }
+
+  const rest = getUnhandledProps(DropdownMessage, props)
+  const ElementType = getElementType(DropdownMessage, props)
+
+  return (
+    <ElementType {...rest} className={classes}>{message}</ElementType>
+  )
+}
+
+DropdownMessage._meta = {
+  name: 'DropdownMessage',
+  parent: 'Dropdown',
+  type: META.TYPES.MODULE,
+}
+
+DropdownMessage.propTypes = {
+  /** An element type to render as (string or function). */
+  as: customPropTypes.as,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+
+  /** Message to display when there are no results. */
+  noResultsMessage: PropTypes.string,
+
+  /** The message type. */
+  type: PropTypes.oneOf('maxSelections', 'noResultsMessage'),
+
+  /** The maxSelections value. */
+  value: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+}
+
+export default DropdownMessage

--- a/src/modules/Dropdown/DropdownMessage.js
+++ b/src/modules/Dropdown/DropdownMessage.js
@@ -49,7 +49,7 @@ DropdownMessage.propTypes = {
   noResultsMessage: PropTypes.string,
 
   /** The message type. */
-  type: PropTypes.oneOf('maxSelections', 'noResultsMessage'),
+  type: PropTypes.oneOf(['maxSelections', 'noResultsMessage']).isRequired,
 
   /** The maxSelections value. */
   value: PropTypes.oneOfType([

--- a/src/modules/Dropdown/DropdownMessage.js
+++ b/src/modules/Dropdown/DropdownMessage.js
@@ -41,8 +41,8 @@ class DropdownMessage extends Component {
   }
 
   static defaultProps = {
-    noResultsMessage: 'No results found.',
     maxSelectionsMessage: 'Max {value} selection{suffix}.',
+    noResultsMessage: 'No results found.',
   }
 
   /**

--- a/src/modules/Dropdown/DropdownMessage.js
+++ b/src/modules/Dropdown/DropdownMessage.js
@@ -37,10 +37,7 @@ class DropdownMessage extends Component {
     type: PropTypes.oneOf(['maxSelectionsMessage', 'noResultsMessage']).isRequired,
 
     /** The maxSelections value. */
-    value: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.string,
-    ]),
+    value: PropTypes.number,
   }
 
   static defaultProps = {

--- a/src/modules/Dropdown/DropdownMessage.js
+++ b/src/modules/Dropdown/DropdownMessage.js
@@ -1,8 +1,9 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { cloneElement, Component, isValidElement } from 'react'
 
 import {
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -12,50 +13,83 @@ import {
 /**
  * A message sub-component for Dropdown component.
  */
-function DropdownMessage(props) {
-  const { className, noResultsMessage, type, value } = props
-
-  const classes = cx('message', className)
-
-  let message = ''
-  if (type === 'noResultsMessage') {
-    message = noResultsMessage
-  } else {
-    message = `Max ${value} selection${value > 1 ? 's' : ''}`
+class DropdownMessage extends Component {
+  static _meta = {
+    name: 'DropdownMessage',
+    parent: 'Dropdown',
+    type: META.TYPES.MODULE,
   }
 
-  const rest = getUnhandledProps(DropdownMessage, props)
-  const ElementType = getElementType(DropdownMessage, props)
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
 
-  return (
-    <ElementType {...rest} className={classes}>{message}</ElementType>
-  )
+    /** Additional classes. */
+    className: PropTypes.string,
+
+    /** Message to display when the maximum selection limit has been reached. */
+    maxSelectionsMessage: customPropTypes.contentShorthand,
+
+    /** Message to display when there are no results. */
+    noResultsMessage: customPropTypes.contentShorthand,
+
+    /** The message type. */
+    type: PropTypes.oneOf(['maxSelectionsMessage', 'noResultsMessage']).isRequired,
+
+    /** The maxSelections value. */
+    value: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
+  }
+
+  static defaultProps = {
+    noResultsMessage: 'No results found.',
+    maxSelectionsMessage: 'Max {value} selection{suffix}.',
+  }
+
+  /**
+   * Method to create the message depending on the type prop
+   */
+  createMessage = () => {
+    const message = this.props[this.props.type]
+
+    if (isValidElement(message)) {
+      return cloneElement(message, { type: this.props.type, value: this.props.value })
+    }
+
+    if (typeof message !== 'string') {
+      return message
+    }
+
+    // Return if we have a string that differs from our default, i.e. we only do replace on default string
+    if (message !== DropdownMessage.defaultProps.maxSelectionsMessage) {
+      return message
+    }
+
+    const suffix = this.props.value > 1 ? 's' : ''
+
+    return message
+      .replace('{value}', this.props.value)
+      .replace('{suffix}', suffix)
+  }
+
+  render() {
+    const { className } = this.props
+
+    const classes = cx('message', className)
+
+    const message = this.createMessage()
+
+    const rest = getUnhandledProps(DropdownMessage, this.props)
+    const ElementType = getElementType(DropdownMessage, this.props)
+
+    return (
+      <ElementType {...rest} className={classes}>{message}</ElementType>
+    )
+  }
 }
 
-DropdownMessage._meta = {
-  name: 'DropdownMessage',
-  parent: 'Dropdown',
-  type: META.TYPES.MODULE,
-}
-
-DropdownMessage.propTypes = {
-  /** An element type to render as (string or function). */
-  as: customPropTypes.as,
-
-  /** Additional classes. */
-  className: PropTypes.string,
-
-  /** Message to display when there are no results. */
-  noResultsMessage: PropTypes.string,
-
-  /** The message type. */
-  type: PropTypes.oneOf(['maxSelections', 'noResultsMessage']).isRequired,
-
-  /** The maxSelections value. */
-  value: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-  ]),
-}
+DropdownMessage.create = createShorthandFactory(DropdownMessage, type => ({ type }))
 
 export default DropdownMessage

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -9,6 +9,7 @@ import DropdownDivider from 'src/modules/Dropdown/DropdownDivider'
 import DropdownHeader from 'src/modules/Dropdown/DropdownHeader'
 import DropdownItem from 'src/modules/Dropdown/DropdownItem'
 import DropdownMenu from 'src/modules/Dropdown/DropdownMenu'
+import DropdownMessage from 'src/modules/Dropdown/DropdownMessage'
 import DropdownSearchInput from 'src/modules/Dropdown/DropdownSearchInput'
 
 let attachTo
@@ -85,7 +86,7 @@ describe('Dropdown', () => {
 
   common.isConformant(Dropdown)
   common.hasUIClassName(Dropdown)
-  common.hasSubComponents(Dropdown, [DropdownDivider, DropdownHeader, DropdownItem, DropdownMenu, DropdownSearchInput])
+  common.hasSubComponents(Dropdown, [DropdownDivider, DropdownHeader, DropdownItem, DropdownMenu, DropdownMessage, DropdownSearchInput])
 
   common.implementsIconProp(Dropdown, {
     assertExactMatch: false,

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -2645,4 +2645,52 @@ describe('Dropdown', () => {
         .should.have.prop('selected', true)
     })
   })
+
+  describe('maxSelections', () => {
+    it('shows max selection message when maxSelections cap is reached', () => {
+      const maxSelections = 3
+      const maxSelectionsText = `Max ${maxSelections} selections`
+
+      const samples = _.sampleSize(options, maxSelections)
+      wrapperMount(<Dropdown options={options} multiple selection maxSelections={maxSelections} value={samples} />)
+
+      wrapper
+        .find('.message')
+        .should.have.text(maxSelectionsText)
+    })
+
+    it('shows singular max selection message when maxSelections={1} and cap is reached', () => {
+      const maxSelections = 1
+      const maxSelectionsText = 'Max 1 selection'
+
+      const samples = _.sampleSize(options, maxSelections)
+      wrapperMount(<Dropdown options={options} multiple selection maxSelections={maxSelections} value={samples} />)
+
+      wrapper
+        .find('.message')
+        .should.have.text(maxSelectionsText)
+    })
+
+    it('prevents more items from being selected when reaching maxSelections cap when using enter', () => {
+      const maxSelections = 2
+
+      wrapperMount(<Dropdown options={options} multiple selection maxSelections={maxSelections} />)
+        .simulate('click')
+
+      // Select item
+      domEvent.keyDown(document, { key: 'Enter' })
+      wrapper.state('value')
+        .should.have.length(1)
+
+      // Select item
+      domEvent.keyDown(document, { key: 'Enter' })
+      wrapper.state('value')
+        .should.have.length(2)
+
+      // Select item, no item should be added
+      domEvent.keyDown(document, { key: 'Enter' })
+      wrapper.state('value')
+        .should.have.length(2)
+    })
+  })
 })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -86,7 +86,14 @@ describe('Dropdown', () => {
 
   common.isConformant(Dropdown)
   common.hasUIClassName(Dropdown)
-  common.hasSubComponents(Dropdown, [DropdownDivider, DropdownHeader, DropdownItem, DropdownMenu, DropdownMessage, DropdownSearchInput])
+  common.hasSubComponents(Dropdown, [
+    DropdownDivider,
+    DropdownHeader,
+    DropdownItem,
+    DropdownMenu,
+    DropdownMessage,
+    DropdownSearchInput,
+  ])
 
   common.implementsIconProp(Dropdown, {
     assertExactMatch: false,

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -2657,7 +2657,7 @@ describe('Dropdown', () => {
   describe('maxSelections', () => {
     it('shows max selection message when maxSelections cap is reached', () => {
       const maxSelections = 3
-      const maxSelectionsText = `Max ${maxSelections} selections`
+      const maxSelectionsText = `Max ${maxSelections} selections.`
 
       const samples = _.sampleSize(options, maxSelections)
       wrapperMount(<Dropdown options={options} multiple selection maxSelections={maxSelections} value={samples} />)
@@ -2669,7 +2669,7 @@ describe('Dropdown', () => {
 
     it('shows singular max selection message when maxSelections={1} and cap is reached', () => {
       const maxSelections = 1
-      const maxSelectionsText = 'Max 1 selection'
+      const maxSelectionsText = 'Max 1 selection.'
 
       const samples = _.sampleSize(options, maxSelections)
       wrapperMount(<Dropdown options={options} multiple selection maxSelections={maxSelections} value={samples} />)

--- a/test/specs/modules/Dropdown/DropdownMessage-test.js
+++ b/test/specs/modules/Dropdown/DropdownMessage-test.js
@@ -1,6 +1,8 @@
 import DropdownMessage from 'src/modules/Dropdown/DropdownMessage'
 import * as common from 'test/specs/commonTests'
 
+const requiredProps = { type: 'noResultsMessage' }
+
 describe('DropdownMessage', () => {
-  common.isConformant(DropdownMessage)
+  common.isConformant(DropdownMessage, { requiredProps })
 })

--- a/test/specs/modules/Dropdown/DropdownMessage-test.js
+++ b/test/specs/modules/Dropdown/DropdownMessage-test.js
@@ -1,3 +1,5 @@
+import React from 'react'
+
 import DropdownMessage from 'src/modules/Dropdown/DropdownMessage'
 import * as common from 'test/specs/commonTests'
 
@@ -7,4 +9,104 @@ describe('DropdownMessage', () => {
   common.isConformant(DropdownMessage, { requiredProps })
 
   common.implementsCreateMethod(DropdownMessage)
+
+  describe('maxSelections', () => {
+    it('shows default max selections formatted appropriately, plural', () => {
+      const maxSelections = 3
+      const maxSelectionsText = `Max ${maxSelections} selections.`
+
+      const wrapper = shallow(
+        <DropdownMessage
+          type={'maxSelectionsMessage'}
+          value={maxSelections}
+        />,
+      )
+
+      wrapper
+        .find('.message')
+        .should.have.text(maxSelectionsText)
+    })
+
+    it('shows default max selections formatted appropriately, singular', () => {
+      const maxSelections = 1
+      const maxSelectionsText = `Max ${maxSelections} selection.`
+
+      const wrapper = shallow(
+        <DropdownMessage
+          type={'maxSelectionsMessage'}
+          value={maxSelections}
+        />,
+      )
+
+      wrapper
+        .find('.message')
+        .should.have.text(maxSelectionsText)
+    })
+
+    it('should render a localized message without problems', () => {
+      const maxSelections = 1
+      const maxSelectionsMessage = 'No more selections for you!'
+
+      const wrapper = shallow(
+        <DropdownMessage
+          type={'maxSelectionsMessage'}
+          value={maxSelections}
+          maxSelectionsMessage={maxSelectionsMessage}
+        />,
+      )
+
+      wrapper
+        .find('.message')
+        .should.have.text(maxSelectionsMessage)
+    })
+    it('should render a localized message element without problems', () => {
+      const maxSelections = 1
+      const text = 'No more selections for you!'
+      const maxSelectionsMessage = <span className={'red'}>{text}</span>
+
+      const wrapper = shallow(
+        <DropdownMessage
+          type={'maxSelectionsMessage'}
+          value={maxSelections}
+          maxSelectionsMessage={maxSelectionsMessage}
+        />,
+      )
+
+      wrapper
+        .should.have.exactly(1).descendants('span.red')
+        .which.contain.text(text)
+    })
+  })
+
+  describe('noResultsMessage', () => {
+    it('shows default no results message appropriately', () => {
+      const text = 'No results found.'
+
+      const wrapper = shallow(
+        <DropdownMessage
+          type={'noResultsMessage'}
+          noResultsMessage={text}
+        />,
+      )
+
+      wrapper
+        .should.have.text(text)
+    })
+
+    it('shows default no results message element appropriately', () => {
+      const text = 'No results found, I\'m sorry about that!'
+      const el = <span className={'red'}>{text}</span>
+
+      const wrapper = shallow(
+        <DropdownMessage
+          type={'noResultsMessage'}
+          noResultsMessage={el}
+        />,
+      )
+
+      wrapper
+        .should.have.exactly(1).descendants('span.red')
+        .which.contain.text(text)
+    })
+  })
 })

--- a/test/specs/modules/Dropdown/DropdownMessage-test.js
+++ b/test/specs/modules/Dropdown/DropdownMessage-test.js
@@ -1,0 +1,6 @@
+import DropdownMessage from 'src/modules/Dropdown/DropdownMessage'
+import * as common from 'test/specs/commonTests'
+
+describe('DropdownMessage', () => {
+  common.isConformant(DropdownMessage)
+})

--- a/test/specs/modules/Dropdown/DropdownMessage-test.js
+++ b/test/specs/modules/Dropdown/DropdownMessage-test.js
@@ -5,4 +5,6 @@ const requiredProps = { type: 'noResultsMessage' }
 
 describe('DropdownMessage', () => {
   common.isConformant(DropdownMessage, { requiredProps })
+
+  common.implementsCreateMethod(DropdownMessage)
 })


### PR DESCRIPTION
Addresses https://github.com/Semantic-Org/Semantic-UI-React/issues/2224

- [x] Add tests
- [x] Add example
- [x] Add prop check (maxSelections prop should only be available with multiple and selection).
- [x] Implement subcomponent DropdownMessage, see feedback below.
- [x] Change ```maxSelections``` prop to allow strings as well, for coherence. (do not implement)
- [x] Use factory for DropdownMessage
- [x] Add specific `DropdownMessage` tests