### PR TITLE
fix(Visibility): cancel RAF on component unmount

### DIFF
--- a/src/behaviors/Visibility/Visibility.js
+++ b/src/behaviors/Visibility/Visibility.js
@@ -214,6 +214,7 @@ export default class Visibility extends Component {
     const { context } = this.props
 
     this.unattachHandlers(context)
+    if (this.frameId) cancelAnimationFrame(this.frameId)
   }
 
   attachHandlers(context) {
@@ -284,7 +285,7 @@ export default class Visibility extends Component {
     if (this.ticking) return
 
     this.ticking = true
-    requestAnimationFrame(this.update)
+    this.frameId = requestAnimationFrame(this.update)
   }
 
   update = () => {

--- a/test/specs/behaviors/Visibility/Visibility-test.js
+++ b/test/specs/behaviors/Visibility/Visibility-test.js
@@ -105,7 +105,10 @@ describe('Visibility', () => {
 
   before(() => {
     requestAnimationFrame = window.requestAnimationFrame
-    window.requestAnimationFrame = fn => fn()
+    window.requestAnimationFrame = (fn) => {
+      fn()
+      return true
+    }
   })
 
   after(() => {
@@ -331,6 +334,18 @@ describe('Visibility', () => {
 
       domEvent.scroll(document)
       onUpdate.should.not.have.been.called()
+    })
+  })
+
+  describe('componentWillUnmount', () => {
+    it('will cancel requestAnimationFrame', () => {
+      const cancelAnimationFrame = sandbox.spy(window, 'cancelAnimationFrame')
+      wrapperMount(<Visibility />)
+
+      mockScroll(0, 0)
+      wrapper.unmount()
+
+      cancelAnimationFrame.should.have.been.calledOnce()
     })
   })
 


### PR DESCRIPTION
Fixes #2570.
Replaces #2571.

### Details

Visibility runs the `update()` method inside `requestAnimationFrame()`. It can be called after the component's unmount and will cause an exception as the ref inside the component stopped to exist.

This PR adds `cancelAnimationFrame()` to `componentWillUnmount()` that will stop RAF's action if component will be unmounted.