### PR TITLE
docs(ComponentDoc): Fix clicking sidebar item doesn't make it active bug

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentDoc.js
+++ b/docs/src/components/ComponentDoc/ComponentDoc.js
@@ -33,7 +33,9 @@ class ComponentDoc extends Component {
     sidebarSections: docTypes.sidebarSections.isRequired,
   }
 
-  state = {}
+  state = {
+    autoScrollingToAnchor: false,
+  }
 
   componentWillMount() {
     const { exampleKeys, history } = this.props
@@ -58,7 +60,9 @@ class ComponentDoc extends Component {
   }
 
   handleExamplePassed = (e, { examplePath }) => {
-    this.setState({ activePath: examplePathToHash(examplePath) })
+    if (!this.state.autoScrollingToAnchor) {
+      this.setState({ activePath: examplePathToHash(examplePath) })
+    }
   }
 
   handleExamplesRef = examplesRef => this.setState({ examplesRef })
@@ -69,7 +73,11 @@ class ComponentDoc extends Component {
 
     history.replace(`${location.pathname}#${activePath}`)
     // set active hash path
-    this.setState({ activePath }, scrollToAnchor)
+    this.setState({ activePath, autoScrollingToAnchor: true }, scrollToAnchor)
+
+    // auto scrolling animation to anchor will finish after ~1 second
+    const ONE_SECOND = 1000
+    setTimeout(() => this.setState({ autoScrollingToAnchor: false }), ONE_SECOND)
   }
 
   render() {


### PR DESCRIPTION
Fix a bug within the documentation site where when a sidebar item is selected that is below the current selection or there is no current selection, the item above the selected will be active not the selected item.

Steps to reproduce issue:

- Go here: http://react.semantic-ui.com/elements/button/
- Expand the `Types` section on the sidebar on the right
- Click `Expand` right below `Button`

Expected Behavior: `Expand` will be emphasized as active within the sidebar
Current Behavior: `Button`, above `Expand` is emphasized as active

This stems from the `onTopPassed` and `onTopPassedReversed` behavior on the `Visibility` component that wraps the example. These features work fine when the user is doing the scrolling, but not as well when the scrolling is being done programmatically, ie. `scrollToAnchor()`.

My solution is simply to set a flag when the sidebar item is selected and `scrollToAnchor()` is called such that the `onPassed` events don't fire for a short time while the animation is occurring.