### PR TITLE
Make searchable dropdown accessible

### DIFF
--- a/docs/src/examples/collections/Form/Shorthand/FormExampleFieldControlId.js
+++ b/docs/src/examples/collections/Form/Shorthand/FormExampleFieldControlId.js
@@ -1,5 +1,10 @@
 import React from 'react'
-import { Form, Input, TextArea, Button } from 'semantic-ui-react'
+import { Form, Input, TextArea, Button, Select } from 'semantic-ui-react'
+
+const genderOptions = [
+  { key: 'm', text: 'Male', value: 'male' },
+  { key: 'f', text: 'Female', value: 'female' },
+]
 
 const FormExampleFieldControlId = () => (
   <Form>
@@ -15,6 +20,14 @@ const FormExampleFieldControlId = () => (
         control={Input}
         label='Last name'
         placeholder='Last name'
+      />
+      <Form.Field
+        id='form-select-control-gender'
+        control={Select}
+        label='Gender'
+        options={genderOptions}
+        placeholder='Gender'
+        search
       />
     </Form.Group>
     <Form.Field

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1202,13 +1202,14 @@ export default class Dropdown extends Component {
     )
   }
 
-  renderSearchInput = () => {
+  renderSearchInput = (HTMLAttributes = {}) => {
     const { search, searchInput } = this.props
     const { searchQuery } = this.state
 
     if (!search) return null
     return DropdownSearchInput.create(searchInput, {
       defaultProps: {
+        ...HTMLAttributes,
         inputRef: this.handleSearchRef,
         style: { width: this.computeSearchInputWidth() },
         tabIndex: this.computeSearchInputTabIndex(),
@@ -1362,7 +1363,7 @@ export default class Dropdown extends Component {
       'dropdown',
       className,
     )
-    const rest = getUnhandledProps(Dropdown, this.props)
+    const { id, ...rest } = getUnhandledProps(Dropdown, this.props)
     const ElementType = getElementType(Dropdown, this.props)
     const ariaOptions = this.getDropdownAriaOptions(ElementType, this.props)
 
@@ -1380,7 +1381,7 @@ export default class Dropdown extends Component {
         ref={this.handleRef}
       >
         {this.renderLabels()}
-        {this.renderSearchInput()}
+        {this.renderSearchInput({ id })}
         {this.renderSearchSizer()}
         {trigger || this.renderText()}
         {Icon.create(icon, {


### PR DESCRIPTION
**Current behaviour:**

A `Dropdown`/`Select` component with the `search` prop inside a Form is not accessible since the `id` prop is passed to the top level component instead of the `input` element.

**New behaviour:**

The `id` prop is passed to the `input` element.

It was added an example of an accessible searchable Dropdown.

If you want tests for this or have any changes to suggest, please let me know.