### PR TITLE
feat(Responsive): add getWidth prop, fix perf

### DIFF
--- a/src/addons/Responsive/Responsive.d.ts
+++ b/src/addons/Responsive/Responsive.d.ts
@@ -25,6 +25,12 @@ export interface ResponsiveProps {
    * @param {object} data - All props and the event value.
    */
   onUpdate?: (event: React.SyntheticEvent<HTMLElement>, data: ResponsiveOnUpdateData) => void;
+
+  /**
+   * Called to get width of screen. Defaults to using `window.innerWidth` when in a browser;
+   * otherwise, assumes a width of 0.
+   */
+  getWidth?: () => number;
 }
 
 export interface ResponsiveOnUpdateData extends ResponsiveProps {

--- a/src/addons/Responsive/Responsive.d.ts
+++ b/src/addons/Responsive/Responsive.d.ts
@@ -12,6 +12,12 @@ export interface ResponsiveProps {
   /** Fires callbacks immediately after mount. */
   fireOnMount?: boolean;
 
+  /**
+   * Called to get width of screen. Defaults to using `window.innerWidth` when in a browser;
+   * otherwise, assumes a width of 0.
+   */
+  getWidth?: () => number;
+
   /** The maximum width at which content will be displayed. */
   maxWidth?: number | string;
 
@@ -25,12 +31,6 @@ export interface ResponsiveProps {
    * @param {object} data - All props and the event value.
    */
   onUpdate?: (event: React.SyntheticEvent<HTMLElement>, data: ResponsiveOnUpdateData) => void;
-
-  /**
-   * Called to get width of screen. Defaults to using `window.innerWidth` when in a browser;
-   * otherwise, assumes a width of 0.
-   */
-  getWidth?: () => number;
 }
 
 export interface ResponsiveOnUpdateData extends ResponsiveProps {

--- a/src/addons/Responsive/Responsive.js
+++ b/src/addons/Responsive/Responsive.js
@@ -60,9 +60,7 @@ export default class Responsive extends Component {
   constructor(...args) {
     super(...args)
 
-    // Measure the root element dimension to handle gesture transitions on iOS safely
-    // https://github.com/Semantic-Org/Semantic-UI-React/pull/2531
-    this.state = { width: isBrowser() ? document.documentElement.clientWidth : 0 }
+    this.state = { width: isBrowser() ? window.innerWidth : 0 }
   }
 
   componentDidMount() {
@@ -114,7 +112,7 @@ export default class Responsive extends Component {
 
   handleUpdate = (e) => {
     this.ticking = false
-    const width = document.documentElement.clientWidth
+    const width = window.innerWidth
 
     this.setSafeState({ width })
     _.invoke(this.props, 'onUpdate', e, { ...this.props, width })

--- a/src/addons/Responsive/Responsive.js
+++ b/src/addons/Responsive/Responsive.js
@@ -44,6 +44,16 @@ export default class Responsive extends Component {
      * @param {object} data - All props and the event value.
      */
     onUpdate: PropTypes.func,
+
+    /**
+     * Called to get width of screen. Defaults to using `window.innerWidth` when in a browser;
+     * otherwise, assumes a width of 0.
+     */
+    getWidth: PropTypes.func,
+  }
+
+  static defaultProps = {
+    getWidth: () => (isBrowser() ? window.innerWidth : 0),
   }
 
   static _meta = {
@@ -60,7 +70,7 @@ export default class Responsive extends Component {
   constructor(...args) {
     super(...args)
 
-    this.state = { width: isBrowser() ? window.innerWidth : 0 }
+    this.state = { width: this.props.getWidth() }
   }
 
   componentDidMount() {
@@ -112,7 +122,7 @@ export default class Responsive extends Component {
 
   handleUpdate = (e) => {
     this.ticking = false
-    const width = window.innerWidth
+    const width = this.props.getWidth()
 
     this.setSafeState({ width })
     _.invoke(this.props, 'onUpdate', e, { ...this.props, width })

--- a/src/addons/Responsive/Responsive.js
+++ b/src/addons/Responsive/Responsive.js
@@ -9,6 +9,7 @@ import {
   getUnhandledProps,
   isBrowser,
   META,
+  shallowEqual,
 } from '../../lib'
 
 /**
@@ -24,6 +25,12 @@ export default class Responsive extends Component {
 
     /** Fires callbacks immediately after mount. */
     fireOnMount: PropTypes.bool,
+
+    /**
+     * Called to get width of screen. Defaults to using `window.innerWidth` when in a browser;
+     * otherwise, assumes a width of 0.
+     */
+    getWidth: PropTypes.func,
 
     /** The maximum width at which content will be displayed. */
     maxWidth: PropTypes.oneOfType([
@@ -44,12 +51,6 @@ export default class Responsive extends Component {
      * @param {object} data - All props and the event value.
      */
     onUpdate: PropTypes.func,
-
-    /**
-     * Called to get width of screen. Defaults to using `window.innerWidth` when in a browser;
-     * otherwise, assumes a width of 0.
-     */
-    getWidth: PropTypes.func,
   }
 
   static defaultProps = {
@@ -70,7 +71,7 @@ export default class Responsive extends Component {
   constructor(...args) {
     super(...args)
 
-    this.state = { width: this.props.getWidth() }
+    this.state = { width: _.invoke(this.props, 'getWidth') }
   }
 
   componentDidMount() {
@@ -89,7 +90,7 @@ export default class Responsive extends Component {
 
   shouldComponentUpdate(nextProps, nextState) {
     // Update when any prop changes or the width changes. If width does not change, no update is required.
-    return !_.isEqual(nextProps, this.props) || nextState.width !== this.state.width
+    return this.state.width !== nextState.width || !shallowEqual(this.props, nextProps)
   }
 
   // ----------------------------------------
@@ -127,7 +128,7 @@ export default class Responsive extends Component {
 
   handleUpdate = (e) => {
     this.ticking = false
-    const width = this.props.getWidth()
+    const width = _.invoke(this.props, 'getWidth')
 
     this.setSafeState({ width })
     _.invoke(this.props, 'onUpdate', e, { ...this.props, width })

--- a/src/addons/Responsive/Responsive.js
+++ b/src/addons/Responsive/Responsive.js
@@ -87,6 +87,11 @@ export default class Responsive extends Component {
     eventStack.unsub('resize', this.handleResize, { target: 'window' })
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    // Update when any prop changes or the width changes. If width does not change, no update is required.
+    return !_.isEqual(nextProps, this.props) || nextState.width !== this.state.width
+  }
+
   // ----------------------------------------
   // Helpers
   // ----------------------------------------

--- a/test/specs/addons/Responsive/Responsive-test.js
+++ b/test/specs/addons/Responsive/Responsive-test.js
@@ -81,7 +81,7 @@ describe('Responsive', () => {
       const width = Responsive.onlyTablet.minWidth
       mount(<Responsive {...Responsive.onlyMobile} onUpdate={onUpdate} />)
 
-      sandbox.stub(document.documentElement, 'clientWidth').value(width)
+      sandbox.stub(window, 'innerWidth').value(width)
       domEvent.fire(window, 'resize')
 
       requestAnimationFrame(() => {

--- a/test/specs/addons/Responsive/Responsive-test.js
+++ b/test/specs/addons/Responsive/Responsive-test.js
@@ -62,8 +62,8 @@ describe('Responsive', () => {
     })
   })
 
-  describe('onUpdate', () => {
-    it('listens for resize', (done) => {
+  describe('on window.resize', () => {
+    it('renders using new width', (done) => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyMobile.minWidth)
       const wrapper = mount(<Responsive {...Responsive.onlyMobile}>Mobile only</Responsive>)
       wrapper.should.be.not.be.blank()
@@ -77,7 +77,50 @@ describe('Responsive', () => {
         done()
       })
     })
+  })
 
+  describe('shouldComponentUpdate', () => {
+    it('returns true when width changes', (done) => {
+      sandbox.stub(window, 'innerWidth').value(Responsive.onlyMobile.minWidth)
+      const wrapper = mount(<Responsive />)
+      const instance = wrapper.instance()
+      const spy = sandbox.spy(instance, 'shouldComponentUpdate')
+
+      sandbox.stub(window, 'innerWidth').value(Responsive.onlyTablet.minWidth)
+      domEvent.fire(window, 'resize')
+
+      requestAnimationFrame(() => {
+        spy.should.have.returned(true)
+        done()
+      })
+    })
+
+    it('returns false when width stays the same', (done) => {
+      sandbox.stub(window, 'innerWidth').value(Responsive.onlyMobile.minWidth)
+      const wrapper = mount(<Responsive />)
+      const instance = wrapper.instance()
+      const spy = sandbox.spy(instance, 'shouldComponentUpdate')
+
+      domEvent.fire(window, 'resize')
+
+      requestAnimationFrame(() => {
+        spy.should.have.returned(false)
+        done()
+      })
+    })
+
+    it('returns true when props change', () => {
+      const wrapper = mount(<Responsive {...Responsive.onlyMobile} />)
+      const instance = wrapper.instance()
+      const spy = sandbox.spy(instance, 'shouldComponentUpdate')
+
+      wrapper.setProps({ ...Responsive.onlyTablet })
+
+      spy.should.have.returned(true)
+    })
+  })
+
+  describe('onUpdate', () => {
     it('is called with (e, data) when window was resized', (done) => {
       const onUpdate = sandbox.spy()
       const width = Responsive.onlyTablet.minWidth

--- a/test/specs/addons/Responsive/Responsive-test.js
+++ b/test/specs/addons/Responsive/Responsive-test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import Responsive from 'src/addons/Responsive/Responsive'
+import { isBrowser } from 'src/lib'
 import * as common from 'test/specs/commonTests'
 import { domEvent, sandbox } from 'test/utils'
 
@@ -90,6 +91,50 @@ describe('Responsive', () => {
         onUpdate.should.have.been.calledWithMatch({}, { ...Responsive.onlyMobile, width })
 
         done()
+      })
+    })
+  })
+
+  describe('getWidth', () => {
+    it('defaults browser to use window.innerWidth', () => {
+      const width = 500
+      sandbox.stub(window, 'innerWidth').value(width)
+
+      const wrapper = shallow(<Responsive />)
+
+      wrapper.state('width').should.equal(width)
+    })
+
+    it('defaults non-browser to use 0', () => {
+      isBrowser.override = false
+
+      const wrapper = shallow(<Responsive />)
+
+      wrapper.state('width').should.equal(0)
+
+      isBrowser.override = null
+    })
+
+    it('allows a custom function that returns a number', () => {
+      const getWidth = () => 500
+      const wrapper = shallow(<Responsive getWidth={getWidth} />)
+
+      wrapper.state('width').should.equal(500)
+    })
+
+    it('is called on resize', () => {
+      const getWidth = sandbox.stub()
+
+      const wrapper = mount(<Responsive getWidth={getWidth} />)
+      getWidth.should.have.been.calledOnce()
+      getWidth.reset()
+
+      getWidth.returns(500)
+      domEvent.fire(window, 'resize')
+
+      requestAnimationFrame(() => {
+        getWidth.should.have.been.calledOnce()
+        wrapper.state('width').should.equal(500)
       })
     })
   })

--- a/test/specs/addons/Responsive/Responsive-test.js
+++ b/test/specs/addons/Responsive/Responsive-test.js
@@ -36,13 +36,13 @@ describe('Responsive', () => {
   describe('maxWidth', () => {
     it('renders when fits', () => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyMobile.maxWidth)
-      shallow(<Responsive {...Responsive.onlyMobile} />)
-        .should.be.present()
+      shallow(<Responsive {...Responsive.onlyMobile}>Show me!</Responsive>)
+        .should.not.be.blank()
     })
 
     it('do not render when not fits', () => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyTablet.maxWidth)
-      shallow(<Responsive {...Responsive.onlyMobile} />)
+      shallow(<Responsive {...Responsive.onlyMobile}>Hide me!</Responsive>)
         .should.be.blank()
     })
   })
@@ -50,13 +50,13 @@ describe('Responsive', () => {
   describe('minWidth', () => {
     it('renders when fits', () => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyMobile.minWidth)
-      shallow(<Responsive {...Responsive.onlyMobile} />)
-        .should.be.present()
+      shallow(<Responsive {...Responsive.onlyMobile}>Show me!</Responsive>)
+        .should.not.be.blank()
     })
 
     it('do not render when not fits', () => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyTablet.minWidth)
-      shallow(<Responsive {...Responsive.onlyMobile} />)
+      shallow(<Responsive {...Responsive.onlyMobile}>Hide me!</Responsive>)
         .should.be.blank()
     })
   })
@@ -64,13 +64,14 @@ describe('Responsive', () => {
   describe('onUpdate', () => {
     it('listens for resize', (done) => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyMobile.minWidth)
-      const wrapper = shallow(<Responsive {...Responsive.onlyMobile} />)
-      wrapper.should.be.present()
+      const wrapper = mount(<Responsive {...Responsive.onlyMobile}>Mobile only</Responsive>)
+      wrapper.should.be.not.be.blank()
 
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyTablet.minWidth)
       domEvent.fire(window, 'resize')
 
       requestAnimationFrame(() => {
+        wrapper.update()
         wrapper.should.be.blank()
         done()
       })


### PR DESCRIPTION
Implements #2614 

1. Revert #2531, as it breaks `Responsive`'s integration with Semantic UI's breakpoints. This ensures `Responsive` uses `window.innerWidth` as the default calculation for screen width. `document.documentElement.clientWidth` does not use the scrollbar in its calculation.

2. Fix false-positive tests in `Responsive-test.js`. [`chai-enzyme`](https://github.com/producthunt/chai-enzyme) provides assertion helpers [`blank()`](https://github.com/producthunt/chai-enzyme#blank) and [`present()`](https://github.com/producthunt/chai-enzyme#present), which were being used as if they were opposites. They are not opposites. For a wrapper to be `empty()`, it must also be `present()`. Tests have been updated to use `not.empty()` and `empty()`, which are opposites. Also, the resizing test was using enzyme's `shallow()`, but `mount()` was needed to support state change and updating render.

3. Add optional `getWidth` property to `Responsive`. The property is a function that returns the width of the screen. This property defaults to a function that returns `window.innerWidth` for browsers and `0` for non-browsers. @Autarc or anyone else wanting to use `document.documentElement.clientWidth` as discussed in #2531 can do so using `<Responsive getWidth={() => document.documentElement.clientWidth} />`.

4. Prevent `Responsive` from updating render when `window.resize` is triggered, but width does not change. `Responsive` currently updates on mobile devices when scrolling and the url bar displays and hides. This happens because the height of the window is changing, triggering `window.resize`. This update allows `Responsive` to ignore these events. `onUpdate` will still be invoked.