### PR TITLE
Fix to Issue-3118 Removed line to stop event propagation

### DIFF
--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -359,7 +359,7 @@ export default class Search extends Component {
     debug('handleInputClick()', e)
 
     // prevent closeOnDocumentClick()
-    e.nativeEvent.stopImmediatePropagation()
+    // e.nativeEvent.stopImmediatePropagation()
 
     this.tryOpen()
   }
@@ -370,7 +370,7 @@ export default class Search extends Component {
     const result = this.getSelectedResult(id)
 
     // prevent closeOnDocumentClick()
-    e.nativeEvent.stopImmediatePropagation()
+    // e.nativeEvent.stopImmediatePropagation()
 
     // notify the onResultSelect prop that the user is trying to change value
     this.setValue(result.title)


### PR DESCRIPTION
Fixes: https://github.com/Semantic-Org/Semantic-UI-React/issues/3118 . I've removed the line that prevented the document.onClick event from bubbling up. The tests seem to pass too.