### PR TITLE
breaking(popup): verticalOffset

### DIFF
--- a/docs/app/Examples/modules/Popup/Variations/PopupExampleOffset.js
+++ b/docs/app/Examples/modules/Popup/Variations/PopupExampleOffset.js
@@ -6,14 +6,26 @@ const PopupExampleOffset = () => (
     <Popup
       trigger={<Icon size='large' name='heart' circular />}
       content='Way off to the left'
-      offset={50}
+      horizontalOffset={50}
       position='left center'
     />
     <Popup
       trigger={<Icon size='large' name='heart' circular />}
       content='As expected this popup is way off to the right'
-      offset={50}
+      horizontalOffset={50}
       position='right center'
+    />
+    <Popup
+      trigger={<Icon size='large' name='heart' circular />}
+      content='Way off to the top'
+      verticalOffset={50}
+      position='top center'
+    />
+    <Popup
+      trigger={<Icon size='large' name='heart' circular />}
+      content='As expected this popup is way off to the bottom'
+      verticalOffset={50}
+      position='bottom center'
     />
   </div>
 )

--- a/docs/app/Examples/modules/Popup/Variations/index.js
+++ b/docs/app/Examples/modules/Popup/Variations/index.js
@@ -36,7 +36,7 @@ const PopupVariationsExamples = () => (
     />
     <ComponentExample
       title='Offset'
-      description='A popup position can be adjusted manually by specifying an offset property.'
+      description='A popup position can be offset from its position.'
       examplePath='modules/Popup/Variations/PopupExampleOffset'
     />
     <ComponentExample

--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -41,6 +41,9 @@ export interface PopupProps extends PortalProps {
   /** Horizontal offset in pixels to be applied to the popup. */
   offset?: number;
 
+  /** Vertical offset in pixels to be applied to the popup. */
+  verticalOffset?: number;
+
   /** Events triggering the popup. */
   on?: 'hover' | 'click' | 'focus' | Array<'hover' | 'click' | 'focus'>;
 

--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -39,7 +39,7 @@ export interface PopupProps extends PortalProps {
   inverted?: boolean;
 
   /** Horizontal offset in pixels to be applied to the popup. */
-  offset?: number;
+  horizontalOffset?: number;
 
   /** Vertical offset in pixels to be applied to the popup. */
   verticalOffset?: number;

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -201,7 +201,7 @@ export default class Popup extends Component {
 
     if (verticalOffset) {
       if (_.isNumber(style.top)) {
-        style.top -= verticalOffset
+        style.top += verticalOffset
       } else {
         style.bottom += verticalOffset
       }

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -75,6 +75,9 @@ export default class Popup extends Component {
     /** Horizontal offset in pixels to be applied to the Popup. */
     offset: PropTypes.number,
 
+    /** Vertical offset in pixels to be applied to the Popup. */
+    verticalOffset: PropTypes.number,
+
     /** Events triggering the popup. */
     on: PropTypes.oneOfType([
       PropTypes.oneOf(['hover', 'click', 'focus']),
@@ -153,7 +156,7 @@ export default class Popup extends Component {
     // Do not access window/document when server side rendering
     if (!isBrowser()) return style
 
-    const { offset } = this.props
+    const { offset, verticalOffset } = this.props
     const { pageYOffset, pageXOffset } = window
     const { clientWidth, clientHeight } = document.documentElement
 
@@ -193,6 +196,14 @@ export default class Popup extends Component {
         style.right -= offset
       } else {
         style.left -= offset
+      }
+    }
+
+    if (verticalOffset) {
+      if (_.isNumber(style.top)) {
+        style.top -= verticalOffset
+      } else {
+        style.bottom += verticalOffset
       }
     }
 

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -73,7 +73,7 @@ export default class Popup extends Component {
     inverted: PropTypes.bool,
 
     /** Horizontal offset in pixels to be applied to the Popup. */
-    offset: PropTypes.number,
+    horizontalOffset: PropTypes.number,
 
     /** Vertical offset in pixels to be applied to the Popup. */
     verticalOffset: PropTypes.number,
@@ -156,7 +156,7 @@ export default class Popup extends Component {
     // Do not access window/document when server side rendering
     if (!isBrowser()) return style
 
-    const { offset, verticalOffset } = this.props
+    const { horizontalOffset, verticalOffset } = this.props
     const { pageYOffset, pageXOffset } = window
     const { clientWidth, clientHeight } = document.documentElement
 
@@ -191,11 +191,11 @@ export default class Popup extends Component {
       }
     }
 
-    if (offset) {
+    if (horizontalOffset) {
       if (_.isNumber(style.right)) {
-        style.right -= offset
+        style.right -= horizontalOffset
       } else {
-        style.left -= offset
+        style.left -= horizontalOffset
       }
     }
 

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -108,6 +108,35 @@ describe('Popup', () => {
     })
   })
 
+  describe('verticalOffest', () => {
+    it('accepts a vertical offest to the top', () => {
+      wrapperMount(
+        <Popup
+          verticalOffset={50}
+          position='bottom right'
+          content='foo'
+          trigger={<button>foo</button>}
+        />,
+      )
+
+      wrapper.find('button').simulate('click')
+      assertInBody('.ui.popup.visible')
+    })
+    it('accepts a vertical offest to the bottom', () => {
+      wrapperMount(
+        <Popup
+          verticalOffset={50}
+          position='top left'
+          content='foo'
+          trigger={<button>foo</button>}
+        />,
+      )
+
+      wrapper.find('button').simulate('click')
+      assertInBody('.ui.popup.visible')
+    })
+  })
+
   describe('position', () => {
     POSITIONS.forEach((position) => {
       it('is always within the viewport', () => {
@@ -129,7 +158,7 @@ describe('Popup', () => {
         expect(bottom).to.be.at.most(document.documentElement.clientHeight)
         expect(right).to.be.at.most(document.documentElement.clientWidth)
       })
-      it('is the original if no position fits within the viewport', () => {
+      it('is the original if no horizontal position fits within the viewport', () => {
         wrapperMount(
           <Popup
             content='_'
@@ -137,6 +166,22 @@ describe('Popup', () => {
             trigger={<button>foo</button>}
             on='click'
             offset={999}
+          />,
+        )
+        wrapper.find('button').simulate('click')
+        const selectedPosition = wrapper.state('position')
+
+        expect(selectedPosition).to.equal(position)
+      })
+
+      it('is the original if no vertical position fits within the viewport', () => {
+        wrapperMount(
+          <Popup
+            content='_'
+            position={position}
+            trigger={<button>foo</button>}
+            on='click'
+            verticalOffset={3000}
           />,
         )
         wrapper.find('button').simulate('click')

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -83,7 +83,7 @@ describe('Popup', () => {
     it('accepts an offest to the left', () => {
       wrapperMount(
         <Popup
-          offset={50}
+          horizontalOffset={50}
           position='bottom right'
           content='foo'
           trigger={<button>foo</button>}
@@ -96,7 +96,7 @@ describe('Popup', () => {
     it('accepts an offest to the right', () => {
       wrapperMount(
         <Popup
-          offset={50}
+          horizontalOffset={50}
           position='bottom left'
           content='foo'
           trigger={<button>foo</button>}
@@ -165,7 +165,7 @@ describe('Popup', () => {
             position={position}
             trigger={<button>foo</button>}
             on='click'
-            offset={999}
+            horizontalOffset={999}
           />,
         )
         wrapper.find('button').simulate('click')


### PR DESCRIPTION
## Breaking Change
Popup must rename the `offset` property to `horizontalOffset`

### Before
```js
<Popup offset={10} />
```

### After
```js
<Popup horizontalOffset={10} />
```

***

Add a `verticalOffset` prop to the popup component.

Fixes #2449. 