### PR TITLE
fix(Dropdown): add event handlers when opened via defaultOpen

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -397,7 +397,10 @@ export default class Dropdown extends Component {
     this.setValue(value)
     this.setSelectedIndex(value)
 
-    if (open) this.open()
+    if (open) {
+      this.open()
+      this.attachHandlersOnOpen()
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -479,14 +482,7 @@ export default class Dropdown extends Component {
     // opened / closed
     if (!prevState.open && this.state.open) {
       debug('dropdown opened')
-      eventStack.sub('keydown', [
-        this.closeOnEscape,
-        this.moveSelectionOnKeyDown,
-        this.selectItemOnEnter,
-        this.removeItemOnBackspace,
-      ])
-      eventStack.sub('click', this.closeOnDocumentClick)
-      eventStack.unsub('keydown', [this.openOnArrow, this.openOnSpace])
+      this.attachHandlersOnOpen()
       this.scrollSelectedItemIntoView()
     } else if (prevState.open && !this.state.open) {
       debug('dropdown closed')
@@ -650,6 +646,17 @@ export default class Dropdown extends Component {
     if (this.ref && _.isFunction(this.ref.contains) && this.ref.contains(e.target)) return
 
     this.close()
+  }
+
+  attachHandlersOnOpen = () => {
+    eventStack.sub('keydown', [
+      this.closeOnEscape,
+      this.moveSelectionOnKeyDown,
+      this.selectItemOnEnter,
+      this.removeItemOnBackspace,
+    ])
+    eventStack.sub('click', this.closeOnDocumentClick)
+    eventStack.unsub('keydown', [this.openOnArrow, this.openOnSpace])
   }
 
   // ----------------------------------------

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -145,6 +145,20 @@ describe('Dropdown', () => {
       .should.have.been.calledOnce()
   })
 
+  it('blurs the Dropdown node on close by clicking outside component', () => {
+    wrapperMount(<Dropdown options={options} selection defaultOpen />)
+
+    const instance = wrapper.instance()
+    sandbox.spy(instance.ref, 'blur')
+
+    dropdownMenuIsOpen()
+    document.body.click()
+    dropdownMenuIsClosed()
+
+    instance.ref.blur
+      .should.have.been.calledOnce()
+  })
+
   it('does not close on click when search is true and options are empty', () => {
     wrapperMount(<Dropdown options={{}} search selection defaultOpen />)
 


### PR DESCRIPTION
This attaches the event handlers to deal with closing the Dropdown such as onBlur and pressing the esc key.

fixes [2332](https://github.com/Semantic-Org/Semantic-UI-React/issues/2332)