### PR TITLE
docs(IconExampleFitted): better demonstrate fitted

### DIFF
--- a/docs/src/examples/elements/Icon/Variations/IconExampleFitted.js
+++ b/docs/src/examples/elements/Icon/Variations/IconExampleFitted.js
@@ -3,9 +3,9 @@ import { Icon } from 'semantic-ui-react'
 
 const IconExampleFitted = () => (
   <div>
-    <p>Tight spacing</p>
-    <Icon fitted name='help' />
-    <p>Tight spacing</p>
+    This icon<Icon fitted name='help' />is fitted.
+    <br />
+    This icon<Icon name='help' />is not.
   </div>
 )
 


### PR DESCRIPTION
The current example is a poor indicator of what "fitted" is doing.  Improved the layout to better show the use of margins:

### Before
![image](https://user-images.githubusercontent.com/5067638/43539893-0e423e6c-957b-11e8-936f-bb96faf1b7dd.png)

### After
![image](https://user-images.githubusercontent.com/5067638/43539874-01acd4e6-957b-11e8-8371-73f9c6c7acdd.png)
