### PR TITLE
feat(Dimmer): update SUI to 2.3, add verticalAlign

### DIFF
--- a/docs/app/Examples/modules/Dimmer/Types/DimmerExampleContent.js
+++ b/docs/app/Examples/modules/Dimmer/Types/DimmerExampleContent.js
@@ -13,22 +13,20 @@ export default class DimmerExampleDimmer extends Component {
     return (
       <div>
         <Dimmer.Dimmable as={Segment} dimmed={active}>
+          <Header as='h3'>Overlayable Section</Header>
+          <Image.Group size='small' className='ui small images'>
+            <Image src='/assets/images/wireframe/image.png' />
+            <Image src='/assets/images/wireframe/image.png' />
+            <Image src='/assets/images/wireframe/image.png' />
+          </Image.Group>
+          <Image size='medium' src='/assets/images/wireframe/media-paragraph.png' />
+
           <Dimmer active={active} onClickOutside={this.handleHide}>
             <Header as='h2' icon inverted>
               <Icon name='heart' />
               Dimmed Message!
             </Header>
           </Dimmer>
-
-          <Header as='h3'>Overlayable Section</Header>
-
-          <Image.Group size='small' className='ui small images'>
-            <Image src='/assets/images/wireframe/image.png' />
-            <Image src='/assets/images/wireframe/image.png' />
-            <Image src='/assets/images/wireframe/image.png' />
-          </Image.Group>
-
-          <Image size='medium' src='/assets/images/wireframe/media-paragraph.png' />
         </Dimmer.Dimmable>
 
         <Button.Group>

--- a/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleVerticalAlignBottom.js
+++ b/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleVerticalAlignBottom.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { Button, Dimmer, Header, Image, Segment } from 'semantic-ui-react'
 
-export default class DimmerExampleDimmer extends Component {
+export default class DimmerExampleVerticalAlignBottom extends Component {
   state = {}
 
   handleShow = () => this.setState({ active: true })
@@ -13,15 +13,19 @@ export default class DimmerExampleDimmer extends Component {
     return (
       <div>
         <Dimmer.Dimmable as={Segment} dimmed={active}>
-          <Header as='h3'>Overlayable Section</Header>
-          <Image.Group size='small' className='ui small images'>
-            <Image src='/assets/images/wireframe/image.png' />
-            <Image src='/assets/images/wireframe/image.png' />
-            <Image src='/assets/images/wireframe/image.png' />
-          </Image.Group>
-          <Image size='medium' src='/assets/images/wireframe/media-paragraph.png' />
+          <p>
+            <Image src='/assets/images/wireframe/short-paragraph.png' />
+          </p>
+          <p>
+            <Image src='/assets/images/wireframe/short-paragraph.png' />
+          </p>
 
-          <Dimmer active={active} onClickOutside={this.handleHide} />
+          <Dimmer active={active} onClickOutside={this.handleHide} verticalAlign='bottom'>
+            <Header as='h2' inverted>Title</Header>
+
+            <Button primary>Add</Button>
+            <Button>View</Button>
+          </Dimmer>
         </Dimmer.Dimmable>
 
         <Button.Group>

--- a/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleVerticalAlignTop.js
+++ b/docs/app/Examples/modules/Dimmer/Variations/DimmerExampleVerticalAlignTop.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { Button, Dimmer, Header, Image, Segment } from 'semantic-ui-react'
 
-export default class DimmerExampleDimmer extends Component {
+export default class DimmerExampleVerticalAlignTop extends Component {
   state = {}
 
   handleShow = () => this.setState({ active: true })
@@ -13,15 +13,19 @@ export default class DimmerExampleDimmer extends Component {
     return (
       <div>
         <Dimmer.Dimmable as={Segment} dimmed={active}>
-          <Header as='h3'>Overlayable Section</Header>
-          <Image.Group size='small' className='ui small images'>
-            <Image src='/assets/images/wireframe/image.png' />
-            <Image src='/assets/images/wireframe/image.png' />
-            <Image src='/assets/images/wireframe/image.png' />
-          </Image.Group>
-          <Image size='medium' src='/assets/images/wireframe/media-paragraph.png' />
+          <p>
+            <Image src='/assets/images/wireframe/short-paragraph.png' />
+          </p>
+          <p>
+            <Image src='/assets/images/wireframe/short-paragraph.png' />
+          </p>
 
-          <Dimmer active={active} onClickOutside={this.handleHide} />
+          <Dimmer active={active} onClickOutside={this.handleHide} verticalAlign='top'>
+            <Header as='h2' inverted>Title</Header>
+
+            <Button primary>Add</Button>
+            <Button>View</Button>
+          </Dimmer>
         </Dimmer.Dimmable>
 
         <Button.Group>

--- a/docs/app/Examples/modules/Dimmer/Variations/index.js
+++ b/docs/app/Examples/modules/Dimmer/Variations/index.js
@@ -23,6 +23,14 @@ const DimmerVariationsExamples = () => (
       description='A dimmer can be formatted to have its colors inverted.'
       examplePath='modules/Dimmer/Variations/DimmerExampleInverted'
     />
+
+    <ComponentExample
+      title='Vertical Alignment'
+      description='A dimmer can have its content top or bottom aligned.'
+      examplePath='modules/Dimmer/Variations/DimmerExampleVerticalAlignTop'
+      suiVersion='2.3.0'
+    />
+    <ComponentExample examplePath='modules/Dimmer/Variations/DimmerExampleVerticalAlignBottom' />
   </ExampleSection>
 )
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -142,6 +142,7 @@ export { default as Checkbox, CheckboxProps } from './dist/commonjs/modules/Chec
 
 export { default as Dimmer, DimmerProps } from './dist/commonjs/modules/Dimmer';
 export { default as DimmerDimmable, DimmerDimmableProps } from './dist/commonjs/modules/Dimmer/DimmerDimmable';
+export { default as DimmerInner, DimmerInnerProps } from './dist/commonjs/modules/Dimmer/DimmerInner';
 
 export { default as Dropdown, DropdownProps, DropdownOnSearchChangeData } from './dist/commonjs/modules/Dropdown';
 export { default as DropdownDivider, DropdownDividerProps } from './dist/commonjs/modules/Dropdown/DropdownDivider';

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ export { default as Checkbox } from './modules/Checkbox'
 
 export { default as Dimmer } from './modules/Dimmer'
 export { default as DimmerDimmable } from './modules/Dimmer/DimmerDimmable'
+export { default as DimmerInner } from './modules/Dimmer/DimmerInner'
 
 export { default as Dropdown } from './modules/Dropdown'
 export { default as DropdownDivider } from './modules/Dropdown/DropdownDivider'

--- a/src/modules/Dimmer/Dimmer.d.ts
+++ b/src/modules/Dimmer/Dimmer.d.ts
@@ -1,57 +1,21 @@
 import * as React from 'react';
 
-import { SemanticShorthandContent } from '../..';
 import DimmerDimmable from './DimmerDimmable';
+import DimmerInner from './DimmerInner';
 
 export interface DimmerProps {
   [key: string]: any;
 
-  /** An element type to render as (string or function). */
-  as?: any;
-
   /** An active dimmer will dim its parent container. */
   active?: boolean;
 
-  /** Primary content. */
-  children?: React.ReactNode;
-
-  /** Additional classes. */
-  className?: string;
-
-  /** Shorthand for primary content. */
-  content?: SemanticShorthandContent;
-
-  /** A disabled dimmer cannot be activated */
-  disabled?: boolean;
-
-  /**
-   * Called when the dimmer is clicked.
-   *
-   * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
-   */
-  onClick?: (event: React.MouseEvent<HTMLDivElement>, data: DimmerProps) => void;
-
-  /**
-   * Handles click outside Dimmer's content, but inside Dimmer area.
-   *
-   * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
-   */
-  onClickOutside?: (event: React.MouseEvent<HTMLDivElement>, data: DimmerProps) => void;
-
-  /** A dimmer can be formatted to have its colors inverted. */
-  inverted?: boolean;
-
   /** A dimmer can be formatted to be fixed to the page. */
   page?: boolean;
-
-  /** A dimmer can be controlled with simple prop. */
-  simple?: boolean;
 }
 
 interface DimmerComponent extends React.ComponentClass<DimmerProps> {
   Dimmable: typeof DimmerDimmable;
+  Inner: typeof DimmerInner;
 }
 
 declare const Dimmer: DimmerComponent;

--- a/src/modules/Dimmer/Dimmer.js
+++ b/src/modules/Dimmer/Dimmer.js
@@ -1,68 +1,26 @@
-import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
 import {
-  childrenUtils,
   createShorthandFactory,
-  customPropTypes,
-  doesNodeContainClick,
-  getElementType,
   getUnhandledProps,
   isBrowser,
   META,
-  useKeyOnly,
 } from '../../lib'
 import Portal from '../../addons/Portal'
 import DimmerDimmable from './DimmerDimmable'
+import DimmerInner from './DimmerInner'
 
 /**
  * A dimmer hides distractions to focus attention on particular content.
  */
 export default class Dimmer extends Component {
   static propTypes = {
-    /** An element type to render as (string or function). */
-    as: customPropTypes.as,
-
     /** An active dimmer will dim its parent container. */
     active: PropTypes.bool,
 
-    /** Primary content. */
-    children: PropTypes.node,
-
-    /** Additional classes. */
-    className: PropTypes.string,
-
-    /** Shorthand for primary content. */
-    content: customPropTypes.contentShorthand,
-
-    /** A disabled dimmer cannot be activated */
-    disabled: PropTypes.bool,
-
-    /**
-     * Called on click.
-     *
-     * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All props.
-     */
-    onClick: PropTypes.func,
-
-    /**
-     * Handles click outside Dimmer's content, but inside Dimmer area.
-     *
-     * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All props.
-     */
-    onClickOutside: PropTypes.func,
-
-    /** A dimmer can be formatted to have its colors inverted. */
-    inverted: PropTypes.bool,
-
     /** A dimmer can be formatted to be fixed to the page. */
     page: PropTypes.bool,
-
-    /** A dimmer can be controlled with simple prop. */
-    simple: PropTypes.bool,
   }
 
   static _meta = {
@@ -71,6 +29,7 @@ export default class Dimmer extends Component {
   }
 
   static Dimmable = DimmerDimmable
+  static Inner = DimmerInner
 
   handlePortalMount = () => {
     if (!isBrowser()) return
@@ -88,54 +47,9 @@ export default class Dimmer extends Component {
     document.body.classList.remove('dimmable')
   }
 
-  handleClick = (e) => {
-    const { onClick, onClickOutside } = this.props
-
-    if (onClick) onClick(e, this.props)
-    if (this.centerRef && (this.centerRef !== e.target && doesNodeContainClick(this.centerRef, e))) return
-    if (onClickOutside) onClickOutside(e, this.props)
-  }
-
-  handleCenterRef = c => (this.centerRef = c)
-
   render() {
-    const {
-      active,
-      children,
-      className,
-      content,
-      disabled,
-      inverted,
-      page,
-      simple,
-    } = this.props
-
-    const classes = cx(
-      'ui',
-      useKeyOnly(active, 'active transition visible'),
-      useKeyOnly(disabled, 'disabled'),
-      useKeyOnly(inverted, 'inverted'),
-      useKeyOnly(page, 'page'),
-      useKeyOnly(simple, 'simple'),
-      'dimmer',
-      className,
-    )
+    const { active, page } = this.props
     const rest = getUnhandledProps(Dimmer, this.props)
-    const ElementType = getElementType(Dimmer, this.props)
-
-    const childrenContent = childrenUtils.isNil(children) ? content : children
-
-    const dimmerElement = (
-      <ElementType{...rest} className={classes} onClick={this.handleClick}>
-        {childrenContent && (
-          <div className='content'>
-            <div className='center' ref={this.handleCenterRef}>
-              {childrenContent}
-            </div>
-          </div>
-        )}
-      </ElementType>
-    )
 
     if (page) {
       return (
@@ -147,12 +61,12 @@ export default class Dimmer extends Component {
           open={active}
           openOnTriggerClick={false}
         >
-          {dimmerElement}
+          <DimmerInner {...rest} active={active} page={page} />
         </Portal>
       )
     }
 
-    return dimmerElement
+    return <DimmerInner {...rest} active={active} page={page} />
   }
 }
 

--- a/src/modules/Dimmer/DimmerInner.d.ts
+++ b/src/modules/Dimmer/DimmerInner.d.ts
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { SemanticShorthandContent } from '../..';
+
+export interface DimmerInnerProps {
+  [key: string]: any;
+
+  /** An element type to render as (string or function). */
+  as?: any;
+
+  /** An active dimmer will dim its parent container. */
+  active?: boolean;
+
+  /** Primary content. */
+  children?: React.ReactNode;
+
+  /** Additional classes. */
+  className?: string;
+
+  /** Shorthand for primary content. */
+  content?: SemanticShorthandContent;
+
+  /** A disabled dimmer cannot be activated */
+  disabled?: boolean;
+
+  /**
+   * Called when the dimmer is clicked.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
+   */
+  onClick?: (event: React.MouseEvent<HTMLDivElement>, data: DimmerInnerProps) => void;
+
+  /**
+   * Handles click outside Dimmer's content, but inside Dimmer area.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
+   */
+  onClickOutside?: (event: React.MouseEvent<HTMLDivElement>, data: DimmerInnerProps) => void;
+
+  /** A dimmer can be formatted to have its colors inverted. */
+  inverted?: boolean;
+
+  /** A dimmer can be formatted to be fixed to the page. */
+  page?: boolean;
+
+  /** A dimmer can be controlled with simple prop. */
+  simple?: boolean;
+
+  /** A dimmer can have its content top or bottom aligned. */
+  verticalAlign?: 'bottom' | 'top';
+}
+
+declare class DimmerInner extends React.Component<DimmerInnerProps, {}> {
+
+}
+
+export default DimmerInner;

--- a/src/modules/Dimmer/DimmerInner.js
+++ b/src/modules/Dimmer/DimmerInner.js
@@ -1,0 +1,148 @@
+import cx from 'classnames'
+import _ from 'lodash'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import {
+  childrenUtils,
+  customPropTypes,
+  doesNodeContainClick,
+  getElementType,
+  getUnhandledProps,
+  META,
+  useKeyOnly,
+  useVerticalAlignProp,
+} from '../../lib'
+
+/**
+ *
+ */
+export default class DimmerInner extends Component {
+  static propTypes = {
+    /** An element type to render as (string or function). */
+    as: customPropTypes.as,
+
+    /** An active dimmer will dim its parent container. */
+    active: PropTypes.bool,
+
+    /** Primary content. */
+    children: PropTypes.node,
+
+    /** Additional classes. */
+    className: PropTypes.string,
+
+    /** Shorthand for primary content. */
+    content: customPropTypes.contentShorthand,
+
+    /** A disabled dimmer cannot be activated */
+    disabled: PropTypes.bool,
+
+    /**
+     * Called on click.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onClick: PropTypes.func,
+
+    /**
+     * Handles click outside Dimmer's content, but inside Dimmer area.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onClickOutside: PropTypes.func,
+
+    /** A dimmer can be formatted to have its colors inverted. */
+    inverted: PropTypes.bool,
+
+    /** A dimmer can be formatted to be fixed to the page. */
+    page: PropTypes.bool,
+
+    /** A dimmer can be controlled with simple prop. */
+    simple: PropTypes.bool,
+
+    /** A dimmer can have its content top or bottom aligned. */
+    verticalAlign: PropTypes.oneOf(['bottom', 'top']),
+  }
+
+  static _meta = {
+    name: 'DimmerInner',
+    parent: 'Dimmer',
+    type: META.TYPES.MODULE,
+  }
+
+  componentWillReceiveProps({ active: nextActive }) {
+    const { active: prevActive } = this.props
+
+    if (prevActive !== nextActive) this.toggleStyles(nextActive)
+  }
+
+  componentDidMount() {
+    const { active } = this.props
+
+    this.toggleStyles(active)
+  }
+
+  handleClick = (e) => {
+    _.invoke(this.props, 'onClick', e, this.props)
+
+    if (this.contentRef && (this.contentRef !== e.target && doesNodeContainClick(this.contentRef, e))) return
+    _.invoke(this.props, 'onClickOutside', e, this.props)
+  }
+
+  handleRef = c => (this.ref = c)
+
+  handleContentRef = c => (this.contentRef = c)
+
+  toggleStyles(active) {
+    if (!this.ref) return
+
+    if (active) {
+      this.ref.style.setProperty('display', 'flex', 'important')
+      return
+    }
+
+    this.ref.style.removeProperty('display')
+  }
+
+  render() {
+    const {
+      active,
+      children,
+      className,
+      content,
+      disabled,
+      inverted,
+      page,
+      simple,
+      verticalAlign,
+    } = this.props
+
+    const classes = cx(
+      'ui',
+      useKeyOnly(active, 'active transition visible'),
+      useKeyOnly(disabled, 'disabled'),
+      useKeyOnly(inverted, 'inverted'),
+      useKeyOnly(page, 'page'),
+      useKeyOnly(simple, 'simple'),
+      useVerticalAlignProp(verticalAlign),
+      'dimmer',
+      className,
+    )
+    const rest = getUnhandledProps(DimmerInner, this.props)
+    const ElementType = getElementType(DimmerInner, this.props)
+
+    const childrenContent = childrenUtils.isNil(children) ? content : children
+
+    return (
+      <ElementType {...rest} className={classes} onClick={this.handleClick} ref={this.handleRef}>
+        {childrenContent && (
+          <div className='content' ref={this.handleContentRef}>
+            {childrenContent}
+          </div>
+        )}
+      </ElementType>
+    )
+  }
+}

--- a/test/specs/modules/Dimmer/Dimmer-test.js
+++ b/test/specs/modules/Dimmer/Dimmer-test.js
@@ -1,67 +1,22 @@
-import faker from 'faker'
 import React from 'react'
 
 import Portal from 'src/addons/Portal/Portal'
 import Dimmer from 'src/modules/Dimmer/Dimmer'
 import DimmerDimmable from 'src/modules/Dimmer/DimmerDimmable'
+import DimmerInner from 'src/modules/Dimmer/DimmerInner'
 import * as common from 'test/specs/commonTests'
-import { sandbox } from 'test/utils'
 
 describe('Dimmer', () => {
   common.isConformant(Dimmer)
-  common.hasSubComponents(Dimmer[DimmerDimmable])
-  common.hasUIClassName(Dimmer)
-  common.rendersChildren(Dimmer)
+  common.hasSubComponents(Dimmer, [DimmerDimmable, DimmerInner])
 
   common.implementsCreateMethod(Dimmer)
 
-  common.propKeyOnlyToClassName(Dimmer, 'active', {
-    className: 'active transition visible',
-  })
-  common.propKeyOnlyToClassName(Dimmer, 'disabled')
-  common.propKeyOnlyToClassName(Dimmer, 'inverted')
-  common.propKeyOnlyToClassName(Dimmer, 'simple')
-
-  describe('onClickOutside', () => {
-    it('omitted when not defined', () => {
-      const wrapper = shallow(<Dimmer>{faker.hacker.phrase()}</Dimmer>)
-      const click = () => wrapper.find('div.center').simulate('click')
-
-      expect(click).to.not.throw()
-    })
-
-    it('called when Dimmer has not children', () => {
-      const spy = sandbox.spy()
-      shallow(<Dimmer onClickOutside={spy} />)
-        .simulate('click')
-
-      spy.should.have.been.calledOnce()
-    })
-
-    it('omitted when click on children', () => {
-      const spy = sandbox.spy()
-      const wrapper = mount(<Dimmer onClickOutside={spy}><div>{faker.hacker.phrase()}</div></Dimmer>, {
-        attachTo: document.body,
-      })
-
-      wrapper.find('div.center').childAt(0).simulate('click')
-      spy.should.have.been.callCount(0)
-    })
-
-    it('called when click on Dimmer', () => {
-      const spy = sandbox.spy()
-
-      mount(<Dimmer onClickOutside={spy}>{faker.hacker.phrase()}</Dimmer>)
-        .simulate('click')
-      spy.should.have.been.calledOnce()
-    })
-
-    it('called when click on center', () => {
-      const spy = sandbox.spy()
-      const wrapper = mount(<Dimmer onClickOutside={spy}>{faker.hacker.phrase()}</Dimmer>)
-
-      wrapper.find('div.center').simulate('click')
-      spy.should.have.been.calledOnce()
+  describe('children', () => {
+    it('renders a DimmerInner', () => {
+      shallow(<Dimmer />)
+        .type()
+        .should.equal(DimmerInner)
     })
   })
 

--- a/test/specs/modules/Dimmer/DimmerInner-test.js
+++ b/test/specs/modules/Dimmer/DimmerInner-test.js
@@ -1,0 +1,66 @@
+import faker from 'faker'
+import React from 'react'
+
+import DimmerInner from 'src/modules/Dimmer/DimmerInner'
+import * as common from 'test/specs/commonTests'
+import { sandbox } from 'test/utils'
+
+describe('DimmerInner', () => {
+  common.isConformant(DimmerInner)
+  common.hasUIClassName(DimmerInner)
+  common.rendersChildren(DimmerInner)
+
+  common.implementsVerticalAlignProp(DimmerInner, ['bottom', 'top'])
+
+  common.propKeyOnlyToClassName(DimmerInner, 'active', {
+    className: 'active transition visible',
+  })
+  common.propKeyOnlyToClassName(DimmerInner, 'disabled')
+  common.propKeyOnlyToClassName(DimmerInner, 'inverted')
+  common.propKeyOnlyToClassName(DimmerInner, 'simple')
+
+  describe('onClickOutside', () => {
+    it('called when Dimmer has not children', () => {
+      const onClickOutside = sandbox.spy()
+      shallow(<DimmerInner onClickOutside={onClickOutside} />)
+        .simulate('click')
+
+      onClickOutside.should.have.been.calledOnce()
+    })
+
+    it('omitted when click on children', () => {
+      const onClickOutside = sandbox.spy()
+      const wrapper = mount(
+        <DimmerInner onClickOutside={onClickOutside}>
+          <div>{faker.hacker.phrase()}</div>
+        </DimmerInner>, {
+          attachTo: document.body,
+        })
+
+      wrapper.find('div.content').childAt(0).simulate('click')
+      onClickOutside.should.have.been.callCount(0)
+    })
+
+    it('called when click on Dimmer', () => {
+      const onClickOutside = sandbox.spy()
+
+      mount(<DimmerInner onClickOutside={onClickOutside}>{faker.hacker.phrase()}</DimmerInner>)
+        .simulate('click')
+      onClickOutside.should.have.been.calledOnce()
+    })
+
+    it('called when click on center', () => {
+      const onClickOutside = sandbox.spy()
+      const wrapper = mount(
+        <DimmerInner onClickOutside={onClickOutside}>
+          {faker.hacker.phrase()}
+        </DimmerInner>,
+      )
+
+      wrapper
+        .find('div.content')
+        .simulate('click')
+      onClickOutside.should.have.been.calledOnce()
+    })
+  })
+})


### PR DESCRIPTION
Refs #2550.

----

This PR is a part of upgrade to SUI 2.3. 

### What is does?

- add new `verticalAlign` prop, see [SUI examples](https://semantic-ui.com/modules/dimmer.html#vertical-alignment)
- splits the `Dimmer`'s content rendering to the new `DimmerInner` component; it's needed because dimmers now need `display: flex !important;` to be visible correctly, a `page` dimmer too
- adds new examples