### PR TITLE
fix(docs): show vertically divided grid in grid layout

### DIFF
--- a/docs/app/Layouts/GridLayout.js
+++ b/docs/app/Layouts/GridLayout.js
@@ -204,7 +204,7 @@ const GridLayout = () => (
 
       <Divider horizontal section>Vertically Divided Grid</Divider>
 
-      <Grid divided='verticallly'>
+      <Grid divided='vertically'>
         <Grid.Row>
           <Grid.Column width={4} />
           <Grid.Column width={4} />


### PR DESCRIPTION
a typo in GridLayout prevents the vertical grid dividers to display