### PR TITLE
fix(docs): Container is not defined (#2684)

### DIFF
--- a/docs/app/Components/ComponentDoc/ComponentExample/ComponentExample.js
+++ b/docs/app/Components/ComponentDoc/ComponentExample/ComponentExample.js
@@ -200,7 +200,7 @@ class ComponentExample extends Component {
     // which can be rendered in this ComponentExample's render() method
 
     // rewrite imports to const statements against the UPPERCASE module names
-    const imports = _.get(/(^import[\s\S]*from[\s\S]*['"]\n)/.exec(sourceCode), '[1]', '')
+    const imports = _.get(/(^[\s\S])*import[\s\S]*from[\s\S]*['"]\n/.exec(sourceCode), '[0]', '')
       .replace(/[\s\n]+/g, ' ')         // normalize spaces and make one line
       .replace(/ import/g, '\nimport')  // one import per line
       .split('\n')                      // split lines


### PR DESCRIPTION
Looks like there was an issue with the regex that pulls the imports out of the component source. The previous regex assumed the imports would always be the first line, but in some cases we have some eslint disables as the first line. I modified the regex to look for previous lines, if there are any.

The editors will still break if someone is a jerk and types an import statement in the middle of the editor, though.