### PR TITLE
fix(Pagination): call `onPageChange` only when change is occurred

### DIFF
--- a/src/addons/Pagination/Pagination.js
+++ b/src/addons/Pagination/Pagination.js
@@ -112,9 +112,14 @@ export default class Pagination extends Component {
 
   static Item = PaginationItem
 
-  handleItemClick = (e, { value }) => {
-    this.trySetState({ activePage: value })
-    _.invoke(this.props, 'onPageChange', e, { ...this.props, activePage: value })
+  handleItemClick = (e, { value: nextActivePage }) => {
+    const { activePage: prevActivePage } = this.state
+
+    // Heads up! We need the cast to the "number" type there, as `activePage` can be a string
+    if (+prevActivePage === +nextActivePage) return
+
+    this.trySetState({ activePage: nextActivePage })
+    _.invoke(this.props, 'onPageChange', e, { ...this.props, activePage: nextActivePage })
   }
 
   handleItemOverrides = (active, type, value) => predefinedProps => ({

--- a/test/specs/addons/Pagination/Pagination-test.js
+++ b/test/specs/addons/Pagination/Pagination-test.js
@@ -34,5 +34,24 @@ describe('Pagination', () => {
       onPageItemClick.should.have.been.calledOnce()
       onPageItemClick.should.have.been.calledWithMatch(event, { value: 3 })
     })
+
+    it('will be omitted if occurred for the same pagination item as the current', () => {
+      const onPageChange = sandbox.spy()
+      const wrapper = mount(
+        <Pagination
+          activePage={1}
+          firstItem={null}
+          onPageChange={onPageChange}
+          prevItem={null}
+          totalPages={3}
+        />,
+      )
+
+      wrapper
+        .find('PaginationItem')
+        .at(0)
+        .simulate('click')
+      onPageChange.should.have.not.been.called()
+    })
   })
 })


### PR DESCRIPTION
Fixes #2627.