### PR TITLE
feat(Sidebar): add `target` prop

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleRenderSource.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleRenderSource.js
@@ -28,6 +28,7 @@ const externals = {
   faker,
   lodash: require('lodash'),
   react: React,
+  'prop-types': PropTypes,
   'semantic-ui-react': SUIR,
 }
 const commons = {

--- a/docs/src/examples/modules/Sidebar/Usage/SidebarExampleTarget.js
+++ b/docs/src/examples/modules/Sidebar/Usage/SidebarExampleTarget.js
@@ -1,0 +1,64 @@
+import React, { Component } from 'react'
+import { Button, Header, Image, Menu, Ref, Segment, Sidebar } from 'semantic-ui-react'
+
+export default class VisibilityExampleTarget extends Component {
+  state = {}
+
+  handleHideClick = () => this.setState({ visible: false })
+  handleShowClick = () => this.setState({ visible: true })
+
+  handleSegmentRef = (c) => {
+    this.segmentRef = c
+  }
+
+  handleSidebarHide = () => this.setState({ visible: false })
+
+  render() {
+    const { visible } = this.state
+
+    return (
+      <div>
+        <Button.Group>
+          <Button disabled={visible} onClick={this.handleShowClick}>
+            Show sidebar
+          </Button>
+          <Button disabled={!visible} onClick={this.handleHideClick}>
+            Hide sidebar
+          </Button>
+        </Button.Group>
+
+        <Sidebar.Pushable as={Segment.Group} raised>
+          {this.segmentRef && (
+            <Sidebar
+              as={Menu}
+              animation='overlay'
+              icon='labeled'
+              inverted
+              onHide={this.handleSidebarHide}
+              vertical
+              target={this.segmentRef}
+              visible={visible}
+              width='thin'
+            >
+              <Menu.Item as='a'>Home</Menu.Item>
+              <Menu.Item as='a'>Games</Menu.Item>
+              <Menu.Item as='a'>Channels</Menu.Item>
+            </Sidebar>
+          )}
+
+          <Ref innerRef={this.handleSegmentRef}>
+            <Segment>
+              <Header as='h3'>Clickable area</Header>
+              <p>When you will click there, the sidebar will be closed.</p>
+            </Segment>
+          </Ref>
+
+          <Segment>
+            <Header as='h3'>Application Content</Header>
+            <Image src='/images/wireframe/paragraph.png' />
+          </Segment>
+        </Sidebar.Pushable>
+      </div>
+    )
+  }
+}

--- a/docs/src/examples/modules/Sidebar/Usage/index.js
+++ b/docs/src/examples/modules/Sidebar/Usage/index.js
@@ -10,6 +10,11 @@ const SidebarUsageExamples = () => (
       description='A sidebar can have callbacks.'
       examplePath='modules/Sidebar/Usage/SidebarExampleCallback'
     />
+    <ComponentExample
+      title='Target'
+      description='A sidebar can handle clicks on the passed element.'
+      examplePath='modules/Sidebar/Usage/SidebarExampleTarget'
+    />
   </ExampleSection>
 )
 

--- a/src/modules/Sidebar/Sidebar.d.ts
+++ b/src/modules/Sidebar/Sidebar.d.ts
@@ -62,6 +62,9 @@ export interface StrictSidebarProps {
    */
   onVisible?: (event: React.MouseEvent<HTMLElement>, data: SidebarProps) => void
 
+  /** Existing element the sidebar will handle clicks. */
+  target?: object
+
   /** Controls whether or not the sidebar is visible on the page. */
   visible?: boolean
 

--- a/src/modules/Sidebar/Sidebar.d.ts
+++ b/src/modules/Sidebar/Sidebar.d.ts
@@ -62,7 +62,7 @@ export interface StrictSidebarProps {
    */
   onVisible?: (event: React.MouseEvent<HTMLElement>, data: SidebarProps) => void
 
-  /** Existing element the sidebar will handle clicks. */
+  /** A sidebar can handle clicks on the passed element. */
   target?: object
 
   /** Controls whether or not the sidebar is visible on the page. */

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -81,6 +81,9 @@ class Sidebar extends Component {
      */
     onVisible: PropTypes.func,
 
+    /** Existing element the sidebar will handle clicks. */
+    target: PropTypes.object,
+
     /** Controls whether or not the sidebar is visible on the page. */
     visible: PropTypes.bool,
 
@@ -146,7 +149,16 @@ class Sidebar extends Component {
   handleRef = c => (this.ref = c)
 
   render() {
-    const { animation, className, children, content, direction, visible, width } = this.props
+    const {
+      animation,
+      className,
+      children,
+      content,
+      direction,
+      target,
+      visible,
+      width,
+    } = this.props
     const { animating } = this.state
 
     const classes = cx(
@@ -166,7 +178,7 @@ class Sidebar extends Component {
       <Ref innerRef={this.handleRef}>
         <ElementType {...rest} className={classes}>
           {childrenUtils.isNil(children) ? content : children}
-          {visible && <EventStack name='click' on={this.handleDocumentClick} />}
+          {visible && <EventStack name='click' on={this.handleDocumentClick} target={target} />}
         </ElementType>
       </Ref>
     )

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -81,7 +81,7 @@ class Sidebar extends Component {
      */
     onVisible: PropTypes.func,
 
-    /** Existing element the sidebar will handle clicks. */
+    /** A sidebar can handle clicks on the passed element. */
     target: PropTypes.object,
 
     /** Controls whether or not the sidebar is visible on the page. */

--- a/test/specs/modules/Sidebar/Sidebar-test.js
+++ b/test/specs/modules/Sidebar/Sidebar-test.js
@@ -131,4 +131,15 @@ describe('Sidebar', () => {
       onVisible.should.have.been.calledWithMatch(null, { visible: true })
     })
   })
+
+  describe('target', () => {
+    it('is passed to the EventStack component', () => {
+      const target = document.createElement('div')
+
+      const wrapper = shallow(<Sidebar target={target} visible />)
+      const stack = wrapper.find('EventStack')
+
+      stack.should.have.prop('target', target)
+    })
+  })
 })


### PR DESCRIPTION
### Why?

The `target` prop allows to pass element to which will be attached event listener. This allows to customize closable area, defaults to `document`.