### PR TITLE
feat(forwardRef): add forwardRefFactory

### DIFF
--- a/docs/src/components/CarbonAd/CarbonAd.js
+++ b/docs/src/components/CarbonAd/CarbonAd.js
@@ -35,7 +35,7 @@ const waitForLoad = () => {
 
 class CarbonAd extends Component {
   componentDidMount() {
-    this.ifRef((ref) => {
+    this.ifRef(ref => {
       // always add the script as it is used to insert the ad
       ref.appendChild(script)
 
@@ -55,13 +55,13 @@ class CarbonAd extends Component {
     return false
   }
 
-  ifRef = (cb) => {
+  ifRef = cb => {
     const ref = document.querySelector('#docs-carbonads')
     if (ref) cb(ref)
   }
 
   render() {
-    return <div id='docs-carbonads' style={style} />
+    return <div id="docs-carbonads" style={style} />
   }
 }
 

--- a/docs/src/components/CarbonAd/CarbonAdNative.js
+++ b/docs/src/components/CarbonAd/CarbonAdNative.js
@@ -60,7 +60,7 @@ class CarbonAdNative extends Component {
     document.getElementsByTagName('head')[0].appendChild(this.script)
   }
 
-  handleNativeJSON = (json) => {
+  handleNativeJSON = json => {
     debug('handleNativeJSON', { mounted: this.mounted })
     try {
       const sanitizedAd = json.ads
@@ -91,28 +91,28 @@ class CarbonAdNative extends Component {
 
     const colors = inverted
       ? {
-        divider: '#333',
-        background: '#222',
-        backgroundHover: '#1d1d1d',
-        color: '#999',
-        colorHover: '#ccc',
-      }
+          divider: '#333',
+          background: '#222',
+          backgroundHover: '#1d1d1d',
+          color: '#999',
+          colorHover: '#ccc',
+        }
       : {
-        divider: '#eee',
-        background: '#fff',
-        backgroundHover: 'whitesmoke',
-        color: '#555',
-        colorHover: '#333',
-      }
+          divider: '#eee',
+          background: '#fff',
+          backgroundHover: 'whitesmoke',
+          color: '#555',
+          colorHover: '#333',
+        }
 
     return (
-      <a id={id} href={ad.statlink} target='_blank' rel='noopener noreferrer'>
+      <a id={id} href={ad.statlink} target="_blank" rel="noopener noreferrer">
         <img src={ad.image} />
         <span>{ad.company}</span>
         {' — '}
         <span>{ad.description}</span>
         <Label
-          content='Ad'
+          content="Ad"
           basic={!inverted}
           color={inverted ? 'black' : undefined}
           horizontal

--- a/docs/src/components/CodeEditor/CodeEditor.js
+++ b/docs/src/components/CodeEditor/CodeEditor.js
@@ -27,7 +27,7 @@ const semanticUIReactCompleter = {
     }
 
     const addPropsFromInfo = (info, score) => {
-      info.props.forEach((prop) => {
+      info.props.forEach(prop => {
         completions.push({
           score,
           caption: `${prop.name}`,
@@ -76,13 +76,13 @@ const semanticUIReactCompleter = {
     const suirNamedImports = value.match(/import\s+\{([\s\S]+?)\}\s+from\s'semantic-ui-react'/)
     const importedDisplayNames = _.words(suirNamedImports[1])
 
-    importedDisplayNames.forEach((displayName) => {
+    importedDisplayNames.forEach(displayName => {
       addPropsFromDisplayName(displayName, 200)
       addComponentDisplayName(displayName, 100)
     })
 
     // local words
-    _.uniq(_.words(value)).forEach((word) => {
+    _.uniq(_.words(value)).forEach(word => {
       completions.push({
         score: 0,
         caption: word,

--- a/docs/src/components/CodeEditor/CodeEditorUniveral.js
+++ b/docs/src/components/CodeEditor/CodeEditorUniveral.js
@@ -14,8 +14,8 @@ export const EDITOR_GUTTER_COLOR = '#25282d'
 // component also allows us to load Editor lazy.
 const CodeEditor = isBrowser()
   ? universal(import('./CodeEditor'), {
-    loading: () => <Loader active inline='centered' />,
-  })
+      loading: () => <Loader active inline="centered" />,
+    })
   : () => null
 
 function CodeEditorUniveral(props) {
@@ -25,9 +25,9 @@ function CodeEditorUniveral(props) {
     <CodeEditor
       name={id}
       mode={mode}
-      theme='tomorrow_night'
-      width='100%'
-      height='100px'
+      theme="tomorrow_night"
+      width="100%"
+      height="100px"
       value={value}
       enableBasicAutocompletion={!readOnly}
       enableLiveAutocompletion={!readOnly}

--- a/docs/src/examples/elements/Flag/Types/FlagExampleFlag.js
+++ b/docs/src/examples/elements/Flag/Types/FlagExampleFlag.js
@@ -1,11 +1,17 @@
 import React from 'react'
 import { Flag, Segment } from 'semantic-ui-react'
 
+const ForwardRef = React.forwardRef((props, ref) => (
+  <span>
+    <i {...props} ref={ref} />
+  </span>
+))
+
 const FlagExampleFlag = () => (
   <Segment>
-    <Flag name='ae' />
-    <Flag name='france' />
-    <Flag name='myanmar' />
+    <Flag as={ForwardRef} name='france' ref={c => console.log('ForwardRef', c)} />
+    <Flag name='myanmar' ref={c => console.log('None', c)} />
+    <Flag as='div' name='russia' ref={c => console.log('Simple', c)} />
   </Segment>
 )
 

--- a/docs/src/examples/elements/Flag/Types/index.js
+++ b/docs/src/examples/elements/Flag/Types/index.js
@@ -9,11 +9,11 @@ const FlagTypesExamples = () => (
       description='A flag can use the two digit country code, the full name, or a common alias.'
       examplePath='elements/Flag/Types/FlagExampleFlag'
     />
-    <ComponentExample
-      title='Country names, codes and aliases.'
-      description=''
-      examplePath='elements/Flag/Types/FlagExampleTable'
-    />
+    {/*<ComponentExample*/}
+      {/*title='Country names, codes and aliases.'*/}
+      {/*description=''*/}
+      {/*examplePath='elements/Flag/Types/FlagExampleTable'*/}
+    {/*/>*/}
   </ExampleSection>
 )
 

--- a/docs/src/examples/elements/Icon/Variations/IconExampleFitted.js
+++ b/docs/src/examples/elements/Icon/Variations/IconExampleFitted.js
@@ -3,9 +3,13 @@ import { Icon } from 'semantic-ui-react'
 
 const IconExampleFitted = () => (
   <div>
-    This icon<Icon fitted name='help' />is fitted.
+    This icon
+    <Icon fitted name='help' />
+    is fitted.
     <br />
-    This icon<Icon name='help' />is not.
+    This icon
+    <Icon name='help' />
+    is not.
   </div>
 )
 

--- a/docs/src/layouts/GridLayout.js
+++ b/docs/src/layouts/GridLayout.js
@@ -157,8 +157,7 @@ const GridLayout = () => (
       <Header as='h3'>Special Variations</Header>
       <p>
         Some special variations that format grids like tables require you to specify rows. For
-        example a
-        <code>divided grid</code> or a <code>celled grid</code> requires row wrappers.
+        example a<code>divided grid</code> or a <code>celled grid</code> requires row wrappers.
       </p>
 
       <Divider section horizontal>
@@ -242,9 +241,8 @@ const GridLayout = () => (
       <Header as='h3'>Centering Content</Header>
       <p>
         If a row does not take up all sixteen grid columns, you can use a{' '}
-        <code>ui centered grid</code>,
-        <code>centered row</code>, or <code>centered column</code> to center the column contents
-        inside the grid.
+        <code>ui centered grid</code>,<code>centered row</code>, or <code>centered column</code> to
+        center the column contents inside the grid.
       </p>
 
       <Grid centered columns={2}>
@@ -258,8 +256,7 @@ const GridLayout = () => (
       <Header as='h3'>Floating Rows</Header>
       <p>
         Since Semantic UI's grid is based on flex box, a <code>left floated</code> item should come
-        first, and a
-        <code>right floated</code> item last in its row.
+        first, and a<code>right floated</code> item last in its row.
       </p>
 
       <Grid>

--- a/docs/src/layouts/StickyLayout.js
+++ b/docs/src/layouts/StickyLayout.js
@@ -174,7 +174,9 @@ export default class StickyLayout extends Component {
         </Visibility>
 
         <Container text>
-          {_.times(3, i => <Paragraph key={i} />)}
+          {_.times(3, i => (
+            <Paragraph key={i} />
+          ))}
 
           {/* Example with overlay menu is more complex, SUI simply clones all elements inside, but we should use a
               different approach.
@@ -213,19 +215,25 @@ export default class StickyLayout extends Component {
             </Menu>
           </div>
 
-          {_.times(3, i => <Paragraph key={i} />)}
+          {_.times(3, i => (
+            <Paragraph key={i} />
+          ))}
           <LeftImage />
 
           <Paragraph />
           <RightImage />
 
-          {_.times(4, i => <Paragraph key={i} />)}
+          {_.times(4, i => (
+            <Paragraph key={i} />
+          ))}
           <LeftImage />
 
           <Paragraph />
           <RightImage />
 
-          {_.times(2, i => <Paragraph key={i} />)}
+          {_.times(2, i => (
+            <Paragraph key={i} />
+          ))}
         </Container>
 
         <Segment inverted style={{ margin: '5em 0em 0em', padding: '5em 0em' }} vertical>

--- a/gulp/plugins/gulp-example-source.js
+++ b/gulp/plugins/gulp-example-source.js
@@ -23,8 +23,7 @@ export default () => {
     }
 
     try {
-      const sourceName = _
-        .split(file.path, path.sep)
+      const sourceName = _.split(file.path, path.sep)
         .slice(-4)
         .join('/')
         .slice(0, -3)

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -5,6 +5,7 @@ import React, { PureComponent } from 'react'
 import {
   createShorthandFactory,
   customPropTypes,
+  forwardRefFactory,
   getElementType,
   getUnhandledProps,
 } from '../../lib'
@@ -535,4 +536,4 @@ class Flag extends PureComponent {
 
 Flag.create = createShorthandFactory(Flag, value => ({ name: value }))
 
-export default Flag
+export default forwardRefFactory(Flag)

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -530,6 +530,8 @@ class Flag extends PureComponent {
     const rest = getUnhandledProps(Flag, this.props)
     const ElementType = getElementType(Flag, this.props)
 
+    console.log('Flag props', rest)
+
     return <ElementType {...rest} className={classes} />
   }
 }

--- a/src/lib/componentUtils.js
+++ b/src/lib/componentUtils.js
@@ -1,25 +1,4 @@
-/**
- * Asserts that the passed Component is a React class component.
- *
- * @param {Function|Component} Component A Component to check
- * @return {Object}
- */
-export const isClassComponent = Component =>
-  typeof Component === 'function' && Component.prototype && !!Component.prototype.isReactComponent
+export const isForwardRef = Component =>
+  (Component && Component.$$typeof && typeof Component.render === 'function') || false
 
-/**
- * Asserts that the passed Component is a React function component.
- *
- * @param {Function|Component} Component A Component to check
- * @return {Object}
- */
-export const isStatelessComponent = Component =>
-  typeof Component === 'function' && Component.prototype && !Component.prototype.render
-
-/**
- * Asserts that the passed Component supports the refs API.
- *
- * @param {Function|Component} Component A Component to check
- * @return {Object}
- */
-export const supportsRef = Component => typeof Component === 'string' || isClassComponent(Component)
+export const isBasic = Component => typeof Component === 'string'

--- a/src/lib/componentUtils.js
+++ b/src/lib/componentUtils.js
@@ -1,0 +1,11 @@
+/* eslint import/prefer-default-export: 0 */
+/* This file will contain more functions in the future */
+
+/**
+ * Asserts that the passed Component is a React class component.
+ *
+ * @param {Function|Component} Component A Component to check
+ * @return {Object}
+ */
+export const isClassComponent = Component =>
+  typeof Component === 'function' && Component.prototype && !!Component.prototype.isReactComponent

--- a/src/lib/componentUtils.js
+++ b/src/lib/componentUtils.js
@@ -1,6 +1,3 @@
-/* eslint import/prefer-default-export: 0 */
-/* This file will contain more functions in the future */
-
 /**
  * Asserts that the passed Component is a React class component.
  *
@@ -9,3 +6,20 @@
  */
 export const isClassComponent = Component =>
   typeof Component === 'function' && Component.prototype && !!Component.prototype.isReactComponent
+
+/**
+ * Asserts that the passed Component is a React function component.
+ *
+ * @param {Function|Component} Component A Component to check
+ * @return {Object}
+ */
+export const isStatelessComponent = Component =>
+  typeof Component === 'function' && Component.prototype && !Component.prototype.render
+
+/**
+ * Asserts that the passed Component supports the refs API.
+ *
+ * @param {Function|Component} Component A Component to check
+ * @return {Object}
+ */
+export const supportsRef = Component => typeof Component === 'string' || isClassComponent(Component)

--- a/src/lib/forwardRefFactory.js
+++ b/src/lib/forwardRefFactory.js
@@ -1,0 +1,47 @@
+import hoistStatics from 'hoist-non-react-statics'
+import _ from 'lodash'
+import React, { forwardRef } from 'react'
+
+import Ref from 'src/addons/Ref/Ref'
+import { isClassComponent } from './componentUtils'
+
+/**
+ * Use just a string for now (react 16.3), since react doesn't support Symbols in props yet
+ * https://github.com/facebook/react/issues/7552
+ * @type {String}
+ */
+export const forwardRefSymbol = '__forwardRef__'
+
+/**
+ * Creates a function that will choose how to pass a ref.
+ *
+ * @param {Function|Component} Component A Component to wrap
+ * @return {Function}
+ */
+export const forwardFunctionFactory = Component => (props, ref) => {
+  // eslint-disable-next-line react/prop-types
+  if (_.isUndefined(props.as) || _.isString(props.as) || isClassComponent(props.as)) {
+    return <Component {...{ [forwardRefSymbol]: ref, ...props }} />
+  }
+
+  return (
+    <Ref innerRef={ref}>
+      <Component {...props} />
+    </Ref>
+  )
+}
+
+/**
+ * Wraps passed component with react 'forwardRef' function, which produce new component with type 'object' and structure
+ * like so: { $$type: Symbol(), render: function }. Assigns (hoists) static methods of passed component to result
+ * forward component using 'hoist-non-react-statics' module.
+ *
+ * @param {Function|Component} Component A Component to wrap with forwardRef()
+ * @return {Object}
+ */
+export const forwardRefFactory = (Component) => {
+  const forwarder = forwardRef(forwardFunctionFactory(Component))
+
+  hoistStatics(forwarder, Component, { $$typeof: true, render: true })
+  return forwarder
+}

--- a/src/lib/forwardRefFactory/forwardFunctionFactory.js
+++ b/src/lib/forwardRefFactory/forwardFunctionFactory.js
@@ -1,0 +1,39 @@
+import React, { createElement } from 'react'
+
+import Ref from '../../addons/Ref'
+import { isStatelessComponent, supportsRef } from '../componentUtils'
+
+/**
+ * Use just a string for now (react 16.3), since react doesn't support Symbols in props yet.
+ * https://github.com/facebook/react/issues/7552
+ * @type {String}
+ */
+export const forwardRefSymbol = '__forwardRef__'
+
+/**
+ * Creates a function that will choose how to pass a ref.
+ *
+ * @param {Function|Component} Component A Component to wrap
+ * @return {Function}
+ */
+const forwardFunctionFactory = Component => (props, ref) => {
+  // eslint-disable-next-line react/prop-types
+  if (isStatelessComponent(props.as)) {
+    return (
+      <Ref innerRef={ref}>
+        <Component {...props} />
+      </Ref>
+    )
+  }
+
+  if (supportsRef(props.as)) {
+    return createElement(Component, {
+      ...props,
+      [forwardRefSymbol]: ref,
+    })
+  }
+
+  return Component
+}
+
+export default forwardFunctionFactory

--- a/src/lib/forwardRefFactory/forwardFunctionFactory.js
+++ b/src/lib/forwardRefFactory/forwardFunctionFactory.js
@@ -1,7 +1,7 @@
 import React, { createElement } from 'react'
 
 import Ref from '../../addons/Ref'
-import { isStatelessComponent, supportsRef } from '../componentUtils'
+import { isBasic, isForwardRef } from '../componentUtils'
 
 /**
  * Use just a string for now (react 16.3), since react doesn't support Symbols in props yet.
@@ -17,23 +17,28 @@ export const forwardRefSymbol = '__forwardRef__'
  * @return {Function}
  */
 const forwardFunctionFactory = Component => (props, ref) => {
-  // eslint-disable-next-line react/prop-types
-  if (isStatelessComponent(props.as)) {
-    return (
-      <Ref innerRef={ref}>
-        <Component {...props} />
-      </Ref>
-    )
-  }
+  console.log('forwardFunctionFactory()', {
+    element: props.as,
+    isBasic: isBasic(props.as),
+    isForwardRef: isForwardRef(props.as),
+  })
 
-  if (supportsRef(props.as)) {
+  // The most simple case when `as='div'`
+  // This component supports ref forwarding!
+  // Magic happens there!
+  if (!props.as || isBasic(props.as) || isForwardRef(props.as)) {
     return createElement(Component, {
       ...props,
       [forwardRefSymbol]: ref,
     })
   }
 
-  return Component
+  // Need to get ref manually
+  return (
+    <Ref innerRef={ref}>
+      <Component {...props} />
+    </Ref>
+  )
 }
 
 export default forwardFunctionFactory

--- a/src/lib/forwardRefFactory/forwardRefFactory.js
+++ b/src/lib/forwardRefFactory/forwardRefFactory.js
@@ -1,9 +1,8 @@
 import hoistStatics from 'hoist-non-react-statics'
-import _ from 'lodash'
 import React, { forwardRef } from 'react'
 
-import Ref from 'src/addons/Ref/Ref'
-import { isClassComponent } from './componentUtils'
+import Ref from '../../addons/Ref'
+import { isStatelessComponent, supportsRef } from '../componentUtils'
 
 /**
  * Use just a string for now (react 16.3), since react doesn't support Symbols in props yet
@@ -20,15 +19,19 @@ export const forwardRefSymbol = '__forwardRef__'
  */
 export const forwardFunctionFactory = Component => (props, ref) => {
   // eslint-disable-next-line react/prop-types
-  if (_.isUndefined(props.as) || _.isString(props.as) || isClassComponent(props.as)) {
+  if (isStatelessComponent(props.as)) {
+    return (
+      <Ref innerRef={ref}>
+        <Component {...props} />
+      </Ref>
+    )
+  }
+
+  if (supportsRef(props.as)) {
     return <Component {...{ [forwardRefSymbol]: ref, ...props }} />
   }
 
-  return (
-    <Ref innerRef={ref}>
-      <Component {...props} />
-    </Ref>
-  )
+  return Component
 }
 
 /**

--- a/src/lib/forwardRefFactory/forwardRefFactory.js
+++ b/src/lib/forwardRefFactory/forwardRefFactory.js
@@ -1,38 +1,7 @@
 import hoistStatics from 'hoist-non-react-statics'
-import React, { forwardRef } from 'react'
+import { forwardRef } from 'react'
 
-import Ref from '../../addons/Ref'
-import { isStatelessComponent, supportsRef } from '../componentUtils'
-
-/**
- * Use just a string for now (react 16.3), since react doesn't support Symbols in props yet
- * https://github.com/facebook/react/issues/7552
- * @type {String}
- */
-export const forwardRefSymbol = '__forwardRef__'
-
-/**
- * Creates a function that will choose how to pass a ref.
- *
- * @param {Function|Component} Component A Component to wrap
- * @return {Function}
- */
-export const forwardFunctionFactory = Component => (props, ref) => {
-  // eslint-disable-next-line react/prop-types
-  if (isStatelessComponent(props.as)) {
-    return (
-      <Ref innerRef={ref}>
-        <Component {...props} />
-      </Ref>
-    )
-  }
-
-  if (supportsRef(props.as)) {
-    return <Component {...{ [forwardRefSymbol]: ref, ...props }} />
-  }
-
-  return Component
-}
+import forwardFunctionFactory from './forwardFunctionFactory'
 
 /**
  * Wraps passed component with react 'forwardRef' function, which produce new component with type 'object' and structure
@@ -42,9 +11,11 @@ export const forwardFunctionFactory = Component => (props, ref) => {
  * @param {Function|Component} Component A Component to wrap with forwardRef()
  * @return {Object}
  */
-export const forwardRefFactory = (Component) => {
+const forwardRefFactory = (Component) => {
   const forwarder = forwardRef(forwardFunctionFactory(Component))
 
   hoistStatics(forwarder, Component, { $$typeof: true, render: true })
   return forwarder
 }
+
+export default forwardRefFactory

--- a/src/lib/forwardRefFactory/index.js
+++ b/src/lib/forwardRefFactory/index.js
@@ -1,0 +1,2 @@
+export { forwardRefSymbol } from './forwardFunctionFactory'
+export forwardRefFactory from './forwardRefFactory'

--- a/src/lib/getUnhandledProps.js
+++ b/src/lib/getUnhandledProps.js
@@ -1,3 +1,5 @@
+import { forwardRefSymbol } from './forwardRefFactory'
+
 /**
  * Returns an object consisting of props beyond the scope of the Component.
  * Useful for getting and spreading unknown props from the user.
@@ -11,6 +13,10 @@ const getUnhandledProps = (Component, props) => {
 
   return Object.keys(props).reduce((acc, prop) => {
     if (prop === 'childKey') return acc
+    if (prop === forwardRefSymbol) {
+      acc.ref = props[forwardRefSymbol]
+      return acc
+    }
     if (handledProps.indexOf(prop) === -1) acc[prop] = props[prop]
     return acc
   }, {})

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -18,8 +18,9 @@ export { debug, makeDebugger } from './debug'
 export eventStack from './eventStack'
 
 export * from './factories'
-export getUnhandledProps from './getUnhandledProps'
+export { forwardRefFactory } from './forwardRefFactory'
 export getElementType from './getElementType'
+export getUnhandledProps from './getUnhandledProps'
 
 export {
   htmlInputAttrs,


### PR DESCRIPTION
Replaces #2306.

---

React 16.3 gives the wonderful `forwardRef` API, this PR implements the `forwardRefFactory` that allows to use it.

Some ideas are taken from [klimashkin/react-forwardref-utils](https://github.com/klimashkin/react-forwardref-utils).