### PR TITLE
fix(customPropTypes): allow to pass an object to "as"

### DIFF
--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -8,7 +8,7 @@ const typeOf = (...args) => Object.prototype.toString.call(...args)
  * Ensure a component can render as a give prop value.
  */
 export const as = (...args) =>
-  PropTypes.oneOfType([PropTypes.func, PropTypes.string, PropTypes.symbol])(...args)
+  PropTypes.oneOfType([PropTypes.object, PropTypes.func, PropTypes.string, PropTypes.symbol])(...args)
 
 /**
  * Ensure a prop is a valid DOM node.

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -8,7 +8,7 @@ const typeOf = (...args) => Object.prototype.toString.call(...args)
  * Ensure a component can render as a give prop value.
  */
 export const as = (...args) =>
-  PropTypes.oneOfType([PropTypes.object, PropTypes.func, PropTypes.string, PropTypes.symbol])(...args)
+  PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.string, PropTypes.symbol])(...args)
 
 /**
  * Ensure a prop is a valid DOM node.


### PR DESCRIPTION
See #3138 for the problem described. 
Solves problem when custom links are used