### PR TITLE
feat(Portal): add `triggerRef` prop

### DIFF
--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -90,6 +90,13 @@ export interface PortalProps {
 
   /** Element to be rendered in-place where the portal is defined. */
   trigger?: React.ReactNode;
+
+  /**
+   * Called when componentDidMount.
+   *
+   * @param {HTMLElement} node - Referred node.
+   */
+  innerRef?: (node: HTMLElement) => void;
 }
 
 declare class Portal extends React.Component<PortalProps, {}> {

--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -96,7 +96,7 @@ export interface PortalProps {
    *
    * @param {HTMLElement} node - Referred node.
    */
-  innerRef?: (node: HTMLElement) => void;
+  triggerRef?: (node: HTMLElement) => void;
 }
 
 declare class Portal extends React.Component<PortalProps, {}> {

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -109,6 +109,13 @@ class Portal extends Component {
 
     /** Element to be rendered in-place where the portal is defined. */
     trigger: PropTypes.node,
+
+    /**
+     * Called with a ref to the trigger node.
+     *
+     * @param {HTMLElement} node - Referred node.
+     */
+    triggerRef: PropTypes.func,
   }
 
   static defaultProps = {
@@ -322,7 +329,10 @@ class Portal extends Component {
     _.invoke(this.props, 'onUnmount', null, this.props)
   }
 
-  handleTriggerRef = c => (this.triggerNode = c)
+  handleTriggerRef = (c) => {
+    this.triggerNode = c
+    _.invoke(this.props, 'triggerRef', c)
+  }
 
   renderTrigger() {
     const { trigger } = this.props

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -18,7 +18,6 @@ import {
 import Portal from '../../addons/Portal'
 import PopupContent from './PopupContent'
 import PopupHeader from './PopupHeader'
-import Ref from '../../addons/Ref'
 
 const debug = makeDebugger('popup')
 
@@ -420,18 +419,17 @@ export default class Popup extends Component {
     debug('portal props:', mergedPortalProps)
 
     return (
-      <Ref innerRef={this.handleTriggerRef}>
-        <Portal
-          {...mergedPortalProps}
-          trigger={trigger}
-          onClose={this.handleClose}
-          onMount={this.handlePortalMount}
-          onOpen={this.handleOpen}
-          onUnmount={this.handlePortalUnmount}
-        >
-          {popupJSX}
-        </Portal>
-      </Ref>
+      <Portal
+        {...mergedPortalProps}
+        trigger={trigger}
+        onClose={this.handleClose}
+        onMount={this.handlePortalMount}
+        onOpen={this.handleOpen}
+        onUnmount={this.handlePortalUnmount}
+        triggerRef={this.handleTriggerRef}
+      >
+        {popupJSX}
+      </Portal>
     )
   }
 }

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -648,4 +648,26 @@ describe('Portal', () => {
       }, 0)
     })
   })
+
+  describe('triggerRef', () => {
+    it('maintains ref on the trigger', () => {
+      const triggerRef = sandbox.spy()
+      const mountNode = document.createElement('div')
+      document.body.appendChild(mountNode)
+
+      wrapperMount(
+        <Portal trigger={<button id='trigger' />} triggerRef={triggerRef}>
+          <p />
+        </Portal>,
+        { attachTo: mountNode },
+      )
+      const trigger = document.querySelector('#trigger')
+
+      triggerRef.should.have.been.calledOnce()
+      triggerRef.should.have.been.calledWithMatch(trigger)
+
+      wrapper.detach()
+      document.body.removeChild(mountNode)
+    })
+  })
 })

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import React from 'react'
 
-import Ref from 'src/addons/Ref/Ref'
+import Portal from 'src/addons/Portal/Portal'
 import { SUI } from 'src/lib'
 import Popup, { POSITIONS } from 'src/modules/Popup/Popup'
 import PopupHeader from 'src/modules/Popup/PopupHeader'
@@ -50,7 +50,7 @@ describe('Popup', () => {
   it('renders a Portal', () => {
     wrapperShallow(<Popup />)
       .type()
-      .should.equal(Ref)
+      .should.equal(Portal)
   })
 
   it('renders to the document body', () => {


### PR DESCRIPTION
When I was performing updates for #2880, I had found that we use `Ref` to catch a ref to `trigger` in `Portal`, however `Portal` makes same action.