### PR TITLE
chore(gulp): fix dist:clean task

### DIFF
--- a/gulp/tasks/dist.js
+++ b/gulp/tasks/dist.js
@@ -15,7 +15,7 @@ const { log, PluginError } = g.util
 // ----------------------------------------
 
 task('clean:dist', (cb) => {
-  rimraf(config.paths.dist(), cb)
+  rimraf(`${config.paths.dist()}/*`, cb)
 })
 
 // ----------------------------------------


### PR DESCRIPTION
Running `gulp dist` fails as the dist directory is removed and babel doesn't seem to want to `mkdirp` when building the `es` dist.

This PR cleans the contents of `dist` opposed to the whole directory.  Babel is able to create the `es` subdir without issue.