### PR TITLE
docs(Header): fix typo in component example description

### DIFF
--- a/docs/app/Examples/elements/Header/Content/index.js
+++ b/docs/app/Examples/elements/Header/Content/index.js
@@ -31,7 +31,7 @@ const HeaderContentExamples = () => (
       examplePath='elements/Header/Content/HeaderExampleSubheader'
     />
     <ComponentExample
-      description='You can pass an Subheader content to the Header subheader prop.'
+      description='You can pass any Subheader content to the Header subheader prop.'
       examplePath='elements/Header/Content/HeaderExampleSubheaderProp'
     />
   </ExampleSection>


### PR DESCRIPTION
As an alternative to merging this PR as-is, you may want to remove the word "an" altogether (and not replace it with anything).