### PR TITLE
Fix(Portal) check for rootNode rendering to prevent race condition 

### DIFF
--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -359,6 +359,10 @@ class Portal extends Component {
       eventStack.unsub('mouseenter', this.handlePortalMouseEnter, { pool: eventPool, target: this.portalNode })
     }
 
+    // Prevent race condition bug
+    // https://github.com/Semantic-Org/Semantic-UI-React/issues/2401
+    if (!this.rootNode) return null
+
     ReactDOM.unstable_renderSubtreeIntoContainer(
       this,
       Children.only(children),

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -359,21 +359,23 @@ class Portal extends Component {
       eventStack.unsub('mouseenter', this.handlePortalMouseEnter, { pool: eventPool, target: this.portalNode })
     }
 
-    // Prevent race condition bug
-    // https://github.com/Semantic-Org/Semantic-UI-React/issues/2401
-    if (!this.rootNode) return null
-
     ReactDOM.unstable_renderSubtreeIntoContainer(
       this,
       Children.only(children),
       this.rootNode,
-      () => {
-        this.portalNode = this.rootNode.firstElementChild
-
-        eventStack.sub('mouseleave', this.handlePortalMouseLeave, { pool: eventPool, target: this.portalNode })
-        eventStack.sub('mouseenter', this.handlePortalMouseEnter, { pool: eventPool, target: this.portalNode })
-      },
+      () => this.attachRenderSubTreeSubscribers(eventPool),
     )
+  }
+
+  attachRenderSubTreeSubscribers = (eventPool) => {
+    // Prevent race condition bug
+    // https://github.com/Semantic-Org/Semantic-UI-React/issues/2401
+    if (!this.rootNode) return null
+
+    this.portalNode = this.rootNode.firstElementChild
+
+    eventStack.sub('mouseleave', this.handlePortalMouseLeave, { pool: eventPool, target: this.portalNode })
+    eventStack.sub('mouseenter', this.handlePortalMouseEnter, { pool: eventPool, target: this.portalNode })
   }
 
   mountPortal = () => {

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -54,6 +54,14 @@ describe('Portal', () => {
     expect(instance.rootNode).to.equal(undefined)
   })
 
+  it('attachRenderSubTreeSubscribers returns null if rootNode is lost', () => {
+    wrapperMount(<Portal open><p /></Portal>)
+    const instance = wrapper.instance()
+    instance.rootNode = null
+    expect(() => instance.attachRenderSubTreeSubscribers()).to.not.throw()
+    expect(instance.attachRenderSubTreeSubscribers()).to.equal(null)
+  })
+
   it('appends portal with children to the document.body', () => {
     wrapperMount(<Portal open><p /></Portal>)
     const instance = wrapper.instance()


### PR DESCRIPTION
We rely heavily on Semantic-UI-React and have had our monitoring reporting the following issue
```
TypeError: Cannot read property 'firstElementChild' of null
```

We've investigated it a few times but recently stumbled upon this issue https://github.com/Semantic-Org/Semantic-UI-React/issues/2401

This commit has been able to successfully prevent this issue without introducing any new issues.