### PR TITLE
Stronger typings for Dropdown and Select components

### DIFF
--- a/src/addons/Select/Select.d.ts
+++ b/src/addons/Select/Select.d.ts
@@ -6,13 +6,13 @@ import DropdownHeader from '../../modules/Dropdown/DropdownHeader'
 import DropdownItem, { DropdownItemProps } from '../../modules/Dropdown/DropdownItem'
 import DropdownMenu from '../../modules/Dropdown/DropdownMenu'
 
-export interface SelectProps extends StrictSelectProps {
+export interface SelectProps<T = any> extends StrictSelectProps<T> {
   [key: string]: any
 }
 
-export interface StrictSelectProps extends StrictDropdownProps {
+export interface StrictSelectProps<T> extends StrictDropdownProps<T> {
   /** Array of Dropdown.Item props e.g. `{ text: '', value: '' }` */
-  options: DropdownItemProps[]
+  options: DropdownItemProps<T>[]
 }
 
 interface SelectComponent extends React.StatelessComponent<SelectProps> {

--- a/src/collections/Form/FormDropdown.d.ts
+++ b/src/collections/Form/FormDropdown.d.ts
@@ -3,11 +3,11 @@ import * as React from 'react'
 import { StrictDropdownProps } from '../../modules/Dropdown'
 import { StrictFormFieldProps } from './FormField'
 
-export interface FormDropdownProps extends StrictFormDropdownProps {
+export interface FormDropdownProps<T = any> extends StrictFormDropdownProps<T> {
   [key: string]: any
 }
 
-export interface StrictFormDropdownProps extends StrictFormFieldProps, StrictDropdownProps {
+export interface StrictFormDropdownProps<T> extends StrictFormFieldProps, StrictDropdownProps<T> {
   /** An element type to render as (string or function). */
   as?: any
 

--- a/src/collections/Form/FormSelect.d.ts
+++ b/src/collections/Form/FormSelect.d.ts
@@ -4,11 +4,11 @@ import { StrictSelectProps } from '../../addons/Select'
 import { DropdownItemProps } from '../../modules/Dropdown/DropdownItem'
 import { StrictFormFieldProps } from './FormField'
 
-export interface FormSelectProps extends StrictFormSelectProps {
+export interface FormSelectProps<T = any> extends StrictFormSelectProps<T> {
   [key: string]: any
 }
 
-export interface StrictFormSelectProps extends StrictFormFieldProps, StrictSelectProps {
+export interface StrictFormSelectProps<T> extends StrictFormFieldProps, StrictSelectProps<T> {
   /** An element type to render as (string or function). */
   as?: any
 
@@ -16,7 +16,7 @@ export interface StrictFormSelectProps extends StrictFormFieldProps, StrictSelec
   control?: any
 
   /** Array of Dropdown.Item props e.g. `{ text: '', value: '' }` */
-  options: DropdownItemProps[]
+  options: DropdownItemProps<T>[]
 }
 
 declare const FormSelect: React.StatelessComponent<FormSelectProps>

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -7,7 +7,7 @@ import { default as DropdownItem, DropdownItemProps } from './DropdownItem'
 import DropdownMenu from './DropdownMenu'
 import DropdownSearchInput from './DropdownSearchInput'
 
-export interface DropdownProps<T = {}> extends StrictDropdownProps<T> {
+export interface DropdownProps<T = any> extends StrictDropdownProps<T> {
   [key: string]: any
 }
 

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -7,11 +7,11 @@ import { default as DropdownItem, DropdownItemProps } from './DropdownItem'
 import DropdownMenu from './DropdownMenu'
 import DropdownSearchInput from './DropdownSearchInput'
 
-export interface DropdownProps extends StrictDropdownProps {
+export interface DropdownProps<T = {}> extends StrictDropdownProps<T> {
   [key: string]: any
 }
 
-export interface StrictDropdownProps {
+export interface StrictDropdownProps<T> {
   /** An element type to render as (string or function). */
   as?: any
 
@@ -208,7 +208,7 @@ export interface StrictDropdownProps {
   openOnFocus?: boolean
 
   /** Array of Dropdown.Item props e.g. `{ text: '', value: '' }` */
-  options?: DropdownItemProps[]
+  options?: DropdownItemProps<T>[]
 
   /** Placeholder text. */
   placeholder?: string

--- a/src/modules/Dropdown/DropdownItem.d.ts
+++ b/src/modules/Dropdown/DropdownItem.d.ts
@@ -6,9 +6,7 @@ import { IconProps } from '../../elements/Icon'
 import { ImageProps } from '../../elements/Image'
 import { LabelProps } from '../../elements/Label'
 
-export interface DropdownItemProps extends StrictDropdownItemProps {
-  [key: string]: any
-}
+export type DropdownItemProps<T = any> = { [K in keyof T]: T[K] } & StrictDropdownItemProps
 
 export interface StrictDropdownItemProps {
   /** An element type to render as (string or function). */


### PR DESCRIPTION
As requested and then suggested by @levithomason in #3001, it would be nice to have improvements to typings. I've chosen not to bring [JSX generics](http://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#generic-type-arguments-in-jsx-elements) at first. We can discuss if that's necessary as part of this story.

So, there are two main improvements to `Dropdown` (and consequently `Select`) typings, mainly related to callbacks, which is where we actually access the data.

First is in `Dropdown.Item`. The callback's data argument is a generic type that can receive one argument with the shape of your data:
![dropdownitem](https://user-images.githubusercontent.com/15076656/48861798-2afb7000-edcd-11e8-9bd8-5bbee6b690d0.gif)
Edit: the prop `legs={4}` appears as `number`, but that's inferred and doesn't come from the generic type passed to the props.

Second is to `Dropdown` itself (also extended to `FormDropdown`, `Select` and `FormSelect`). Callback's data is also a generic type that can receive one argument that will be passed all the way down to `options`:
![shorthanddropdown](https://user-images.githubusercontent.com/15076656/48861896-64cc7680-edcd-11e8-8acd-f69f37468d8a.gif)

There's a gotcha with the tests, though, that's why three are failing. `hasValidTypings` checks only for `interfaces`, but the mapped type in `DropdownItemProps` is in fact a `type` (apparently it can't be an `interface` otherwise it can't extend `StrictDropdownItemProps`).

But I decided to open the PR anyway to first get feedback before deciding what to do about the use of `type` and the tests.

Cheers!
(fixes #3001)