### PR TITLE
feat(Sidebar): closing sidebar on blur

### DIFF
--- a/docs/app/Examples/modules/Sidebar/Overlay/SidebarExampleLeftOverlay.js
+++ b/docs/app/Examples/modules/Sidebar/Overlay/SidebarExampleLeftOverlay.js
@@ -6,13 +6,24 @@ class SidebarLeftOverlay extends Component {
 
   toggleVisibility = () => this.setState({ visible: !this.state.visible })
 
+  handleBlur = () => this.setState({ visible: false })
+
   render() {
     const { visible } = this.state
     return (
       <div>
         <Button onClick={this.toggleVisibility}>Toggle Visibility</Button>
         <Sidebar.Pushable as={Segment}>
-          <Sidebar as={Menu} animation='overlay' width='thin' visible={visible} icon='labeled' vertical inverted>
+          <Sidebar
+            as={Menu}
+            animation='overlay'
+            onSidebarBlur={this.handleBlur}
+            width='thin'
+            visible={visible}
+            icon='labeled'
+            vertical
+            inverted
+          >
             <Menu.Item name='home'>
               <Icon name='home' />
               Home
@@ -26,7 +37,7 @@ class SidebarLeftOverlay extends Component {
               Channels
             </Menu.Item>
           </Sidebar>
-          <Sidebar.Pusher>
+          <Sidebar.Pusher dimmed={visible}>
             <Segment basic>
               <Header as='h3'>Application Content</Header>
               <Image src='/assets/images/wireframe/paragraph.png' />

--- a/src/modules/Sidebar/Sidebar.d.ts
+++ b/src/modules/Sidebar/Sidebar.d.ts
@@ -28,6 +28,9 @@ export interface SidebarProps {
   /** Direction the sidebar should appear on. */
   direction?: 'top' | 'right' | 'bottom' | 'left';
 
+  /** Called when the user clicks away from the sidebar. */
+  onSidebarBlur?: () => void;
+
   /** Controls whether or not the sidebar is visible on the page. */
   visible?: boolean;
 

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -1,11 +1,14 @@
 import cx from 'classnames'
+import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import Ref from '../../addons/Ref'
 import {
   AutoControlledComponent as Component,
   childrenUtils,
   customPropTypes,
+  eventStack,
   getUnhandledProps,
   getElementType,
   META,
@@ -40,6 +43,37 @@ class Sidebar extends Component {
     /** Direction the sidebar should appear on. */
     direction: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
+    /**
+     * Called before a sidebar begins to animate out.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onHide: PropTypes.func,
+
+    /**
+     * Called after a sidebar has finished animating out.
+     *
+     * @param {null}
+     * @param {object} data - All props.
+     */
+    onHidden: PropTypes.func,
+
+    /**
+     * Called when a sidebar has finished animating in.
+     *
+     * @param {null}
+     * @param {object} data - All props.
+     */
+    onShow: PropTypes.func,
+
+    /** Called when a sidebar begins animating in.
+     *
+     * @param {null}
+     * @param {object} data - All props.
+     */
+    onVisible: PropTypes.func,
+
     /** Controls whether or not the sidebar is visible on the page. */
     visible: PropTypes.bool,
 
@@ -63,19 +97,45 @@ class Sidebar extends Component {
   static Pushable = SidebarPushable
   static Pusher = SidebarPusher
 
+  componentDidMount() {
+    if (this.state.visible) eventStack.sub('click', this.handleDocumentClick)
+  }
+
+  componentWillUnmount() {
+    if (this.state.visible) eventStack.unsub('click', this.handleDocumentClick)
+  }
+
+  componentDidUpdate(prevProps, { visible: prev }) {
+    const { visible: next } = this.state
+
+    if (prev === next) return
+
+    this.startAnimating()
+    if (next) eventStack.sub('click', this.handleDocumentClick)
+    if (!next) eventStack.unsub('click', this.handleDocumentClick)
+  }
+
   startAnimating = (duration = 500) => {
-    clearTimeout(this.stopAnimatingTimer)
-
-    this.setState({ animating: true })
-
-    this.stopAnimatingTimer = setTimeout(() => this.setState({ animating: false }), duration)
+    this.setState({ animating: true }, () => {
+      clearTimeout(this.stopAnimatingTimer)
+      this.stopAnimatingTimer = setTimeout(this.handleAnimationEnd, duration)
+    })
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.visible !== this.props.visible) {
-      this.startAnimating()
-    }
+  handleAnimationEnd = () => {
+    this.setState({ animating: false })
+    _.invoke(this.props, this.state.visible ? 'onShow' : 'onHidden', null, this.props)
   }
+
+  handleDocumentClick = (e) => {
+    if (!this.state.visible || this.ref.contains(e.target)) return
+
+    this.trySetState({ visible: false })
+    _.invoke(this.props, 'onChange', e, { ...this.props, visible: false })
+    _.invoke(this.props, 'onHide', e, { ...this.props, visible: false })
+  }
+
+  handleRef = c => (this.ref = c)
 
   render() {
     const {
@@ -104,9 +164,11 @@ class Sidebar extends Component {
     const ElementType = getElementType(Sidebar, this.props)
 
     return (
-      <ElementType {...rest} className={classes}>
-        {childrenUtils.isNil(children) ? content : children}
-      </ElementType>
+      <Ref innerRef={this.handleRef}>
+        <ElementType {...rest} className={classes}>
+          {childrenUtils.isNil(children) ? content : children}
+        </ElementType>
+      </Ref>
     )
   }
 }

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -3,6 +3,7 @@ import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import Ref from '../../addons/Ref'
 import {
   AutoControlledComponent as Component,
   childrenUtils,
@@ -134,9 +135,11 @@ class Sidebar extends Component {
     const ElementType = getElementType(Sidebar, this.props)
 
     return (
-      <ElementType {...rest} className={classes}>
-        {childrenUtils.isNil(children) ? content : children}
-      </ElementType>
+      <Ref innerRef={this.handleRef}>
+        <ElementType {...rest} className={classes}>
+          {childrenUtils.isNil(children) ? content : children}
+        </ElementType>
+      </Ref>
     )
   }
 }

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -3,7 +3,6 @@ import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import Ref from '../../addons/Ref'
 import {
   AutoControlledComponent as Component,
   childrenUtils,
@@ -43,36 +42,8 @@ class Sidebar extends Component {
     /** Direction the sidebar should appear on. */
     direction: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
-    /**
-     * Called before a sidebar begins to animate out.
-     *
-     * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All props.
-     */
-    onHide: PropTypes.func,
-
-    /**
-     * Called after a sidebar has finished animating out.
-     *
-     * @param {null}
-     * @param {object} data - All props.
-     */
-    onHidden: PropTypes.func,
-
-    /**
-     * Called when a sidebar has finished animating in.
-     *
-     * @param {null}
-     * @param {object} data - All props.
-     */
-    onShow: PropTypes.func,
-
-    /** Called when a sidebar begins animating in.
-     *
-     * @param {null}
-     * @param {object} data - All props.
-     */
-    onVisible: PropTypes.func,
+    /** Called when the user clicks away from the sidebar. */
+    onSidebarBlur: PropTypes.func,
 
     /** Controls whether or not the sidebar is visible on the page. */
     visible: PropTypes.bool,
@@ -123,16 +94,15 @@ class Sidebar extends Component {
   }
 
   handleAnimationEnd = () => {
+    if (!this.state.visible) _.invoke(this.props, 'onHidden')
     this.setState({ animating: false })
-    _.invoke(this.props, this.state.visible ? 'onShow' : 'onHidden', null, this.props)
   }
 
   handleDocumentClick = (e) => {
     if (!this.state.visible || this.ref.contains(e.target)) return
 
     this.trySetState({ visible: false })
-    _.invoke(this.props, 'onChange', e, { ...this.props, visible: false })
-    _.invoke(this.props, 'onHide', e, { ...this.props, visible: false })
+    _.invoke(this.props, 'onSidebarBlur')
   }
 
   handleRef = c => (this.ref = c)
@@ -164,11 +134,9 @@ class Sidebar extends Component {
     const ElementType = getElementType(Sidebar, this.props)
 
     return (
-      <Ref innerRef={this.handleRef}>
-        <ElementType {...rest} className={classes}>
-          {childrenUtils.isNil(children) ? content : children}
-        </ElementType>
-      </Ref>
+      <ElementType {...rest} className={classes}>
+        {childrenUtils.isNil(children) ? content : children}
+      </ElementType>
     )
   }
 }

--- a/test/specs/modules/Sidebar/Sidebar-test.js
+++ b/test/specs/modules/Sidebar/Sidebar-test.js
@@ -37,17 +37,11 @@ class TestComponent extends Component {
 }
 
 describe('Sidebar', () => {
-  common.isConformant(Sidebar)
-  common.hasUIClassName(Sidebar)
-  common.rendersChildren(Sidebar)
-
-  common.propKeyOnlyToClassName(Sidebar, 'visible')
-
-  common.propValueOnlyToClassName(Sidebar, 'animation', [
-    'overlay', 'push', 'scale down', 'uncover', 'slide out', 'slide along',
-  ])
-  common.propValueOnlyToClassName(Sidebar, 'direction', ['top', 'right', 'bottom', 'left'])
-  common.propValueOnlyToClassName(Sidebar, 'width', ['very thin', 'thin', 'wide', 'very wide'])
+  it('has ui className', () => {
+    const wrapper = mount(<TestComponent visible />)
+    const SidebarComponent = wrapper.find('Sidebar')
+    common.hasUIClassName(SidebarComponent)
+  })
 
   it('renders a <div /> element', () => {
     shallow(<Sidebar />)

--- a/test/specs/modules/Sidebar/Sidebar-test.js
+++ b/test/specs/modules/Sidebar/Sidebar-test.js
@@ -1,7 +1,38 @@
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
 
 import Sidebar from 'src/modules/Sidebar/Sidebar'
 import * as common from 'test/specs/commonTests'
+
+class TestComponent extends Component {
+  static propTypes = {
+    visible: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    visible: false,
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      visible: props.visible,
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <Sidebar
+          visible={this.state.visible}
+          closable
+        >
+          <div className='inside' />
+        </Sidebar>
+      </div>
+    )
+  }
+}
 
 describe('Sidebar', () => {
   common.isConformant(Sidebar)
@@ -19,5 +50,43 @@ describe('Sidebar', () => {
   it('renders a <div /> element', () => {
     shallow(<Sidebar />)
       .should.have.tagName('div')
+  })
+
+  it('close Sidebar when clicking outside', () => {
+    const wrapper = mount(<TestComponent visible />)
+    const SidebarComponent = wrapper.find('Sidebar')
+    SidebarComponent.should.have.prop('visible', true)
+    document.body.click()
+    SidebarComponent.should.have.prop('visible', false)
+  })
+
+  it('doesn\'t close when clicking on element inside Sidebar', () => {
+    const wrapper = mount(<TestComponent visible />)
+    const SidebarComponent = wrapper.find('Sidebar')
+    SidebarComponent.should.have.prop('visible', true)
+    SidebarComponent.find('.inside').simulate('click')
+    SidebarComponent.should.have.prop('visible', true)
+  })
+
+  it('doesn\'t close when clicking on Sidebar', () => {
+    const wrapper = mount(<TestComponent visible />)
+    const SidebarComponent = wrapper.find('Sidebar')
+
+    SidebarComponent.should.have.prop('visible', true)
+    SidebarComponent.simulate('click')
+    SidebarComponent.should.have.prop('visible', true)
+  })
+
+  it('close Sidebar after opening and then clicking outside', () => {
+    const wrapper = mount(<TestComponent />)
+    const SidebarComponent = wrapper.find('Sidebar')
+
+    SidebarComponent.should.have.prop('visible', false)
+
+    wrapper.setState({ visible: true })
+    SidebarComponent.should.have.prop('visible', true)
+
+    document.body.click()
+    SidebarComponent.should.have.prop('visible', false)
   })
 })

--- a/test/specs/modules/Sidebar/Sidebar-test.js
+++ b/test/specs/modules/Sidebar/Sidebar-test.js
@@ -20,16 +20,18 @@ class TestComponent extends Component {
     }
   }
 
+  handleBlur = () => {
+    this.setState({ visible: false })
+  }
+
   render() {
     return (
-      <div>
-        <Sidebar
-          visible={this.state.visible}
-          closable
-        >
-          <div className='inside' />
-        </Sidebar>
-      </div>
+      <Sidebar
+        visible={this.state.visible}
+        onSidebarBlur={this.handleBlur}
+      >
+        <div className='inside' />
+      </Sidebar>
     )
   }
 }
@@ -55,38 +57,38 @@ describe('Sidebar', () => {
   it('close Sidebar when clicking outside', () => {
     const wrapper = mount(<TestComponent visible />)
     const SidebarComponent = wrapper.find('Sidebar')
-    SidebarComponent.should.have.prop('visible', true)
+    SidebarComponent.should.have.className('visible')
     document.body.click()
-    SidebarComponent.should.have.prop('visible', false)
+    SidebarComponent.should.not.have.className('visible')
   })
 
   it('doesn\'t close when clicking on element inside Sidebar', () => {
     const wrapper = mount(<TestComponent visible />)
     const SidebarComponent = wrapper.find('Sidebar')
-    SidebarComponent.should.have.prop('visible', true)
+    SidebarComponent.should.have.className('visible')
     SidebarComponent.find('.inside').simulate('click')
-    SidebarComponent.should.have.prop('visible', true)
+    SidebarComponent.should.have.className('visible')
   })
 
   it('doesn\'t close when clicking on Sidebar', () => {
     const wrapper = mount(<TestComponent visible />)
     const SidebarComponent = wrapper.find('Sidebar')
 
-    SidebarComponent.should.have.prop('visible', true)
+    SidebarComponent.should.have.className('visible')
     SidebarComponent.simulate('click')
-    SidebarComponent.should.have.prop('visible', true)
+    SidebarComponent.should.have.className('visible')
   })
 
   it('close Sidebar after opening and then clicking outside', () => {
     const wrapper = mount(<TestComponent />)
     const SidebarComponent = wrapper.find('Sidebar')
 
-    SidebarComponent.should.have.prop('visible', false)
+    SidebarComponent.should.not.have.className('visible')
 
     wrapper.setState({ visible: true })
-    SidebarComponent.should.have.prop('visible', true)
+    SidebarComponent.should.have.className('visible')
 
     document.body.click()
-    SidebarComponent.should.have.prop('visible', false)
+    SidebarComponent.should.not.have.className('visible')
   })
 })


### PR DESCRIPTION
This is a follow up to the abandoned [#1473](https://github.com/Semantic-Org/Semantic-UI-React/pull/1473/files). This implementation is very similar to the original PR.

The biggest remaining gap is in testing. The use of `<Ref>` breaks the standard test methods like `isConformant` as well as tests that presume to affect the root node.

I'm interested in suggestions regarding a path forward. Should standard methods be updated to support `<Ref>` or should Sidebar have its own, more specific series of tests.