### PR TITLE
fix(Popup): missing CSS style update

### DIFF
--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -152,6 +152,17 @@ export default class Popup extends Component {
     this.mounted = true
   }
 
+  componentDidUpdate(prevProps) {
+    // if horizontal/vertical offsets change, re-calculate the CSS style
+    const { horizontalOffset, verticalOffset } = this.props
+    if (
+      horizontalOffset !== prevProps.horizontalOffset ||
+      verticalOffset !== prevProps.verticalOffset
+    ) {
+      this.setPopupStyle()
+    }
+  }
+
   componentWillUnmount() {
     this.mounted = false
   }

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -79,8 +79,8 @@ describe('Popup', () => {
     assertInBody('.ui.popup.visible.some-class')
   })
 
-  describe('offest', () => {
-    it('accepts an offest to the left', () => {
+  describe('offset', () => {
+    it('accepts an offset to the left', () => {
       wrapperMount(
         <Popup
           horizontalOffset={50}
@@ -93,7 +93,7 @@ describe('Popup', () => {
       wrapper.find('button').simulate('click')
       assertInBody('.ui.popup.visible')
     })
-    it('accepts an offest to the right', () => {
+    it('accepts an offset to the right', () => {
       wrapperMount(
         <Popup
           horizontalOffset={50}
@@ -108,8 +108,8 @@ describe('Popup', () => {
     })
   })
 
-  describe('verticalOffest', () => {
-    it('accepts a vertical offest to the top', () => {
+  describe('verticalOffset', () => {
+    it('accepts a vertical offset to the top', () => {
       wrapperMount(
         <Popup
           verticalOffset={50}
@@ -122,7 +122,7 @@ describe('Popup', () => {
       wrapper.find('button').simulate('click')
       assertInBody('.ui.popup.visible')
     })
-    it('accepts a vertical offest to the bottom', () => {
+    it('accepts a vertical offset to the bottom', () => {
       wrapperMount(
         <Popup
           verticalOffset={50}

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -106,6 +106,22 @@ describe('Popup', () => {
       wrapper.find('button').simulate('click')
       assertInBody('.ui.popup.visible')
     })
+    it('causes the style to be updated', () => {
+      wrapperMount(
+        <Popup
+          horizontalOffset={50}
+          position='bottom left'
+          content='foo'
+          trigger={<button>foo</button>}
+        />,
+      )
+
+      wrapper.find('button').simulate('click')
+      const element = document.querySelector('.popup.ui')
+      element.style.should.have.property('left', '-50px')
+      wrapper.setProps({ horizontalOffset: 60 })
+      element.style.should.have.property('left', '-60px')
+    })
   })
 
   describe('verticalOffset', () => {
@@ -134,6 +150,22 @@ describe('Popup', () => {
 
       wrapper.find('button').simulate('click')
       assertInBody('.ui.popup.visible')
+    })
+    it('causes the style to be updated', () => {
+      wrapperMount(
+        <Popup
+          verticalOffset={50}
+          position='bottom right'
+          content='foo'
+          trigger={<button>foo</button>}
+        />,
+      )
+
+      wrapper.find('button').simulate('click')
+      const element = document.querySelector('.popup.ui')
+      element.style.should.have.property('top', '50px')
+      wrapper.setProps({ verticalOffset: 60 })
+      element.style.should.have.property('top', '60px')
     })
   })
 


### PR DESCRIPTION
This PR should fix #3050. I suspect this was introduced by 06ab95f39bf3f60b9b9461a42d58da60a98dd730, with the removal of `requestAnimationFrame(...)`.