### PR TITLE
fix(Dropdown): allow `defaultValue` to be a boolean

### DIFF
--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -66,7 +66,7 @@ export interface DropdownProps {
   defaultUpward?: boolean
 
   /** Initial value or value array if multiple. */
-  defaultValue?: string | number | (number | string)[]
+  defaultValue?: string | number | boolean | (number | string | boolean)[]
 
   /** A dropdown menu can open to the left or to the right. */
   direction?: 'left' | 'right'

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -109,7 +109,8 @@ export default class Dropdown extends Component {
     defaultValue: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string,
-      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+      PropTypes.bool,
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])),
     ]),
 
     /** A dropdown menu can open to the left or to the right. */


### PR DESCRIPTION
A previous fix allowed using booleans as options for dropdowns. This adds the ability to also use a boolean as the defaultValue for a dropdown.

Booleans currently work as default value for dropdowns, but this change removes annoying console errors about propType errors.