### PR TITLE
fix(Portal): remove non-working `style` prop

### DIFF
--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -101,9 +101,6 @@ export interface PortalProps {
   /** Controls whether the portal should be prepended to the mountNode instead of appended. */
   prepend?: boolean
 
-  /** Any inline styles to the Portal container. */
-  style?: object
-
   /** Element to be rendered in-place where the portal is defined. */
   trigger?: React.ReactNode
 }

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -352,7 +352,7 @@ class Portal extends Component {
     if (!isBrowser()) return null
 
     this.rootNode.className = className || ''
-    this.rootNode.style = style || ''
+    this.rootNode.cssText = style || ''
 
     // when re-rendering, first remove listeners before re-adding them to the new node
     if (this.portalNode) {

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -121,10 +121,7 @@ class Portal extends Component {
 
     /** Controls whether the portal should be prepended to the mountNode instead of appended. */
     prepend: PropTypes.bool,
-
-    /** Any inline styles to the Portal container. */
-    style: PropTypes.object,
-
+    
     /** Element to be rendered in-place where the portal is defined. */
     trigger: PropTypes.node,
   }
@@ -344,7 +341,7 @@ class Portal extends Component {
     if (!this.state.open) return
     debug('renderPortal()')
 
-    const { children, className, eventPool, style } = this.props
+    const { children, className, eventPool } = this.props
 
     this.mountPortal()
 
@@ -352,7 +349,6 @@ class Portal extends Component {
     if (!isBrowser()) return null
 
     this.rootNode.className = className || ''
-    this.rootNode.cssText = style || ''
 
     // when re-rendering, first remove listeners before re-adding them to the new node
     if (this.portalNode) {

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -121,7 +121,7 @@ class Portal extends Component {
 
     /** Controls whether the portal should be prepended to the mountNode instead of appended. */
     prepend: PropTypes.bool,
-    
+
     /** Element to be rendered in-place where the portal is defined. */
     trigger: PropTypes.node,
   }


### PR DESCRIPTION
Instead of setting the style property of a dom node (which is a read-only attribute), we set the cssText property instead.

See https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style for additional documentation.

Even so, most browsers allow setting style directly.  However, doing this in IE causes a crash.


This fixes #2886.