### PR TITLE
feat(Dropdown): add direction prop

### DIFF
--- a/docs/app/Examples/modules/Dropdown/Variations/DropdownExampleMenuDirection.js
+++ b/docs/app/Examples/modules/Dropdown/Variations/DropdownExampleMenuDirection.js
@@ -1,29 +1,19 @@
 import React from 'react'
-import { Dropdown, Icon } from 'semantic-ui-react'
+import { Menu, Dropdown } from 'semantic-ui-react'
+
+const options = [
+  { key: 1, text: 'This is a super long item', value: 1 },
+  { key: 2, text: 'Dropdown direction can help', value: 2 },
+  { key: 3, text: 'Items are kept within view', value: 3 },
+]
 
 const DropdownExampleMenuDirection = () => (
-  <Dropdown text='Menu' floating labeled button className='icon'>
-    <Dropdown.Menu>
-      <Dropdown.Item>
-        <Icon name='left dropdown' />
-        <span className='text'>Left</span>
-        <Dropdown.Menu className='left'>
-          <Dropdown.Item>1</Dropdown.Item>
-          <Dropdown.Item>2</Dropdown.Item>
-          <Dropdown.Item>3</Dropdown.Item>
-        </Dropdown.Menu>
-      </Dropdown.Item>
-      <Dropdown.Item>
-        <Icon name='dropdown' />
-        <span className='text'>Right</span>
-        <Dropdown.Menu className='right'>
-          <Dropdown.Item>1</Dropdown.Item>
-          <Dropdown.Item>2</Dropdown.Item>
-          <Dropdown.Item>3</Dropdown.Item>
-        </Dropdown.Menu>
-      </Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+  <Menu>
+    <Dropdown item simple text='Left menu' direction='right' options={options} />
+    <Menu.Menu position='right'>
+      <Dropdown item simple text='Right menu' direction='right' options={options} />
+    </Menu.Menu>
+  </Menu>
 )
 
 export default DropdownExampleMenuDirection

--- a/docs/app/Examples/modules/Dropdown/Variations/index.js
+++ b/docs/app/Examples/modules/Dropdown/Variations/index.js
@@ -33,12 +33,7 @@ const DropdownVariationsExamples = () => (
       title='Menu Direction'
       description='A dropdown menu or sub-menu can specify the direction it should open.'
       examplePath='modules/Dropdown/Variations/DropdownExampleMenuDirection'
-    >
-      <ContributionPrompt>
-        The example below shows (roughly) the desired markup but is not functional
-        since we don't currently support nested dropdowns.
-      </ContributionPrompt>
-    </ComponentExample>
+    />
     <ComponentExample
       examplePath='modules/Dropdown/Variations/DropdownExampleMenuDirectionLeft'
     >

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -65,6 +65,9 @@ export interface DropdownProps {
   /** Initial value or value array if multiple. */
   defaultValue?: string | number | Array<number | string>;
 
+  /** A dropdown menu can open to the left or to the right. */
+  direction?: 'left'  | 'right';
+
   /** A disabled dropdown menu or item does not allow user interaction. */
   disabled?: boolean;
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -119,6 +119,9 @@ export default class Dropdown extends Component {
       ])),
     ]),
 
+    /** A dropdown menu can open to the left or to the right. */
+    direction: PropTypes.oneOf(['left', 'right']),
+
     /** A disabled dropdown menu or item does not allow user interaction. */
     disabled: PropTypes.bool,
 
@@ -1233,21 +1236,24 @@ export default class Dropdown extends Component {
   }
 
   renderMenu = () => {
-    const { children, header } = this.props
+    const { children, direction, header } = this.props
     const { open } = this.state
-    const menuClasses = open ? 'visible' : ''
     const ariaOptions = this.getDropdownMenuAriaOptions()
 
     // single menu child
     if (!childrenUtils.isNil(children)) {
       const menuChild = Children.only(children)
-      const className = cx(menuClasses, menuChild.props.className)
+      const className = cx(
+        direction,
+        useKeyOnly(open, 'visible'),
+        menuChild.props.className,
+      )
 
       return cloneElement(menuChild, { className, ...ariaOptions })
     }
 
     return (
-      <DropdownMenu {...ariaOptions} className={menuClasses}>
+      <DropdownMenu {...ariaOptions} direction={direction} open={open}>
         {DropdownHeader.create(header)}
         {this.renderOptions()}
       </DropdownMenu>

--- a/src/modules/Dropdown/DropdownMenu.d.ts
+++ b/src/modules/Dropdown/DropdownMenu.d.ts
@@ -16,6 +16,12 @@ export interface DropdownMenuProps {
   /** Shorthand for primary content. */
   content?: SemanticShorthandContent;
 
+  /** A dropdown menu can open to the left or to the right. */
+  direction?: 'left'  | 'right';
+
+  /** Whether or not the dropdown menu is displayed. */
+  open?: boolean;
+
   /** A dropdown menu can scroll. */
   scrolling?: boolean;
 }

--- a/src/modules/Dropdown/DropdownMenu.js
+++ b/src/modules/Dropdown/DropdownMenu.js
@@ -15,8 +15,10 @@ import {
  * A dropdown menu can contain a menu.
  */
 function DropdownMenu(props) {
-  const { children, className, content, scrolling } = props
+  const { children, className, content, direction, open, scrolling } = props
   const classes = cx(
+    direction,
+    useKeyOnly(open, 'visible'),
     useKeyOnly(scrolling, 'scrolling'),
     'menu transition',
     className,
@@ -49,6 +51,12 @@ DropdownMenu.propTypes = {
 
   /** Shorthand for primary content. */
   content: customPropTypes.contentShorthand,
+
+  /** A dropdown menu can open to the left or to the right. */
+  direction: PropTypes.oneOf(['left', 'right']),
+
+  /** Whether or not the dropdown menu is displayed. */
+  open: PropTypes.bool,
 
   /** A dropdown menu can scroll. */
   scrolling: PropTypes.bool,

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -43,16 +43,30 @@ const getOptions = (count = 5) => _.times(count, (i) => {
 // Common Assertions
 // -------------------------------
 const dropdownMenuIsClosed = () => {
-  const menu = wrapper.find('DropdownMenu')
   wrapper.should.not.have.className('visible')
-  menu.should.not.have.className('visible')
+
+  const menu = wrapper.find('DropdownMenu')
+  try {
+    // when shallow rendered
+    menu.should.not.have.prop('open', true)
+  } catch (err) {
+    // when mounted
+    menu.should.not.have.className('visible')
+  }
 }
 
 const dropdownMenuIsOpen = () => {
-  const menu = wrapper.find('DropdownMenu')
   wrapper.should.have.className('active')
   wrapper.should.have.className('visible')
-  menu.should.have.className('visible')
+
+  const menu = wrapper.find('DropdownMenu')
+  try {
+    // when shallow rendered
+    menu.should.have.prop('open', true)
+  } catch (err) {
+    // when mounted
+    menu.should.have.className('visible')
+  }
 }
 
 const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }

--- a/test/specs/modules/Dropdown/DropdownMenu-test.js
+++ b/test/specs/modules/Dropdown/DropdownMenu-test.js
@@ -5,5 +5,7 @@ describe('DropdownMenu', () => {
   common.isConformant(DropdownMenu)
   common.rendersChildren(DropdownMenu)
 
+  common.propValueOnlyToClassName(DropdownMenu, 'direction', ['left', 'right'])
+  common.propKeyOnlyToClassName(DropdownMenu, 'open', { className: 'visible' })
   common.propKeyOnlyToClassName(DropdownMenu, 'scrolling')
 })


### PR DESCRIPTION
Fixes #1897

This PR adds the `direction` prop to the Dropdown.  This enables opening the menu aligned the left or right of the dropdown element.  Great for right aligned dropdowns with long items.

It also moves the responsibility of className build up to the DropdownMenu.  The DropdownMenu now has props for `open` and `direction`.