### PR TITLE
fix(Tab): Added a prop menuAligned to Tab and removed an invalid prop

### DIFF
--- a/src/modules/Tab/Tab.d.ts
+++ b/src/modules/Tab/Tab.d.ts
@@ -18,6 +18,9 @@ export interface TabProps {
   /** Shorthand props for the Menu. */
   menu?: any;
 
+  /** The alignment of the menu */
+  menuAligned?: string,
+
   /** Shorthand props for the Grid. */
   grid?: any;
 

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -39,6 +39,9 @@ class Tab extends Component {
     /** Shorthand props for the Menu. */
     menu: PropTypes.object,
 
+    /** The alignment of the menu */
+    menuAligned: PropTypes.string,
+
     /** Shorthand props for the Grid. */
     grid: PropTypes.object,
 
@@ -73,8 +76,9 @@ class Tab extends Component {
 
   static defaultProps = {
     grid: { paneWidth: 12, tabWidth: 4 },
-    menu: { attached: true, tabular: true, aligned: 'left' },
-    renderActiveOnly: true,
+    menu: { attached: true, tabular: true },
+    menuAligned: 'left',
+    renderActiveOnly: true
   }
 
   static _meta = {
@@ -119,18 +123,18 @@ class Tab extends Component {
   }
 
   renderVertical(menu) {
-    const { grid } = this.props
+    const { grid, menuAligned } = this.props
     const { paneWidth, tabWidth, ...gridProps } = grid
 
     return (
       <Grid {...gridProps}>
-        {menu.props.aligned !== 'right' && GridColumn.create({ width: tabWidth, children: menu })}
+        {menuAligned !== 'right' && GridColumn.create({ width: tabWidth, children: menu })}
         {GridColumn.create({
           width: paneWidth,
           children: this.renderItems(),
           stretched: true,
         })}
-        {menu.props.aligned === 'right' && GridColumn.create({ width: tabWidth, children: menu })}
+        {menuAligned === 'right' && GridColumn.create({ width: tabWidth, children: menu })}
       </Grid>
     )
   }

--- a/test/specs/modules/Tab/Tab-test.js
+++ b/test/specs/modules/Tab/Tab-test.js
@@ -19,7 +19,9 @@ describe('Tab', () => {
     it('defaults to an attached left aligned tabular menu', () => {
       Tab.defaultProps
         .should.have.property('menu')
-        .which.deep.equals({ attached: true, tabular: true, aligned: 'left' })
+        .which.deep.equals({ attached: true, tabular: true })
+      Tab.defaultProps
+        .should.have.property('menuAligned', 'left')
     })
 
     it('passes the props to the Menu', () => {
@@ -55,7 +57,7 @@ describe('Tab', () => {
     })
 
     it("renders right of the pane when aligned='right'", () => {
-      const wrapper = shallow(<Tab menu={{ fluid: true, vertical: true, aligned: 'right' }} panes={panes} />)
+      const wrapper = shallow(<Tab menu={{ fluid: true, vertical: true }} menuAligned='right' panes={panes} />)
 
       wrapper.childAt(0).should.match('Grid')
       wrapper.childAt(0).shallow().childAt(0).should.match('GridColumn')


### PR DESCRIPTION
As proposed in #2430, a new prop menuAligned with default value 'left' is added to Tab, and the invalid prop aligned passed to the Menu inside of Tab is removed.