### PR TITLE
fix(Dropdown): fix `additionLabel` definition

### DIFF
--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -14,7 +14,7 @@ export interface DropdownProps {
   as?: any
 
   /** Label prefixed to an option added by a user. */
-  additionLabel?: number | string
+  additionLabel?: number | string | React.ReactNode
 
   /** Position of the `Add: ...` option in the dropdown list ('top' or 'bottom'). */
   additionPosition?: 'top' | 'bottom'

--- a/test/typings.tsx
+++ b/test/typings.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
-import { Button } from '../'
+import { Button, Dropdown } from '../'
 
 const Test = () => <Button />
+const DropdownTest = () => (
+  <Dropdown additionLabel={<i style={{ color: 'red' }}>Custom Language: </i>} />
+)
 
 export default Test


### PR DESCRIPTION
Change the type definition for the additionLabel prop on the
Dropdown component to allow components.

see issue #3054