### PR TITLE
feat(Progress): Add value option, to just show the value in the bar

### DIFF
--- a/docs/app/Examples/modules/Progress/Content/ProgressExampleProgressValue.js
+++ b/docs/app/Examples/modules/Progress/Content/ProgressExampleProgressValue.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Progress } from 'semantic-ui-react'
+
+const ProgressExampleProgressValue = () => (
+  <Progress progress='value' value={35} />
+)
+
+export default ProgressExampleProgressValue

--- a/docs/app/Examples/modules/Progress/Content/index.js
+++ b/docs/app/Examples/modules/Progress/Content/index.js
@@ -31,6 +31,10 @@ const ProgressContentExamples = () => (
       description='A progress element display progress as a ratio.'
       examplePath='modules/Progress/Content/ProgressExampleProgressRatio'
     />
+    <ComponentExample
+      description='A progress element display progress as a value.'
+      examplePath='modules/Progress/Content/ProgressExampleProgressValue'
+    />
   </ExampleSection>
 )
 

--- a/src/modules/Progress/Progress.d.ts
+++ b/src/modules/Progress/Progress.d.ts
@@ -55,7 +55,7 @@ export interface ProgressProps {
   precision?: number;
 
   /** A progress bar can contain a text value indicating current progress. */
-  progress?: boolean | 'percent' | 'ratio';
+  progress?: boolean | 'percent' | 'ratio' | 'value';
 
   /** A progress bar can vary in size. */
   size?: 'tiny' | 'small' | 'medium' | 'large' | 'big';

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -150,13 +150,13 @@ class Progress extends Component {
     } = this.props
 
     if (!progress && _.isUndefined(precision)) return
-    
+
     let text
-    
-    if(progress === 'value') text = value
-    else if(progress === 'percent') text = `${percent}%`
-    else if(progress === 'ratio') text = `${value}/${total}`
-    
+
+    if (progress === 'value') text = value
+    else if (progress === 'percent') text = `${percent}%`
+    else if (progress === 'ratio') text = `${value}/${total}`
+
     return (
       <div className='progress'>
         { text }

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -151,11 +151,10 @@ class Progress extends Component {
 
     if (!progress && _.isUndefined(precision)) return
 
-    let text
+    let text = `${percent}%`
 
-    if (progress === 'value') text = value
-    else if (progress === 'percent') text = `${percent}%`
-    else if (progress === 'ratio') text = `${value}/${total}`
+    if (progress === 'value') text = `${value}`
+    if (progress === 'ratio') text = `${value}/${total}`
 
     return (
       <div className='progress'>

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -95,7 +95,6 @@ class Progress extends Component {
 
     /** For use with total. Together, these will calculate the percent. Mutually excludes percent. */
     value: customPropTypes.every([
-      customPropTypes.demand(['total']),
       customPropTypes.disallow(['percent']),
       PropTypes.oneOfType([
         PropTypes.number,
@@ -119,10 +118,19 @@ class Progress extends Component {
     if (!_.isUndefined(total) && !_.isUndefined(value)) return (value / total) * 100
   }
 
+  computeValueText = (percent) => {
+    const { progress, total, value } = this.props
+
+    if (progress === 'value') return value
+    if (progress === 'ratio') return `${value}/${total}`
+    return `${percent}%`
+  }
+
   getPercent = () => {
-    const { precision } = this.props
+    const { precision, progress, value } = this.props
     const percent = _.clamp(this.calculatePercent(), 0, 100)
 
+    if (progress === 'value') return value
     if (_.isUndefined(precision)) return percent
     return _.round(percent, precision)
   }
@@ -142,23 +150,12 @@ class Progress extends Component {
   }
 
   renderProgress = (percent) => {
-    const {
-      precision,
-      progress,
-      total,
-      value,
-    } = this.props
+    const { precision, progress } = this.props
 
     if (!progress && _.isUndefined(precision)) return
-
-    let text = `${percent}%`
-
-    if (progress === 'value') text = `${value}`
-    if (progress === 'ratio') text = `${value}/${total}`
-
     return (
       <div className='progress'>
-        { text }
+        {this.computeValueText(percent)}
       </div>
     )
   }

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -74,7 +74,7 @@ class Progress extends Component {
     /** A progress bar can contain a text value indicating current progress. */
     progress: PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.oneOf(['percent', 'ratio']),
+      PropTypes.oneOf(['percent', 'ratio', 'value']),
     ]),
 
     /** A progress bar can vary in size. */
@@ -150,9 +150,16 @@ class Progress extends Component {
     } = this.props
 
     if (!progress && _.isUndefined(precision)) return
+    
+    let text
+    
+    if(progress === 'value') text = value
+    else if(progress === 'percent') text = `${percent}%`
+    else if(progress === 'ratio') text = `${value}/${total}`
+    
     return (
       <div className='progress'>
-        { progress !== 'ratio' ? `${percent}%` : `${value}/${total}` }
+        { text }
       </div>
     )
   }

--- a/test/specs/modules/Progress/Progress-test.js
+++ b/test/specs/modules/Progress/Progress-test.js
@@ -159,6 +159,12 @@ describe('Progress', () => {
         .find('.progress')
         .should.contain.text('50%')
     })
+    it('displays the progress as text when set to "value"', () => {
+      shallow(<Progress progress='value' value={1} total={2} />)
+        .children()
+        .find('.progress')
+        .should.contain.text('1')
+    })
     it('shows the percent complete', () => {
       shallow(<Progress percent={72} progress />)
         .children()


### PR DESCRIPTION
This PR adds ability to pass `value` to `Progress`:

```jsx
  <Progress progress='value' value={35} />
```