### PR TITLE
docs(ComponentDoc): remove SUI links

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentDoc.js
+++ b/docs/src/components/ComponentDoc/ComponentDoc.js
@@ -45,7 +45,6 @@ class ComponentDoc extends Component {
         type: PropTypes.string,
       }),
     ).isRequired,
-    suiLink: PropTypes.string,
   }
 
   state = {}
@@ -75,15 +74,7 @@ class ComponentDoc extends Component {
   }
 
   render() {
-    const {
-      componentGroup,
-      componentName,
-      description,
-      ghLink,
-      path,
-      seeItems,
-      suiLink,
-    } = this.props
+    const { componentGroup, componentName, description, ghLink, path, seeItems } = this.props
     const { activePath, examplesRef } = this.state
 
     return (
@@ -93,12 +84,7 @@ class ComponentDoc extends Component {
             <Grid.Column>
               <ComponentDocHeader componentName={componentName} description={description} />
               <ComponentDocSee items={seeItems} />
-              <ComponentDocLinks
-                componentName={componentName}
-                ghLink={ghLink}
-                path={path}
-                suiLink={suiLink}
-              />
+              <ComponentDocLinks ghLink={ghLink} path={path} />
               <ComponentProps componentGroup={componentGroup} componentName={componentName} />
             </Grid.Column>
           </Grid.Row>

--- a/docs/src/components/ComponentDoc/ComponentDocLinks.js
+++ b/docs/src/components/ComponentDoc/ComponentDocLinks.js
@@ -14,7 +14,7 @@ const linkListStyle = {
   top: '0',
 }
 
-const ComponentDocLinks = ({ componentName, ghLink, path, suiLink }) => (
+const ComponentDocLinks = ({ ghLink, path }) => (
   <List link style={linkListStyle}>
     <List.Item
       content={
@@ -26,24 +26,12 @@ const ComponentDocLinks = ({ componentName, ghLink, path, suiLink }) => (
       }
       icon='github'
     />
-    {suiLink && (
-      <List.Item
-        content={
-          <a href={suiLink} target='_blank'>
-            Semantic UI {componentName} Docs
-          </a>
-        }
-        icon='book'
-      />
-    )}
   </List>
 )
 
 ComponentDocLinks.propTypes = {
-  componentName: PropTypes.string.isRequired,
   ghLink: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
-  suiLink: PropTypes.string,
 }
 
 export default pure(ComponentDocLinks)

--- a/docs/src/hoc/withDocInfo.js
+++ b/docs/src/hoc/withDocInfo.js
@@ -22,18 +22,16 @@ const withDocInfo = ChildComponent =>
       this.setState(this.computeProps(nextProps))
     }
 
-    computeProps = ({ name, parent, type }) => {
+    computeProps = ({ name }) => {
       const { docBlock, path } = docInfo[name]
       const { description } = docBlock
 
       const ghLink = `${repoURL}/blob/master/${path}`
-      const suiLink = `https://semantic-ui.com/${type}s/${name || parent}`.toLowerCase()
 
       return {
         description,
         ghLink,
         path,
-        suiLink,
         componentGroup: getComponentGroup(docInfo, name),
         componentName: name,
         seeItems: getSeeItems(docInfo, name),


### PR DESCRIPTION
This PR is a breakout of #2782.

Our `v2` components are no longer 1:1 with Semantic UI components.  We therefore will not show links directly to SUI docs for each component:

## Before

![image](https://user-images.githubusercontent.com/5067638/39941899-d419ae94-5512-11e8-807a-bb756d2f9d75.png)

## After

![image](https://user-images.githubusercontent.com/5067638/39941916-dd05cb6e-5512-11e8-80ea-d91b9dfb8a8e.png)
