### PR TITLE
docs(issue_templates): add new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,21 +1,6 @@
-✖ CSS ISSUES → Post on https://github.com/Semantic-Org/Semantic-UI
+<!---
+Thanks for filing an issue 😄 ! Before you submit, please read the following:
 
-✖ USAGE QUESTIONS → Use these dedicated resources:
-      Docs - http://react.semantic-ui.com
-      Chat - https://gitter.im/Semantic-Org/Semantic-UI-React
-      SO - https://stackoverflow.com/questions/tagged/semantic-ui-react?sort=votes
-
-✔ BUGS → This form is required:
-
-### Steps
-
-### Expected Result
-
-### Actual Result
-
-### Version
-x.y.z
-
-### Testcase
-[Fork, update, and replace this pen to show the bug]:
-https://codesandbox.io/s/2l3n74j9y
+Check the other issue templates if you are trying to submit a bug report, feature request, or question
+Search open/closed issues before submitting since someone might have asked the same thing before!
+-->

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,23 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🔧.
+
+---
+
+## Bug Report
+
+### Steps
+A clear and concise description of steps to reproduce the problem.
+
+### Expected Result
+The result that you expected.
+
+### Actual Result
+The actual result that happened 💣
+
+### Version
+x.y.z
+
+### Testcase
+[Fork, update, and replace this pen to show the bug]:
+https://codesandbox.io/s/2l3n74j9y

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: 🚀 Feature Request
+about: I have a suggestion (and may want to implement it 💪)!
+
+---
+
+## Feature Request
+
+### Problem description
+A clear and concise description of what the problem is. Ex. I have an issue when [...]
+
+### Proposed solution
+A clear and concise description of what you want to happen. Add any considered drawbacks.
+
+### MVP
+[Fork, update, and replace this pen if you can show the proposed solution]:
+https://codesandbox.io/s/2l3n74j9y

--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -1,0 +1,14 @@
+---
+name: 📓 Support Question
+about: If you have a question 💬, please check out our Gitter or StackOverflow!
+
+---
+
+--------------^ Click "Preview" for a nicer view!
+We primarily use GitHub as an issue tracker; for usage and support questions, please check out these resources below. Thanks! 😁.
+
+---
+
+* Gitter Community Chat: https://gitter.im/Semantic-Org/Semantic-UI-React
+* StackOverflow: https://stackoverflow.com/questions/tagged/semantic-ui-react using the tag `semantic-ui-react`
+* Also have a look at our docs: http://react.semantic-ui.com


### PR DESCRIPTION
Github added new awesome issue tempates, you can check them there:
- https://github.com/babel/babel/issues/new/choose
- https://github.com/facebook/jest/issues/new/choose

I fetched templates from `babel`'s repo and added some changes.