### PR TITLE
[WIP] Animated Accordion API

### DIFF
--- a/docs/app/Examples/addons/Pagination/Usage/PaginationExampleOptions.js
+++ b/docs/app/Examples/addons/Pagination/Usage/PaginationExampleOptions.js
@@ -37,6 +37,7 @@ export default class PaginationExampleCustomization extends Component {
             boundaryRange={boundaryRange}
             onPageChange={this.handlePaginationChange}
             size='mini'
+            siblingRange={siblingRange}
             totalPages={totalPages}
             // Heads up! All items are powered by shorthands, if you want to hide one of them, just pass `null` as value
             ellipsisItem={showEllipsis ? undefined : null}

--- a/docs/app/Examples/modules/Accordion/Advanced/AccordionExampleAnimated.js
+++ b/docs/app/Examples/modules/Accordion/Advanced/AccordionExampleAnimated.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Accordion } from 'semantic-ui-react'
+
+const ShortContent = (
+  <div>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut varius,
+    nulla quis ornare suscipit, lacus diam lacinia tellus, quis pharetra
+    odio nulla nec erat. Nulla odio tortor, convallis vitae purus a,
+  </div>
+)
+
+const LongContent = (
+  <div>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut varius,
+    nulla quis ornare suscipit, lacus diam lacinia tellus, quis pharetra
+    odio nulla nec erat. Nulla odio tortor, convallis vitae purus a,
+    finibus commodo mauris. Proin in tristique ipsum, sit amet suscipit
+    nulla. Nullam sed felis nec sem pharetra venenatis. Sed porta nunc vitae
+    ipsum feugiat, quis faucibus velit iaculis. Nam vel lacus feugiat, gravida
+    sapien quis, cursus nisl. Etiam mattis semper justo tincidunt fringilla.
+    Mauris sodales,
+  </div>
+)
+
+const rootPanels = [
+  {
+    title: 'Short Content',
+    content: {
+      content: ShortContent,
+      key: 'content-1',
+    },
+  },
+  {
+    title: 'Long Content',
+    content: {
+      content: LongContent,
+      key: 'content-2',
+    },
+  },
+]
+
+const AccordionExampleTransition = () => (
+  <Accordion.Animated
+    animated
+    defaultActiveIndex={0}
+    panels={rootPanels}
+    styled
+  />
+)
+
+export default AccordionExampleTransition

--- a/docs/app/Examples/modules/Accordion/Advanced/AccordionExampleAnimatedContent.js
+++ b/docs/app/Examples/modules/Accordion/Advanced/AccordionExampleAnimatedContent.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Accordion } from 'semantic-ui-react'
+
+const ShortContent = (
+  <div>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut varius,
+    nulla quis ornare suscipit, lacus diam lacinia tellus, quis pharetra
+    odio nulla nec erat. Nulla odio tortor, convallis vitae purus a,
+  </div>
+)
+
+const LongContent = (
+  <div>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut varius,
+    nulla quis ornare suscipit, lacus diam lacinia tellus, quis pharetra
+    odio nulla nec erat. Nulla odio tortor, convallis vitae purus a,
+    finibus commodo mauris. Proin in tristique ipsum, sit amet suscipit
+    nulla. Nullam sed felis nec sem pharetra venenatis. Sed porta nunc vitae
+    ipsum feugiat, quis faucibus velit iaculis. Nam vel lacus feugiat, gravida
+    sapien quis, cursus nisl. Etiam mattis semper justo tincidunt fringilla.
+    Mauris sodales,
+  </div>
+)
+
+const rootPanels = [
+  {
+    title: 'Short Content',
+    content: {
+      animation: 'slide down',
+      content: ShortContent,
+      key: 'content-1',
+      transitionDuration: 300,
+    },
+  },
+  {
+    title: 'Long Content',
+    content: {
+      animation: 'fade down',
+      content: LongContent,
+      key: 'content-2',
+      transitionDuration: 300,
+    },
+  },
+]
+
+const AccordionExampleTransition = () => (
+  <Accordion defaultActiveIndex={0} panels={rootPanels} styled />
+)
+
+export default AccordionExampleTransition

--- a/docs/app/Examples/modules/Accordion/Advanced/index.js
+++ b/docs/app/Examples/modules/Accordion/Advanced/index.js
@@ -28,6 +28,16 @@ const AccordionAdvancedExamples = () => (
       description='Panels of Accordion can be rendered via shorthand prop.'
       examplePath='modules/Accordion/Advanced/AccordionExampleShorthand'
     />
+    <ComponentExample
+      title='Animated Accordion'
+      description='The accordion content will render with an animation.'
+      examplePath='modules/Accordion/Advanced/AccordionExampleAnimated'
+    />
+    <ComponentExample
+      title='Animated Accordion Content'
+      description='The accordion content will render with an animation.'
+      examplePath='modules/Accordion/Advanced/AccordionExampleAnimatedContent'
+    />
   </ExampleSection>
 )
 

--- a/src/modules/Accordion/AccordionAnimated.d.ts
+++ b/src/modules/Accordion/AccordionAnimated.d.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { default as AccordionAccordion, AccordionAccordionProps } from './AccordionAccordion';
-import { default as AccordionAnimated } from './AccordionAnimated';
 import { default as AccordionContent } from './AccordionContent';
 import { default as AccordionTitle } from './AccordionTitle';
 
@@ -23,7 +22,6 @@ export interface AccordionProps extends AccordionAccordionProps {
 
 interface AccordionComponent extends React.ComponentClass<AccordionProps> {
   Accordion: typeof AccordionAccordion;
-  Animated: typeof AccordionAnimated;
   Content: typeof AccordionContent;
   Title: typeof AccordionTitle;
 }

--- a/src/modules/Accordion/AccordionAnimated.js
+++ b/src/modules/Accordion/AccordionAnimated.js
@@ -3,24 +3,23 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import {
+  customPropTypes,
+  useKeyOnly,
   getUnhandledProps,
   META,
-  useKeyOnly,
 } from '../../lib'
 import AccordionAccordion from './AccordionAccordion'
-import AccordionAnimated from './AccordionAnimated'
-import AccordionContent from './AccordionContent'
-import AccordionTitle from './AccordionTitle'
 
 /**
  * An accordion allows users to toggle the display of sections of content.
  */
-function Accordion(props) {
+function AccordionAnimated(props) {
   const {
     className,
     fluid,
     inverted,
     styled,
+    panels,
   } = props
 
   const classes = cx(
@@ -30,17 +29,24 @@ function Accordion(props) {
     useKeyOnly(styled, 'styled'),
     className,
   )
-  const rest = getUnhandledProps(Accordion, props)
-
-  return <AccordionAccordion {...rest} className={classes} />
+  const rest = getUnhandledProps(AccordionAnimated, props)
+  const animatedPanels = panels.map(panel => ({
+    content: {
+      ...panel.content,
+      animation: 'fade down',
+      transitionDuration: 300,
+    },
+    title: panel.title,
+  }))
+  return <AccordionAccordion {...rest} panels={animatedPanels} className={classes} />
 }
 
-Accordion._meta = {
-  name: 'Accordion',
+AccordionAnimated._meta = {
+  name: 'AccordionAnimated',
   type: META.TYPES.MODULE,
 }
 
-Accordion.propTypes = {
+AccordionAnimated.propTypes = {
   /** Additional classes. */
   className: PropTypes.string,
 
@@ -52,11 +58,17 @@ Accordion.propTypes = {
 
   /** Adds some basic styling to accordion panels. */
   styled: PropTypes.bool,
+
+  /** Shorthand array of props for Accordion. */
+  panels: customPropTypes.every([
+    customPropTypes.disallow(['children']),
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        content: customPropTypes.itemShorthand,
+        title: customPropTypes.itemShorthand,
+      }),
+    ),
+  ]),
 }
 
-Accordion.Accordion = AccordionAccordion
-Accordion.Animated = AccordionAnimated
-Accordion.Content = AccordionContent
-Accordion.Title = AccordionTitle
-
-export default Accordion
+export default AccordionAnimated

--- a/src/modules/Accordion/AccordionContent.js
+++ b/src/modules/Accordion/AccordionContent.js
@@ -11,20 +11,43 @@ import {
   META,
   useKeyOnly,
 } from '../../lib'
+import Transition from '../Transition'
 
 /**
  * A content sub-component for Accordion component.
  */
 function AccordionContent(props) {
-  const { active, children, className, content } = props
+  const {
+    active,
+    animation,
+    children,
+    className,
+    content,
+    transitionDuration,
+  } = props
+  const rest = getUnhandledProps(AccordionContent, props)
+  const ElementType = getElementType(AccordionContent, props)
+
+  if (transitionDuration) {
+    const classes = cx(
+      'content',
+      className,
+    )
+    return (
+      <Transition.Group animation={animation} duration={transitionDuration}>
+        {active && (
+          <ElementType {...rest} className={classes}>
+            {childrenUtils.isNil(children) ? content : children}
+          </ElementType>
+        )}
+      </Transition.Group>
+    )
+  }
   const classes = cx(
     'content',
     useKeyOnly(active, 'active'),
     className,
   )
-  const rest = getUnhandledProps(AccordionContent, props)
-  const ElementType = getElementType(AccordionContent, props)
-
   return (
     <ElementType {...rest} className={classes}>
       {childrenUtils.isNil(children) ? content : children}
@@ -47,6 +70,17 @@ AccordionContent.propTypes = {
 
   /** Shorthand for primary content. */
   content: customPropTypes.contentShorthand,
+
+  /** Animation type */
+  animation: PropTypes.string,
+
+  /** Animation type */
+  transitionDuration: PropTypes.number,
+}
+
+AccordionContent.defaultProps = {
+  animation: 'slide down',
+  transitionDuration: 0,
 }
 
 AccordionContent._meta = {


### PR DESCRIPTION
Hey guys, 

I've made this in response to issue: https://github.com/Semantic-Org/Semantic-UI-React/issues/2114

Disclaimer: This isn't completed I want to talk to the maintainers on API design. I haven't included test coverage but I will when the API design is solidified.  

I am opening up this PR to promote a conversation on how to expose decorated animated interfaces. I was looking for examples of modules being decorated by Transitions and couldn't find a convention. 

I've included with this PR two ways of accomplishing the behavior one from a new top layer decorator of the Accordion -> AccordionAnimated. Secondly, I've also included a more intrusive example where I define the animation props against the AccordionContent. I don't expose the full transition API in the current implementation and would like to discuss a strategy on doing that gracefully. 

Looking forward to some feedback when you guys get the chance!

Also kudos on the codebase this being my first exposure it was extremely easy to bootstrap and contribute. 