### PR TITLE
fix(icon): omit aria-hidden attribute when aria-label prop is truthy

### DIFF
--- a/src/elements/Icon/Icon.d.ts
+++ b/src/elements/Icon/Icon.d.ts
@@ -52,6 +52,9 @@ export interface IconProps {
 
   /** Size of the icon. */
   size?: IconSizeProp;
+
+  /** Icon can have an aria label. */
+  'aria-label'?: string;
 }
 
 declare class Icon extends React.Component<IconProps, {}> {

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -66,6 +66,9 @@ class Icon extends Component {
 
     /** Size of the icon. */
     size: PropTypes.oneOf(_.without(SUI.SIZES, 'medium')),
+
+    /** Icon can have an aria label. */
+    'aria-label': PropTypes.string,
   }
 
   static defaultProps = {
@@ -81,6 +84,17 @@ class Icon extends Component {
 
   shouldComponentUpdate(nextProps) {
     return !shallowEqual(this.props, nextProps)
+  }
+
+  getIconAriaOptions() {
+    const ariaOptions = {}
+    const { 'aria-label': ariaLabel } = this.props
+
+    if (!ariaLabel) {
+      ariaOptions['aria-hidden'] = 'true'
+    }
+
+    return ariaOptions
   }
 
   render() {
@@ -120,8 +134,9 @@ class Icon extends Component {
     )
     const rest = getUnhandledProps(Icon, this.props)
     const ElementType = getElementType(Icon, this.props)
+    const ariaOptions = this.getIconAriaOptions()
 
-    return <ElementType {...rest} aria-hidden='true' className={classes} />
+    return <ElementType {...rest} {...ariaOptions} className={classes} />
   }
 }
 

--- a/test/specs/elements/Icon/Icon-test.js
+++ b/test/specs/elements/Icon/Icon-test.js
@@ -39,5 +39,11 @@ describe('Icon', () => {
 
       wrapper.should.have.prop('aria-hidden', 'true')
     })
+
+    it('should omit aria-hidden when aria-label is set', () => {
+      const wrapper = shallow(<Icon aria-label='icon' />)
+
+      wrapper.should.not.have.prop('aria-hidden')
+    })
   })
 })


### PR DESCRIPTION
Fixes [#2652](https://github.com/Semantic-Org/Semantic-UI-React/issues/2652)

### Details

Prevent setting aria-hidden attribute when aria-label property is passed. For all other cases aria-hidden="true" is set.