### PR TITLE
docs(LabelExamplePointingColored): Remove basic property from labels

### DIFF
--- a/docs/src/examples/elements/Label/Types/LabelExamplePointingColored.js
+++ b/docs/src/examples/elements/Label/Types/LabelExamplePointingColored.js
@@ -5,14 +5,14 @@ const LabelExamplePointing = () => (
   <Form>
     <Form.Field>
       <input type='text' placeholder='First name' />
-      <Label basic color='red' pointing>
+      <Label color='red' pointing>
         Please enter a value
       </Label>
     </Form.Field>
     <Divider />
 
     <Form.Field>
-      <Label basic color='red' pointing='below'>
+      <Label color='red' pointing='below'>
         Please enter a value
       </Label>
       <input type='text' placeholder='Last Name' />
@@ -21,14 +21,14 @@ const LabelExamplePointing = () => (
 
     <Form.Field inline>
       <input type='text' placeholder='Username' />
-      <Label basic color='red' pointing='left'>
+      <Label color='red' pointing='left'>
         That name is taken!
       </Label>
     </Form.Field>
     <Divider />
 
     <Form.Field inline>
-      <Label basic color='red' pointing='right'>
+      <Label color='red' pointing='right'>
         Your password must be 6 characters or more
       </Label>
       <input type='password' placeholder='Password' />


### PR DESCRIPTION
Prior to this commit, label text was illegible as both the text and label background color were red.

Before:
<img width="836" alt="screen shot 2018-10-11 at 15 17 29" src="https://user-images.githubusercontent.com/1678968/46806917-19a05c00-cd69-11e8-81df-01fc6da182f3.png">
After:
<img width="840" alt="screen shot 2018-10-11 at 15 17 55" src="https://user-images.githubusercontent.com/1678968/46806916-19a05c00-cd69-11e8-8973-3d7dc71f3af6.png">
