### PR TITLE
fix(customPropTypes|typings): allow to pass a function to itemShorthand, update typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -369,7 +369,7 @@ export {
 } from './dist/commonjs/elements/Step/StepTitle'
 
 // Generics
-export * from './dist/commonjs'
+export * from './src/generic'
 
 // Modules
 export {

--- a/src/addons/Confirm/Confirm.d.ts
+++ b/src/addons/Confirm/Confirm.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../..'
+import { SemanticShorthandItem } from '../../generic'
 import { ButtonProps } from '../../elements/Button'
 import { StrictModalProps } from '../../modules/Modal'
 import { ModalContentProps } from '../../modules/Modal/ModalContent'

--- a/src/addons/Pagination/Pagination.d.ts
+++ b/src/addons/Pagination/Pagination.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../..'
+import { SemanticShorthandItem } from '../../generic'
 import { default as PaginationItem, PaginationItemProps } from './PaginationItem'
 
 export interface PaginationProps extends StrictPaginationProps {

--- a/src/collections/Breadcrumb/Breadcrumb.d.ts
+++ b/src/collections/Breadcrumb/Breadcrumb.d.ts
@@ -4,7 +4,7 @@ import {
   SemanticShorthandCollection,
   SemanticShorthandContent,
   SemanticShorthandItem,
-} from '../..'
+} from '../../generic'
 import { IconProps } from '../../elements/Icon'
 import BreadcrumbDivider from './BreadcrumbDivider'
 import { default as BreadcrumbSection, BreadcrumbSectionProps } from './BreadcrumbSection'

--- a/src/collections/Breadcrumb/BreadcrumbDivider.d.ts
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface BreadcrumbDividerProps extends StrictBreadcrumbDividerProps {

--- a/src/collections/Breadcrumb/BreadcrumbSection.d.ts
+++ b/src/collections/Breadcrumb/BreadcrumbSection.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface BreadcrumbSectionProps extends StrictBreadcrumbSectionProps {
   [key: string]: any

--- a/src/collections/Form/FormButton.d.ts
+++ b/src/collections/Form/FormButton.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../..'
+import { SemanticShorthandItem } from '../../generic'
 import { StrictButtonProps } from '../../elements/Button'
 import { LabelProps } from '../../elements/Label'
 import { StrictFormFieldProps } from './FormField'

--- a/src/collections/Form/FormField.d.ts
+++ b/src/collections/Form/FormField.d.ts
@@ -4,7 +4,7 @@ import {
   SemanticShorthandContent,
   SemanticShorthandItem,
   SemanticWIDTHS,
-} from '../..'
+} from '../../generic'
 
 export interface FormFieldProps extends StrictFormFieldProps {
   [key: string]: any

--- a/src/collections/Form/FormGroup.d.ts
+++ b/src/collections/Form/FormGroup.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticWIDTHS } from '../..'
+import { SemanticWIDTHS } from '../../generic'
 
 export interface FormGroupProps extends StrictFormGroupProps {
   [key: string]: any

--- a/src/collections/Form/FormInput.d.ts
+++ b/src/collections/Form/FormInput.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../..'
+import { SemanticShorthandItem } from '../../generic'
 import { LabelProps } from '../../elements/Label'
 import { StrictInputProps } from '../../elements/Input'
 import { StrictFormFieldProps } from './FormField'

--- a/src/collections/Grid/Grid.d.ts
+++ b/src/collections/Grid/Grid.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticTEXTALIGNMENTS, SemanticVERTICALALIGNMENTS, SemanticWIDTHS } from '../..'
+import { SemanticTEXTALIGNMENTS, SemanticVERTICALALIGNMENTS, SemanticWIDTHS } from '../../generic'
 import GridColumn from './GridColumn'
 import GridRow from './GridRow'
 

--- a/src/collections/Grid/GridColumn.d.ts
+++ b/src/collections/Grid/GridColumn.d.ts
@@ -5,7 +5,7 @@ import {
   SemanticTEXTALIGNMENTS,
   SemanticVERTICALALIGNMENTS,
   SemanticWIDTHS,
-} from '../..'
+} from '../../generic'
 
 export type GridOnlyProp =
   | string

--- a/src/collections/Grid/GridRow.d.ts
+++ b/src/collections/Grid/GridRow.d.ts
@@ -5,7 +5,7 @@ import {
   SemanticTEXTALIGNMENTS,
   SemanticVERTICALALIGNMENTS,
   SemanticWIDTHS,
-} from '../..'
+} from '../../generic'
 import { GridReversedProp } from './Grid'
 import { GridOnlyProp } from './GridColumn'
 

--- a/src/collections/Menu/Menu.d.ts
+++ b/src/collections/Menu/Menu.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticShorthandCollection, SemanticWIDTHS } from '../..'
+import { SemanticCOLORS, SemanticShorthandCollection, SemanticWIDTHS } from '../../generic'
 import MenuHeader from './MenuHeader'
 import { default as MenuItem, MenuItemProps } from './MenuItem'
 import MenuMenu from './MenuMenu'

--- a/src/collections/Menu/MenuHeader.d.ts
+++ b/src/collections/Menu/MenuHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface MenuHeaderProps extends StrictMenuHeaderProps {
   [key: string]: any

--- a/src/collections/Menu/MenuItem.d.ts
+++ b/src/collections/Menu/MenuItem.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticCOLORS, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface MenuItemProps extends StrictMenuItemProps {

--- a/src/collections/Menu/MenuMenu.d.ts
+++ b/src/collections/Menu/MenuMenu.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface MenuMenuProps extends StrictMenuMenuProps {
   [key: string]: any

--- a/src/collections/Message/Message.d.ts
+++ b/src/collections/Message/Message.d.ts
@@ -5,7 +5,7 @@ import {
   SemanticShorthandCollection,
   SemanticShorthandContent,
   SemanticShorthandItem,
-} from '../..'
+} from '../../generic'
 import MessageContent from './MessageContent'
 import { default as MessageHeader, MessageHeaderProps } from './MessageHeader'
 import { default as MessageItem, MessageItemProps } from './MessageItem'

--- a/src/collections/Message/MessageContent.d.ts
+++ b/src/collections/Message/MessageContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface MessageContentProps extends StrictMessageContentProps {
   [key: string]: any

--- a/src/collections/Message/MessageHeader.d.ts
+++ b/src/collections/Message/MessageHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface MessageHeaderProps extends StrictMessageHeaderProps {
   [key: string]: any

--- a/src/collections/Message/MessageItem.d.ts
+++ b/src/collections/Message/MessageItem.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface MessageItemProps extends StrictMessageItemProps {
   [key: string]: any

--- a/src/collections/Message/MessageList.d.ts
+++ b/src/collections/Message/MessageList.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection } from '../..'
+import { SemanticShorthandCollection } from '../../generic'
 import { MessageItemProps } from './MessageItem'
 
 export interface MessageListProps extends StrictMessageListProps {

--- a/src/collections/Table/Table.d.ts
+++ b/src/collections/Table/Table.d.ts
@@ -5,7 +5,7 @@ import {
   SemanticShorthandItem,
   SemanticVERTICALALIGNMENTS,
   SemanticWIDTHS,
-} from '../..'
+} from '../../generic'
 import TableBody from './TableBody'
 import TableCell from './TableCell'
 import TableFooter from './TableFooter'

--- a/src/collections/Table/TableCell.d.ts
+++ b/src/collections/Table/TableCell.d.ts
@@ -5,7 +5,7 @@ import {
   SemanticShorthandItem,
   SemanticVERTICALALIGNMENTS,
   SemanticWIDTHS,
-} from '../..'
+} from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface TableCellProps extends StrictTableCellProps {

--- a/src/collections/Table/TableHeader.d.ts
+++ b/src/collections/Table/TableHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface TableHeaderProps extends StrictTableHeaderProps {
   [key: string]: any

--- a/src/collections/Table/TableRow.d.ts
+++ b/src/collections/Table/TableRow.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection, SemanticVERTICALALIGNMENTS } from '../..'
+import { SemanticShorthandCollection, SemanticVERTICALALIGNMENTS } from '../../generic'
 import { TableCellProps } from './TableCell'
 
 export interface TableRowProps extends StrictTableRowProps {

--- a/src/elements/Button/Button.d.ts
+++ b/src/elements/Button/Button.d.ts
@@ -6,7 +6,8 @@ import {
   SemanticShorthandContent,
   SemanticShorthandItem,
   SemanticSIZES,
-} from '../..'
+} from '../../generic'
+import { IconProps } from '../Icon'
 import { LabelProps } from '../Label'
 import ButtonContent from './ButtonContent'
 import ButtonGroup from './ButtonGroup'
@@ -68,7 +69,7 @@ export interface StrictButtonProps {
   fluid?: boolean
 
   /** Add an Icon by name, props object, or pass an <Icon />. */
-  icon?: any
+  icon?: boolean | SemanticShorthandItem<IconProps>
 
   /** A button can be formatted to appear on dark backgrounds. */
   inverted?: boolean

--- a/src/elements/Button/ButtonContent.d.ts
+++ b/src/elements/Button/ButtonContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ButtonContentProps extends StrictButtonContentProps {
   [key: string]: any

--- a/src/elements/Button/ButtonGroup.d.ts
+++ b/src/elements/Button/ButtonGroup.d.ts
@@ -7,7 +7,7 @@ import {
   SemanticShorthandCollection,
   SemanticSIZES,
   SemanticWIDTHS,
-} from '../..'
+} from '../../generic'
 import { ButtonProps } from './Button'
 
 export interface ButtonGroupProps extends StrictButtonGroupProps {

--- a/src/elements/Container/Container.d.ts
+++ b/src/elements/Container/Container.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent, SemanticTEXTALIGNMENTS } from '../..'
+import { SemanticShorthandContent, SemanticTEXTALIGNMENTS } from '../../generic'
 
 export interface ContainerProps extends StrictContainerProps {
   [key: string]: any

--- a/src/elements/Divider/Divider.d.ts
+++ b/src/elements/Divider/Divider.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface DividerProps extends StrictDividerProps {
   [key: string]: any

--- a/src/elements/Header/Header.d.ts
+++ b/src/elements/Header/Header.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticFLOATS, SemanticTEXTALIGNMENTS } from '../..'
+import { SemanticCOLORS, SemanticFLOATS, SemanticTEXTALIGNMENTS } from '../../generic'
 import HeaderContent from './HeaderContent'
 import HeaderSubHeader from './HeaderSubheader'
 

--- a/src/elements/Header/HeaderContent.d.ts
+++ b/src/elements/Header/HeaderContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface HeaderContentProps extends StrictHeaderContentProps {
   [key: string]: any

--- a/src/elements/Header/HeaderSubheader.d.ts
+++ b/src/elements/Header/HeaderSubheader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface HeaderSubheaderProps extends StrictHeaderSubheaderProps {
   [key: string]: any

--- a/src/elements/Icon/Icon.d.ts
+++ b/src/elements/Icon/Icon.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticICONS } from '../..'
+import { SemanticCOLORS, SemanticICONS } from '../../generic'
 import IconGroup from './IconGroup'
 
 export type IconSizeProp = 'mini' | 'tiny' | 'small' | 'large' | 'big' | 'huge' | 'massive'

--- a/src/elements/Icon/IconGroup.d.ts
+++ b/src/elements/Icon/IconGroup.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 import { IconSizeProp } from './Icon'
 
 export interface IconGroupProps extends StrictIconGroupProps {

--- a/src/elements/Image/Image.d.ts
+++ b/src/elements/Image/Image.d.ts
@@ -7,7 +7,7 @@ import {
   SemanticSIZES,
   SemanticVERTICALALIGNMENTS,
   SemanticWIDTHS,
-} from '../..'
+} from '../../generic'
 import { DimmerProps } from '../../modules/Dimmer'
 import { LabelProps } from '../Label'
 import ImageGroup from './ImageGroup'

--- a/src/elements/Image/ImageGroup.d.ts
+++ b/src/elements/Image/ImageGroup.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticSIZES, SemanticShorthandContent } from '../..'
+import { SemanticSIZES, SemanticShorthandContent } from '../../generic'
 
 export interface ImageGroupProps extends StrictImageGroupProps {
   [key: string]: any

--- a/src/elements/Input/Input.d.ts
+++ b/src/elements/Input/Input.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { HtmlInputrops, SemanticShorthandItem, SemanticSIZES } from '../..'
+import { HtmlInputrops, SemanticShorthandItem, SemanticSIZES } from '../../generic'
 import { LabelProps } from '../Label'
 
 export interface InputProps extends StrictInputProps {

--- a/src/elements/Label/Label.d.ts
+++ b/src/elements/Label/Label.d.ts
@@ -5,7 +5,7 @@ import {
   SemanticShorthandContent,
   SemanticShorthandItem,
   SemanticSIZES,
-} from '../..'
+} from '../../generic'
 import { IconProps } from '../Icon'
 import { default as LabelDetail, LabelDetailProps } from './LabelDetail'
 import LabelGroup from './LabelGroup'

--- a/src/elements/Label/LabelDetail.d.ts
+++ b/src/elements/Label/LabelDetail.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface LabelDetailProps extends StrictLabelDetailProps {
   [key: string]: any

--- a/src/elements/Label/LabelGroup.d.ts
+++ b/src/elements/Label/LabelGroup.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticCOLORS, SemanticShorthandContent, SemanticSIZES } from '../..'
+import { SemanticCOLORS, SemanticShorthandContent, SemanticSIZES } from '../../generic'
 
 export interface LabelGroupProps extends StrictLabelGroupProps {
   [key: string]: any

--- a/src/elements/List/List.d.ts
+++ b/src/elements/List/List.d.ts
@@ -6,7 +6,7 @@ import {
   SemanticShorthandContent,
   SemanticSIZES,
   SemanticVERTICALALIGNMENTS,
-} from '../..'
+} from '../../generic'
 import ListContent from './ListContent'
 import ListDescription from './ListDescription'
 import ListHeader from './ListHeader'

--- a/src/elements/List/ListContent.d.ts
+++ b/src/elements/List/ListContent.d.ts
@@ -5,7 +5,7 @@ import {
   SemanticShorthandContent,
   SemanticShorthandItem,
   SemanticVERTICALALIGNMENTS,
-} from '../..'
+} from '../../generic'
 import { ListDescriptionProps } from './ListDescription'
 import { ListHeaderProps } from './ListHeader'
 

--- a/src/elements/List/ListDescription.d.ts
+++ b/src/elements/List/ListDescription.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ListDescriptionProps extends StrictListDescriptionProps {
   [key: string]: any

--- a/src/elements/List/ListHeader.d.ts
+++ b/src/elements/List/ListHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ListHeaderProps extends StrictListHeaderProps {
   [key: string]: any

--- a/src/elements/List/ListIcon.d.ts
+++ b/src/elements/List/ListIcon.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticVERTICALALIGNMENTS } from '../..'
+import { SemanticVERTICALALIGNMENTS } from '../../generic'
 import { StrictIconProps } from '../Icon'
 
 export interface ListIconProps extends StrictListIconProps {

--- a/src/elements/List/ListItem.d.ts
+++ b/src/elements/List/ListItem.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../..'
+import { SemanticShorthandItem } from '../../generic'
 import { ImageProps } from '../Image'
 import { ListContentProps } from './ListContent'
 import { ListDescriptionProps } from './ListDescription'

--- a/src/elements/List/ListList.d.ts
+++ b/src/elements/List/ListList.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ListListProps extends StrictListListProps {
   [key: string]: any

--- a/src/elements/Loader/Loader.d.ts
+++ b/src/elements/Loader/Loader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent, SemanticSIZES } from '../..'
+import { SemanticShorthandContent, SemanticSIZES } from '../../generic'
 
 export interface LoaderProps extends StrictLoaderProps {
   [key: string]: any

--- a/src/elements/Rail/Rail.d.ts
+++ b/src/elements/Rail/Rail.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticFLOATS, SemanticShorthandContent } from '../..'
+import { SemanticFLOATS, SemanticShorthandContent } from '../../generic'
 
 export interface RailProps extends StrictRailProps {
   [key: string]: any

--- a/src/elements/Reveal/Reveal.d.ts
+++ b/src/elements/Reveal/Reveal.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 import RevealContent from './RevealContent'
 
 export interface RevealProps extends StrictRevealProps {

--- a/src/elements/Reveal/RevealContent.d.ts
+++ b/src/elements/Reveal/RevealContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface RevealContentProps extends StrictRevealContentProps {
   [key: string]: any

--- a/src/elements/Segment/Segment.d.ts
+++ b/src/elements/Segment/Segment.d.ts
@@ -5,7 +5,7 @@ import {
   SemanticFLOATS,
   SemanticShorthandContent,
   SemanticTEXTALIGNMENTS,
-} from '../..'
+} from '../../generic'
 import SegmentGroup from './SegmentGroup'
 
 export type SegmentSizeProp = 'mini' | 'tiny' | 'small' | 'large' | 'big' | 'huge' | 'massive'

--- a/src/elements/Segment/SegmentGroup.d.ts
+++ b/src/elements/Segment/SegmentGroup.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 import { SegmentSizeProp } from './Segment'
 
 export interface SegmentGroupProps extends StrictSegmentGroupProps {

--- a/src/elements/Step/Step.d.ts
+++ b/src/elements/Step/Step.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../Icon'
 import StepContent from './StepContent'
 import { default as StepDescription, StepDescriptionProps } from './StepDescription'

--- a/src/elements/Step/StepContent.d.ts
+++ b/src/elements/Step/StepContent.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem, SemanticShorthandContent } from '../..'
+import { SemanticShorthandItem, SemanticShorthandContent } from '../../generic'
 import { StepDescriptionProps } from './StepDescription'
 import { StepTitleProps } from './StepTitle'
 

--- a/src/elements/Step/StepDescription.d.ts
+++ b/src/elements/Step/StepDescription.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface StepDescriptionProps extends StrictStepDescriptionProps {
   [key: string]: any

--- a/src/elements/Step/StepGroup.d.ts
+++ b/src/elements/Step/StepGroup.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection, SemanticShorthandContent, SemanticWIDTHS } from '../..'
+import { SemanticShorthandCollection, SemanticShorthandContent } from '../../generic'
 import { StepProps } from './Step'
 
 export interface StepGroupProps extends StrictStepGroupProps {

--- a/src/elements/Step/StepTitle.d.ts
+++ b/src/elements/Step/StepTitle.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface StepTitleProps extends StrictStepTitleProps {
   [key: string]: any

--- a/src/generic.d.ts
+++ b/src/generic.d.ts
@@ -56,9 +56,18 @@ export interface StrictHtmlSpanProps {
 // Types
 // ======================================================
 
-export type SemanticShorthandCollection<T> = SemanticShorthandItem<T>[]
+export type SemanticShorthandItemFunc<TProps> = (
+  component: React.ComponentType<TProps>,
+  props: TProps,
+  children?: React.ReactChildren,
+) => React.ReactElement<any> | null
+
+export type SemanticShorthandCollection<TProps> = SemanticShorthandItem<TProps>[]
 export type SemanticShorthandContent = React.ReactNode
-export type SemanticShorthandItem<T> = React.ReactNode | T
+export type SemanticShorthandItem<TProps> =
+  | React.ReactNode
+  | TProps
+  | SemanticShorthandItemFunc<TProps>
 
 // ======================================================
 // Styling

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -8,7 +8,9 @@ const typeOf = (...args) => Object.prototype.toString.call(...args)
  * Ensure a component can render as a give prop value.
  */
 export const as = (...args) =>
-  PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.string, PropTypes.symbol])(...args)
+  PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.string, PropTypes.symbol])(
+    ...args,
+  )
 
 /**
  * Ensure a prop is a valid DOM node.
@@ -245,8 +247,7 @@ export const givenProps = (propsShape, validator) => (props, propName, component
 
   if (error) {
     // poor mans shallow pretty print, prevents JSON circular reference errors
-    const prettyProps = `{ ${_
-      .keys(_.pick(_.keys(propsShape), props))
+    const prettyProps = `{ ${_.keys(_.pick(_.keys(propsShape), props))
       .map((key) => {
         const val = props[key]
         let renderedValue = val
@@ -340,6 +341,7 @@ export const itemShorthand = (...args) =>
   every([
     disallow(['children']),
     PropTypes.oneOfType([
+      PropTypes.func,
       PropTypes.node,
       PropTypes.object,
       PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.node, PropTypes.object])),

--- a/src/modules/Accordion/AccordionAccordion.d.ts
+++ b/src/modules/Accordion/AccordionAccordion.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection, SemanticShorthandItem } from '../../'
+import { SemanticShorthandCollection } from '../../generic'
 import { AccordionPanelProps } from './AccordionPanel'
 import { AccordionTitleProps } from './AccordionTitle'
 

--- a/src/modules/Accordion/AccordionContent.d.ts
+++ b/src/modules/Accordion/AccordionContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface AccordionContentProps extends StrictAccordionContentProps {
   [key: string]: any

--- a/src/modules/Accordion/AccordionPanel.d.ts
+++ b/src/modules/Accordion/AccordionPanel.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../../'
+import { SemanticShorthandItem } from '../../generic'
 import { AccordionContentProps } from './AccordionContent'
 import { AccordionTitleProps } from './AccordionTitle'
 

--- a/src/modules/Accordion/AccordionTitle.d.ts
+++ b/src/modules/Accordion/AccordionTitle.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface AccordionTitleProps extends StrictAccordionTitleProps {
   [key: string]: any

--- a/src/modules/Checkbox/Checkbox.d.ts
+++ b/src/modules/Checkbox/Checkbox.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { HtmlLabelProps, SemanticShorthandItem } from '../..'
+import { HtmlLabelProps, SemanticShorthandItem } from '../../generic'
 
 export interface CheckboxProps extends StrictCheckboxProps {
   [key: string]: any

--- a/src/modules/Dimmer/DimmerDimmable.d.ts
+++ b/src/modules/Dimmer/DimmerDimmable.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface DimmerDimmableProps extends StrictDimmerDimmableProps {
   [key: string]: any

--- a/src/modules/Dimmer/DimmerInner.d.ts
+++ b/src/modules/Dimmer/DimmerInner.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface DimmerInnerProps extends StrictDimmerInnerProps {
   [key: string]: any

--- a/src/modules/Dropdown/DropdownHeader.d.ts
+++ b/src/modules/Dropdown/DropdownHeader.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface DropdownHeaderProps extends StrictDropdownHeaderProps {

--- a/src/modules/Dropdown/DropdownItem.d.ts
+++ b/src/modules/Dropdown/DropdownItem.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { HtmlSpanProps, SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { HtmlSpanProps, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { FlagProps } from '../../elements/Flag'
 import { IconProps } from '../../elements/Icon'
 import { ImageProps } from '../../elements/Image'

--- a/src/modules/Dropdown/DropdownMenu.d.ts
+++ b/src/modules/Dropdown/DropdownMenu.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface DropdownMenuProps extends StrictDropdownMenuProps {
   [key: string]: any

--- a/src/modules/Embed/Embed.d.ts
+++ b/src/modules/Embed/Embed.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { HtmlIframeProps, SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { HtmlIframeProps, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface EmbedProps extends StrictEmbedProps {

--- a/src/modules/Modal/Modal.d.ts
+++ b/src/modules/Modal/Modal.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../..'
+import { SemanticShorthandItem } from '../../generic'
 import { StrictPortalProps } from '../../addons/Portal'
 import { default as ModalActions, ModalActionsProps } from './ModalActions'
 import { default as ModalContent, ModalContentProps } from './ModalContent'

--- a/src/modules/Modal/ModalActions.d.ts
+++ b/src/modules/Modal/ModalActions.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { ButtonProps } from '../../elements/Button'
-import { SemanticShorthandCollection, SemanticShorthandContent } from '../..'
+import { SemanticShorthandCollection, SemanticShorthandContent } from '../../generic'
 
 export interface ModalActionsProps extends StrictModalActionsProps {
   [key: string]: any

--- a/src/modules/Modal/ModalContent.d.ts
+++ b/src/modules/Modal/ModalContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ModalContentProps extends StrictModalContentProps {
   [key: string]: any

--- a/src/modules/Modal/ModalDescription.d.ts
+++ b/src/modules/Modal/ModalDescription.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ModalDescriptionProps extends StrictModalDescriptionProps {
   [key: string]: any

--- a/src/modules/Modal/ModalHeader.d.ts
+++ b/src/modules/Modal/ModalHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ModalHeaderProps extends StrictModalHeaderProps {
   [key: string]: any

--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../..'
+import { SemanticShorthandItem } from '../../generic'
 import { StrictPortalProps } from '../../addons/Portal'
 import { default as PopupContent, PopupContentProps } from './PopupContent'
 import { default as PopupHeader, PopupHeaderProps } from './PopupHeader'

--- a/src/modules/Popup/PopupContent.d.ts
+++ b/src/modules/Popup/PopupContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface PopupContentProps extends StrictPopupContentProps {
   [key: string]: any

--- a/src/modules/Popup/PopupHeader.d.ts
+++ b/src/modules/Popup/PopupHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface PopupHeaderProps extends StrictPopupHeaderProps {
   [key: string]: any

--- a/src/modules/Progress/Progress.d.ts
+++ b/src/modules/Progress/Progress.d.ts
@@ -4,7 +4,7 @@ import {
   SemanticCOLORS,
   SemanticShorthandContent,
   SemanticShorthandItem,
-} from '../..'
+} from '../../generic'
 
 export interface ProgressProps extends StrictProgressProps {
   [key: string]: any

--- a/src/modules/Search/Search.d.ts
+++ b/src/modules/Search/Search.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../..'
+import { SemanticShorthandItem } from '../../generic'
 import { InputProps } from '../../elements/Input'
 import { default as SearchCategory, SearchCategoryProps } from './SearchCategory'
 import { default as SearchResult, SearchResultProps } from './SearchResult'

--- a/src/modules/Search/SearchCategory.d.ts
+++ b/src/modules/Search/SearchCategory.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 import SearchResult from './SearchResult'
 
 export interface SearchCategoryProps extends StrictSearchCategoryProps {

--- a/src/modules/Search/SearchResult.d.ts
+++ b/src/modules/Search/SearchResult.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface SearchResultProps extends StrictSearchResultProps {
   [key: string]: any

--- a/src/modules/Search/SearchResults.d.ts
+++ b/src/modules/Search/SearchResults.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface SearchResultsProps extends StrictSearchResultsProps {
   [key: string]: any

--- a/src/modules/Sidebar/Sidebar.d.ts
+++ b/src/modules/Sidebar/Sidebar.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 import SidebarPushable from './SidebarPushable'
 import SidebarPusher from './SidebarPusher'

--- a/src/modules/Sidebar/SidebarPushable.d.ts
+++ b/src/modules/Sidebar/SidebarPushable.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface SidebarPushableProps extends StrictSidebarPushableProps {
   [key: string]: any

--- a/src/modules/Sidebar/SidebarPusher.d.ts
+++ b/src/modules/Sidebar/SidebarPusher.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface SidebarPusherProps extends StrictSidebarPusherProps {
   [key: string]: any

--- a/src/modules/Tab/Tab.d.ts
+++ b/src/modules/Tab/Tab.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../..'
+import { SemanticShorthandItem } from '../../generic'
 import { default as TabPane, TabPaneProps } from './TabPane'
 
 export interface TabProps extends StrictTabProps {

--- a/src/modules/Tab/TabPane.d.ts
+++ b/src/modules/Tab/TabPane.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface TabPaneProps extends StrictTabPaneProps {
   [key: string]: any

--- a/src/modules/Transition/Transition.d.ts
+++ b/src/modules/Transition/Transition.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticTRANSITIONS } from '../../'
+import { SemanticTRANSITIONS } from '../../generic'
 import TransitionGroup from './TransitionGroup'
 
 export type TRANSITION_STATUSES = 'ENTERED' | 'ENTERING' | 'EXITED' | 'EXITING' | 'UNMOUNTED'

--- a/src/modules/Transition/TransitionGroup.d.ts
+++ b/src/modules/Transition/TransitionGroup.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticTRANSITIONS } from '../../'
+import { SemanticTRANSITIONS } from '../../generic'
 import { TransitionPropDuration } from './Transition'
 
 export interface TransitionGroupProps extends StrictTransitionGroupProps {

--- a/src/views/Advertisement/Advertisement.d.ts
+++ b/src/views/Advertisement/Advertisement.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface AdvertisementProps extends StrictAdvertisementProps {
   [key: string]: any

--- a/src/views/Card/Card.d.ts
+++ b/src/views/Card/Card.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticCOLORS, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { ImageProps } from '../../elements/Image'
 import CardContent from './CardContent'
 import { default as CardDescription, CardDescriptionProps } from './CardDescription'

--- a/src/views/Card/CardContent.d.ts
+++ b/src/views/Card/CardContent.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { CardDescriptionProps } from './CardDescription'
 import { CardHeaderProps } from './CardHeader'
 import { CardMetaProps } from './CardMeta'

--- a/src/views/Card/CardDescription.d.ts
+++ b/src/views/Card/CardDescription.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface CardDescriptionProps extends StrictCardDescriptionProps {
   [key: string]: any

--- a/src/views/Card/CardGroup.d.ts
+++ b/src/views/Card/CardGroup.d.ts
@@ -1,6 +1,10 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection, SemanticShorthandContent, SemanticWIDTHS } from '../..'
+import {
+  SemanticShorthandCollection,
+  SemanticShorthandContent,
+  SemanticWIDTHS,
+} from '../../generic'
 import { CardProps } from './Card'
 
 export interface CardGroupProps extends StrictCardGroupProps {

--- a/src/views/Card/CardHeader.d.ts
+++ b/src/views/Card/CardHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface CardHeaderProps extends StrictCardHeaderProps {
   [key: string]: any

--- a/src/views/Card/CardMeta.d.ts
+++ b/src/views/Card/CardMeta.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface CardMetaProps extends StrictCardMetaProps {
   [key: string]: any

--- a/src/views/Comment/Comment.d.ts
+++ b/src/views/Comment/Comment.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 import CommentAction from './CommentAction'
 import CommentActions from './CommentActions'
 import CommentAuthor from './CommentAuthor'

--- a/src/views/Comment/CommentAction.d.ts
+++ b/src/views/Comment/CommentAction.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface CommentActionProps extends StrictCommentActionProps {
   [key: string]: any

--- a/src/views/Comment/CommentActions.d.ts
+++ b/src/views/Comment/CommentActions.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface CommentActionsProps extends StrictCommentActionsProps {
   [key: string]: any

--- a/src/views/Comment/CommentAuthor.d.ts
+++ b/src/views/Comment/CommentAuthor.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface CommentAuthorProps extends StrictCommentAuthorProps {
   [key: string]: any

--- a/src/views/Comment/CommentContent.d.ts
+++ b/src/views/Comment/CommentContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface CommentContentProps extends StrictCommentContentProps {
   [key: string]: any

--- a/src/views/Comment/CommentGroup.d.ts
+++ b/src/views/Comment/CommentGroup.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface CommentGroupProps extends StrictCommentGroupProps {
   [key: string]: any

--- a/src/views/Comment/CommentMetadata.d.ts
+++ b/src/views/Comment/CommentMetadata.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface CommentMetadataProps extends StrictCommentMetadataProps {
   [key: string]: any

--- a/src/views/Comment/CommentText.d.ts
+++ b/src/views/Comment/CommentText.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface CommentTextProps extends StrictCommentTextProps {
   [key: string]: any

--- a/src/views/Feed/Feed.d.ts
+++ b/src/views/Feed/Feed.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection } from '../..'
+import { SemanticShorthandCollection } from '../../generic'
 import FeedContent from './FeedContent'
 import FeedDate from './FeedDate'
 import { default as FeedEvent, FeedEventProps } from './FeedEvent'

--- a/src/views/Feed/FeedContent.d.ts
+++ b/src/views/Feed/FeedContent.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { FeedDateProps } from './FeedDate'
 import { FeedExtraProps } from './FeedExtra'
 import { FeedMetaProps } from './FeedMeta'

--- a/src/views/Feed/FeedDate.d.ts
+++ b/src/views/Feed/FeedDate.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface FeedDateProps extends StrictFeedDateProps {
   [key: string]: any

--- a/src/views/Feed/FeedEvent.d.ts
+++ b/src/views/Feed/FeedEvent.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../..'
+import { SemanticShorthandItem } from '../../generic'
 import { FeedContentProps } from './FeedContent'
 import { FeedDateProps } from './FeedDate'
 import { FeedLabelProps } from './FeedLabel'

--- a/src/views/Feed/FeedExtra.d.ts
+++ b/src/views/Feed/FeedExtra.d.ts
@@ -1,5 +1,9 @@
 import * as React from 'react'
-import { HtmlImageProps, SemanticShorthandContent, SemanticShorthandCollection } from '../..'
+import {
+  HtmlImageProps,
+  SemanticShorthandContent,
+  SemanticShorthandCollection,
+} from '../../generic'
 
 export interface FeedExtraProps extends StrictFeedExtraProps {
   [key: string]: any

--- a/src/views/Feed/FeedLabel.d.ts
+++ b/src/views/Feed/FeedLabel.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { HtmlImageProps, SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { HtmlImageProps, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface FeedLabelProps extends StrictFeedLabelProps {

--- a/src/views/Feed/FeedLike.d.ts
+++ b/src/views/Feed/FeedLike.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface FeedLikeProps extends StrictFeedLikeProps {

--- a/src/views/Feed/FeedMeta.d.ts
+++ b/src/views/Feed/FeedMeta.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { FeedLikeProps } from './FeedLike'
 
 export interface FeedMetaProps extends StrictFeedMetaProps {

--- a/src/views/Feed/FeedSummary.d.ts
+++ b/src/views/Feed/FeedSummary.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { FeedDateProps } from './FeedDate'
 import { FeedUserProps } from './FeedUser'
 

--- a/src/views/Feed/FeedUser.d.ts
+++ b/src/views/Feed/FeedUser.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface FeedUserProps extends StrictFeedUserProps {
   [key: string]: any

--- a/src/views/Item/Item.d.ts
+++ b/src/views/Item/Item.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../..'
+import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import ItemContent from './ItemContent'
 import { default as ItemDescription, ItemDescriptionProps } from './ItemDescription'
 import { default as ItemExtra, ItemExtraProps } from './ItemExtra'

--- a/src/views/Item/ItemContent.d.ts
+++ b/src/views/Item/ItemContent.d.ts
@@ -1,6 +1,10 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem, SemanticVERTICALALIGNMENTS } from '../..'
+import {
+  SemanticShorthandContent,
+  SemanticShorthandItem,
+  SemanticVERTICALALIGNMENTS,
+} from '../../generic'
 import { ItemDescriptionProps } from './ItemDescription'
 import { ItemExtraProps } from './ItemExtra'
 import { ItemHeaderProps } from './ItemHeader'

--- a/src/views/Item/ItemDescription.d.ts
+++ b/src/views/Item/ItemDescription.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ItemDescriptionProps extends StrictItemDescriptionProps {
   [key: string]: any

--- a/src/views/Item/ItemExtra.d.ts
+++ b/src/views/Item/ItemExtra.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ItemExtraProps extends StrictItemExtraProps {
   [key: string]: any

--- a/src/views/Item/ItemGroup.d.ts
+++ b/src/views/Item/ItemGroup.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection, SemanticShorthandContent } from '../..'
+import { SemanticShorthandCollection, SemanticShorthandContent } from '../../generic'
 import { ItemProps } from './Item'
 
 export interface ItemGroupProps extends StrictItemGroupProps {

--- a/src/views/Item/ItemHeader.d.ts
+++ b/src/views/Item/ItemHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ItemHeaderProps extends StrictItemHeaderProps {
   [key: string]: any

--- a/src/views/Item/ItemMeta.d.ts
+++ b/src/views/Item/ItemMeta.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface ItemMetaProps extends StrictItemMetaProps {
   [key: string]: any

--- a/src/views/Statistic/Statistic.d.ts
+++ b/src/views/Statistic/Statistic.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticFLOATS, SemanticShorthandContent } from '../..'
+import { SemanticCOLORS, SemanticFLOATS, SemanticShorthandContent } from '../../generic'
 import StatisticGroup from './StatisticGroup'
 import StatisticLabel from './StatisticLabel'
 import StatisticValue from './StatisticValue'

--- a/src/views/Statistic/StatisticGroup.d.ts
+++ b/src/views/Statistic/StatisticGroup.d.ts
@@ -5,7 +5,7 @@ import {
   SemanticShorthandCollection,
   SemanticShorthandContent,
   SemanticWIDTHS,
-} from '../..'
+} from '../../generic'
 import { StatisticProps, StatisticSizeProp } from './Statistic'
 
 export interface StatisticGroupProps extends StrictStatisticGroupProps {

--- a/src/views/Statistic/StatisticLabel.d.ts
+++ b/src/views/Statistic/StatisticLabel.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface StatisticLabelProps extends StrictStatisticLabelProps {
   [key: string]: any

--- a/src/views/Statistic/StatisticValue.d.ts
+++ b/src/views/Statistic/StatisticValue.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../..'
+import { SemanticShorthandContent } from '../../generic'
 
 export interface StatisticValueProps extends StrictStatisticValueProps {
   [key: string]: any

--- a/test/typings.tsx
+++ b/test/typings.tsx
@@ -1,9 +1,23 @@
 import * as React from 'react'
-import { Button, Dropdown } from '../'
+import { Button, Dropdown } from '../index'
 
-const Test = () => <Button />
-const DropdownTest = () => (
+const BasicAssert = () => <Button />
+
+const ShorthandItemElementAssert = () => (
   <Dropdown additionLabel={<i style={{ color: 'red' }}>Custom Language: </i>} />
 )
 
-export default Test
+const ShorthandItemFuncAssert = () => (
+  <Button
+    content="Foo"
+    icon={(Component, props) => (
+      <div className="bar">
+        <Component name={props.name} />
+      </div>
+    )}
+  />
+)
+
+const ShorthandItemFuncNullAssert = () => <Button content="Foo" icon={() => null} />
+
+export default BasicAssert

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
-    "jsx": "react"
+    "jsx": "react",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true
   },
   "include": [
     "src/**/*.d.ts"


### PR DESCRIPTION
# POSSIBLE BREAKING CHANGE

`src/index.d.ts` was renamed to `src/generic.d.ts` I hope that noone used it from `dist/commonjs/index.d.ts` because all types are reexported from the root. However I think that this thing should be noticed.

## Fixes and improvements

1. In #2790 we introduced a small update to shorthands, however `customPropTypes.itemShorthand` wasn't updated. This PR does this. Fixes #3181.

2. Typings were improved, you will get working autocomplete there :+1: It also satisfies `noImplicitAny` :v: 

```tsx
  <Button
    content="Foo"
    icon={(Component, props) => (
      <div className="bar">
        <Component name={props.name} />
      </div>
    )}
  />
```

![peek 2018-09-30 13-26](https://user-images.githubusercontent.com/14183168/46256518-8c315200-c4b4-11e8-8c70-2850f217e755.gif)

3. Some typings tests were added.