### PR TITLE
feat(Transition): update SUI to 2.3, add `zoom` and `glow`

### DIFF
--- a/docs/app/Examples/addons/TransitionablePortal/Usage/TransitionablePortalExampleTransition.js
+++ b/docs/app/Examples/addons/TransitionablePortal/Usage/TransitionablePortalExampleTransition.js
@@ -10,6 +10,7 @@ const transitions = [
   'scale',
   'slide up', 'slide down', 'slide left', 'slide right',
   'swing up', 'swing down', 'swing left', 'swing right',
+  'zoom',
 ]
 const options = transitions.map(name => ({ key: name, text: name, value: name }))
 

--- a/docs/app/Examples/modules/Transition/Explorers/TransitionExampleGroupExplorer.js
+++ b/docs/app/Examples/modules/Transition/Explorers/TransitionExampleGroupExplorer.js
@@ -10,6 +10,7 @@ const transitions = [
   'scale',
   'slide up', 'slide down', 'slide left', 'slide right',
   'swing up', 'swing down', 'swing left', 'swing right',
+  'zoom',
 ]
 const options = transitions.map(name => ({ key: name, text: name, value: name }))
 

--- a/docs/app/Examples/modules/Transition/Explorers/TransitionExampleTransitionExplorer.js
+++ b/docs/app/Examples/modules/Transition/Explorers/TransitionExampleTransitionExplorer.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { Form, Grid, Image, Transition } from 'semantic-ui-react'
 
-const transitions = ['jiggle', 'flash', 'shake', 'pulse', 'tada', 'bounce']
+const transitions = ['jiggle', 'flash', 'shake', 'pulse', 'tada', 'bounce', 'glow']
 
 const options = transitions.map(name => ({ key: name, text: name, value: name }))
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -64,8 +64,9 @@ type SemanticDIRECTIONALTRANSITIONS =  'browse' | 'browse right' |
   'horizontal flip' | 'vertical flip' |
   'scale' |
   'slide up' | 'slide down' | 'slide left' | 'slide right' |
-  'swing up' | 'swing down' | 'swing left' | 'swing right';
-type SemanticSTATICTRANSITIONS = 'jiggle' | 'flash' | 'shake' | 'pulse' | 'tada' | 'bounce';
+  'swing up' | 'swing down' | 'swing left' | 'swing right' |
+  'zoom';
+type SemanticSTATICTRANSITIONS = 'jiggle' | 'flash' | 'shake' | 'pulse' | 'tada' | 'bounce' | 'glow';
 
 export type SemanticTRANSITIONS = SemanticDIRECTIONALTRANSITIONS | SemanticSTATICTRANSITIONS;
 

--- a/src/lib/SUI.js
+++ b/src/lib/SUI.js
@@ -38,8 +38,9 @@ export const DIRECTIONAL_TRANSITIONS = [
   'scale',
   'slide up', 'slide down', 'slide left', 'slide right',
   'swing up', 'swing down', 'swing left', 'swing right',
+  'zoom',
 ]
-export const STATIC_TRANSITIONS = ['jiggle', 'flash', 'shake', 'pulse', 'tada', 'bounce']
+export const STATIC_TRANSITIONS = ['jiggle', 'flash', 'shake', 'pulse', 'tada', 'bounce', 'glow']
 export const TRANSITIONS = [...DIRECTIONAL_TRANSITIONS, ...STATIC_TRANSITIONS]
 
 // Generated from:


### PR DESCRIPTION
Refs #2550.

This PR is a part of upgrade to SUI 2.3,  add support for new `Transition` names `zoom` and `glow`.