### PR TITLE
docs(TableExamplePagination): order icon names per docs

### DIFF
--- a/docs/app/Examples/collections/Table/Types/TableExamplePagination.js
+++ b/docs/app/Examples/collections/Table/Types/TableExamplePagination.js
@@ -36,14 +36,14 @@ const TableExamplePagination = () => (
         <Table.HeaderCell colSpan='3'>
           <Menu floated='right' pagination>
             <Menu.Item as='a' icon>
-              <Icon name='left chevron' />
+              <Icon name='chevron left' />
             </Menu.Item>
             <Menu.Item as='a'>1</Menu.Item>
             <Menu.Item as='a'>2</Menu.Item>
             <Menu.Item as='a'>3</Menu.Item>
             <Menu.Item as='a'>4</Menu.Item>
             <Menu.Item as='a' icon>
-              <Icon name='right chevron' />
+              <Icon name='chevron right' />
             </Menu.Item>
           </Menu>
         </Table.HeaderCell>


### PR DESCRIPTION
According to https://react.semantic-ui.com/elements/icon, `chevron left` and `chevron right` should be used.