### PR TITLE
UX and styling improvements to Datetime

### DIFF
--- a/src/addons/Datetime/Datetime.js
+++ b/src/addons/Datetime/Datetime.js
@@ -353,13 +353,17 @@ export default class Datetime extends Component {
           />
         )}
       >
-        <DatetimeMenu
-          mode={mode}
-          onDateChangeMode={this.handleChangeMode}
-          onNextPage={this.handleNextPage}
-          onPreviousPage={this.handlePreviousPage}
-          value={value}
-        />
+        {mode != 'hour' && mode != 'minute' &&
+            <DatetimeMenu
+              compact
+              size='small'
+              mode={mode}
+              onDateChangeMode={this.handleChangeMode}
+              onNextPage={this.handleNextPage}
+              onPreviousPage={this.handlePreviousPage}
+              value={value}
+            />
+        }
         <DatetimeCalendar
           date={date}
           dateFormatter={dateFormatter}

--- a/src/addons/Datetime/Datetime.js
+++ b/src/addons/Datetime/Datetime.js
@@ -163,7 +163,7 @@ export default class Datetime extends Component {
     timeFormatter: dateUtils.defaultTimeFormatter,
     hourFormatter: dateUtils.defaultHourFormatter,
     date: true,
-    time: true,
+    time: false,
     defaultValue: new Date(),
   }
 

--- a/src/addons/Datetime/Datetime.js
+++ b/src/addons/Datetime/Datetime.js
@@ -165,6 +165,7 @@ export default class Datetime extends Component {
     date: true,
     time: false,
     defaultValue: new Date(),
+    size: 'tiny',
   }
 
   componentWillMount() {
@@ -312,6 +313,7 @@ export default class Datetime extends Component {
       placeholder,
       time,
       timeFormatter,
+      size
     } = this.props
 
     const { open, value, mode } = this.state
@@ -320,6 +322,7 @@ export default class Datetime extends Component {
     return (
       <Popup
         {...rest}
+        size={size}
         closeOnDocumentClick
         // TODO: Fix close on trigger blur, it closes when clicking inside the calendar.
         // DatetimeCalendar contents are changed on click, so Popup cannot find the clicked node within calendar.

--- a/src/addons/Datetime/Datetime.js
+++ b/src/addons/Datetime/Datetime.js
@@ -12,6 +12,7 @@ import {
 } from '../../lib'
 
 import Input from '../../elements/Input/Input'
+import Divider from '../../elements/Divider'
 import Popup from '../../modules/Popup'
 
 import DatetimeGrid from './DatetimeGrid'
@@ -321,6 +322,7 @@ export default class Datetime extends Component {
 
     return (
       <Popup
+        style={{paddingTop: '0.25rem'}}
         {...rest}
         size={size}
         closeOnDocumentClick
@@ -354,6 +356,7 @@ export default class Datetime extends Component {
         )}
       >
         {mode != 'hour' && mode != 'minute' &&
+          <React.Fragment>
             <DatetimeMenu
               compact
               size='small'
@@ -363,6 +366,8 @@ export default class Datetime extends Component {
               onPreviousPage={this.handlePreviousPage}
               value={value}
             />
+            <Divider fitted style={{marginBottom: '0.5rem'}}/>
+          </React.Fragment>
         }
         <DatetimeCalendar
           date={date}

--- a/src/addons/Datetime/Datetime.js
+++ b/src/addons/Datetime/Datetime.js
@@ -356,7 +356,6 @@ export default class Datetime extends Component {
         )}
       >
         {mode != 'hour' && mode != 'minute' &&
-          <React.Fragment>
             <DatetimeMenu
               compact
               size='small'
@@ -366,8 +365,6 @@ export default class Datetime extends Component {
               onPreviousPage={this.handlePreviousPage}
               value={value}
             />
-            <Divider fitted style={{marginBottom: '0.5rem'}}/>
-          </React.Fragment>
         }
         <DatetimeCalendar
           date={date}

--- a/src/addons/Datetime/DatetimeCalendar.js
+++ b/src/addons/Datetime/DatetimeCalendar.js
@@ -101,7 +101,7 @@ export default class DatetimeCalendar extends Component {
   static defaultProps = {
     firstDayOfWeek: 1,
     date: true,
-    time: true,
+    time: false,
     mode: 'day',
     value: new Date(),
     dateFormatter: dateUtils.defaultDateFormatter,

--- a/src/addons/Datetime/DatetimeCalendar.js
+++ b/src/addons/Datetime/DatetimeCalendar.js
@@ -17,7 +17,6 @@ import {
 
 const style = {
   float: 'left',    // for side-by-side calendar ranges
-  width: '20em',
 }
 
 /**

--- a/src/addons/Datetime/DatetimeGrid.js
+++ b/src/addons/Datetime/DatetimeGrid.js
@@ -95,7 +95,7 @@ DatetimeGrid.propTypes = {
 
 DatetimeGrid.defaultProps = {
   as: Table,
-  basic: 'very',
+  basic: true,
   singleLine: true,
   size: 'small',
   textAlign: 'center',

--- a/src/addons/Datetime/DatetimeHours.js
+++ b/src/addons/Datetime/DatetimeHours.js
@@ -52,7 +52,7 @@ export default class DatetimeHours extends Component {
     type: META.TYPES.ADDON,
   }
 
-  getCells = () => _.map(_.range(0, 12), hour => ({
+  getCells = () => _.map(_.range(0, 24), hour => ({
     content: this.getHourLabel(hour),
     onClick: this.handleCellClick(hour),
   }))

--- a/src/addons/Datetime/DatetimeHours.js
+++ b/src/addons/Datetime/DatetimeHours.js
@@ -64,7 +64,7 @@ export default class DatetimeHours extends Component {
     date.setMinutes(0)
     date.setHours(hour)
 
-    return `${formatter(date)}:00`
+    return `${formatter(date)}`
   }
 
   handleCellClick = hours => (e) => {

--- a/src/addons/Datetime/DatetimeMenu.js
+++ b/src/addons/Datetime/DatetimeMenu.js
@@ -104,10 +104,10 @@ export default class DatetimeMenu extends Component {
     ])
 
     return (
-      <ElementType fluid secondary widths={items.length + 2} {...rest}>
-        <Menu.Item icon='angle double left' onClick={onPreviousPage} />
+      <ElementType fluid text widths={items.length + 2} {...rest}>
+        <Menu.Item icon='angle left' onClick={onPreviousPage} />
         {items}
-        <Menu.Item icon='angle double right' onClick={onNextPage} />
+        <Menu.Item icon='angle right' onClick={onNextPage} />
       </ElementType>
     )
   }

--- a/src/lib/dateUtils.js
+++ b/src/lib/dateUtils.js
@@ -4,7 +4,7 @@ import _ from 'lodash'
 const tzo = new Date().getTimezoneOffset()*6e4
 
 const daysOfMonth = (fmt) => Array(12).fill().map((o,i) => new Date(0, i).toLocaleDateString(navigator.language, {month: fmt}))
-const daysOfWeek = (fmt) => Array(7).fill().map((o,i) => new Date(tzo+1/1.2e-8*(i+4)).toLocaleDateString('en-US', {weekday: fmt}))
+const daysOfWeek = (fmt) => Array(7).fill().map((o,i) => new Date(tzo+1/1.2e-8*(i+4)).toLocaleDateString(navigator.language, {weekday: fmt}))
 
 export const labels = {
   daysShort: daysOfWeek('short'), // ['Sun', 'Mon', 'Tue', ...] --- localized

--- a/src/lib/dateUtils.js
+++ b/src/lib/dateUtils.js
@@ -1,22 +1,15 @@
 import _ from 'lodash'
 
+// timezone offset in ms
+const tzo = new Date().getTimezoneOffset()*6e4
+
+const daysOfMonth = (fmt) => Array(12).fill().map((o,i) => new Date(0, i).toLocaleDateString(navigator.language, {month: fmt}))
+const daysOfWeek = (fmt) => Array(7).fill().map((o,i) => new Date(tzo+1/1.2e-8*(i+4)).toLocaleDateString('en-US', {weekday: fmt}))
+
 export const labels = {
-  daysShort: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  daysFull: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  months: [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ],
+  daysShort: daysOfWeek('short'), // ['Sun', 'Mon', 'Tue', ...] --- localized
+  daysFull: daysOfWeek('long'), // ['Sunday', 'Monday', 'Tuesday', ...] --- localized
+  months: daysOfMonth('long') // ['January', 'February', 'March', ...] --- localized
 }
 
 /**

--- a/src/lib/dateUtils.js
+++ b/src/lib/dateUtils.js
@@ -109,6 +109,8 @@ function ampmFormatter(date) {
 
 export function defaultHourFormatter(date) {
   if (!date) return ''
+  if(Date.prototype.toLocaleTimeString)
+    return date.toLocaleTimeString(navigator.language, {hour: '2-digit'});
   return date.getHours() % 12 || 12
 }
 


### PR DESCRIPTION
First PR here. Attempted to implement input typing but thought I'd at least try
some more basic things first.  I took some time and looked at several other
Datepickers out there including my own ractive-datepicker, Antd, MUI, 
react-datepicker, react-date, react-times, etc. 

Most of the changes here are cosmetic to improve the UX
of what is already there. There are two *minor* inline styles that I deliberated
over but couldn't avoid. Without them it looks very lobsided due to Popover's
default padding and the Divider's margin.

There is currently an issue where clicking on hours 5pm - 11pm don't show 
the minutes mode after. Any idea about that? I was having trouble finding
the flow after the _.invokeARgs.

Let me know your thoughts.