### PR TITLE
fix(Sidebar): clear timer when unmounting

### DIFF
--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -110,6 +110,7 @@ class Sidebar extends Component {
     const { visible } = this.props
 
     if (visible) this.removeListener()
+    clearTimeout(this.animationTimer)
   }
 
   componentDidUpdate(prevProps) {

--- a/test/specs/modules/Sidebar/Sidebar-test.js
+++ b/test/specs/modules/Sidebar/Sidebar-test.js
@@ -26,6 +26,16 @@ describe('Sidebar', () => {
     nestingLevel,
   })
 
+  describe('componentWillUnmount', () => {
+    it('will call "clearTimeout"', () => {
+      const clear = sandbox.spy(window, 'clearTimeout')
+      const wrapper = mount(<Sidebar />)
+
+      wrapper.setProps({ visible: true })
+      clear.should.have.been.calledOnce()
+    })
+  })
+
   describe('onHide', () => {
     it('is called when the "visible" prop changes to "false"', () => {
       const onHide = sandbox.spy()


### PR DESCRIPTION
…omponent (#3045)

The animation timer was not cleared when unmounting the Sidebar
component resulting in a React warning if the Sidebar was unmounted
while closing or opening.

fixes #3045