### PR TITLE
fix(docs): fix issues with local builds

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
@@ -71,13 +71,17 @@ class ComponentExample extends PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
+    const { examplePath, exampleSources, location } = nextProps
+    const nextSourceCode = exampleSources[examplePath]
+
     // deactivate examples when switching from one to the next
-    if (
-      this.isActiveHash() &&
-      this.isActiveState() &&
-      this.props.location.hash !== nextProps.location.hash
-    ) {
+    if (this.isActiveHash() && this.isActiveState() && this.props.location.hash !== location.hash) {
       this.clearActiveState()
+    }
+
+    // for local environment
+    if (process.env.NODE_ENV !== 'production' && this.getOriginalSourceCode() !== nextSourceCode) {
+      this.setState({ sourceCode: nextSourceCode })
     }
   }
 

--- a/gulp/plugins/gulp-example-source.js
+++ b/gulp/plugins/gulp-example-source.js
@@ -1,14 +1,16 @@
-import Vinyl from 'vinyl'
 import gutil from 'gulp-util'
 import _ from 'lodash'
 import path from 'path'
 import through from 'through2'
+import Vinyl from 'vinyl'
 
+// Heads up!
+// This plugin is not universal, so it's okay to keep all existing sources as the state.
+// https://github.com/Semantic-Org/Semantic-UI-React/issues/3095
+const exampleSources = {}
 const pluginName = 'gulp-example-source'
 
 export default () => {
-  const exampleSources = {}
-
   function bufferContents(file, enc, cb) {
     if (file.isNull()) {
       cb(null, file)
@@ -41,16 +43,9 @@ export default () => {
   function endStream(cb) {
     const file = new Vinyl({
       path: './exampleSources.json',
+      contents: Buffer.from(JSON.stringify(exampleSources, null, 2)),
     })
-    let existingSources = {}
 
-    // Heads up!
-    // In watch mode we should update only single entry that matches changed file.
-    if (file.contents) {
-      existingSources = JSON.parse(file.contents.toString())
-    }
-
-    file.contents = Buffer.from(JSON.stringify({ ...existingSources, ...exampleSources }, null, 2))
     this.push(file)
     cb()
   }


### PR DESCRIPTION
Fixes #3095. Contains multiple fixes:
- `gulp-example-source`: cache all sources, to all will be written to `exampleSources.json`
- `gulp docs`: fix paths on Windows, now `chockidar` will watch correctly, https://github.com/paulmillr/chokidar/issues/668#issuecomment-357235531
- `ComponentExample.js`: update `componentWillReceive` props to listen for changes in sources

/cc @levithomason 