### PR TITLE
docs(Layouts): fix examples with incorrect props

### DIFF
--- a/docs/src/layouts/GridLayout.js
+++ b/docs/src/layouts/GridLayout.js
@@ -277,17 +277,17 @@ const GridLayout = () => (
       </p>
 
       <Grid>
-        <Grid.Column verticalAlign='right' width={8}>
+        <Grid.Column textAlign='right' width={8}>
           right aligned column
         </Grid.Column>
-        <Grid.Column verticalAlign='left' width={8}>
+        <Grid.Column textAlign='left' width={8}>
           left aligned column
         </Grid.Column>
-        <Grid.Row columns={2} verticalAlign='center'>
+        <Grid.Row columns={2} textAlign='center'>
           <Grid.Column>center aligned row</Grid.Column>
           <Grid.Column>center aligned row</Grid.Column>
         </Grid.Row>
-        <Grid.Column verticalAlign='right' width={16}>
+        <Grid.Column textAlign='right' width={16}>
           right aligned column
         </Grid.Column>
       </Grid>

--- a/docs/src/layouts/ResponsiveLayout.js
+++ b/docs/src/layouts/ResponsiveLayout.js
@@ -578,7 +578,7 @@ const ResponsiveLayout = () => (
             <Item.Extra>
               <Button floated='right' primary>
                 Primary
-                <Icon name='right chevron' />
+                <Icon name='chevron right' />
               </Button>
               <Label>Limited</Label>
             </Item.Extra>
@@ -598,7 +598,7 @@ const ResponsiveLayout = () => (
             <Item.Extra>
               <Button primary floated='right'>
                 Primary
-                <Icon name='right chevron' />
+                <Icon name='chevron right' />
               </Button>
             </Item.Extra>
           </Item.Content>

--- a/docs/src/layouts/ThemingLayout.js
+++ b/docs/src/layouts/ThemingLayout.js
@@ -53,7 +53,7 @@ const ThemingLayout = () => (
           padded
           stackable
           style={{ margin: '-1.5em', width: 400 }}
-          textAlign='middle'
+          textAlign='center'
         >
           <Grid.Column color='red' style={{ margin: '0.5em', height: 50 }}>
             Red
@@ -224,8 +224,8 @@ const ThemingLayout = () => (
         <Button size='tiny'>Tiny</Button>
         <Button size='small'>Small</Button>
         <Button size='large'>Large</Button>
-        <Button size='big button'>Big</Button>
-        <Button size='huge button'>Huge</Button>
+        <Button size='big'>Big</Button>
+        <Button size='huge'>Huge</Button>
         <Button size='massive'>Massive</Button>
 
         <Divider />


### PR DESCRIPTION
Hey, I noticed that some of the docs were using invalid React props. I've got ahead and fixed the issues I could spot within `docs/layouts`, and if I notice any other examples being wrong in the future I'll update them too :+1: