### PR TITLE
fix(Icon): add 'file text outline' type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1892,6 +1892,7 @@ export type SemanticICONS =
   | 'feed'
   | 'female homosexual'
   | 'file text'
+  | 'file text outline'
   | 'find'
   | 'first aid'
   | 'fork'

--- a/src/lib/SUI.js
+++ b/src/lib/SUI.js
@@ -1889,6 +1889,7 @@ export const ICON_ALIASES = [
   'feed',
   'female homosexual',
   'file text',
+  'file text outline',
   'find',
   'first aid',
   'fork',


### PR DESCRIPTION
Icon "file text outline" exists in the code but not in the `SemanticICONS` type.

This PR adds the missing string literal to the `SemanticICONS` type as well as `SUI.js`.

Left (highlighted):
`<Icon name="file text outline" />`

Right:
`<Icon name="file text" />`

<img width="68" alt="sh-602-prod-fr2 2018-07-10 12-38-17" src="https://user-images.githubusercontent.com/32278124/42505590-724e6b1c-843f-11e8-949b-807db1ffe844.png">
