### PR TITLE
fix(Sticky): scrollContext changes cause memory leak and incorrect scroll events

### DIFF
--- a/src/modules/Sticky/Sticky.js
+++ b/src/modules/Sticky/Sticky.js
@@ -106,7 +106,6 @@ export default class Sticky extends Component {
     const { active: current, scrollContext: currentScrollContext } = this.props
     const { active: next, scrollContext: nextScrollContext } = nextProps
 
-
     if (current === next) {
       if (currentScrollContext !== nextScrollContext) {
         this.removeListeners()
@@ -114,11 +113,13 @@ export default class Sticky extends Component {
       }
       return
     }
+
     if (next) {
       this.handleUpdate()
       this.addListeners(nextProps)
       return
     }
+
     this.removeListeners()
     this.setState({ sticky: false })
   }

--- a/src/modules/Sticky/Sticky.js
+++ b/src/modules/Sticky/Sticky.js
@@ -103,10 +103,17 @@ export default class Sticky extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { active: current } = this.props
-    const { active: next } = nextProps
+    const { active: current, scrollContext: currentScrollContext } = this.props
+    const { active: next, scrollContext: nextScrollContext } = nextProps
 
-    if (current === next) return
+
+    if (current === next) {
+      if (currentScrollContext !== nextScrollContext) {
+        this.removeListeners()
+        this.addListeners(nextProps)
+      }
+      return
+    }
     if (next) {
       this.handleUpdate()
       this.addListeners(nextProps)
@@ -130,15 +137,19 @@ export default class Sticky extends Component {
   addListeners = (props) => {
     const { scrollContext } = props
 
-    eventStack.sub('resize', this.handleUpdate, { target: scrollContext })
-    eventStack.sub('scroll', this.handleUpdate, { target: scrollContext })
+    if (scrollContext) {
+      eventStack.sub('resize', this.handleUpdate, { target: scrollContext })
+      eventStack.sub('scroll', this.handleUpdate, { target: scrollContext })
+    }
   }
 
   removeListeners = () => {
     const { scrollContext } = this.props
 
-    eventStack.unsub('resize', this.handleUpdate, { target: scrollContext })
-    eventStack.unsub('scroll', this.handleUpdate, { target: scrollContext })
+    if (scrollContext) {
+      eventStack.unsub('resize', this.handleUpdate, { target: scrollContext })
+      eventStack.unsub('scroll', this.handleUpdate, { target: scrollContext })
+    }
   }
 
   // ----------------------------------------

--- a/test/specs/modules/Sticky/Sticky-test.js
+++ b/test/specs/modules/Sticky/Sticky-test.js
@@ -305,6 +305,46 @@ describe('Sticky', () => {
       domEvent.scroll(div)
       onStick.should.have.been.called()
     })
+
+    it('should not call onStick when context is null', () => {
+      const onStick = sandbox.spy()
+      const instance = mount(<Sticky scrollContext={null} onStick={onStick} />).instance()
+
+      instance.triggerRef = mockRect({ top: -1 })
+
+      domEvent.scroll(document)
+      onStick.should.not.have.been.called()
+    })
+
+    it('should call onStick when scrollContext changes', () => {
+      const div = document.createElement('div')
+      const onStick = sandbox.spy()
+      const renderedComponent = mount(<Sticky scrollContext={null} onStick={onStick} />)
+      const instance = renderedComponent.instance()
+
+      instance.triggerRef = mockRect({ top: -1 })
+      renderedComponent.setProps({ scrollContext: div })
+
+      domEvent.scroll(div)
+      onStick.should.have.been.called()
+    })
+
+    it('should not call onStick when scrollContext changes and component is unmounted', () => {
+      const div = document.createElement('div')
+      const onStick = sandbox.spy()
+      const renderedComponent = mount(<Sticky scrollContext={null} onStick={onStick} />)
+      const instance = renderedComponent.instance()
+
+      instance.triggerRef = mockRect({ top: -1 })
+      renderedComponent.setProps({ scrollContext: div })
+      renderedComponent.unmount()
+
+      domEvent.scroll(div)
+      onStick.should.not.have.been.called()
+
+      domEvent.scroll(document)
+      onStick.should.not.have.been.called()
+    })
   })
 
   describe('update', () => {


### PR DESCRIPTION
This PR is similar to #2458. 

When the scrollContext prop changes, we don't change the event listeners so we don't fire scroll events on the new scrollContext, and continue to fire scroll events on the old listener. We also have a memory leak when the scrollContext changes and the component unmounts because it will remove the listener on the wrong scrollContext

I also added an if statement where if the scrollContext is null, it doesn't listen for scroll events similar to the change I made in #2458 so they now behave the same.