### PR TITLE
Fixed the redundant aligned prop passing to div issue

### DIFF
--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -73,7 +73,8 @@ class Tab extends Component {
 
   static defaultProps = {
     grid: { paneWidth: 12, tabWidth: 4 },
-    menu: { attached: true, tabular: true, aligned: 'left' },
+    menu: { attached: true, tabular: true },
+    tab : {menuAligned : 'left'},
     renderActiveOnly: true,
   }
 
@@ -119,18 +120,18 @@ class Tab extends Component {
   }
 
   renderVertical(menu) {
-    const { grid } = this.props
+    const { grid,tab} = this.props
     const { paneWidth, tabWidth, ...gridProps } = grid
 
     return (
       <Grid {...gridProps}>
-        {menu.props.aligned !== 'right' && GridColumn.create({ width: tabWidth, children: menu })}
+        {tab.menuAligned !== 'right' && GridColumn.create({ width: tabWidth, children: menu })}
         {GridColumn.create({
           width: paneWidth,
           children: this.renderItems(),
           stretched: true,
         })}
-        {menu.props.aligned === 'right' && GridColumn.create({ width: tabWidth, children: menu })}
+        {tab.menuAligned === 'right' && GridColumn.create({ width: tabWidth, children: menu })}
       </Grid>
     )
   }


### PR DESCRIPTION
# Fix to Redundant 'aligned' props passing to div issue - #2430 .

Issue was introduced in #2430  that in development while using Tab component, React console gives this  `Warning: Unknown prop aligned on <div> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop.`

This PR fixes this issue, with a separate 'tab' prop having a 'menuAligned' property, same as the solution stated in #2430 . Since tab prop is not passing in the Menu component, it is not being rendered as unused props. 

So in order to make the menu right aligned, change will be as below:

## Before

`const panes = [ ...{} ]
const menu = {
  fluid: true,
  vertical: true,
  secondary: true,
  aligned: 'right'
}

<Tab menu={menu} panes={panes} />`

## After
`const panes = [ ...{} ]
const menu = {
  fluid: true,
  vertical: true,
  secondary: true
}
const tab = {
  menuAligned : 'right'
}

<Tab menu={menu} panes={panes} tab={tab} />`

tab props will not be passed in Menu component, so will not be rendered in any case.