### PR TITLE
fix(Visibility): context changes cause memory leak and incorrect scroll events

### DIFF
--- a/src/behaviors/Visibility/Visibility.js
+++ b/src/behaviors/Visibility/Visibility.js
@@ -188,11 +188,16 @@ export default class Visibility extends Component {
   // Lifecycle
   // ----------------------------------------
 
-  componentWillReceiveProps({ continuous, once }) {
+  componentWillReceiveProps({ continuous, once, context }) {
     const cleanHappened = continuous !== this.props.continuous || once !== this.props.once
 
     // Heads up! We should clean up array of happened callbacks, if values of these props are changed
     if (cleanHappened) this.firedCallbacks = []
+
+    if (this.props.context !== context) {
+      this.unattachHandlers(this.props.context)
+      this.attachHandlers(context)
+    }
   }
 
   componentDidMount() {
@@ -200,8 +205,7 @@ export default class Visibility extends Component {
     const { context, fireOnMount } = this.props
 
     this.pageYOffset = window.pageYOffset
-    eventStack.sub('resize', this.handleUpdate, { target: context })
-    eventStack.sub('scroll', this.handleUpdate, { target: context })
+    this.attachHandlers(context)
 
     if (fireOnMount) this.update()
   }
@@ -209,8 +213,21 @@ export default class Visibility extends Component {
   componentWillUnmount() {
     const { context } = this.props
 
-    eventStack.unsub('resize', this.handleUpdate, { target: context })
-    eventStack.unsub('scroll', this.handleUpdate, { target: context })
+    this.unattachHandlers(context)
+  }
+
+  attachHandlers(context) {
+    if (context) {
+      eventStack.sub('resize', this.handleUpdate, { target: context })
+      eventStack.sub('scroll', this.handleUpdate, { target: context })
+    }
+  }
+
+  unattachHandlers(context) {
+    if (context) {
+      eventStack.unsub('resize', this.handleUpdate, { target: context })
+      eventStack.unsub('scroll', this.handleUpdate, { target: context })
+    }
   }
 
   // ----------------------------------------

--- a/test/specs/behaviors/Visibility/Visibility-test.js
+++ b/test/specs/behaviors/Visibility/Visibility-test.js
@@ -300,6 +300,38 @@ describe('Visibility', () => {
       domEvent.scroll(div)
       onUpdate.should.have.been.called()
     })
+
+    it('should not call onUpdate when context is null', () => {
+      const onUpdate = sandbox.spy()
+      mount(<Visibility context={null} onUpdate={onUpdate} />)
+
+      domEvent.scroll(document)
+      onUpdate.should.not.have.been.called()
+    })
+
+    it('should call onUpdate when context changes', () => {
+      const div = document.createElement('div')
+      const onUpdate = sandbox.spy()
+      const renderedComponent = mount(<Visibility context={null} onUpdate={onUpdate} />)
+      renderedComponent.setProps({ context: div })
+
+      domEvent.scroll(div)
+      onUpdate.should.have.been.called()
+    })
+
+    it('should not call onUpdate when context changes and component is unmounted', () => {
+      const div = document.createElement('div')
+      const onUpdate = sandbox.spy()
+      const renderedComponent = mount(<Visibility context={null} onUpdate={onUpdate} />)
+      renderedComponent.setProps({ context: div })
+      renderedComponent.unmount()
+
+      domEvent.scroll(div)
+      onUpdate.should.not.have.been.called()
+
+      domEvent.scroll(document)
+      onUpdate.should.not.have.been.called()
+    })
   })
 
   describe('fireOnMount', () => {


### PR DESCRIPTION
There's a couple of bugs in visibility regarding custom contexts. 
* If the context changes through a prop update, we leak the original scroll and resize handlers because on unmount, we look at the current context prop and unsub that, instead of what was originally sub'd
* If we provide a null context (like if the ref={} call is delayed), we listen to document scroll events and never listen to the scroll events of the context. Along those lines, I'm assuming sending the document scroll events are incorrect and shouldn't be sent to the onUpdate handler, but I'm open to arguments otherwise