### PR TITLE
docs(Form): fix group variations typo

### DIFF
--- a/docs/app/Examples/collections/Form/GroupVariations/index.js
+++ b/docs/app/Examples/collections/Form/GroupVariations/index.js
@@ -12,7 +12,7 @@ const FormGroupVariationsExamples = () => (
       examplePath='collections/Form/GroupVariations/FormExampleEvenlyDividedGroup'
     >
       <Message info>
-        When using the <code>widths='equals'</code> prop declaration on a <code>Form.Group</code>,
+        When using the <code>widths='equal'</code> prop declaration on a <code>Form.Group</code>,
         all child <code>Form.Dropdown</code>, <code>Form.Input</code>, <code>Form.Select</code>
         components must be rendered with a <code>fluid</code> prop to work correctly.
       </Message>

--- a/docs/app/Examples/collections/Form/GroupVariations/index.js
+++ b/docs/app/Examples/collections/Form/GroupVariations/index.js
@@ -12,7 +12,7 @@ const FormGroupVariationsExamples = () => (
       examplePath='collections/Form/GroupVariations/FormExampleEvenlyDividedGroup'
     >
       <Message info>
-        When using the <code>widths='even'</code> prop declaration on a <code>Form.Group</code>,
+        When using the <code>widths='equals'</code> prop declaration on a <code>Form.Group</code>,
         all child <code>Form.Dropdown</code>, <code>Form.Input</code>, <code>Form.Select</code>
         components must be rendered with a <code>fluid</code> prop to work correctly.
       </Message>


### PR DESCRIPTION
The message info references `widths='even'` which is an invalid widths type - the correct value should be `equals`.