### PR TITLE
fix(Input): add lang prop for input fields

### DIFF
--- a/src/lib/htmlPropsUtils.js
+++ b/src/lib/htmlPropsUtils.js
@@ -8,7 +8,6 @@ export const htmlInputAttrs = [
 
   // LIMITED HTML PROPS
   'accept',
-  'lang',
   'autoCapitalize',
   'autoComplete',
   'autoCorrect',
@@ -17,6 +16,7 @@ export const htmlInputAttrs = [
   'disabled',
   'form',
   'id',
+  'lang',
   'list',
   'max',
   'maxLength',

--- a/src/lib/htmlPropsUtils.js
+++ b/src/lib/htmlPropsUtils.js
@@ -8,6 +8,7 @@ export const htmlInputAttrs = [
 
   // LIMITED HTML PROPS
   'accept',
+  'lang',
   'autoCapitalize',
   'autoComplete',
   'autoCorrect',


### PR DESCRIPTION
Lang attribute on input elements help the browser provide better localization support. Right now, adding lang prop to input adds that as an attribute to the wrapping div which doesn't serve the localization purpose. 

Fixes #2979.