### PR TITLE
docs(Form): add an example of accessible Form.Select

### DIFF
--- a/docs/src/examples/collections/Form/Shorthand/FormExampleFieldControlId.js
+++ b/docs/src/examples/collections/Form/Shorthand/FormExampleFieldControlId.js
@@ -1,5 +1,10 @@
 import React from 'react'
-import { Form, Input, TextArea, Button } from 'semantic-ui-react'
+import { Form, Input, TextArea, Button, Select } from 'semantic-ui-react'
+
+const genderOptions = [
+  { key: 'm', text: 'Male', value: 'male' },
+  { key: 'f', text: 'Female', value: 'female' },
+]
 
 const FormExampleFieldControlId = () => (
   <Form>
@@ -15,6 +20,14 @@ const FormExampleFieldControlId = () => (
         control={Input}
         label='Last name'
         placeholder='Last name'
+      />
+      <Form.Field
+        control={Select}
+        options={genderOptions}
+        label={{ children: 'Gender', htmlFor: 'form-select-control-gender' }}
+        placeholder='Gender'
+        search
+        searchInput={{ id: 'form-select-control-gender' }}
       />
     </Form.Group>
     <Form.Field


### PR DESCRIPTION
As discussed in #3149, this PR adds an example of how to accomplish an accessible select inside a form.