### PR TITLE
chore(package): restore babel option `modules: false` for ESM builds

### DIFF
--- a/build/preset-env.js
+++ b/build/preset-env.js
@@ -18,9 +18,14 @@ const browsers = [
   'not ie_mob <= 11',
 ]
 
-module.exports = {
-  presets: [['env', {
+const envOptions = {
     targets: { browsers },
-  }]],
+}
+if (env === 'build-es') {
+    envOptions.modules = false
+}
+
+module.exports = {
+  presets: [['env', envOptions]],
   plugins,
 }

--- a/build/preset-env.js
+++ b/build/preset-env.js
@@ -19,11 +19,9 @@ const browsers = [
 ]
 
 const envOptions = {
-    targets: { browsers },
+  targets: { browsers },
 }
-if (env === 'build-es') {
-    envOptions.modules = false
-}
+if (env === 'build-es') envOptions.modules = false
 
 module.exports = {
   presets: [['env', envOptions]],


### PR DESCRIPTION
Fixes #2661.