### PR TITLE
docs(Step): fix display of an icon in StepExampleEvenlyDivided

### DIFF
--- a/docs/app/Examples/elements/Step/Variations/StepExampleEvenlyDivided.js
+++ b/docs/app/Examples/elements/Step/Variations/StepExampleEvenlyDivided.js
@@ -4,7 +4,7 @@ import { Icon, Step } from 'semantic-ui-react'
 const StepExampleEvenlyDivided = () => (
   <Step.Group widths={3}>
     <Step>
-      <Icon icon='truck' />
+      <Icon name='truck' />
       <Step.Content>
         <Step.Title>Shipping</Step.Title>
       </Step.Content>


### PR DESCRIPTION
 'Truck' icon wasn't showing in the step docs due to a typo.
Somebody accidentally used the 'icon' attribute instead of the 'name' attribute.