### PR TITLE
fix(Layouts): fix propTypes error in StickyLayout

### DIFF
--- a/docs/src/layouts/StickyLayout.js
+++ b/docs/src/layouts/StickyLayout.js
@@ -139,7 +139,7 @@ export default class StickyLayout extends Component {
         >
           <Menu
             borderless
-            fixed={menuFixed && 'top'}
+            fixed={menuFixed ? 'top' : undefined}
             style={menuFixed ? fixedMenuStyle : menuStyle}
           >
             <Container text>


### PR DESCRIPTION
since `fixed` is an enum type, sending `false` instead of `undefined` causes a proptypes error:

```
Warning: Failed prop type: Invalid prop `fixed` of value `false` supplied to `Menu`, expected one of ["left","right","bottom","top"].
    in Menu (created by Context.Consumer)
    in HeaderFooter (created by Layout)
    in Query
    in Unknown (created by Route)
    in Route (created by withRouter())
    in withRouter() (created by Layout)
    in Layout (created by App)
    in Router (created by BrowserRouter)
    in BrowserRouter (created by App)
    in ApolloProvider (created by App)
    in App

```