### PR TITLE
fix(Responsive): use setState() safely

### DIFF
--- a/src/addons/Responsive/Responsive.js
+++ b/src/addons/Responsive/Responsive.js
@@ -66,11 +66,14 @@ export default class Responsive extends Component {
   componentDidMount() {
     const { fireOnMount } = this.props
 
+    this.mounted = true
+
     eventStack.sub('resize', this.handleResize, { target: 'window' })
     if (fireOnMount) this.handleUpdate()
   }
 
   componentWillUnmount() {
+    this.mounted = false
     eventStack.unsub('resize', this.handleResize, { target: 'window' })
   }
 
@@ -92,6 +95,8 @@ export default class Responsive extends Component {
     return _.isNil(minWidth) ? true : width >= minWidth
   }
 
+  setSafeState = (...args) => this.mounted && this.setState(...args)
+
   isVisible = () => this.fitsMinWidth() && this.fitsMaxWidth()
 
   // ----------------------------------------
@@ -109,7 +114,7 @@ export default class Responsive extends Component {
     this.ticking = false
     const width = window.innerWidth
 
-    this.setState({ width })
+    this.setSafeState({ width })
     _.invoke(this.props, 'onUpdate', e, { ...this.props, width })
   }
 


### PR DESCRIPTION
### Problem

`Responsive` uses RAF for event handling and it means that `setState()` will be called after component will be unmounted.

Here is repro on [codesandox](https://codesandbox.io/s/koql1pn5ro), just resize preview area multiple times and you will see:

> Warning: Can only update a mounted or mounting component. This usually means you called setState, replaceState, or forceUpdate on an unmounted component. This is a no-op.
>
> Please check the code for the Responsive component.

### Solution

Use `safeSetState` in same manner as in the `Transition` component.

---

Based on [SO question](https://stackoverflow.com/questions/48093185/semantic-ui-react-responsive-not-working-for-table-cell).