### PR TITLE
docs(Search): debounce search change handler

### DIFF
--- a/docs/app/Examples/modules/Search/Types/SearchExampleCategory.js
+++ b/docs/app/Examples/modules/Search/Types/SearchExampleCategory.js
@@ -50,7 +50,7 @@ export default class SearchExampleCategory extends Component {
         isLoading: false,
         results: filteredResults,
       })
-    }, 500)
+    }, 300)
   }
 
   render() {
@@ -63,7 +63,7 @@ export default class SearchExampleCategory extends Component {
             category
             loading={isLoading}
             onResultSelect={this.handleResultSelect}
-            onSearchChange={this.handleSearchChange}
+            onSearchChange={_.debounce(this.handleSearchChange, 500, { 'leading': true })}
             results={results}
             value={value}
             {...this.props}

--- a/docs/app/Examples/modules/Search/Types/SearchExampleCategory.js
+++ b/docs/app/Examples/modules/Search/Types/SearchExampleCategory.js
@@ -63,7 +63,7 @@ export default class SearchExampleCategory extends Component {
             category
             loading={isLoading}
             onResultSelect={this.handleResultSelect}
-            onSearchChange={_.debounce(this.handleSearchChange, 500, { 'leading': true })}
+            onSearchChange={_.debounce(this.handleSearchChange, 500, { leading: true })}
             results={results}
             value={value}
             {...this.props}

--- a/docs/app/Examples/modules/Search/Types/SearchExampleStandard.js
+++ b/docs/app/Examples/modules/Search/Types/SearchExampleStandard.js
@@ -32,7 +32,7 @@ export default class SearchExampleStandard extends Component {
         isLoading: false,
         results: _.filter(source, isMatch),
       })
-    }, 500)
+    }, 300)
   }
 
   render() {
@@ -44,7 +44,7 @@ export default class SearchExampleStandard extends Component {
           <Search
             loading={isLoading}
             onResultSelect={this.handleResultSelect}
-            onSearchChange={this.handleSearchChange}
+            onSearchChange={_.debounce(this.handleSearchChange, 500, { 'leading': true })}
             results={results}
             value={value}
             {...this.props}

--- a/docs/app/Examples/modules/Search/Types/SearchExampleStandard.js
+++ b/docs/app/Examples/modules/Search/Types/SearchExampleStandard.js
@@ -44,7 +44,7 @@ export default class SearchExampleStandard extends Component {
           <Search
             loading={isLoading}
             onResultSelect={this.handleResultSelect}
-            onSearchChange={_.debounce(this.handleSearchChange, 500, { 'leading': true })}
+            onSearchChange={_.debounce(this.handleSearchChange, 500, { leading: true })}
             results={results}
             value={value}
             {...this.props}


### PR DESCRIPTION
Added a debounce around the search change event as to not execute the callback on every key press. Dropped the timeout to be just under the debounce. This includes standard and category search examples.