### PR TITLE
fix(Sticky): prevent npe error after unmount of component

### DIFF
--- a/src/modules/Sticky/Sticky.js
+++ b/src/modules/Sticky/Sticky.js
@@ -130,7 +130,7 @@ export default class Sticky extends Component {
 
     if (active) {
       this.removeListeners()
-      cancelAnimationFrame(this.requestId)
+      cancelAnimationFrame(this.frameId)
     }
   }
 
@@ -188,7 +188,7 @@ export default class Sticky extends Component {
   handleUpdate = (e) => {
     if (!this.ticking) {
       this.ticking = true
-      this.requestId = requestAnimationFrame(() => this.update(e))
+      this.frameId = requestAnimationFrame(() => this.update(e))
     }
   }
 

--- a/src/modules/Sticky/Sticky.js
+++ b/src/modules/Sticky/Sticky.js
@@ -128,7 +128,10 @@ export default class Sticky extends Component {
     if (!isBrowser()) return
     const { active } = this.props
 
-    if (active) this.removeListeners()
+    if (active) {
+      this.removeListeners()
+      cancelAnimationFrame(this.requestId)
+    }
   }
 
   // ----------------------------------------
@@ -185,7 +188,7 @@ export default class Sticky extends Component {
   handleUpdate = (e) => {
     if (!this.ticking) {
       this.ticking = true
-      requestAnimationFrame(() => this.update(e))
+      this.requestId = requestAnimationFrame(() => this.update(e))
     }
   }
 
@@ -217,7 +220,7 @@ export default class Sticky extends Component {
   didReachContextBottom = () => {
     const { offset } = this.props
 
-    return (this.stickyRect.height + offset) >= this.contextRect.bottom
+    return this.stickyRect.height + offset >= this.contextRect.bottom
   }
 
   // Return true when the component reached the starting point
@@ -230,7 +233,7 @@ export default class Sticky extends Component {
   didTouchScreenBottom = () => {
     const { bottomOffset } = this.props
 
-    return (this.contextRect.bottom + bottomOffset) > window.innerHeight
+    return this.contextRect.bottom + bottomOffset > window.innerHeight
   }
 
   // Return true if the height of the component is higher than the window
@@ -308,7 +311,9 @@ export default class Sticky extends Component {
     return (
       <ElementType {...rest} className={className}>
         <div ref={this.handleTriggerRef} />
-        <div ref={this.handleStickyRef} style={this.computeStyle()}>{children}</div>
+        <div ref={this.handleStickyRef} style={this.computeStyle()}>
+          {children}
+        </div>
       </ElementType>
     )
   }

--- a/test/specs/modules/Sticky/Sticky-test.js
+++ b/test/specs/modules/Sticky/Sticky-test.js
@@ -404,8 +404,7 @@ describe('Sticky', () => {
       sandbox.stub(window, 'requestAnimationFrame').callsFake(fn => setTimeout(fn, 0))
       sandbox.stub(window, 'cancelAnimationFrame').callsFake(id => clearTimeout(id))
 
-      const wrapper = mount(<Sticky />)
-      const instance = renderedComponent.instance()
+      const instance = wrapperMount(<Sticky />).instance()
       const update = sandbox.spy(instance, 'update')
 
       domEvent.resize(window)

--- a/test/specs/modules/Sticky/Sticky-test.js
+++ b/test/specs/modules/Sticky/Sticky-test.js
@@ -398,5 +398,21 @@ describe('Sticky', () => {
       domEvent.resize(window)
       update.should.have.been.calledOnce()
     })
+
+    it('is not called after unmount', (done) => {
+      const renderedComponent = mount(<Sticky />)
+      const instance = renderedComponent.instance()
+      const update = sandbox.spy(instance, 'update')
+      window.requestAnimationFrame.restore()
+      sandbox.stub(window, 'requestAnimationFrame').callsFake(fn => setTimeout(fn, 0))
+      sandbox.stub(window, 'cancelAnimationFrame').callsFake(id => clearTimeout(id))
+
+      domEvent.resize(window)
+      renderedComponent.unmount()
+      window.requestAnimationFrame(() => {
+        update.should.not.have.been.called()
+        done()
+      })
+    })
   })
 })

--- a/test/specs/modules/Sticky/Sticky-test.js
+++ b/test/specs/modules/Sticky/Sticky-test.js
@@ -400,15 +400,16 @@ describe('Sticky', () => {
     })
 
     it('is not called after unmount', (done) => {
-      const renderedComponent = mount(<Sticky />)
-      const instance = renderedComponent.instance()
-      const update = sandbox.spy(instance, 'update')
       window.requestAnimationFrame.restore()
       sandbox.stub(window, 'requestAnimationFrame').callsFake(fn => setTimeout(fn, 0))
       sandbox.stub(window, 'cancelAnimationFrame').callsFake(id => clearTimeout(id))
 
+      const wrapper = mount(<Sticky />)
+      const instance = renderedComponent.instance()
+      const update = sandbox.spy(instance, 'update')
+
       domEvent.resize(window)
-      renderedComponent.unmount()
+      wrapper.unmount()
       window.requestAnimationFrame(() => {
         update.should.not.have.been.called()
         done()


### PR DESCRIPTION
This fixes a simple problem where the event listeners call handleUpdate() which calls requestAnimationFrame to call the update function in the next tick, but if the component unmounts between the handleUpdate call and the requestAnimationFrame firing, we get an NPE error because the handleTriggerRef function has been fired with null as the ref ( reference: https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element ). 

This prevents that from happening by saving the requestId from requestAnimationFrame and clearing it on componentWillUnmount