### PR TITLE
fix(Portal): hover behavior fixed in Portal's event handlers

### DIFF
--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -173,6 +173,9 @@ class Portal extends Component {
 
     if (!closeOnPortalMouseLeave) return
 
+    // Do not close the portal when 'mouseleave' is triggered by children
+    if (e.target !== this.portalNode) return
+
     debug('handlePortalMouseLeave()')
     this.mouseLeaveTimer = this.closeWithTimeout(e, mouseLeaveDelay)
   }

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -14,7 +14,6 @@ import PortalInner from './PortalInner'
 
 const debug = makeDebugger('portal')
 
-
 /**
  * A component that allows you to render children outside their parent.
  * @see Modal

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -14,6 +14,7 @@ import PortalInner from './PortalInner'
 
 const debug = makeDebugger('portal')
 
+
 /**
  * A component that allows you to render children outside their parent.
  * @see Modal

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -415,6 +415,25 @@ describe('Portal', () => {
         done()
       }, 1)
     })
+
+    it("does not close the portal on mouseleave triggered by the portal's children", (done) => {
+      wrapperMount(
+        <Portal closeOnPortalMouseLeave defaultOpen mouseLeaveDelay={0} trigger={<button />}>
+          <div>
+            <p id='child' />
+          </div>
+        </Portal>,
+      )
+      wrapper.should.have.descendants(PortalInner)
+
+      domEvent.mouseLeave('#child')
+      setTimeout(() => {
+        wrapper.update()
+        wrapper.should.have.descendants(PortalInner)
+
+        done()
+      }, 1)
+    })
   })
 
   describe('closeOnTriggerMouseLeave + closeOnPortalMouseLeave', () => {


### PR DESCRIPTION
Originally `Portal` closes on `mouseleave`. However, `mouseleave` is fired when "the pointer has exited the element and all of its descendants" (ref: https://developer.mozilla.org/en-US/docs/Web/Events/mouseleave).

For that reason the `Popup` was closing when the pointer exited the inner elements, but not necessarily the `Portal` itself (which is used to render the `Popup`).

Gif of the fixed behavior:
![popup-onmouseleave-fixed](https://user-images.githubusercontent.com/15076656/48019866-22ecd080-e13d-11e8-9a5e-c8762e02da1f.gif)

The solution was to cancel the `handlePortalMouseLeave` event in case the event's target doesn't match the portal node. A test was also added. It seemed a clean enough solution for this bug, let me know what you think!

Cheers!
(fixes #3239)