### PR TITLE
chore(CI): use prebuilt image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,22 +6,10 @@ general:
 jobs:
   build:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:8-browsers
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
     steps:
-      # Chrome HeadlessBrowser is missing deps on Debian, see:
-      # https://github.com/GoogleChrome/puppeteer/issues/290
-      - run:
-          name: Update Puppeteer Dependencies
-          command: |
-            sudo apt-get update
-            sudo apt-get install --yes --quiet gconf-service libasound2 libatk1.0-0 libc6 \
-              libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 \
-              libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 \
-              libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 \
-              libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation \
-              libappindicator1 libnss3 lsb-release xdg-utils wget
       - run:
           name: Update yarn
           command: |


### PR DESCRIPTION
CircleCI has prebuilt images with browsers, they already have all needed deps. Free speedup of build upto 1 minute :+1: 

![image](https://user-images.githubusercontent.com/14183168/40534963-5e6880f4-6010-11e8-816f-49c77cc4e98e.png)
