### PR TITLE
test(Portal): fix tests with timeouts

### DIFF
--- a/test/specs/addons/TransitionablePortal/TransitionablePortal-test.js
+++ b/test/specs/addons/TransitionablePortal/TransitionablePortal-test.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import TransitionablePortal from 'src/addons/TransitionablePortal/TransitionablePortal'
 import * as common from 'test/specs/commonTests'
-import { domEvent, sandbox } from 'test/utils'
+import { domEvent, sandbox, assertWithTimeout } from 'test/utils'
 
 // ----------------------------------------
 // Wrapper
@@ -77,12 +77,10 @@ describe('TransitionablePortal', () => {
       wrapper.find('button').simulate('click')
       domEvent.click(document.body)
 
-      setTimeout(() => {
+      assertWithTimeout(() => {
         onClose.should.have.been.calledOnce()
         onClose.should.have.been.calledWithMatch(null, { portalOpen: false })
-
-        done()
-      }, 10)
+      }, done)
     })
 
     it('changes `portalOpen` to false', () => {
@@ -111,16 +109,14 @@ describe('TransitionablePortal', () => {
       )
 
       wrapper.setProps({ open: false })
-      setTimeout(() => {
+      assertWithTimeout(() => {
         onHide.should.have.been.calledOnce()
         onHide.should.have.been.calledWithMatch(null, {
           ...quickTransition,
           portalOpen: false,
           transitionVisible: false,
         })
-
-        done()
-      }, 10)
+      }, done)
     })
   })
 

--- a/test/utils/assertWithTimeout.js
+++ b/test/utils/assertWithTimeout.js
@@ -1,0 +1,28 @@
+/**
+ * Repeatedly attempt to make an assertion over a period of time.
+ * If the assertion never passes, it will eventually throw.
+ * Good for tests with unknown or unreliable execution times.
+ *
+ * @param {function} assertion - A callback that makes test assertions.
+ * @param {function} done - The done callback.
+ */
+const assertWithTimeout = (assertion, done) => {
+  const timeout = 1000
+  const start = Date.now()
+  const didTimeout = () => Date.now() - start >= timeout
+
+  const assert = () => {
+    try {
+      assertion()
+      done()
+    } catch (err) {
+      if (didTimeout()) done(err)
+      else setTimeout(assert, 10)
+    }
+  }
+
+  assert()
+}
+
+
+export default assertWithTimeout

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,5 +1,6 @@
 export { default as assertBodyClasses } from './assertBodyClasses'
 export * from './assertNodeContains'
+export { default as assertWithTimeout } from './assertWithTimeout'
 export { default as consoleUtil } from './consoleUtil'
 export { default as domEvent } from './domEvent'
 export { default as sandbox } from './sandbox'


### PR DESCRIPTION
`TransitionablePortal` tests are intermittently failing due to unpredictable animation durations and set timeout times.

This PR adds a new util `assertWithTimeout` which repeatedly makes the assertion until it passes or until 2s have passed.  In the event 2s is reached without the assertion passing, the error will be thrown.  This allows us to execute tests as fast as possible but also account for unknown execution times.