### PR TITLE
fix(Portal): onClose and onOpen don't get called on prop changes

### DIFF
--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -147,6 +147,18 @@ class Portal extends Component {
     this.renderPortal()
   }
 
+  componentWillReceiveProps(nextProps) {
+    super.componentWillReceiveProps(nextProps)
+    if (nextProps.open !== this.props.open) {
+      if (nextProps.open && nextProps.onOpen) {
+        nextProps.onOpen(null, nextProps)
+      }
+      if (!nextProps.open && nextProps.onClose) {
+        nextProps.onClose(null, nextProps)
+      }
+    }
+  }
+
   componentDidUpdate(prevProps, prevState) {
     debug('componentDidUpdate()')
     // NOTE: Ideally the portal rendering would happen in the render() function

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -85,6 +85,14 @@ describe('Portal', () => {
       document.body.lastElementChild.should.equal(instance.rootNode)
       document.body.childElementCount.should.equal(1)
     })
+    it('calls onOpen when toggled from false to true', () => {
+      const spy = sandbox.spy()
+      wrapperMount(<Portal open={false} onOpen={spy}><p /></Portal>)
+
+      // Enzyme docs say it merges previous props but without children, react complains
+      wrapper.setProps({ open: true, children: <p /> })
+      spy.should.have.been.called()
+    })
 
     it('closes the portal when toggled from true to false ', () => {
       wrapperMount(<Portal open><p /></Portal>)
@@ -95,6 +103,15 @@ describe('Portal', () => {
 
       wrapper.setProps({ open: false, children: <p /> })
       document.body.childElementCount.should.equal(0)
+    })
+
+    it('calls onClose when toggled from true to false', () => {
+      const spy = sandbox.spy()
+      wrapperMount(<Portal open onClose={spy}><p /></Portal>)
+
+      // Enzyme docs say it merges previous props but without children, react complains
+      wrapper.setProps({ open: false, children: <p /> })
+      spy.should.have.been.called()
     })
   })
 


### PR DESCRIPTION
So onClose and onOpen only ever get called by the internal event handlers managing the portal. That's great unless you want to control the opening and closing of a portal using the open autocontrolled prop. While the opening and closing do work just fine, the onClose and onOpen callbacks don't get called which causes really subtle bugs like the Popup component not rendering in the right place. 

This fixes that by overriding the componentWillReceiveProps and detecting when the open prop changes and firing the appropriate callback. 

Fixes #2381
