### PR TITLE
fix(Checkbox): only add "fitted" class if label is nil

### DIFF
--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -226,7 +226,7 @@ export default class Checkbox extends Component {
       useKeyOnly(indeterminate, 'indeterminate'),
       // auto apply fitted class to compact white space when there is no label
       // https://semantic-ui.com/modules/checkbox.html#fitted
-      useKeyOnly(label == null, 'fitted'),
+      useKeyOnly(_.isNil(label), 'fitted'),
       useKeyOnly(radio, 'radio'),
       useKeyOnly(readOnly, 'read-only'),
       useKeyOnly(slider, 'slider'),

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -226,7 +226,7 @@ export default class Checkbox extends Component {
       useKeyOnly(indeterminate, 'indeterminate'),
       // auto apply fitted class to compact white space when there is no label
       // https://semantic-ui.com/modules/checkbox.html#fitted
-      useKeyOnly(!label, 'fitted'),
+      useKeyOnly(label == null, 'fitted'),
       useKeyOnly(radio, 'radio'),
       useKeyOnly(readOnly, 'read-only'),
       useKeyOnly(slider, 'slider'),

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -207,9 +207,15 @@ describe('Checkbox', () => {
         .should.have.className('fitted')
     })
 
-    it('does not add the "fitted" class when falsey but not null', () => {
+    it('adds the "fitted" class when is null', () => {
+      shallow(<Checkbox name='firstName' />)
+        .should.have.className('fitted')
+    })
+
+    it('does not add the "fitted" class when is not nil', () => {
       shallow(<Checkbox name='firstName' label='' />)
         .should.not.have.className('fitted')
+
       shallow(<Checkbox name='firstName' label={0} />)
         .should.not.have.className('fitted')
     })

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -206,6 +206,13 @@ describe('Checkbox', () => {
       shallow(<Checkbox name='firstName' />)
         .should.have.className('fitted')
     })
+
+    it('does not add the "fitted" class when falsey but not null', () => {
+      shallow(<Checkbox name='firstName' label='' />)
+        .should.not.have.className('fitted')
+      shallow(<Checkbox name='firstName' label={0} />)
+        .should.not.have.className('fitted')
+    })
   })
 
   describe('onChange', () => {


### PR DESCRIPTION
# The issue
The fitted class was added to a checkbox when the value was falsey but not null.
This results in labels such as **0** gets fitted, which IMHO is a bug.

I stumbled upon this when adding check boxes in a loop, e.g.
```jsx
const boxes = []
for (let i = -1; i <= 1; ++i) {
  // the checkbox with label/value 0 will get "fitted"
  const box = <Checkbox label={i} value={i} />;
  boxes.push(box);
}
```

# The solution
Only add fitted if the label is null.
The documentation states "Auto applied when there is no label.", and I would say only `null` should constitute "no label".

# Discussion
With this PR it only check that the label is not `null`. 
Some might argue that an empty string is also "no label", but I took a stance and I'm willing to change if anyone disagrees.

# Example
## Code
```jsx
import React, { Component } from 'react';
import { Divider, Header, Container, Checkbox } from 'semantic-ui-react';

class App extends Component {
  render() {
    return (
      [
        <Container style={{ marginTop: '30px' }} textAlign="center">
        <Header as='h3'>Counting</Header>
        <Checkbox label={-1} />
        <Checkbox label={0} />
        <Checkbox label={1} />
      </Container>,
      <Divider />,
      <Container textAlign="center">
        <Header as='h3'>Empty string</Header>
        <Checkbox label="The next checkbox has empty string" />
        <Checkbox label="" />
        <Checkbox label="But I'm not empty" />
      </Container>
      ]);
  }
}

export default App;

```
## Before
![Before](https://imgur.com/HNeJFfG.png)
## After
![After](https://imgur.com/PkoKYsk.png)
