### PR TITLE
fix(Ref) Add a workaround for findDomNode to work with React 16.6.0

### DIFF
--- a/src/addons/Ref/Ref.js
+++ b/src/addons/Ref/Ref.js
@@ -24,8 +24,11 @@ export default class Ref extends Component {
 
     // Heads up! Don't move this condition, it's a short circuit that avoids run of `findDOMNode`
     // if `innerRef` isn't passed
-    // eslint-disable-next-line react/no-find-dom-node
-    if (innerRef) innerRef(findDOMNode(this))
+    try {
+      // eslint-disable-next-line react/no-find-dom-node
+      if (innerRef) innerRef(findDOMNode(this))
+      // eslint-disable-next-line no-empty
+    } catch (_) {}
   }
 
   render() {


### PR DESCRIPTION
This is a workaround for the following issue: https://github.com/Semantic-Org/Semantic-UI-React/issues/3255

React 16.6.0 throws an error if `findDOMNode` is called on an unmounted component which is the case in `enzyme`'s `shallow` component testing. 

Please consider this change as a temporary workaround until there's a better way to handle `findDOMNode`. React states that it's an antipattern to use it in `componentDidMount`. 