### PR TITLE
chore(stalebot): update stalebot's messaging and timeframes

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,7 +2,7 @@
 daysUntilStale: 90
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 30
+daysUntilClose: 90
 
 # Issues with these labels will never be considered stale
 exemptLabels:
@@ -14,9 +14,20 @@ staleLabel: stale
 
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed in 30 days if no further activity occurs.
-  Thank you for your contributions.
+  There has been no activity in this thread for 90 days. While we care about
+  every issue and we’d love to see this fixed, the core team’s time is 
+  limited so we have to focus our attention on the issues that are most 
+  pressing. Therefore, we will likely not be able to get to this one.
+  
+  
+  However, PRs for this issue will of course be accepted and welcome!
+  
+  
+  If there is no more activity in the next 90 days, this issue will be closed
+  automatically for housekeeping. To prevent this, simply leave a reply here. 
+  Thanks!
 
 # Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+closeComment: >
+  This issue will be closed due to lack of activity for 6 months. If you’d
+  like this to be reopened, just leave a comment; we do monitor them!


### PR DESCRIPTION
This is an update inspired by the discussion in #1126, attempting to better communicate the reasoning behind the stalebot.

Also, I've adjusted the closing timeframe (as opposed to the stale timeframe), because closing feels more harsh than the marking as stale, and is harder for a community member to reverse.

Suggestions/changes welcome of course!