### PR TITLE
accordion initial PR

### DIFF
--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -49,6 +49,7 @@ export default class AccordionTitle extends Component {
   render() {
     const { active, children, className, content } = this.props
 
+    // TODO: instead of adding 'active' class use renderActiveOnly logic ex: as in ../../../Tab/Tab.js 97:2
     const classes = cx(useKeyOnly(active, 'active'), 'title', className)
     const rest = getUnhandledProps(AccordionTitle, this.props)
     const ElementType = getElementType(AccordionTitle, this.props)


### PR DESCRIPTION
Opening PR for https://github.com/Semantic-Org/Semantic-UI-React/issues/3087

Updating Accordion logic to adhere to the same logic as Tabs with using `renderActiveOnly` prop for only rendering active AccordionPanels instead of adding a class to hide.