### PR TITLE
fix(getComponentInfo): subcomponents from js files

### DIFF
--- a/gulp/plugins/util/getComponentInfo.js
+++ b/gulp/plugins/util/getComponentInfo.js
@@ -43,7 +43,7 @@ const getComponentInfo = (filepath) => {
   info.subcomponents = info.isParent
     ? fs
       .readdirSync(dir)
-      .filter(file => !/(index\.js|d\.ts)$/.test(file))
+      .filter(file => /^(?!index).*\.js$/.test(file))
       .filter(file => dirname !== path.basename(file, path.extname(file)))
       .map(file => path.basename(file, path.extname(file)))
     : null


### PR DESCRIPTION
Currently, we consider any file in a component directory to be a subcomponent.  However, there was a stray markdown file in `/src/modules/Dropdown/TODO.md` that resulted in a "subcomponent" called "TODO" on the Dropdown.

This PR strictly limits subcomponent identification to JS files in component directories.