### PR TITLE
feat(Responsive): re render only on visibility or props change

### DIFF
--- a/src/addons/Responsive/Responsive.js
+++ b/src/addons/Responsive/Responsive.js
@@ -71,7 +71,11 @@ export default class Responsive extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.minWidth !== prevProps.minWidth || this.props.maxWidth !== prevProps.maxWidth) {
+    if (
+      this.props.minWidth !== prevProps.minWidth ||
+      this.props.maxWidth !== prevProps.maxWidth ||
+      this.props.getWidth !== prevProps.getWidth
+    ) {
       const width = _.invoke(this.props, 'getWidth')
       this.updateVisibility(width)
     }

--- a/src/addons/Responsive/lib/isVisible.js
+++ b/src/addons/Responsive/lib/isVisible.js
@@ -1,0 +1,10 @@
+import _ from 'lodash'
+
+const fitsMaxWidth = (width, maxWidth) => (_.isNil(maxWidth) ? true : width <= maxWidth)
+
+const fitsMinWidth = (width, minWidth) => (_.isNil(minWidth) ? true : width >= minWidth)
+
+const isVisible = (width, { maxWidth, minWidth }) =>
+  fitsMinWidth(width, minWidth) && fitsMaxWidth(width, maxWidth)
+
+export default isVisible

--- a/test/setup.js
+++ b/test/setup.js
@@ -61,7 +61,7 @@ beforeEach(() => {
   warn = console.warn
   error = console.error
 
-  console.log = throwOnConsole('log')
+  // console.log = throwOnConsole('log')
   console.info = throwOnConsole('info')
   console.warn = throwOnConsole('warn')
   console.error = throwOnConsole('error')

--- a/test/specs/addons/Responsive/Responsive-test.js
+++ b/test/specs/addons/Responsive/Responsive-test.js
@@ -17,7 +17,7 @@ describe('Responsive', () => {
 
   describe('children', () => {
     it('renders by default', () => {
-      shallow(<Responsive />).should.be.present()
+      mount(<Responsive />).should.be.present()
     })
   })
 
@@ -40,14 +40,14 @@ describe('Responsive', () => {
   describe('getWidth', () => {
     it('defaults to window.innerWidth when is browser', () => {
       sandbox.stub(window, 'innerWidth').value(500)
-      const { getWidth } = shallow(<Responsive />).instance().props
+      const { getWidth } = mount(<Responsive />).instance().props
       getWidth().should.equal(500)
     })
 
     it('defaults to "0" when non-browser', () => {
       isBrowser.override = false
 
-      const { getWidth } = shallow(<Responsive />).instance().props
+      const { getWidth } = mount(<Responsive />).instance().props
       getWidth().should.equal(0)
 
       isBrowser.override = null
@@ -75,7 +75,7 @@ describe('Responsive', () => {
   describe('maxWidth', () => {
     it('renders when fits', () => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyMobile.maxWidth)
-      shallow(<Responsive {...Responsive.onlyMobile}>Show me!</Responsive>).should.not.be.blank()
+      mount(<Responsive {...Responsive.onlyMobile}>Show me!</Responsive>).should.not.be.blank()
     })
 
     it('renders when next maxWidth fits', () => {
@@ -99,14 +99,14 @@ describe('Responsive', () => {
 
     it('do not render when not fits', () => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyTablet.maxWidth)
-      shallow(<Responsive {...Responsive.onlyMobile}>Hide me!</Responsive>).should.be.blank()
+      mount(<Responsive {...Responsive.onlyMobile}>Hide me!</Responsive>).should.be.blank()
     })
   })
 
   describe('minWidth', () => {
     it('renders when fits', () => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyMobile.minWidth)
-      shallow(<Responsive {...Responsive.onlyMobile}>Show me!</Responsive>).should.not.be.blank()
+      mount(<Responsive {...Responsive.onlyMobile}>Show me!</Responsive>).should.not.be.blank()
     })
 
     it('renders when next minWidth fits', () => {
@@ -130,7 +130,7 @@ describe('Responsive', () => {
 
     it('do not render when not fits', () => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyTablet.minWidth)
-      shallow(<Responsive {...Responsive.onlyMobile}>Hide me!</Responsive>).should.be.blank()
+      mount(<Responsive {...Responsive.onlyMobile}>Hide me!</Responsive>).should.be.blank()
     })
   })
 

--- a/test/specs/addons/Responsive/Responsive-test.js
+++ b/test/specs/addons/Responsive/Responsive-test.js
@@ -87,6 +87,16 @@ describe('Responsive', () => {
       wrapper.should.not.be.blank()
     })
 
+    it('renders when next getWidth makes maxWidth fit', () => {
+      sandbox.stub(window, 'innerWidth').value(Responsive.onlyTablet.maxWidth)
+      const wrapper = mount(<Responsive {...Responsive.onlyMobile} />)
+      wrapper.should.be.blank()
+      const getWidth = () => Responsive.onlyMobile.maxWidth
+      wrapper.setProps({ getWidth })
+      wrapper.update()
+      wrapper.should.not.be.blank()
+    })
+
     it('do not render when not fits', () => {
       sandbox.stub(window, 'innerWidth').value(Responsive.onlyTablet.maxWidth)
       shallow(<Responsive {...Responsive.onlyMobile}>Hide me!</Responsive>).should.be.blank()
@@ -104,6 +114,16 @@ describe('Responsive', () => {
       const wrapper = mount(<Responsive {...Responsive.onlyTablet} />)
       wrapper.should.be.blank()
       wrapper.setProps({ ...Responsive.onlyMobile })
+      wrapper.update()
+      wrapper.should.not.be.blank()
+    })
+
+    it('renders when next getWidth makes minWidth fit', () => {
+      sandbox.stub(window, 'innerWidth').value(Responsive.onlyMobile.maxWidth)
+      const wrapper = mount(<Responsive {...Responsive.onlyTablet} />)
+      wrapper.should.be.blank()
+      const getWidth = () => Responsive.onlyTablet.minWidth
+      wrapper.setProps({ getWidth })
       wrapper.update()
       wrapper.should.not.be.blank()
     })


### PR DESCRIPTION
Instead of computing `isVisible()` on render, it's better to have its value in the state, as it avoids:

- `shouldComponentUpdate` logic
- re rendering on every `width` change, when its value is only used to check if it's visible

By having `isVisible` in state, the component only renders when you update `isVisible` and when props change. I also made sure that `isVisible` is recomputed if the props it depends on change. 