### PR TITLE
docs(List): fix duplicate Types sections

### DIFF
--- a/docs/app/Examples/elements/List/Variations/index.js
+++ b/docs/app/Examples/elements/List/Variations/index.js
@@ -5,7 +5,7 @@ import ComponentExample from 'docs/app/Components/ComponentDoc/ComponentExample'
 import ExampleSection from 'docs/app/Components/ComponentDoc/ExampleSection'
 
 const ListVariations = () => (
-  <ExampleSection title='Types'>
+  <ExampleSection title='Variations'>
     <ComponentExample
       title='Horizontal'
       description='A list can be formatted to have items appear horizontally'


### PR DESCRIPTION
The List's `Variations` section is mislabeled and is duplicating `Types`.