### PR TITLE
feat(factories): support functions

### DIFF
--- a/test/specs/lib/factories-test.js
+++ b/test/specs/lib/factories-test.js
@@ -67,8 +67,9 @@ const itMergesClassNames = (classNameSource, extraClassName, shorthandConfig) =>
     const defaultProps = { className: 'default' }
     const overrideProps = { className: 'override' }
 
-    shallow(getShorthand({ defaultProps, overrideProps, ...shorthandConfig }))
-      .should.have.same.className(`default override ${extraClassName}`)
+    shallow(
+      getShorthand({ defaultProps, overrideProps, ...shorthandConfig }),
+    ).should.have.same.className(`default override ${extraClassName}`)
   })
 }
 
@@ -170,61 +171,49 @@ describe('factories', () => {
 
     describe('key', () => {
       it('is not consumed', () => {
-        getShorthand({ value: { key: 123 } })
-          .props.should.have.property('key')
+        getShorthand({ value: { key: 123 } }).props.should.have.property('key')
       })
 
       describe('on an element', () => {
         it('works with a string', () => {
-          getShorthand({ value: <div key='foo' /> })
-            .should.have.property('key', 'foo')
+          getShorthand({ value: <div key='foo' /> }).should.have.property('key', 'foo')
         })
 
         it('works with a number', () => {
-          getShorthand({ value: <div key={123} /> })
-            .should.have.property('key', '123')
+          getShorthand({ value: <div key={123} /> }).should.have.property('key', '123')
         })
 
         it('works with falsy values', () => {
-          getShorthand({ value: <div key={null} /> })
-            .should.have.property('key', 'null')
+          getShorthand({ value: <div key={null} /> }).should.have.property('key', 'null')
 
-          getShorthand({ value: <div key={0} /> })
-            .should.have.property('key', '0')
+          getShorthand({ value: <div key={0} /> }).should.have.property('key', '0')
 
-          getShorthand({ value: <div key='' /> })
-            .should.have.property('key', '')
+          getShorthand({ value: <div key='' /> }).should.have.property('key', '')
         })
       })
 
       describe('on an object', () => {
         it('works with a string', () => {
-          getShorthand({ value: { key: 'foo' } })
-            .should.have.property('key', 'foo')
+          getShorthand({ value: { key: 'foo' } }).should.have.property('key', 'foo')
         })
 
         it('works with a number', () => {
-          getShorthand({ value: { key: 123 } })
-            .should.have.property('key', '123')
+          getShorthand({ value: { key: 123 } }).should.have.property('key', '123')
         })
 
         it('works with falsy values', () => {
-          getShorthand({ value: { key: null } })
-            .should.have.property('key', 'null')
+          getShorthand({ value: { key: null } }).should.have.property('key', 'null')
 
-          getShorthand({ value: { key: 0 } })
-            .should.have.property('key', '0')
+          getShorthand({ value: { key: 0 } }).should.have.property('key', '0')
 
-          getShorthand({ value: { key: '' } })
-            .should.have.property('key', '')
+          getShorthand({ value: { key: '' } }).should.have.property('key', '')
         })
       })
     })
 
     describe('childKey', () => {
       it('is consumed', () => {
-        getShorthand({ value: { childKey: 123 } })
-          .props.should.not.have.property('childKey')
+        getShorthand({ value: { childKey: 123 } }).props.should.not.have.property('childKey')
       })
 
       it('is called with the final `props` if it is a function', () => {
@@ -239,47 +228,37 @@ describe('factories', () => {
 
       describe('on an element', () => {
         it('works with a string', () => {
-          getShorthand({ value: <div childKey='foo' /> })
-            .should.have.property('key', 'foo')
+          getShorthand({ value: <div childKey='foo' /> }).should.have.property('key', 'foo')
         })
 
         it('works with a number', () => {
-          getShorthand({ value: <div childKey={123} /> })
-            .should.have.property('key', '123')
+          getShorthand({ value: <div childKey={123} /> }).should.have.property('key', '123')
         })
 
         it('works with falsy values', () => {
-          getShorthand({ value: <div childKey={null} /> })
-            .should.have.property('key', null)
+          getShorthand({ value: <div childKey={null} /> }).should.have.property('key', null)
 
-          getShorthand({ value: <div childKey={0} /> })
-            .should.have.property('key', '0')
+          getShorthand({ value: <div childKey={0} /> }).should.have.property('key', '0')
 
-          getShorthand({ value: <div childKey='' /> })
-            .should.have.property('key', '')
+          getShorthand({ value: <div childKey='' /> }).should.have.property('key', '')
         })
       })
 
       describe('on an object', () => {
         it('works with a string', () => {
-          getShorthand({ value: { childKey: 'foo' } })
-            .should.have.property('key', 'foo')
+          getShorthand({ value: { childKey: 'foo' } }).should.have.property('key', 'foo')
         })
 
         it('works with a number', () => {
-          getShorthand({ value: { childKey: 123 } })
-            .should.have.property('key', '123')
+          getShorthand({ value: { childKey: 123 } }).should.have.property('key', '123')
         })
 
         it('works with falsy values', () => {
-          getShorthand({ value: { childKey: null } })
-            .should.have.property('key', null)
+          getShorthand({ value: { childKey: null } }).should.have.property('key', null)
 
-          getShorthand({ value: { childKey: 0 } })
-            .should.have.property('key', '0')
+          getShorthand({ value: { childKey: 0 } }).should.have.property('key', '0')
 
-          getShorthand({ value: { childKey: '' } })
-            .should.have.property('key', '')
+          getShorthand({ value: { childKey: '' } }).should.have.property('key', '')
         })
       })
     })
@@ -376,10 +355,14 @@ describe('factories', () => {
         mapValueToProps: () => ({ className: 'mapped' }),
       })
 
-      itAppliesProps('mapValueToProps', { 'data-prop': 'present' }, {
-        value: 'foo',
-        mapValueToProps: () => ({ 'data-prop': 'present' }),
-      })
+      itAppliesProps(
+        'mapValueToProps',
+        { 'data-prop': 'present' },
+        {
+          value: 'foo',
+          mapValueToProps: () => ({ 'data-prop': 'present' }),
+        },
+      )
 
       itOverridesDefaultProps(
         'mapValueToProps',
@@ -419,6 +402,45 @@ describe('factories', () => {
       })
     })
 
+    describe('from a function', () => {
+      itReturnsAValidElement(() => <div />)
+      itDoesNotIncludePropsFromMapValueToProps(() => <div />)
+
+      it('is called once', () => {
+        const spy = sandbox.spy()
+
+        getShorthand({ value: spy })
+
+        spy.should.have.been.calledOnce()
+      })
+
+      it('is called with Component, props, children', () => {
+        const spy = sandbox.spy(() => <div />)
+
+        getShorthand({ Component: 'p', value: spy })
+
+        spy.should.have.been.calledWithExactly('p', {}, undefined)
+      })
+
+      it('receives defaultProps in its props argument', () => {
+        const spy = sandbox.spy(() => <div />)
+        const defaultProps = { defaults: true }
+
+        getShorthand({ Component: 'p', defaultProps, value: spy })
+
+        spy.should.have.been.calledWithExactly('p', defaultProps, undefined)
+      })
+
+      it('receives overrideProps in its props argument', () => {
+        const spy = sandbox.spy(() => <div />)
+        const overrideProps = { overrides: true }
+
+        getShorthand({ Component: 'p', overrideProps, value: spy })
+
+        spy.should.have.been.calledWithExactly('p', overrideProps, undefined)
+      })
+    })
+
     describe('from an array', () => {
       itReturnsAValidElement(['foo'])
       itAppliesDefaultProps(['foo'])
@@ -427,10 +449,14 @@ describe('factories', () => {
         mapValueToProps: () => ({ className: 'mapped' }),
       })
 
-      itAppliesProps('mapValueToProps', { 'data-prop': 'present' }, {
-        value: ['foo'],
-        mapValueToProps: () => ({ 'data-prop': 'present' }),
-      })
+      itAppliesProps(
+        'mapValueToProps',
+        { 'data-prop': 'present' },
+        {
+          value: ['foo'],
+          mapValueToProps: () => ({ 'data-prop': 'present' }),
+        },
+      )
 
       itOverridesDefaultProps(
         'mapValueToProps',
@@ -455,7 +481,8 @@ describe('factories', () => {
         const overrideProps = { style: { right: 5 } }
 
         shallow(getShorthand({ defaultProps, overrideProps, value: userProps }))
-          .should.have.prop('style').deep.equal({ left: 5, bottom: 5, right: 5 })
+          .should.have.prop('style')
+          .deep.equal({ left: 5, bottom: 5, right: 5 })
       })
 
       it('merges style prop and handles override by userProps', () => {
@@ -463,7 +490,8 @@ describe('factories', () => {
         const userProps = { style: { bottom: 10 } }
 
         shallow(getShorthand({ defaultProps, value: userProps }))
-          .should.have.prop('style').deep.equal({ left: 10, bottom: 10 })
+          .should.have.prop('style')
+          .deep.equal({ left: 10, bottom: 10 })
       })
 
       it('merges style prop and handles override by overrideProps', () => {
@@ -471,7 +499,8 @@ describe('factories', () => {
         const overrideProps = { style: { right: 10 } }
 
         shallow(getShorthand({ overrideProps, value: userProps }))
-          .should.have.prop('style').deep.equal({ bottom: 10, right: 10 })
+          .should.have.prop('style')
+          .deep.equal({ bottom: 10, right: 10 })
       })
 
       it('merges style prop from defaultProps and overrideProps', () => {
@@ -479,7 +508,8 @@ describe('factories', () => {
         const overrideProps = { style: { bottom: 10 } }
 
         shallow(getShorthand({ defaultProps, overrideProps, value: 'foo' }))
-          .should.have.prop('style').deep.equal({ left: 10, bottom: 10 })
+          .should.have.prop('style')
+          .deep.equal({ left: 10, bottom: 10 })
       })
     })
   })


### PR DESCRIPTION
As part of the v2 manifesto, we are allowing users to construct the render tree shorthand props themselves.  More details to come.  This is now possible:

![image](https://user-images.githubusercontent.com/5067638/39950736-4f6c6116-5538-11e8-8569-cd2fee31adc5.png)

```jsx
  <Button
    content='Nice!'
    icon={(Icon, props) => <Icon name='thumbs up' {...props} />}
  />
```


We simply give the user the component, props, and children of what ever the shorthand prop was going to render.  This allows the user to control the render tree, previously not possible with shorthand props.