### PR TITLE
fix(Popup): remove logic with setSafeState()

### DIFF
--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -148,10 +148,6 @@ export default class Popup extends Component {
 
   state = {}
 
-  componentDidMount() {
-    this.mounted = true
-  }
-
   componentDidUpdate(prevProps) {
     // if horizontal/vertical offsets change, re-calculate the CSS style
     const { horizontalOffset, verticalOffset } = this.props
@@ -164,7 +160,7 @@ export default class Popup extends Component {
   }
 
   componentWillUnmount() {
-    this.mounted = false
+    clearTimeout(this.timeoutId)
   }
 
   computePopupStyle(positions) {
@@ -319,8 +315,8 @@ export default class Popup extends Component {
     this.setState({ closed: true })
 
     eventStack.unsub('scroll', this.hideOnScroll, { target: window })
-    setTimeout(() => {
-      if (this.mounted) this.setState({ closed: false })
+    this.timeoutId = setTimeout(() => {
+      this.setState({ closed: false })
     }, 50)
 
     this.handleClose(e)


### PR DESCRIPTION
This PR removes useless logic with `setSafeState()`, we just need to clear properly intervales and frames.