### PR TITLE
BREAKING(Accordion): refactor shorthand API to use AccordionPanel

### DIFF
--- a/docs/src/examples/modules/Accordion/Advanced/AccordionExampleForm.js
+++ b/docs/src/examples/modules/Accordion/Advanced/AccordionExampleForm.js
@@ -3,10 +3,10 @@ import { Accordion, Button, Form, Segment } from 'semantic-ui-react'
 
 const panels = [
   {
+    key: 'details',
     title: 'Optional Details',
     content: {
       as: Form.Input,
-      key: 'content',
       label: 'Maiden Name',
       placeholder: 'Maiden Name',
     },

--- a/docs/src/examples/modules/Accordion/Advanced/AccordionExampleNested.js
+++ b/docs/src/examples/modules/Accordion/Advanced/AccordionExampleNested.js
@@ -2,8 +2,8 @@ import React from 'react'
 import { Accordion } from 'semantic-ui-react'
 
 const level1Panels = [
-  { title: 'Level 1A', content: 'Level 1A Contents' },
-  { title: 'Level 1B', content: 'Level 1B Contents' },
+  { key: 'panel-1a', title: 'Level 1A', content: 'Level 1A Contents' },
+  { key: 'panel-ba', title: 'Level 1B', content: 'Level 1B Contents' },
 ]
 
 const Level1Content = (
@@ -14,8 +14,8 @@ const Level1Content = (
 )
 
 const level2Panels = [
-  { title: 'Level 2A', content: 'Level 2A Contents' },
-  { title: 'Level 2B', content: 'Level 2B Contents' },
+  { key: 'panel-2a', title: 'Level 2A', content: 'Level 2A Contents' },
+  { key: 'panel-2b', title: 'Level 2B', content: 'Level 2B Contents' },
 ]
 
 const Level2Content = (
@@ -26,8 +26,8 @@ const Level2Content = (
 )
 
 const rootPanels = [
-  { title: 'Level 1', content: { content: Level1Content, key: 'content-1' } },
-  { title: 'Level 2', content: { content: Level2Content, key: 'content-2' } },
+  { key: 'panel-1', title: 'Level 1', content: { content: Level1Content } },
+  { key: 'panel-2', title: 'Level 2', content: { content: Level2Content } },
 ]
 
 const AccordionExampleNested = () => <Accordion defaultActiveIndex={0} panels={rootPanels} styled />

--- a/docs/src/examples/modules/Accordion/Advanced/AccordionExampleShorthand.js
+++ b/docs/src/examples/modules/Accordion/Advanced/AccordionExampleShorthand.js
@@ -4,13 +4,12 @@ import React from 'react'
 import { Accordion, Label, Message } from 'semantic-ui-react'
 
 const panels = _.times(3, i => ({
+  key: `panel-${i}`,
   title: {
     content: <Label color='blue' content={faker.lorem.sentence()} />,
-    key: `title-${i}`,
   },
   content: {
     content: <Message info header={faker.lorem.sentence()} content={faker.lorem.paragraph()} />,
-    key: `content-${i}`,
   },
 }))
 

--- a/docs/src/examples/modules/Accordion/Types/AccordionExampleStandardShorthand.js
+++ b/docs/src/examples/modules/Accordion/Types/AccordionExampleStandardShorthand.js
@@ -3,6 +3,7 @@ import { Accordion } from 'semantic-ui-react'
 
 const panels = [
   {
+    key: 'what-is-dog',
     title: 'What is a dog?',
     content: [
       'A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome',
@@ -10,6 +11,7 @@ const panels = [
     ].join(' '),
   },
   {
+    key: 'kinds-of-dogs',
     title: 'What kinds of dogs are there?',
     content: [
       'There are many breeds of dogs. Each breed varies in size and temperament. Owners often select a breed of dog',
@@ -17,6 +19,7 @@ const panels = [
     ].join(' '),
   },
   {
+    key: 'acquire-dog',
     title: 'How do you acquire a dog?',
     content: {
       content: (
@@ -33,7 +36,6 @@ const panels = [
           </p>
         </div>
       ),
-      key: 'content-dog',
     },
   },
 ]

--- a/docs/src/examples/modules/Accordion/Usage/AccordionExampleActiveIndex.js
+++ b/docs/src/examples/modules/Accordion/Usage/AccordionExampleActiveIndex.js
@@ -3,7 +3,8 @@ import _ from 'lodash'
 import React, { Component } from 'react'
 import { Accordion, Segment } from 'semantic-ui-react'
 
-const panels = _.times(3, () => ({
+const panels = _.times(3, i => ({
+  key: `panel-${i}`,
   title: faker.lorem.sentence(),
   content: faker.lorem.paragraphs(),
 }))

--- a/docs/src/examples/modules/Accordion/Usage/AccordionExampleExclusive.js
+++ b/docs/src/examples/modules/Accordion/Usage/AccordionExampleExclusive.js
@@ -3,7 +3,8 @@ import _ from 'lodash'
 import React from 'react'
 import { Accordion } from 'semantic-ui-react'
 
-const panels = _.times(3, () => ({
+const panels = _.times(3, i => ({
+  key: `panel-${i}`,
   title: faker.lorem.sentence(),
   content: faker.lorem.paragraphs(),
 }))

--- a/index.d.ts
+++ b/index.d.ts
@@ -214,8 +214,7 @@ export * from './dist/commonjs';
 export { default as Accordion, AccordionProps } from './dist/commonjs/modules/Accordion/Accordion';
 export {
   default as AccordionAccordion,
-  AccordionAccordionProps,
-  AccordionPanelProps
+  AccordionAccordionProps
 } from './dist/commonjs/modules/Accordion/AccordionAccordion';
 export {
   default as AccordionContent,

--- a/index.d.ts
+++ b/index.d.ts
@@ -222,6 +222,10 @@ export {
   AccordionContentProps
 } from './dist/commonjs/modules/Accordion/AccordionContent';
 export {
+  default as AccordionPanel,
+  AccordionPanelProps
+} from './dist/commonjs/modules/Accordion/AccordionPanel';
+export {
   default as AccordionTitle,
   AccordionTitleProps
 } from './dist/commonjs/modules/Accordion/AccordionTitle';

--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,7 @@ export StepTitle from './elements/Step/StepTitle'
 export Accordion from './modules/Accordion/Accordion'
 export AccordionAccordion from './modules/Accordion/AccordionAccordion'
 export AccordionContent from './modules/Accordion/AccordionContent'
+export AccordionPanel from './modules/Accordion/AccordionPanel'
 export AccordionTitle from './modules/Accordion/AccordionTitle'
 
 export Checkbox from './modules/Checkbox'

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -5,6 +5,7 @@ import React from 'react'
 import { getUnhandledProps, useKeyOnly } from '../../lib'
 import AccordionAccordion from './AccordionAccordion'
 import AccordionContent from './AccordionContent'
+import AccordionPanel from './AccordionPanel'
 import AccordionTitle from './AccordionTitle'
 
 /**
@@ -41,6 +42,7 @@ Accordion.propTypes = {
 
 Accordion.Accordion = AccordionAccordion
 Accordion.Content = AccordionContent
+Accordion.Panel = AccordionPanel
 Accordion.Title = AccordionTitle
 
 export default Accordion

--- a/src/modules/Accordion/AccordionAccordion.d.ts
+++ b/src/modules/Accordion/AccordionAccordion.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import { SemanticShorthandCollection, SemanticShorthandItem } from '../../';
-import { AccordionContentProps } from './AccordionContent';
+import { SemanticShorthandCollection } from '../../';
+import { AccordionPanelProps } from './AccordionPanel';
 import { AccordionTitleProps } from './AccordionTitle';
 
 export interface AccordionAccordionProps {
@@ -35,11 +35,6 @@ export interface AccordionAccordionProps {
 
   /** Shorthand array of props for Accordion. */
   panels?: SemanticShorthandCollection<AccordionPanelProps>;
-}
-
-export interface AccordionPanelProps {
-  content: SemanticShorthandItem<AccordionContentProps>;
-  title: SemanticShorthandItem<AccordionTitleProps>;
 }
 
 declare const AccordionAccordion: React.ComponentClass<AccordionAccordionProps>;

--- a/src/modules/Accordion/AccordionAccordion.js
+++ b/src/modules/Accordion/AccordionAccordion.js
@@ -69,7 +69,7 @@ export default class AccordionAccordion extends Component {
   static autoControlledProps = ['activeIndex']
 
   getInitialAutoControlledState({ exclusive }) {
-    return { activeIndex: exclusive ? -1 : [-1] }
+    return { activeIndex: exclusive ? -1 : [] }
   }
 
   computeNewIndex = (index) => {
@@ -77,6 +77,7 @@ export default class AccordionAccordion extends Component {
     const { activeIndex } = this.state
 
     if (exclusive) return index === activeIndex ? -1 : index
+
     // check to see if index is in array, and remove it, if not then add it
     return _.includes(activeIndex, index) ? _.without(activeIndex, index) : [...activeIndex, index]
   }

--- a/src/modules/Accordion/AccordionPanel.d.ts
+++ b/src/modules/Accordion/AccordionPanel.d.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import { SemanticShorthandItem } from '../../';
+import { AccordionContentProps } from './AccordionContent';
+import { AccordionTitleProps } from './AccordionTitle';
+
+export interface AccordionPanelProps {
+  [key: string]: any;
+
+  /** Whether or not the title is in the open state. */
+  active?: boolean;
+
+  /** A shorthand for Accordion.Content. */
+  content?: SemanticShorthandItem<AccordionContentProps>;
+
+  /** A panel index. */
+  index?: number | string;
+
+  /**
+   * Called when a panel title is clicked.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {AccordionTitleProps} data - All item props.
+   */
+  onTitleClick?: (event: React.MouseEvent<HTMLDivElement>, data: AccordionTitleProps) => void;
+
+  /** A shorthand for Accordion.Title. */
+  title: SemanticShorthandItem<AccordionTitleProps>;
+}
+
+declare class AccordionPanel extends React.Component<AccordionPanelProps, {}> {}
+
+export default AccordionPanel;

--- a/src/modules/Accordion/AccordionPanel.d.ts
+++ b/src/modules/Accordion/AccordionPanel.d.ts
@@ -25,7 +25,7 @@ export interface AccordionPanelProps {
   onTitleClick?: (event: React.MouseEvent<HTMLDivElement>, data: AccordionTitleProps) => void;
 
   /** A shorthand for Accordion.Title. */
-  title: SemanticShorthandItem<AccordionTitleProps>;
+  title?: SemanticShorthandItem<AccordionTitleProps>;
 }
 
 declare class AccordionPanel extends React.Component<AccordionPanelProps, {}> {}

--- a/src/modules/Accordion/AccordionPanel.js
+++ b/src/modules/Accordion/AccordionPanel.js
@@ -1,0 +1,40 @@
+import _ from 'lodash'
+import PropTypes from 'prop-types'
+import { Component } from 'react'
+
+import { createShorthandFactory, customPropTypes } from '../../lib'
+import AccordionTitle from './AccordionTitle'
+import AccordionContent from './AccordionContent'
+
+class AccordionPanel extends Component {
+  static propTypes = {
+    active: PropTypes.bool,
+    content: customPropTypes.itemShorthand,
+    index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    onTitleClick: PropTypes.func,
+    title: customPropTypes.itemShorthand,
+  }
+
+  handleTitleOverrides = predefinedProps => ({
+    onClick: (e, titleProps) => {
+      _.invoke(predefinedProps, 'onClick', e, titleProps)
+      _.invoke(this.props, 'onTitleClick', e, titleProps)
+    },
+  })
+
+  render() {
+    const { active, content, index, title } = this.props
+
+    return [
+      AccordionTitle.create(title, {
+        defaultProps: { active, index },
+        overrideProps: this.handleTitleOverrides,
+      }),
+      AccordionContent.create(content, { defaultProps: { active } }),
+    ]
+  }
+}
+
+AccordionPanel.create = createShorthandFactory(AccordionPanel, content => ({ content }))
+
+export default AccordionPanel

--- a/src/modules/Accordion/AccordionPanel.js
+++ b/src/modules/Accordion/AccordionPanel.js
@@ -8,10 +8,20 @@ import AccordionContent from './AccordionContent'
 
 class AccordionPanel extends Component {
   static propTypes = {
+    /** Whether or not the title is in the open state. */
     active: PropTypes.bool,
+    /** A shorthand for Accordion.Content. */
     content: customPropTypes.itemShorthand,
+    /** A panel index. */
     index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    /**
+     * Called when a panel title is clicked.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All item props.
+     */
     onTitleClick: PropTypes.func,
+    /** A shorthand for Accordion.Title. */
     title: customPropTypes.itemShorthand,
   }
 
@@ -27,14 +37,18 @@ class AccordionPanel extends Component {
 
     return [
       AccordionTitle.create(title, {
-        defaultProps: { active, index },
+        autoGenerateKey: false,
+        defaultProps: { active, index, key: 'title' },
         overrideProps: this.handleTitleOverrides,
       }),
-      AccordionContent.create(content, { defaultProps: { active } }),
+      AccordionContent.create(content, {
+        autoGenerateKey: false,
+        defaultProps: { active, key: 'content' },
+      }),
     ]
   }
 }
 
-AccordionPanel.create = createShorthandFactory(AccordionPanel, content => ({ content }))
+AccordionPanel.create = createShorthandFactory(AccordionPanel, null)
 
 export default AccordionPanel

--- a/src/modules/Accordion/AccordionPanel.js
+++ b/src/modules/Accordion/AccordionPanel.js
@@ -10,10 +10,13 @@ class AccordionPanel extends Component {
   static propTypes = {
     /** Whether or not the title is in the open state. */
     active: PropTypes.bool,
+
     /** A shorthand for Accordion.Content. */
     content: customPropTypes.itemShorthand,
+
     /** A panel index. */
     index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
     /**
      * Called when a panel title is clicked.
      *
@@ -21,6 +24,7 @@ class AccordionPanel extends Component {
      * @param {object} data - All item props.
      */
     onTitleClick: PropTypes.func,
+
     /** A shorthand for Accordion.Title. */
     title: customPropTypes.itemShorthand,
   }

--- a/test/setup.js
+++ b/test/setup.js
@@ -61,7 +61,7 @@ beforeEach(() => {
   warn = console.warn
   error = console.error
 
-  console.log = throwOnConsole('log')
+  // console.log = throwOnConsole('log')
   console.info = throwOnConsole('info')
   console.warn = throwOnConsole('warn')
   console.error = throwOnConsole('error')

--- a/test/specs/modules/Accordion/Accordion-test.js
+++ b/test/specs/modules/Accordion/Accordion-test.js
@@ -3,12 +3,18 @@ import React from 'react'
 import Accordion from 'src/modules/Accordion/Accordion'
 import AccordionAccordion from 'src/modules/Accordion/AccordionAccordion'
 import AccordionContent from 'src/modules/Accordion/AccordionContent'
+import AccordionPanel from 'src/modules/Accordion/AccordionPanel'
 import AccordionTitle from 'src/modules/Accordion/AccordionTitle'
 import * as common from 'test/specs/commonTests'
 
 describe('Accordion', () => {
   common.isConformant(Accordion)
-  common.hasSubcomponents(Accordion, [AccordionAccordion, AccordionContent, AccordionTitle])
+  common.hasSubcomponents(Accordion, [
+    AccordionAccordion,
+    AccordionContent,
+    AccordionPanel,
+    AccordionTitle,
+  ])
   common.hasUIClassName(Accordion)
 
   common.propKeyOnlyToClassName(Accordion, 'fluid')

--- a/test/specs/modules/Accordion/AccordionAccordion-test.js
+++ b/test/specs/modules/Accordion/AccordionAccordion-test.js
@@ -16,182 +16,138 @@ describe('AccordionAccordion', () => {
 
   describe('activeIndex', () => {
     const panels = [
-      { title: 'A', content: 'Something A' },
-      { title: 'B', content: 'Something B' },
-      { title: 'C', content: 'Something C' },
+      { key: 'A', title: 'A', content: 'Something A' },
+      { key: 'B', title: 'B', content: 'Something B' },
+      { key: 'C', title: 'C', content: 'Something C' },
     ]
 
     it('defaults to -1', () => {
-      shallow(<AccordionAccordion />)
-        .should.have.state('activeIndex', -1)
+      shallow(<AccordionAccordion />).should.have.state('activeIndex', -1)
+    })
+
+    it('defaults to -1 when "exclusive" is false', () => {
+      shallow(<AccordionAccordion exclusive={false} />)
+        .should.have.state('activeIndex')
+        .that.is.empty()
     })
 
     it('makes Accordion.Content at activeIndex - 0 "active"', () => {
-      const contents = shallow(<AccordionAccordion activeIndex={0} panels={panels} />)
-        .find('AccordionContent')
+      const wrapper = shallow(<AccordionAccordion activeIndex={0} panels={panels} />)
 
-      contents.at(0).should.have.prop('active', true)
-      contents.at(1).should.have.prop('active', false)
+      wrapper.childAt(0).should.have.prop('active', true)
+      wrapper.childAt(1).should.have.prop('active', false)
+      wrapper.childAt(2).should.have.prop('active', false)
     })
 
     it('is toggled to -1 when clicking Title a second time', () => {
       const wrapper = mount(<AccordionAccordion panels={panels} />)
 
-      // open panel (activeIndex 0)
       wrapper
-        .find('AccordionTitle')
+        .find(AccordionTitle)
         .at(0)
         .simulate('click')
       wrapper.should.have.state('activeIndex', 0)
-      wrapper
-        .find('AccordionTitle')
-        .at(0)
-        .should.have.prop('active', true)
 
-      // close panel (activeIndex -1)
       wrapper
-        .find('AccordionTitle')
+        .find(AccordionTitle)
         .at(0)
         .simulate('click')
       wrapper.should.have.state('activeIndex', -1)
-      wrapper
-        .find('AccordionTitle')
-        .at(0)
-        .should.have.prop('active', false)
     })
 
-    it('sets the correct pair of title/content active', () => {
-      const wrapper = shallow(<AccordionAccordion panels={panels} />)
-      wrapper.setProps({ activeIndex: 0 })
+    it('sets the correct panel active', () => {
+      const wrapper = shallow(<AccordionAccordion activeIndex={0} panels={panels} />)
+
       wrapper.childAt(0).should.have.prop('active', true)
-      wrapper.childAt(1).should.have.prop('active', true)
+      wrapper.childAt(1).should.have.prop('active', false)
       wrapper.childAt(2).should.have.prop('active', false)
-      wrapper.childAt(3).should.have.prop('active', false)
 
       wrapper.setProps({ activeIndex: 1 })
       wrapper.childAt(0).should.have.prop('active', false)
-      wrapper.childAt(1).should.have.prop('active', false)
-      wrapper.childAt(2).should.have.prop('active', true)
-      wrapper.childAt(3).should.have.prop('active', true)
+      wrapper.childAt(1).should.have.prop('active', true)
+      wrapper.childAt(2).should.have.prop('active', false)
     })
 
     it('can be an array', () => {
-      const wrapper = shallow(<AccordionAccordion exclusive={false} panels={panels} />)
-      wrapper.setProps({ activeIndex: [0, 1] })
+      const wrapper = shallow(
+        <AccordionAccordion activeIndex={[0, 1]} exclusive={false} panels={panels} />,
+      )
       wrapper.childAt(0).should.have.prop('active', true)
       wrapper.childAt(1).should.have.prop('active', true)
-      wrapper.childAt(2).should.have.prop('active', true)
-      wrapper.childAt(3).should.have.prop('active', true)
-      wrapper.childAt(4).should.have.prop('active', false)
-      wrapper.childAt(5).should.have.prop('active', false)
+      wrapper.childAt(2).should.have.prop('active', false)
 
       wrapper.setProps({ activeIndex: [1, 2] })
       wrapper.childAt(0).should.have.prop('active', false)
-      wrapper.childAt(1).should.have.prop('active', false)
+      wrapper.childAt(1).should.have.prop('active', true)
       wrapper.childAt(2).should.have.prop('active', true)
-      wrapper.childAt(3).should.have.prop('active', true)
-      wrapper.childAt(4).should.have.prop('active', true)
-      wrapper.childAt(5).should.have.prop('active', true)
     })
 
     it('can be inclusive and makes Accordion.Content at activeIndex - 1 "active"', () => {
-      const contents = shallow(<AccordionAccordion activeIndex={[0]} exclusive={false} panels={panels} />)
-        .find('AccordionTitle')
+      const wrapper = shallow(
+        <AccordionAccordion activeIndex={[0]} exclusive={false} panels={panels} />,
+      )
 
-      contents.at(0).should.have.prop('active', true)
-      contents.at(1).should.have.prop('active', false)
+      wrapper.childAt(0).should.have.prop('active', true)
+      wrapper.childAt(1).should.have.prop('active', false)
+      wrapper.childAt(2).should.have.prop('active', false)
     })
 
     it('can be inclusive and allows multiple open', () => {
-      const contents = shallow(<AccordionAccordion activeIndex={[0, 1]} exclusive={false} panels={panels} />)
-        .find('AccordionTitle')
+      const wrapper = shallow(
+        <AccordionAccordion activeIndex={[0, 1]} exclusive={false} panels={panels} />,
+      )
 
-      contents.at(0).should.have.prop('active', true)
-      contents.at(1).should.have.prop('active', true)
+      wrapper.childAt(0).should.have.prop('active', true)
+      wrapper.childAt(1).should.have.prop('active', true)
+      wrapper.childAt(2).should.have.prop('active', false)
     })
 
     it('can be inclusive and can open multiple panels by clicking', () => {
       const wrapper = mount(<AccordionAccordion exclusive={false} panels={panels} />)
 
       wrapper
-        .find('AccordionTitle')
+        .find(AccordionTitle)
         .at(0)
         .simulate('click')
-      wrapper
-        .find('AccordionTitle')
-        .at(0)
-        .should.have.prop('active', true)
-      wrapper
-        .find('AccordionContent')
-        .at(0)
-        .should.have.prop('active', true)
+      wrapper.should.have.state('activeIndex').that.includes(0)
 
       wrapper
-        .find('AccordionTitle')
+        .find(AccordionTitle)
         .at(1)
         .simulate('click')
-      wrapper
-        .find('AccordionTitle')
-        .at(1)
-        .should.have.prop('active', true)
-      wrapper
-        .find('AccordionContent')
-        .at(1)
-        .should.have.prop('active', true)
+      wrapper.should.have.state('activeIndex').that.includes(0, 1)
     })
 
     it('can be inclusive and close multiple panels by clicking', () => {
-      const wrapper = mount(<AccordionAccordion defaultActiveIndex={[0, 1]} exclusive={false} panels={panels} />)
+      const wrapper = mount(
+        <AccordionAccordion defaultActiveIndex={[0, 1]} exclusive={false} panels={panels} />,
+      )
 
       wrapper
-        .find('AccordionTitle')
+        .find(AccordionTitle)
         .at(0)
         .simulate('click')
-      wrapper
-        .find('AccordionTitle')
-        .at(0)
-        .should.have.prop('active', false)
-      wrapper
-        .find('AccordionContent')
-        .at(0)
-        .should.have.prop('active', false)
+      wrapper.should.have.state('activeIndex').that.includes(1)
 
       wrapper
-        .find('AccordionTitle')
+        .find(AccordionTitle)
         .at(1)
         .simulate('click')
-      wrapper
-        .find('AccordionTitle')
-        .at(1)
-        .should.have.prop('active', false)
-      wrapper
-        .find('AccordionContent')
-        .at(1)
-        .should.have.prop('active', false)
+      wrapper.should.have.state('activeIndex').that.is.empty()
     })
   })
 
   describe('defaultActiveIndex', () => {
     it('sets the initial activeIndex state', () => {
-      shallow(<AccordionAccordion defaultActiveIndex={123} />)
-        .should.have.state('activeIndex', 123)
+      shallow(<AccordionAccordion defaultActiveIndex={123} />).should.have.state('activeIndex', 123)
     })
   })
 
   describe('onTitleClick', () => {
     const event = { target: null }
-
     const onClick = sandbox.spy()
     const onTitleClick = sandbox.spy()
-    const panels = [
-      { title: { content: 'A', onClick } },
-      { title: 'B' },
-    ]
-
-    it('can be omitted', () => {
-      const click = () => mount(<AccordionAccordion panels={panels} />).find(AccordionTitle).at(1).simulate('click')
-      expect(click).to.not.throw()
-    })
+    const panels = [{ key: 'A', title: { content: 'A', onClick } }, { key: 'B', title: 'B' }]
 
     it('is called with (e, titleProps) when clicked', () => {
       mount(<AccordionAccordion panels={panels} onTitleClick={onTitleClick} />)
@@ -209,11 +165,15 @@ describe('AccordionAccordion', () => {
 
   describe('panels', () => {
     const event = { target: null }
-    const spy = sandbox.spy()
+    const onClick = sandbox.spy()
 
     const panels = [
-      { title: { content: 'A', onClick: spy }, content: { content: 'Content A', 'data-foo': 'something' } },
-      { title: 'B', content: { content: 'Content B', 'data-foo': 'something' } },
+      {
+        key: 'A',
+        title: { content: 'A', onClick },
+        content: { content: 'Content A', 'data-foo': 'something' },
+      },
+      { key: 'B', title: 'B', content: { content: 'Content B', 'data-foo': 'something' } },
     ]
     const children = mount(<AccordionAccordion panels={panels} />)
 
@@ -228,20 +188,20 @@ describe('AccordionAccordion', () => {
       contents.at(1).should.have.prop('content', 'Content B')
     })
 
-    it('onClick can omitted', () => {
-      const click = () => children.find(AccordionTitle).at(1).simulate('click')
-      expect(click).to.not.throw()
-    })
-
     it('passes onClick handler', () => {
-      children.find(AccordionTitle).at(0).simulate('click', event)
+      children
+        .find(AccordionTitle)
+        .at(0)
+        .simulate('click', event)
 
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(event, { content: 'A', index: 0 })
+      onClick.should.have.been.calledOnce()
+      onClick.should.have.been.calledWithMatch(event, { content: 'A', index: 0 })
     })
 
     it('passes arbitrary props', () => {
-      children.find(AccordionContent).everyWhere(item => item.should.have.prop('data-foo', 'something'))
+      children
+        .find(AccordionContent)
+        .everyWhere(item => item.should.have.prop('data-foo', 'something'))
     })
   })
 })

--- a/test/specs/modules/Accordion/AccordionPanel-test.js
+++ b/test/specs/modules/Accordion/AccordionPanel-test.js
@@ -1,5 +1,9 @@
+import React from 'react'
+
 import AccordionPanel from 'src/modules/Accordion/AccordionPanel'
+import AccordionTitle from 'src/modules/Accordion/AccordionTitle'
 import * as common from 'test/specs/commonTests'
+import { sandbox } from 'test/utils'
 
 describe('AccordionPanel', () => {
   common.isConformant(AccordionPanel, { rendersChildren: false })
@@ -18,4 +22,47 @@ describe('AccordionPanel', () => {
   //   ShorthandComponent: AccordionTitle,
   //   mapValueToProps: content => ({ content }),
   // })
+
+  describe('active', () => {
+    it('should passed to children', () => {
+      const wrapper = shallow(<AccordionPanel active content='Content' title='Title' />).at(0)
+
+      wrapper.at(0).should.have.prop('active', true)
+      wrapper.at(1).should.have.prop('active', true)
+    })
+  })
+
+  describe('index', () => {
+    it('should passed to title', () => {
+      const wrapper = shallow(<AccordionPanel content='Content' index={5} title='Title' />).at(0)
+
+      wrapper.at(0).should.have.prop('index', 5)
+      wrapper.at(1).should.have.not.prop('index')
+    })
+  })
+
+  describe('onTitleClick', () => {
+    it('is called with (e, titleProps) when clicked', () => {
+      const event = { target: null }
+      const onClick = sandbox.spy()
+      const onTitleClick = sandbox.spy()
+
+      mount(
+        <AccordionPanel
+          content='Content'
+          onTitleClick={onTitleClick}
+          title={{ content: 'Title', onClick }}
+        />,
+      )
+        .find(AccordionTitle)
+        .at(0)
+        .simulate('click', event)
+
+      onClick.should.have.been.calledOnce()
+      onClick.should.have.been.calledWithMatch(event, { content: 'Title' })
+
+      onTitleClick.should.have.been.calledOnce()
+      onTitleClick.should.have.been.calledWithMatch(event, { content: 'Title' })
+    })
+  })
 })

--- a/test/specs/modules/Accordion/AccordionPanel-test.js
+++ b/test/specs/modules/Accordion/AccordionPanel-test.js
@@ -1,0 +1,21 @@
+import AccordionPanel from 'src/modules/Accordion/AccordionPanel'
+import * as common from 'test/specs/commonTests'
+
+describe('AccordionPanel', () => {
+  common.isConformant(AccordionPanel, { rendersChildren: false })
+
+  // TODO: Reenable tests in future
+  // https://github.com/airbnb/enzyme/issues/1553
+  //
+  // common.implementsShorthandProp(AccordionPanel, {
+  //   assertExactMatch: false,
+  //   propKey: 'content',
+  //   ShorthandComponent: AccordionContent,
+  //   mapValueToProps: content => ({ content }),
+  // })
+  // common.implementsShorthandProp(AccordionPanel, {
+  //   propKey: 'title',
+  //   ShorthandComponent: AccordionTitle,
+  //   mapValueToProps: content => ({ content }),
+  // })
+})


### PR DESCRIPTION
Is part of #2880.

# BREAKING CHANGES

With React 16 we can return an array of elements in `render()`, this allows us to simplify the shorthand API there.

**Changes in this PR affect only the shorthand API.**

## 1. `key` handling is better now

The usage of `AccordionPanel` in the shorthand API allows us to make handling of `keys` more simple and intuitive.

### Before

```jsx
const panels = [
  { title: 'title 1', content: 'content 1' },
  {
    title: {
      key: 'title-2',
      content: <div>title 2</div>,
    },
    content: {
      key: 'content-2',
      content: <div>content 2</div>,
    },
  },
]

<Accordion panels={panels} />
```

### After

```jsx
const panels = [
  { key: 'panel-1', title: 'title 1', content: 'content 1' },
  {
    key: 'panel-2',
    title: {
      content: <div>title 2</div>,
    },
    content: {
      content: <div>content 2</div>,
    },
  },
]

<Accordion panels={panels} />
```

## 2. (_Typescript only_) Export of AccordionPanelProps

The `AccordionPanelProps` interface is now exported from `AccordionPanel.d.ts`.