### PR TITLE
 docs(Divider): rework component docs

### DIFF
--- a/docs/src/examples/elements/Divider/Types/DividerExampleHorizontal.js
+++ b/docs/src/examples/elements/Divider/Types/DividerExampleHorizontal.js
@@ -1,15 +1,18 @@
 import React from 'react'
-import { Segment, Button, Divider } from 'semantic-ui-react'
+import { Button, Divider, Input, Segment } from 'semantic-ui-react'
 
 const DividerExampleHorizontal = () => (
-  <Segment padded>
-    <Button primary fluid>
-      Login
-    </Button>
+  <Segment basic textAlign='center'>
+    <Input
+      action={{ color: 'blue', content: 'Search' }}
+      icon='search'
+      iconPosition='left'
+      placeholder='Order #'
+    />
+
     <Divider horizontal>Or</Divider>
-    <Button secondary fluid>
-      Sign Up Now
-    </Button>
+
+    <Button color='teal' content='Create New Order' icon='add' labelPosition='left' />
   </Segment>
 )
 

--- a/docs/src/examples/elements/Divider/Types/DividerExampleHorizontalTable.js
+++ b/docs/src/examples/elements/Divider/Types/DividerExampleHorizontalTable.js
@@ -32,10 +32,10 @@ const DividerExampleHorizontalTable = () => (
           <Table.Cell>Weight</Table.Cell>
           <Table.Cell>6 ounces</Table.Cell>
         </Table.Row>
-        <tr>
+        <Table.Row>
           <Table.Cell>Color</Table.Cell>
           <Table.Cell>Yellowish</Table.Cell>
-        </tr>
+        </Table.Row>
         <Table.Row>
           <Table.Cell>Odor</Table.Cell>
           <Table.Cell>Not Much Usually</Table.Cell>

--- a/docs/src/examples/elements/Divider/Types/DividerExampleHorizontalTable.js
+++ b/docs/src/examples/elements/Divider/Types/DividerExampleHorizontalTable.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { Divider, Header, Icon, Table } from 'semantic-ui-react'
+
+const DividerExampleHorizontalTable = () => (
+  <React.Fragment>
+    <Divider horizontal>
+      <Header as='h4'>
+        <Icon name='tag' />
+        Description
+      </Header>
+    </Divider>
+
+    <p>
+      Doggie treats are good for all times of the year. Proven to be eaten by 99.9% of all dogs
+      worldwide.
+    </p>
+
+    <Divider horizontal>
+      <Header as='h4'>
+        <Icon name='bar chart' />
+        Specifications
+      </Header>
+    </Divider>
+
+    <Table definition>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell width={2}>Size</Table.Cell>
+          <Table.Cell>1" x 2"</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>Weight</Table.Cell>
+          <Table.Cell>6 ounces</Table.Cell>
+        </Table.Row>
+        <tr>
+          <Table.Cell>Color</Table.Cell>
+          <Table.Cell>Yellowish</Table.Cell>
+        </tr>
+        <Table.Row>
+          <Table.Cell>Odor</Table.Cell>
+          <Table.Cell>Not Much Usually</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  </React.Fragment>
+)
+
+export default DividerExampleHorizontalTable

--- a/docs/src/examples/elements/Divider/Types/DividerExampleVertical.js
+++ b/docs/src/examples/elements/Divider/Types/DividerExampleVertical.js
@@ -1,20 +1,41 @@
 import React from 'react'
-import { Grid, Segment, Divider } from 'semantic-ui-react'
+import { Divider, Grid, Image, Segment } from 'semantic-ui-react'
 
 const DividerExampleVertical = () => (
-  <Grid columns={3} relaxed>
-    <Grid.Column>
-      <Segment basic>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio.</Segment>
-    </Grid.Column>
-    <Divider vertical>Or</Divider>
-    <Grid.Column>
-      <Segment basic>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio.</Segment>
-    </Grid.Column>
+  <Segment>
+    <Grid columns={2} relaxed='very'>
+      <Grid.Column>
+        <p>
+          <Image src='/images/wireframe/short-paragraph.png' />
+        </p>
+        <p>
+          <Image src='/images/wireframe/short-paragraph.png' />
+        </p>
+        <p>
+          <Image src='/images/wireframe/short-paragraph.png' />
+        </p>
+        <p>
+          <Image src='/images/wireframe/short-paragraph.png' />
+        </p>
+      </Grid.Column>
+      <Grid.Column>
+        <p>
+          <Image src='/images/wireframe/short-paragraph.png' />
+        </p>
+        <p>
+          <Image src='/images/wireframe/short-paragraph.png' />
+        </p>
+        <p>
+          <Image src='/images/wireframe/short-paragraph.png' />
+        </p>
+        <p>
+          <Image src='/images/wireframe/short-paragraph.png' />
+        </p>
+      </Grid.Column>
+    </Grid>
+
     <Divider vertical>And</Divider>
-    <Grid.Column>
-      <Segment basic>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio.</Segment>
-    </Grid.Column>
-  </Grid>
+  </Segment>
 )
 
 export default DividerExampleVertical

--- a/docs/src/examples/elements/Divider/Types/DividerExampleVerticalForm.js
+++ b/docs/src/examples/elements/Divider/Types/DividerExampleVerticalForm.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Button, Divider, Form, Grid, Segment } from 'semantic-ui-react'
+
+const DividerExampleVerticalForm = () => (
+  <Segment placeholder>
+    <Grid columns={2} relaxed='very' stackable>
+      <Grid.Column>
+        <Form>
+          <Form.Input icon='user' iconPosition='left' label='Username' placeholder='Username' />
+          <Form.Input icon='lock' iconPosition='left' label='Password' type='password' />
+
+          <Button content='Login' primary />
+        </Form>
+      </Grid.Column>
+
+      <Grid.Column verticalAlign='middle'>
+        <Button content='Sign up' icon='signup' size='big' />
+      </Grid.Column>
+    </Grid>
+
+    <Divider vertical>Or</Divider>
+  </Segment>
+)
+
+export default DividerExampleVerticalForm

--- a/docs/src/examples/elements/Divider/Types/index.js
+++ b/docs/src/examples/elements/Divider/Types/index.js
@@ -1,4 +1,7 @@
 import React from 'react'
+import { Link } from 'react-static'
+import { Message } from 'semantic-ui-react'
+
 import ComponentExample from 'docs/src/components/ComponentDoc/ComponentExample'
 import ExampleSection from 'docs/src/components/ComponentDoc/ExampleSection'
 
@@ -8,17 +11,60 @@ const DividerTypesExamples = () => (
       title='Divider'
       description='A standard divider.'
       examplePath='elements/Divider/Types/DividerExampleDivider'
-    />
+    >
+      <Message info>
+        To add a divider between parts of a grid use a{' '}
+        <Link to='/collections/grid/#types-divided-number'>
+          divided <code>Grid</code>
+        </Link>{' '}
+        variation.
+      </Message>
+    </ComponentExample>
+
     <ComponentExample
       title='Vertical Divider'
       description='A divider can segment content vertically.'
       examplePath='elements/Divider/Types/DividerExampleVertical'
-    />
+    >
+      <Message>
+        Vertical dividers requires <code>position: relative</code> on the element that you would
+        like to contain the divider.
+      </Message>
+      <Message warning>
+        Due to a change in W3C implementation of{' '}
+        <a
+          href='https://github.com/w3c/csswg-drafts/issues/401'
+          rel='noopener noreferrer'
+          target='_blank'
+        >
+          absolutely positioned elements in flex containers
+        </a>{' '}
+        vertical dividers now currently only support 50/50 splits automatically, and only if not
+        positioned <b>as direct children of flex containers</b> (like grid).
+      </Message>
+    </ComponentExample>
+    <ComponentExample examplePath='elements/Divider/Types/DividerExampleVerticalForm'>
+      <Message info>
+        A vertical divider will automatically swap to a horizontal divider at mobile resolutions
+        when used inside a <code>stackable Grid</code>.
+      </Message>
+    </ComponentExample>
+
     <ComponentExample
       title='Horizontal Divider'
       description='A divider can segement content horizontally.'
       examplePath='elements/Divider/Types/DividerExampleHorizontal'
-    />
+    >
+      <Message>
+        Horizontal dividers can also be used in combination with headers and icons to create
+        different styles of dividers.
+      </Message>
+      <Message info>
+        Dividers will automatically vary the size of their dividing rules to match the length of
+        your text.
+      </Message>
+    </ComponentExample>
+    <ComponentExample examplePath='elements/Divider/Types/DividerExampleHorizontalTable' />
   </ExampleSection>
 )
 

--- a/docs/src/examples/elements/Divider/Variations/DividerExampleClearing.js
+++ b/docs/src/examples/elements/Divider/Variations/DividerExampleClearing.js
@@ -1,12 +1,14 @@
 import React from 'react'
-import { Segment, Button, Divider } from 'semantic-ui-react'
+import { Divider, Header, Image, Segment } from 'semantic-ui-react'
 
 const DividerExampleClearing = () => (
   <Segment>
-    <Button floated='right'>Floated Button</Button>
+    <Header as='h2' floated='right'>
+      Floated Content
+    </Header>
+
     <Divider clearing />
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore...
+    <Image src='/images/wireframe/short-paragraph.png' />
   </Segment>
 )
 

--- a/docs/src/examples/elements/Divider/Variations/DividerExampleFitted.js
+++ b/docs/src/examples/elements/Divider/Variations/DividerExampleFitted.js
@@ -3,11 +3,13 @@ import { Divider, Segment } from 'semantic-ui-react'
 
 const DividerExampleFitted = () => (
   <Segment>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore...
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis
+    eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit,
+    posuere a, pede.
     <Divider fitted />
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore...
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis
+    eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit,
+    posuere a, pede.
   </Segment>
 )
 

--- a/docs/src/examples/elements/Divider/Variations/DividerExampleHidden.js
+++ b/docs/src/examples/elements/Divider/Variations/DividerExampleHidden.js
@@ -1,14 +1,16 @@
 import React from 'react'
-import { Divider, Segment } from 'semantic-ui-react'
+import { Divider, Header, Image } from 'semantic-ui-react'
 
 const DividerExampleHidden = () => (
-  <Segment>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore...
+  <React.Fragment>
+    <Header as='h3'>Section One</Header>
+    <Image src='/images/wireframe/short-paragraph.png' />
+
     <Divider hidden />
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore...
-  </Segment>
+
+    <Header as='h3'>Section Two</Header>
+    <Image src='/images/wireframe/short-paragraph.png' />
+  </React.Fragment>
 )
 
 export default DividerExampleHidden

--- a/docs/src/examples/elements/Divider/Variations/DividerExampleInverted.js
+++ b/docs/src/examples/elements/Divider/Variations/DividerExampleInverted.js
@@ -1,9 +1,12 @@
 import React from 'react'
-import { Divider, Segment } from 'semantic-ui-react'
+import { Divider, Image, Segment } from 'semantic-ui-react'
 
 const DividerExampleInverted = () => (
   <Segment inverted>
+    <Image src='/images/wireframe/short-paragraph.png' />
     <Divider inverted />
+
+    <Image src='/images/wireframe/short-paragraph.png' />
     <Divider horizontal inverted>
       Horizontal
     </Divider>

--- a/docs/src/examples/elements/Divider/Variations/DividerExampleSection.js
+++ b/docs/src/examples/elements/Divider/Variations/DividerExampleSection.js
@@ -1,13 +1,15 @@
 import React from 'react'
-import { Divider, Segment } from 'semantic-ui-react'
+import { Divider, Header, Image, Segment } from 'semantic-ui-react'
 
 const DividerExampleSection = () => (
   <Segment>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore...
+    <Header as='h3'>Section One</Header>
+    <Image src='/images/wireframe/short-paragraph.png' />
+
     <Divider section />
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore...
+
+    <Header as='h3'>Section Two</Header>
+    <Image src='/images/wireframe/short-paragraph.png' />
   </Segment>
 )
 


### PR DESCRIPTION
This PR syncs the `Divider`'s docs with SUI:
- updates many examples to make them more friendly
- fixes issues with `vertical`
- adds new examples

## Vertical

#### Before

![image](https://user-images.githubusercontent.com/14183168/48299136-575fe400-e4d1-11e8-9b3b-ffbca7ccc3ed.png)

#### After

![image](https://user-images.githubusercontent.com/14183168/48299140-60e94c00-e4d1-11e8-9da7-63e221007da4.png)

## Section

#### Before

![image](https://user-images.githubusercontent.com/14183168/48299149-968e3500-e4d1-11e8-9df8-2cc3cb39dc4a.png)

#### After

![image](https://user-images.githubusercontent.com/14183168/48299151-a0179d00-e4d1-11e8-8294-60f330cd558d.png)

## Clearing

#### Before

![image](https://user-images.githubusercontent.com/14183168/48299144-72325880-e4d1-11e8-954b-e813f97e5921.png)

#### After

![image](https://user-images.githubusercontent.com/14183168/48299145-7f4f4780-e4d1-11e8-9f58-000f6cba3a84.png)
