### PR TITLE
fix(AccordionTitle): allow strings in index PropType

### DIFF
--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -34,7 +34,10 @@ export default class AccordionTitle extends Component {
     content: customPropTypes.contentShorthand,
 
     /** AccordionTitle index inside Accordion. */
-    index: PropTypes.number,
+    index: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
 
     /**
      * Called on click.


### PR DESCRIPTION
Earlier AccordionTitle's prop index used to type check only for number,
now it also supports a string.

Fixes: https://github.com/Semantic-Org/Semantic-UI-React/issues/2478
Signed-off-by: bp <bharatzvm@github.com>