### PR TITLE
docs(readme): simplify and focus content

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,6 +37,7 @@ CONTRIBUTING
   - [Components](#components)
   - [Props](#props)
   - [Examples](#examples)
+- [Releasing](#releasing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -556,6 +557,17 @@ Label.propTypes = {
 Usage examples for a component live in `docs/app/Examples`.  The examples follow the SUI doc site examples.
 
 Adding documentation for new components is a bit tedious.  The best way to do this (for now) is to copy an existing component's and update them.
+
+## Releasing
+
+On the latest clean `master`:
+
+```sh
+npm run release:<major|minor|patch>
+```
+> :warning: `npm` must be used. At the time of writing`yarn` does not properly handle the credentials.
+
+Releasing will update the changelog which requires [github_changelog_generator][15].
 
 [1]: https://github.com/Semantic-Org/Semantic-UI-React/blob/master/test/specs/commonTests.js
 [2]: https://facebook.github.io/react/docs/forms.html#controlled-components

--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@
   </a>
 </p>
 
-Hey, we're in development. Prior to reaching [v1.0.0][6]:
-
-1. **MINOR** versions represent **breaking changes**
-1. **PATCH** versions represent **fixes _and_ features**
-1. There are **no deprecation warnings** between releases
-1. You should consult the [**CHANGELOG**][18] and related issues/PRs for more information
+>Hey, we're in development. Prior to reaching [v1.0.0][6]:
+>
+>1. **MINOR** versions represent **breaking changes**
+>1. **PATCH** versions represent **fixes _and_ features**
+>1. There are **no deprecation warnings** between releases
+>1. You should consult the [**CHANGELOG**][18] and related issues/PRs for more information
 
 ## Installation & Usage
 
-See the [Documentation][2] for an introduction, usage information, and extensive examples.
+See the [**Documentation**][2] for an introduction, usage information, and examples.
 
 ## Built With Semantic UI React
 
@@ -51,60 +51,78 @@ See the [Documentation][2] for an introduction, usage information, and extensive
   <img height="50" src="https://github.com/Semantic-Org/Semantic-UI-React/raw/master/docs/app/add-yours.png" />
 </a>
 
-These great products are built on Semantic UI React. Add yours [here][22].
-
-- Netflix's Edge Developer Experience team's numerous [internal apps](https://github.com/Semantic-Org/Semantic-UI-React/issues/1604)
 - Amazon Publishing — the full-service publisher of Amazon — [APub.com](https://amazonpublishing.amazon.com)
+- Netflix's Edge Developer Experience team's numerous [internal apps](https://github.com/Semantic-Org/Semantic-UI-React/issues/1604)
+- Netflix's [flamescope][31]
 - Microsoft's [Teams](https://products.office.com/en-US/microsoft-teams/group-chat-software) prototyping
-- https://gitconnected.com - The community for developers and software engineers
-- http://stoplight.io
-- https://roadmap.space
-- https://edabit.com
-- https://blackship.com
-- http://www.brewhousesolutions.com
-- https://www.seeuletter.com
-- https://www.stackforge.co
-- https://sublimefund.org
-- https://thefaithcircle.com
-- https://appfollow.io
-- http://according.to.localsourc.es
-- http://www.aircip.ir
-- https://www.bailfacile.fr
-- http://platform.nazarbazaar.ir
-- https://build.games
-- https://platform.forecastcycles.com
-- https://www.findlectures.com
-- https://github.com/ayastreb/bandwidth-hero
-- https://re.yomeshgupta.com
-- https://moneytracker.cc
-- https://tax.cryptact.com
-- https://www.hurriyetoto.com
-- https://173app.com
-- https://disten.se
+
+<details>
+  <summary>And many more...</summary>
+  <ul>
+    <li><a href="https://gitconnected.com">https://gitconnected.com</a></li>
+    <li><a href="http://stoplight.io">http://stoplight.io</a></li>
+    <li><a href="https://roadmap.space">https://roadmap.space</a></li>
+    <li><a href="https://edabit.com">https://edabit.com</a></li>
+    <li><a href="https://blackship.com">https://blackship.com</a></li>
+    <li><a href="http://www.brewhousesolutions.com">http://www.brewhousesolutions.com</a></li>
+    <li><a href="https://www.seeuletter.com">https://www.seeuletter.com</a></li>
+    <li><a href="https://www.stackforge.co">https://www.stackforge.co</a></li>
+    <li><a href="https://sublimefund.org">https://sublimefund.org</a></li>
+    <li><a href="https://thefaithcircle.com">https://thefaithcircle.com</a></li>
+    <li><a href="https://appfollow.io">https://appfollow.io</a></li>
+    <li><a href="http://according.to.localsourc.es">http://according.to.localsourc.es</a></li>
+    <li><a href="http://www.aircip.ir">http://www.aircip.ir</a></li>
+    <li><a href="https://www.bailfacile.fr">https://www.bailfacile.fr</a></li>
+    <li><a href="http://platform.nazarbazaar.ir">http://platform.nazarbazaar.ir</a></li>
+    <li><a href="https://build.games">https://build.games</a></li>
+    <li><a href="https://platform.forecastcycles.com">https://platform.forecastcycles.com</a></li>
+    <li><a href="https://www.findlectures.com">https://www.findlectures.com</a></li>
+    <li><a href="https://github.com/ayastreb/bandwidth-hero">https://github.com/ayastreb/bandwidth-hero</a></li>
+    <li><a href="https://re.yomeshgupta.com">https://re.yomeshgupta.com</a></li>
+    <li><a href="https://moneytracker.cc">https://moneytracker.cc</a></li>
+    <li><a href="https://tax.cryptact.com">https://tax.cryptact.com</a></li>
+    <li><a href="https://www.hurriyetoto.com">https://www.hurriyetoto.com</a></li>
+    <li><a href="https://173app.com">https://173app.com</a></li>
+    <li><a href="https://disten.se">https://disten.se</a></li>
+    <li><a href="https://github.com/Semantic-Org/Semantic-UI-React/edit/master/README.md">add your site here</a></li>
+  </ul>
+</details>
 
 ## Example Projects
 
 This is a listing of example projects and guides that will help you integrate Semantic UI React into your new or existing projects.
 
-### [webpack][28]
-Our example project right [here][28] in this repo. Includes theming examples.
- 
-### [SUIcrux][102]
-Advanced universal starter with Semantic-UI-React. React/Redux/Lazy-loading/SSR/PWA.
+<details>
+  <summary>Show projects</summary>
 
-### [semantic-ui-react-todos][100]
-This example modifies the well-known [react-redux Todo List][101] to use Semantic UI components. There is also a write-up on the process in the project README.
+  ### [webpack][28]
+  See our webpack 3 example project [here][28] (includes theming).
+   
+  ### [SUIcrux][102]
+  Advanced universal starter with Semantic-UI-React. React/Redux/Lazy-loading/SSR/PWA.
+  
+  ### [semantic-ui-react-todos][100]
+  Semantic UI React implementation of [react-redux Todo List][101].
+</details>
 
 ## FAQ
 
-### Can I use custom Icons?
-Yes.  Just use `<Icon className='my-icon' />` instead of `<Icon name='my-icon' />`.  See https://github.com/Semantic-Org/Semantic-UI-React/issues/931#issuecomment-263643210 for detailed info and examples.
+<details>
+  <summary><b>Can I use custom Icons?</b></summary>
+  Yes.  Just use <code>&lt;Icon className='my-icon' /&gt;</code> instead of `&lt;Icon name='my-icon' /&gt;`.  See https://github.com/Semantic-Org/Semantic-UI-React/issues/931#issuecomment-263643210 for detailed info and examples.
+</details>
 
-### How do I setup CSS?
-There are several options.  Refer to our doc on [CSS Usage][23].
+<details>
+  <summary><b>How do I setup CSS?</b></summary>
+  There are several options.  Refer to our doc on [CSS Usage][23].
+</details>
 
-### Can I use a custom CSS theme?
-Yes.  Semantic UI React includes components that render valid Semantic UI HTML, no CSS is included.  This allows you to load any Semantic UI CSS theme on top of your Semantic UI React app.
+<details>
+  <summary><b>Can I use a custom CSS theme?</b></summary>
+  Yes.  Semantic UI React includes components that render valid Semantic UI HTML, no CSS is included.  This allows you to load any Semantic UI CSS theme on top of your Semantic UI React app.
+</details>
+
+<br />
 
 Here are some helpful links:
 
@@ -112,13 +130,15 @@ Here are some helpful links:
 - [Building CSS with Meteor][30]
 - [Creating a standalone theme][25]
 
-## Voice Your Opinion
+## How Can I Help?
+
+### [Voice Your Opinion][19]
 
 Help shape this library by weighing in on our [RFC (request for comments)][19] issues. 
 
-## How Can I Help?
+### [Contribute][1]
 
-Our [CONTRIBUTING.md][1] is a step-by-step setup and development guide. It is meant to be read from top to bottom.  Once you're up to speed, each issue here includes more information on how you can help:
+Our [CONTRIBUTING.md][1] is a step-by-step setup and development guide.
 
 ### [Good First Issue][21]
 
@@ -132,58 +152,20 @@ We're seeking component parity with Semantic UI, plus some addons.  There is an 
 
 Any other issue labeled [`help wanted`][4] is ready for a PR.
 
-## 100% Semantic UI Support
-
-|    Elements     |   Collections   |      Views      |     Modules     |     Behaviors      |
-|-----------------|-----------------|-----------------|-----------------|--------------------|
-| ✓ Button        | ✓ Breadcrumb    | ✓ Advertisement | ✓ Accordion     |   Form Validation  |
-| ✓ Container     | ✓ Form          | ✓ Card          | ✓ Checkbox      | *API (NA)*         |
-| ✓ Divider       | ✓ Grid          | ✓ Comment       | ✓ Dimmer        | ✓ Visibility       |
-| ✓ Flag          | ✓ Menu          | ✓ Feed          | ✓ Dropdown      |                    |
-| ✓ Header        | ✓ Message       | ✓ Item          | ✓ Embed         |                    |
-| ✓ Icon          | ✓ Table         | ✓ Statistic     | ✓ Modal         |                    |
-| ✓ Image         |                 |                 | ✓ Popup         |                    |
-| ✓ Input         |                 |                 | ✓ Progress      |                    |
-| ✓ Label         |                 |                 | ✓ Rating        |                    |
-| ✓ List          |                 |                 | ✓ Search        |                    |
-| ✓ Loader        |                 |                 |   Shape         |                    |
-| ✓ Rail          |                 |                 | ✓ Sidebar       |                    |
-| ✓ Reveal        |                 |                 | ✓ Sticky        |                    |
-| ✓ Segment       |                 |                 | ✓ Tab           |                    |
-| ✓ Step          |                 |                 | ✓ Transition    |                    |
-
 ## Principles
 
-- No jQuery dependency
 - No animation dependencies
-- Reuse SUI CSS transitions
-- Simple declarative component APIs vs intricate HTML markup
+- Simple declarative component APIs vs brittle HTML markup
 - Complete keyboard support
 - Complete SUI component definition support
 - Completely documented
 - Completely tested
 
-## Releasing
-
-On the latest clean `master`:
-
-```sh
-yarn release:major
-yarn release:minor
-yarn release:patch
-```
-
-Releasing will update the changelog which requires [github_changelog_generator][15].
-
 ## Credit
 
-Originally made for [@TechnologyAdvice][9] by [@levithomason][26].
+Created by [@levithomason][26] and an amazing community of [contributors][20].
 
-Big thanks to our [contributors][20], especially:
-
-- [@layershifter][27] for essentially taking over during [@levithomason][26]'s unavailability
-- @jcarbo for thoughtful engineering
-- @jamiehill for early engineering and support
+Made possible only by [@jlukic][32] authoring [Semantic UI][5].
 
 [1]: https://github.com/Semantic-Org/Semantic-UI-React/blob/master/.github/CONTRIBUTING.md
 [2]: https://react.semantic-ui.com/
@@ -211,8 +193,10 @@ Big thanks to our [contributors][20], especially:
 [25]: http://learnsemantic.com/themes/creating.html
 [26]: https://github.com/levithomason
 [27]: https://github.com/layershifter
-[28]: https://github.com/Semantic-Org/Semantic-UI-React/tree/master/examples/webpack3
+[28]: https://github.com/Semantic-Org/Semantic-UI-React/tree/master/examples
 [30]: https://github.com/Semantic-Org/Semantic-UI-Meteor
+[31]: https://github.com/Netflix/flamescope
+[32]: https://github.com/jlukic
 
 <!-- Examples -->
 [100]: https://github.com/wyc/semantic-ui-react-todos


### PR DESCRIPTION
Our readme was getting out of hand and losing its usefulness.  I've moved some parts to CONTRIBUTING, collapsed some things into `<details>`, and completely removed other bits.

See it [here](https://github.com/Semantic-Org/Semantic-UI-React/blob/bbac075ec2c5904355a12cd55169e69f38820ceb/README.md).