### PR TITLE
docs(Dropdown): update suggested markup for nested dropdowns

### DIFF
--- a/docs/src/examples/modules/Dropdown/Types/DropdownExamplePointing.js
+++ b/docs/src/examples/modules/Dropdown/Types/DropdownExamplePointing.js
@@ -7,22 +7,20 @@ const DropdownExamplePointing = () => (
     <Dropdown text='Shopping' pointing className='link item'>
       <Dropdown.Menu>
         <Dropdown.Header>Categories</Dropdown.Header>
-        <Dropdown.Item>
-          <Dropdown text='Clothing'>
-            <Dropdown.Menu>
-              <Dropdown.Header>Mens</Dropdown.Header>
-              <Dropdown.Item>Shirts</Dropdown.Item>
-              <Dropdown.Item>Pants</Dropdown.Item>
-              <Dropdown.Item>Jeans</Dropdown.Item>
-              <Dropdown.Item>Shoes</Dropdown.Item>
-              <Dropdown.Divider />
-              <Dropdown.Header>Womens</Dropdown.Header>
-              <Dropdown.Item>Dresses</Dropdown.Item>
-              <Dropdown.Item>Shoes</Dropdown.Item>
-              <Dropdown.Item>Bags</Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
-        </Dropdown.Item>
+        <Dropdown item text='Clothing'>
+          <Dropdown.Menu>
+            <Dropdown.Header>Mens</Dropdown.Header>
+            <Dropdown.Item>Shirts</Dropdown.Item>
+            <Dropdown.Item>Pants</Dropdown.Item>
+            <Dropdown.Item>Jeans</Dropdown.Item>
+            <Dropdown.Item>Shoes</Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Header>Womens</Dropdown.Header>
+            <Dropdown.Item>Dresses</Dropdown.Item>
+            <Dropdown.Item>Shoes</Dropdown.Item>
+            <Dropdown.Item>Bags</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
         <Dropdown.Item>Home Goods</Dropdown.Item>
         <Dropdown.Item>Bedroom</Dropdown.Item>
         <Dropdown.Divider />


### PR DESCRIPTION
Update for the suggested markup in the Dropdown Examples for Nested Dropdowns

<img width="1680" alt="screen shot 2018-09-29 at 11 50 25 pm" src="https://user-images.githubusercontent.com/9765685/46249179-8c910500-c442-11e8-93f2-b03ebecd864a.png">
<img width="1680" alt="screen shot 2018-09-29 at 11 50 30 pm" src="https://user-images.githubusercontent.com/9765685/46249180-8c910500-c442-11e8-8def-7aef8ac9bb6a.png">
