### PR TITLE
The text property also takes an element.

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -331,7 +331,10 @@ export default class Dropdown extends Component {
     ]),
 
     /** The text displayed in the dropdown, usually for the active item. */
-    text: PropTypes.string,
+    text: PropTypes.oneOfTypes([
+      PropsTypes.string,
+      PropTypes.element,
+    ]),
 
     /** Custom element to trigger the menu to become visible. Takes place of 'text'. */
     trigger: customPropTypes.every([


### PR DESCRIPTION
The text property should also take an Element as a PropType.
If you want to bold, or change color of your text, you can't do that without using an element.