### PR TITLE
Fixed Dropdown setSelectedIndex and getMenuOptions

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -726,8 +726,8 @@ export default class Dropdown extends Component {
     this.setValue(newValue)
     this.setSelectedIndex(value)
 
-    const optionSize = _.size(this.getMenuOptions())
-    if (!multiple || isAdditionItem || optionSize === 1) this.clearSearchQuery()
+    const optionSize = _.size(this.getMenuOptions(value))
+    if (!multiple || isAdditionItem || optionSize === 1) this.clearSearchQuery(value)
 
     this.handleChange(e, newValue)
     this.closeOnChange(e)
@@ -906,10 +906,10 @@ export default class Dropdown extends Component {
   // Setters
   // ----------------------------------------
 
-  clearSearchQuery = () => {
+  clearSearchQuery = (value = this.state.value) => {
     debug('clearSearchQuery()')
     this.trySetState({ searchQuery: '' })
-    this.setSelectedIndex(undefined, undefined, '')
+    this.setSelectedIndex(value, undefined, '')
   }
 
   setValue = (value) => {

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -917,7 +917,10 @@ export default class Dropdown extends Component {
     this.trySetState({ value })
   }
 
-  setSelectedIndex = (value = this.state.value, optionsProps = this.props.options, searchQuery = this.state.searchQuery) => {
+  setSelectedIndex = (
+    value = this.state.value,
+    optionsProps = this.props.options,
+    searchQuery = this.state.searchQuery) => {
     const { multiple } = this.props
     const { selectedIndex } = this.state
     const options = this.getMenuOptions(value, optionsProps, searchQuery)

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -432,11 +432,11 @@ export default class Dropdown extends Component {
     if (!shallowEqual(nextProps.value, this.props.value)) {
       debug('value changed, setting', nextProps.value)
       this.setValue(nextProps.value)
-      this.setSelectedIndex(nextProps.value)
+      this.setSelectedIndex(nextProps.value, nextProps.options, nextProps.searchQuery)
     }
 
     if (!_.isEqual(nextProps.options, this.props.options)) {
-      this.setSelectedIndex(undefined, nextProps.options)
+      this.setSelectedIndex(undefined, nextProps.options, nextProps.searchQuery)
     }
   }
 
@@ -798,9 +798,8 @@ export default class Dropdown extends Component {
 
   // There are times when we need to calculate the options based on a value
   // that hasn't yet been persisted to state.
-  getMenuOptions = (value = this.state.value, options = this.props.options) => {
+  getMenuOptions = (value = this.state.value, options = this.props.options, searchQuery = this.state.searchQuery) => {
     const { additionLabel, additionPosition, allowAdditions, deburr, multiple, search } = this.props
-    const { searchQuery } = this.state
 
     let filteredOptions = options
 
@@ -910,6 +909,7 @@ export default class Dropdown extends Component {
   clearSearchQuery = () => {
     debug('clearSearchQuery()')
     this.trySetState({ searchQuery: '' })
+    this.setSelectedIndex(undefined, undefined, '')
   }
 
   setValue = (value) => {
@@ -917,10 +917,10 @@ export default class Dropdown extends Component {
     this.trySetState({ value })
   }
 
-  setSelectedIndex = (value = this.state.value, optionsProps = this.props.options) => {
+  setSelectedIndex = (value = this.state.value, optionsProps = this.props.options, searchQuery = this.state.searchQuery) => {
     const { multiple } = this.props
     const { selectedIndex } = this.state
-    const options = this.getMenuOptions(value, optionsProps)
+    const options = this.getMenuOptions(value, optionsProps, searchQuery)
     const enabledIndicies = this.getEnabledIndices(options)
 
     let newSelectedIndex


### PR DESCRIPTION
The Dropdown is not handling the following properly:
1) If the parent is managing the prop searchQuery, the componentWillReceiveProp updates the state value using the AutoControlledComponent.  The value is not actually set in this.state though, so the later call to setSelectedIndex will produce incorrect results.  This is because that call uses the state.searchQuery value to index the list.
2) When clearing the state.searchQuery, the selected index value is not updated appropriately.  When using state.searchQuery, the menu options will be different than the full menu options list, hence the selected index is a different value.  To fix this, simply call setSelectedIndex after clearing searchQuery in the clearSearchQuery function.  This address #2375.

The issue being seen was the following:
When performing a search, select an item from the filtered list of items per the search term.  If you then drop the menu list again, it should show the selected item highlighted, but it actually is showing a different selected item.  This is because the selected item index value is being computed based on the filtered list, but once the filtered list is reset (searchQuery is removed), the index never gets updated based on the currently selected value.

This PR passes both yarn lint and yarn test.  Let me know if you need anything else