### PR TITLE
BREAKING(eventStack): fix issues with event subscriptions

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleRenderSource.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleRenderSource.js
@@ -28,6 +28,7 @@ const externals = {
   faker,
   lodash: require('lodash'),
   react: React,
+  'prop-types': PropTypes,
   'semantic-ui-react': SUIR,
 }
 const commons = {

--- a/docs/src/examples/modules/Sidebar/Examples/SidebarExampleMultiple.js
+++ b/docs/src/examples/modules/Sidebar/Examples/SidebarExampleMultiple.js
@@ -4,8 +4,8 @@ import { Button, Header, Icon, Image, Menu, Segment, Sidebar } from 'semantic-ui
 export default class SidebarExampleMultiple extends Component {
   state = { visible: false }
 
-  handleButtonClick = () => this.setState({ visible: !this.state.visible })
-
+  handleHideClick = () => this.setState({ visible: false })
+  handleShowClick = () => this.setState({ visible: true })
   handleSidebarHide = () => this.setState({ visible: false })
 
   render() {
@@ -13,7 +13,14 @@ export default class SidebarExampleMultiple extends Component {
 
     return (
       <div>
-        <Button onClick={this.handleButtonClick}>Toggle visibility</Button>
+        <Button.Group>
+          <Button disabled={visible} onClick={this.handleShowClick}>
+            Show sidebars
+          </Button>
+          <Button disabled={!visible} onClick={this.handleHideClick}>
+            Hide sidebars
+          </Button>
+        </Button.Group>
 
         <Sidebar.Pushable as={Segment}>
           <Sidebar

--- a/docs/src/examples/modules/Sidebar/States/SidebarExampleDimmed.js
+++ b/docs/src/examples/modules/Sidebar/States/SidebarExampleDimmed.js
@@ -4,8 +4,8 @@ import { Button, Header, Icon, Image, Menu, Segment, Sidebar } from 'semantic-ui
 export default class SidebarExampleDimmed extends Component {
   state = { visible: false }
 
-  handleButtonClick = () => this.setState({ visible: !this.state.visible })
-
+  handleHideClick = () => this.setState({ visible: false })
+  handleShowClick = () => this.setState({ visible: true })
   handleSidebarHide = () => this.setState({ visible: false })
 
   render() {
@@ -13,7 +13,14 @@ export default class SidebarExampleDimmed extends Component {
 
     return (
       <div>
-        <Button onClick={this.handleButtonClick}>Toggle visibility</Button>
+        <Button.Group>
+          <Button disabled={visible} onClick={this.handleShowClick}>
+            Show sidebar
+          </Button>
+          <Button disabled={!visible} onClick={this.handleHideClick}>
+            Hide sidebar
+          </Button>
+        </Button.Group>
 
         <Sidebar.Pushable as={Segment}>
           <Sidebar

--- a/docs/src/examples/modules/Sidebar/Types/SidebarExampleSidebar.js
+++ b/docs/src/examples/modules/Sidebar/Types/SidebarExampleSidebar.js
@@ -4,8 +4,8 @@ import { Button, Header, Icon, Image, Menu, Segment, Sidebar } from 'semantic-ui
 export default class SidebarExampleSidebar extends Component {
   state = { visible: false }
 
-  handleButtonClick = () => this.setState({ visible: !this.state.visible })
-
+  handleHideClick = () => this.setState({ visible: false })
+  handleShowClick = () => this.setState({ visible: true })
   handleSidebarHide = () => this.setState({ visible: false })
 
   render() {
@@ -13,7 +13,14 @@ export default class SidebarExampleSidebar extends Component {
 
     return (
       <div>
-        <Button onClick={this.handleButtonClick}>Toggle visibility</Button>
+        <Button.Group>
+          <Button disabled={visible} onClick={this.handleShowClick}>
+            Show sidebar
+          </Button>
+          <Button disabled={!visible} onClick={this.handleHideClick}>
+            Hide sidebar
+          </Button>
+        </Button.Group>
 
         <Sidebar.Pushable as={Segment}>
           <Sidebar

--- a/docs/src/examples/modules/Sidebar/Usage/SidebarExampleCallback.js
+++ b/docs/src/examples/modules/Sidebar/Usage/SidebarExampleCallback.js
@@ -9,8 +9,8 @@ export default class VisibilityExampleCallbackFrequency extends Component {
 
   clearLog = () => this.setState({ log: [], logCount: 0 })
 
-  handleButtonClick = () => this.setState({ visible: !this.state.visible })
-
+  handleHideClick = () => this.setState({ visible: false })
+  handleShowClick = () => this.setState({ visible: true })
   handleSidebarHide = () => this.setState({ visible: false })
 
   updateLog = eventName => () =>
@@ -26,7 +26,14 @@ export default class VisibilityExampleCallbackFrequency extends Component {
       <Grid columns={2}>
         <Grid.Row>
           <Grid.Column>
-            <Button onClick={this.handleButtonClick}>Toggle visibility</Button>
+            <Button.Group>
+              <Button disabled={visible} onClick={this.handleShowClick}>
+                Show sidebar
+              </Button>
+              <Button disabled={!visible} onClick={this.handleHideClick}>
+                Hide sidebar
+              </Button>
+            </Button.Group>
           </Grid.Column>
         </Grid.Row>
 
@@ -72,7 +79,11 @@ export default class VisibilityExampleCallbackFrequency extends Component {
                 Event Log <Label circular>{logCount}</Label>
               </Segment>
               <Segment secondary>
-                <pre>{log.map((e, i) => <div key={i}>{e}</div>)}</pre>
+                <pre>
+                  {log.map((e, i) => (
+                    <div key={i}>{e}</div>
+                  ))}
+                </pre>
               </Segment>
             </Segment.Group>
           </Grid.Column>

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://github.com/Semantic-Org/Semantic-UI-React#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@semantic-ui-react/event-stack": "^2.0.0",
+    "@semantic-ui-react/event-stack": "^3.0.0",
     "classnames": "^2.2.6",
     "keyboard-key": "^1.0.2",
     "lodash": "^4.17.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,9 +793,9 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@semantic-ui-react/event-stack@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@semantic-ui-react/event-stack/-/event-stack-2.0.0.tgz#d2d568a9fb0ee204b0e40d6b73ac2a2403c08451"
+"@semantic-ui-react/event-stack@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@semantic-ui-react/event-stack/-/event-stack-3.0.0.tgz#fde997c4613328b4f85cacfe8feaf1f4dcf53f6f"
   dependencies:
     exenv "^1.2.2"
     prop-types "^15.6.2"


### PR DESCRIPTION
Fixes: #3006.
Details: https://github.com/layershifter/event-stack/pull/4

# BREAKING CHANGES

This PR fixes existing issues with multiple Modals, Popups and Dropdown's. However, it changes the behaviour of the Sidebar component that was introduced in [v0.81.2](https://github.com/Semantic-Org/Semantic-UI-React/blob/master/CHANGELOG.md#v0812-2018-06-26). This update is strongly recommend if you're using `0.81.0` or higher.

You also can control the behaviour of Sidebar with the `target` prop, #3191.

### Manual checks

- [x] Modal: Multiple, https://react.semantic-ui.com/modules/modal/#types-multiple
- [x] Dropdown: Close on blur, https://react.semantic-ui.com/modules/dropdown/#usage-close-on-blur
- [x] Popup: Clickable sequence, https://codesandbox.io/s/3rx96jzjr6