### PR TITLE
fix(Image): correct the type of the width prop

### DIFF
--- a/src/elements/Image/Image.d.ts
+++ b/src/elements/Image/Image.d.ts
@@ -88,7 +88,7 @@ export interface ImageProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS;
 
   /** The img element width attribute. */
-  width?: SemanticWIDTHS;
+  width?: string | number;
 
   /** An image can render wrapped in a `div.ui.image` as alternative HTML markup. */
   wrapped?: boolean;


### PR DESCRIPTION
The image width prop maps directly to the img width html attribute.  It is incorrectly defined as 
SemanticWIDTHS.  It should be string | number similar to the height prop.