### PR TITLE
BREAKING(Accordion): add renderActiveOnly prop (#3087)

### DIFF
--- a/src/modules/Accordion/AccordionAccordion.d.ts
+++ b/src/modules/Accordion/AccordionAccordion.d.ts
@@ -37,6 +37,9 @@ export interface StrictAccordionAccordionProps {
 
   /** Shorthand array of props for Accordion. */
   panels?: SemanticShorthandCollection<AccordionPanelProps>
+
+  /** An Accordion will only render content from active panels */
+  renderActiveOnly?: boolean
 }
 
 declare const AccordionAccordion: React.ComponentClass<AccordionAccordionProps>

--- a/src/modules/Accordion/AccordionAccordion.js
+++ b/src/modules/Accordion/AccordionAccordion.js
@@ -60,10 +60,14 @@ export default class AccordionAccordion extends Component {
         }),
       ),
     ]),
+
+    /** An Accordion will only render content from active panels */
+    renderActiveOnly: PropTypes.bool,
   }
 
   static defaultProps = {
     exclusive: true,
+    renderActiveOnly: true,
   }
 
   static autoControlledProps = ['activeIndex']
@@ -89,6 +93,18 @@ export default class AccordionAccordion extends Component {
     _.invoke(this.props, 'onTitleClick', e, titleProps)
   }
 
+  renderPanels = (panels, renderActiveOnly) =>
+    _.map(panels, (panel, index) =>
+      AccordionPanel.create(panel, {
+        defaultProps: {
+          active: this.isIndexActive(index),
+          renderActiveOnly,
+          index,
+          onTitleClick: this.handleTitleClick,
+        },
+      }),
+    )
+
   isIndexActive = (index) => {
     const { exclusive } = this.props
     const { activeIndex } = this.state
@@ -97,7 +113,7 @@ export default class AccordionAccordion extends Component {
   }
 
   render() {
-    const { className, children, panels } = this.props
+    const { className, children, panels, renderActiveOnly } = this.props
 
     const classes = cx('accordion', className)
     const rest = getUnhandledProps(AccordionAccordion, this.props)
@@ -105,17 +121,7 @@ export default class AccordionAccordion extends Component {
 
     return (
       <ElementType {...rest} className={classes}>
-        {childrenUtils.isNil(children)
-          ? _.map(panels, (panel, index) =>
-            AccordionPanel.create(panel, {
-              defaultProps: {
-                active: this.isIndexActive(index),
-                index,
-                onTitleClick: this.handleTitleClick,
-              },
-            }),
-          )
-          : children}
+        {childrenUtils.isNil(children) ? this.renderPanels(panels, renderActiveOnly) : children}
       </ElementType>
     )
   }

--- a/src/modules/Accordion/AccordionContent.d.ts
+++ b/src/modules/Accordion/AccordionContent.d.ts
@@ -10,7 +10,10 @@ export interface StrictAccordionContentProps {
   as?: any
 
   /** Whether or not the content is visible. */
-  active?: boolean
+  active: boolean
+
+  /** Only render content or children if active */
+  renderActiveOnly?: boolean
 
   /** Primary content. */
   children?: React.ReactNode

--- a/src/modules/Accordion/AccordionContent.js
+++ b/src/modules/Accordion/AccordionContent.js
@@ -11,18 +11,30 @@ import {
   useKeyOnly,
 } from '../../lib'
 
+function shouldRender(active, renderActiveOnly) {
+  if (renderActiveOnly) {
+    return active
+  }
+
+  return true
+}
+
+function renderChildrenOrContent(children, content) {
+  return childrenUtils.isNil(children) ? content : children
+}
+
 /**
  * A content sub-component for Accordion component.
  */
 function AccordionContent(props) {
-  const { active, children, className, content } = props
+  const { active, renderActiveOnly, children, className, content } = props
   const classes = cx('content', useKeyOnly(active, 'active'), className)
   const rest = getUnhandledProps(AccordionContent, props)
   const ElementType = getElementType(AccordionContent, props)
 
   return (
     <ElementType {...rest} className={classes}>
-      {childrenUtils.isNil(children) ? content : children}
+      {shouldRender(active, renderActiveOnly) ? renderChildrenOrContent(children, content) : null}
     </ElementType>
   )
 }
@@ -34,6 +46,9 @@ AccordionContent.propTypes = {
   /** Whether or not the content is visible. */
   active: PropTypes.bool,
 
+  /** Only render content or children if active */
+  renderActiveOnly: PropTypes.bool,
+
   /** Primary content. */
   children: PropTypes.node,
 
@@ -42,6 +57,10 @@ AccordionContent.propTypes = {
 
   /** Shorthand for primary content. */
   content: customPropTypes.contentShorthand,
+}
+
+AccordionContent.defaultProps = {
+  renderActiveOnly: true,
 }
 
 AccordionContent.create = createShorthandFactory(AccordionContent, content => ({ content }))

--- a/src/modules/Accordion/AccordionPanel.d.ts
+++ b/src/modules/Accordion/AccordionPanel.d.ts
@@ -12,6 +12,9 @@ export interface StrictAccordionPanelProps {
   /** Whether or not the title is in the open state. */
   active?: boolean
 
+  /** Only render content if active */
+  renderActiveOnly?: boolean
+
   /** A shorthand for Accordion.Content. */
   content?: SemanticShorthandItem<AccordionContentProps>
 

--- a/src/modules/Accordion/AccordionPanel.js
+++ b/src/modules/Accordion/AccordionPanel.js
@@ -14,6 +14,9 @@ class AccordionPanel extends Component {
     /** Whether or not the title is in the open state. */
     active: PropTypes.bool,
 
+    /** Only render content if active */
+    renderActiveOnly: PropTypes.bool,
+
     /** A shorthand for Accordion.Content. */
     content: customPropTypes.itemShorthand,
 
@@ -40,7 +43,7 @@ class AccordionPanel extends Component {
   })
 
   render() {
-    const { active, content, index, title } = this.props
+    const { active, content, index, title, renderActiveOnly } = this.props
 
     return [
       AccordionTitle.create(title, {
@@ -50,7 +53,7 @@ class AccordionPanel extends Component {
       }),
       AccordionContent.create(content, {
         autoGenerateKey: false,
-        defaultProps: { active, key: 'content' },
+        defaultProps: { active, renderActiveOnly, key: 'content' },
       }),
     ]
   }

--- a/test/specs/modules/Accordion/AccordionAccordion-test.js
+++ b/test/specs/modules/Accordion/AccordionAccordion-test.js
@@ -170,22 +170,25 @@ describe('AccordionAccordion', () => {
     const panels = [
       {
         key: 'A',
-        title: { content: 'A', onClick },
+        title: { content: 'Title A', onClick },
         content: { content: 'Content A', 'data-foo': 'something' },
       },
-      { key: 'B', title: 'B', content: { content: 'Content B', 'data-foo': 'something' } },
+      { key: 'B', title: 'Title B', content: { content: 'Content B', 'data-foo': 'something' } },
     ]
-    const children = mount(<AccordionAccordion panels={panels} />)
+    const children = mount(<AccordionAccordion panels={panels} activeIndex={0} />)
 
-    it('renders children', () => {
+    it('renders title of all panels', () => {
       const titles = children.find(AccordionTitle)
+
+      titles.at(0).should.contain.text('Title A')
+      titles.at(1).should.contain.text('Title B')
+    })
+
+    it('renders only content of active panels', () => {
       const contents = children.find(AccordionContent)
 
-      titles.at(0).should.have.prop('content', 'A')
-      contents.at(0).should.have.prop('content', 'Content A')
-
-      titles.at(1).should.have.prop('content', 'B')
-      contents.at(1).should.have.prop('content', 'Content B')
+      contents.at(0).should.contain.text('Content A')
+      contents.at(1).should.not.contain.text('Content B')
     })
 
     it('passes onClick handler', () => {
@@ -195,7 +198,7 @@ describe('AccordionAccordion', () => {
         .simulate('click', event)
 
       onClick.should.have.been.calledOnce()
-      onClick.should.have.been.calledWithMatch(event, { content: 'A', index: 0 })
+      onClick.should.have.been.calledWithMatch(event, { content: 'Title A', index: 0 })
     })
 
     it('passes arbitrary props', () => {

--- a/test/specs/modules/Accordion/AccordionContent-test.js
+++ b/test/specs/modules/Accordion/AccordionContent-test.js
@@ -1,11 +1,59 @@
+import React from 'react'
+
 import AccordionContent from 'src/modules/Accordion/AccordionContent'
 import * as common from 'test/specs/commonTests'
 
 describe('AccordionContent', () => {
-  common.isConformant(AccordionContent)
-  common.rendersChildren(AccordionContent)
+  // must be active to render children and content with the defaultProp renderActiveOnly = true
+  const requiredProps = { active: true }
+
+  common.isConformant(AccordionContent, { requiredProps })
+
+  common.rendersChildren(AccordionContent, { requiredProps })
 
   common.implementsCreateMethod(AccordionContent)
 
   common.propKeyOnlyToClassName(AccordionContent, 'active')
+
+  it('Renders an empty .content if not active', () => {
+    const wrapper = shallow(<AccordionContent active={false} content={'test text'} />)
+
+    expect(wrapper.hasClass('content'))
+    wrapper
+      .find('.content')
+      .children()
+      .should.have.length(0)
+  })
+
+  it('Does not render content if not active', () => {
+    const wrapper = shallow(<AccordionContent active={false} content={'test text'} />)
+
+    wrapper.children().should.have.length(0)
+  })
+
+  it('Renders content if not active and renderActiveOnly is false', () => {
+    const wrapper = shallow(
+      <AccordionContent active={false} renderActiveOnly={false} content={'test text'} />,
+    )
+
+    wrapper.children().should.have.length(1)
+    wrapper.childAt(0).should.contain.text('test text')
+  })
+
+  it('Does not render children if not active', () => {
+    const wrapper = shallow(<AccordionContent active={false}>test text</AccordionContent>)
+
+    wrapper.children().should.have.length(0)
+  })
+
+  it('Renders children if not active and renderActiveOnly is false', () => {
+    const wrapper = shallow(
+      <AccordionContent active={false} renderActiveOnly={false}>
+        test text
+      </AccordionContent>,
+    )
+
+    wrapper.children().should.have.length(1)
+    wrapper.childAt(0).should.contain.text('test text')
+  })
 })

--- a/test/specs/modules/Accordion/AccordionPanel-test.js
+++ b/test/specs/modules/Accordion/AccordionPanel-test.js
@@ -30,7 +30,7 @@ describe('AccordionPanel', () => {
   })
 
   describe('active', () => {
-    it('should passed to children', () => {
+    it('should be passed to children', () => {
       const wrapper = shallow(<AccordionPanel active content='Content' title='Title' />)
 
       wrapper.at(0).should.have.prop('active', true)
@@ -39,11 +39,22 @@ describe('AccordionPanel', () => {
   })
 
   describe('index', () => {
-    it('should passed to title', () => {
+    it('should be passed to title', () => {
       const wrapper = shallow(<AccordionPanel content='Content' index={5} title='Title' />)
 
       wrapper.at(0).should.have.prop('index', 5)
-      wrapper.at(1).should.have.not.prop('index')
+      wrapper.at(1).should.not.have.prop('index')
+    })
+  })
+
+  describe('renderActiveOnly', () => {
+    it('should be passed to content', () => {
+      const wrapper = shallow(
+        <AccordionPanel content='Content' index={5} title='Title' renderActiveOnly={false} />,
+      )
+
+      wrapper.at(0).should.not.have.prop('renderActiveOnly')
+      wrapper.at(1).should.have.prop('renderActiveOnly', false)
     })
   })
 


### PR DESCRIPTION
This PR fixes #3087. Namely it allows an Accordion to not render content that is not active, and sets not rendering inactive content to be the default behavior.

The solution differs from `Tab` due to the surrounding API. Namely that `Accordion` supports the `children` prop, requiring `renderActiveOnly` to possibly be passed all throughout `Accordion` -> `AccordionPane` -> `AccordionContent` when the user utilizes the `panes` prop. It's possible that the `Accordion` API should be changed to match the `Tab` API, where the `panes` prop accept a render function. However I felt as if this was out of scope for this issue/PR and should be discussed elsewhere.

Note that I had to set `active` to be a required prop for the `AccordionContent`. I could not figure out how to get it to pass the tests otherwise. Let me know if this is a rash decision.

Furthermore, I chose to render an empty `<div class="content" />` instead of nothing at all in `AccordionContent`. Rendering _something_ seems to be a requirement to be conformant, but let me know if you would've implemented it in another way.