### PR TITLE
fix(Search): strict validation to avoid errors when not using title

### DIFF
--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -71,7 +71,7 @@ export default class Search extends Component {
      */
     results: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.shape(SearchResult.propTypes)),
-      PropTypes.object,
+      PropTypes.shape(SearchCategory.propTypes),
     ]),
 
     /** Whether the search should automatically select the first result after searching. */

--- a/src/modules/Search/SearchResult.d.ts
+++ b/src/modules/Search/SearchResult.d.ts
@@ -45,7 +45,7 @@ export interface SearchResultProps {
   renderer?: (props: SearchResultProps) => Array<React.ReactElement<any>>;
 
   /** Display title. */
-  title?: string;
+  title: string;
 }
 
 declare const SearchResult: React.ComponentClass<SearchResultProps>;

--- a/src/modules/Search/SearchResult.js
+++ b/src/modules/Search/SearchResult.js
@@ -73,7 +73,7 @@ export default class SearchResult extends Component {
     renderer: PropTypes.func,
 
     /** Display title. */
-    title: PropTypes.string,
+    title: PropTypes.string.isRequired,
   }
 
   static defaultProps = {

--- a/test/specs/modules/Search/SearchResult-test.js
+++ b/test/specs/modules/Search/SearchResult-test.js
@@ -1,7 +1,9 @@
 import SearchResult from 'src/modules/Search/SearchResult'
 import * as common from 'test/specs/commonTests'
 
+const requiredProps = { title: '' }
+
 describe('SearchResult', () => {
-  common.isConformant(SearchResult)
+  common.isConformant(SearchResult, { requiredProps })
   common.propKeyOnlyToClassName(SearchResult, 'active')
 })


### PR DESCRIPTION
Hi,
at here
https://github.com/Semantic-Org/Semantic-UI-React/blob/master/src/modules/Search/Search.js#L375

we are using setValue(result.title), if the title is not a mandatory field then value will be set to undefined, and for my use case i'm getting error here, for checking length attribute of undefined.

https://github.com/Semantic-Org/Semantic-UI-React/blob/master/src/modules/Search/Search.js#L496

