### PR TITLE
fix(ComponentExample): remove filter effect

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
@@ -419,7 +419,7 @@ class ComponentExample extends PureComponent {
   }
 
   render() {
-    const { children, description, examplePath, location, suiVersion, title } = this.props
+    const { children, description, examplePath, suiVersion, title } = this.props
     const {
       handleMouseLeave,
       handleMouseMove,
@@ -431,13 +431,9 @@ class ComponentExample extends PureComponent {
 
     const isActive = this.isActiveHash() || this.isActiveState()
 
-    const isInFocus = !location.hash || (location.hash && (this.isActiveHash() || isHovering))
-
     const exampleStyle = {
       position: 'relative',
-      transition: 'box-shadow 200ms, background 200ms, opacity 200ms, filter 200ms',
-      opacity: isInFocus ? 1 : 0.4,
-      filter: isInFocus ? 'grayscale(0)' : 'grayscale(1)',
+      transition: 'box-shadow 200ms, background 200ms',
       ...(isActive
         ? {
           background: '#fff',


### PR DESCRIPTION
Fixes #2865 

The grayscale filter effect was intended to bring focus to an example when editing code.  However, it is also made active when clicking an example link in the right menu.  This is confusing and distracting, ironic as it is.