### PR TITLE
#3200 Fix dropdown autocomplete 

### DIFF
--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -27,6 +27,9 @@ export interface StrictDropdownProps {
    */
   allowAdditions?: boolean
 
+  /** An input can have the auto complete. */
+  autoComplete?: string
+
   /** A Dropdown can reduce its complexity. */
   basic?: boolean
 
@@ -274,6 +277,9 @@ export interface StrictDropdownProps {
 
   /** Custom element to trigger the menu to become visible. Takes place of 'text'. */
   trigger?: React.ReactNode
+
+  /** The HTML input type. */
+  type?: string
 
   /** Current value or value array if multiple. Creates a controlled component. */
   value?: boolean | number | string | (boolean | number | string)[]

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -56,6 +56,9 @@ export default class Dropdown extends Component {
       PropTypes.bool,
     ]),
 
+    /** An input can have the auto complete. */
+    autoComplete: PropTypes.string,
+
     /** A Dropdown can reduce its complexity. */
     basic: PropTypes.bool,
 
@@ -335,6 +338,9 @@ export default class Dropdown extends Component {
       customPropTypes.disallow(['selection', 'text']),
       PropTypes.node,
     ]),
+
+    /** The HTML input type. */
+    type: PropTypes.string,
 
     /** Current value or value array if multiple. Creates a controlled component. */
     value: PropTypes.oneOfType([
@@ -1235,7 +1241,7 @@ export default class Dropdown extends Component {
   }
 
   renderSearchInput = () => {
-    const { search, searchInput } = this.props
+    const { search, searchInput, autoComplete, type } = this.props
     const { searchQuery } = this.state
 
     if (!search) return null
@@ -1245,6 +1251,8 @@ export default class Dropdown extends Component {
         style: { width: this.computeSearchInputWidth() },
         tabIndex: this.computeSearchInputTabIndex(),
         value: searchQuery,
+        autoComplete,
+        type,
       },
       overrideProps: this.handleSearchInputOverrides,
     })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -279,6 +279,20 @@ describe('Dropdown', () => {
     })
   })
 
+  describe('autoComplete', () => {
+    it('defaults to off', () => {
+      shallow(<Dropdown options={options} search />)
+        .find(DropdownSearchInput)
+        .should.have.prop('autoComplete', 'off')
+    })
+
+    it('allows explicitly setting the search input autocomplete prop', () => {
+      shallow(<Dropdown options={options} search autoComplete='nope' />)
+        .find(DropdownSearchInput)
+        .should.have.prop('autoComplete', 'nope')
+    })
+  })
+
   describe('aria', () => {
     it('should label normal dropdown as a listbox', () => {
       wrapperMount(<Dropdown />)


### PR DESCRIPTION
Fixes #3200 
Passes down values of the autoComplete and type props to the Dropdown underlying search input