### PR TITLE
change from "right chevron" to "chevron right" for typescript

### DIFF
--- a/docs/app/Examples/modules/Modal/Variations/ModalExampleScrollingContent.js
+++ b/docs/app/Examples/modules/Modal/Variations/ModalExampleScrollingContent.js
@@ -27,7 +27,7 @@ const ModalExampleScrollingContent = () => (
     </Modal.Content>
     <Modal.Actions>
       <Button primary>
-        Proceed <Icon name='right chevron' />
+        Proceed <Icon name='chevron right' />
       </Button>
     </Modal.Actions>
   </Modal>


### PR DESCRIPTION
To conform with typescript definition files