### PR TITLE
Fix Dropdown componentWillReceiveProps to handle setting of state correctly

### DIFF
--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -152,8 +152,9 @@ export default class AutoControlledComponent extends Component {
     this.state = { ...state, ...initialAutoControlledState }
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps, callback) {
     const { autoControlledProps } = this.constructor
+    const afterStateCallback = typeof callback === 'function' ? callback : undefined
 
     // Solve the next state for autoControlledProps
     const newState = autoControlledProps.reduce((acc, prop) => {
@@ -169,7 +170,9 @@ export default class AutoControlledComponent extends Component {
       return acc
     }, {})
 
-    if (Object.keys(newState).length > 0) this.setState(newState)
+    if (Object.keys(newState).length > 0) {
+      this.setState(newState, afterStateCallback)
+    } else if (afterStateCallback) afterStateCallback()
   }
 
   /**

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -405,7 +405,6 @@ export default class Dropdown extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    super.componentWillReceiveProps(nextProps)
     debug('componentWillReceiveProps()')
     debug('to props:', objectDiff(this.props, nextProps))
 
@@ -429,15 +428,17 @@ export default class Dropdown extends Component {
     }
     /* eslint-enable no-console */
 
-    if (!shallowEqual(nextProps.value, this.props.value)) {
-      debug('value changed, setting', nextProps.value)
-      this.setValue(nextProps.value)
-      this.setSelectedIndex(nextProps.value)
-    }
-
-    if (!_.isEqual(nextProps.options, this.props.options)) {
-      this.setSelectedIndex(undefined, nextProps.options)
-    }
+    super.componentWillReceiveProps(nextProps, () => {
+      if (!shallowEqual(nextProps.value, this.props.value)) {
+        debug('value changed, setting', nextProps.value)
+        this.setValue(nextProps.value)
+        this.setSelectedIndex(nextProps.value)
+      }
+  
+      if (!_.isEqual(nextProps.options, this.props.options)) {
+        this.setSelectedIndex(undefined, nextProps.options)
+      }
+    })
   }
 
   shouldComponentUpdate(nextProps, nextState) {


### PR DESCRIPTION
I noted when reviewing issue #2375 that the Dropdown was incorrectly calling setState() multiple times in the componentWillReceiveProps.  The main issue is that the functions setValue() and setSelectedIndex() both operate on this.state, even though this.state was not updated correctly by the AutoControlledComponent prior to calling them.  This fix addresses this by allowing a callback to be invoked to set further state after the AutoControlledComponent has called setState.

yarn test was run with full tests passing. 
