### PR TITLE
docs(Grid): fix typo in GridExampleStretched example description

### DIFF
--- a/docs/src/examples/collections/Grid/Variations/index.js
+++ b/docs/src/examples/collections/Grid/Variations/index.js
@@ -32,7 +32,7 @@ const GridVariationsExamples = () => (
 
     <ComponentExample
       title='Stretched'
-      description='A row can automatically resize all elements to split the available width evenly.'
+      description='A row can automatically resize all elements to split the available height evenly.'
       examplePath='collections/Grid/Variations/GridExampleStretched'
     />
     <ComponentExample examplePath='collections/Grid/Variations/GridExampleStretchedEqual' />


### PR DESCRIPTION
The description of the `stretched` property of a grid row mentioned 'width', but should have mentioned 'height'.