### PR TITLE
fix(Rating): conditionally set tabIndex when element is disabled

### DIFF
--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -126,6 +126,7 @@ export default class Rating extends Component {
       >
         {_.times(maxRating, i => (
           <RatingIcon
+            tabIndex={disabled ? -1 : 0}
             active={rating >= i + 1}
             aria-checked={rating === i + 1}
             aria-posinset={i + 1}

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -123,6 +123,7 @@ export default class Rating extends Component {
         className={classes}
         role='radiogroup'
         onMouseLeave={this.handleMouseLeave}
+        tabIndex={disabled ? 0 : -1}
       >
         {_.times(maxRating, i => (
           <RatingIcon

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -94,7 +94,6 @@ export default class RatingIcon extends Component {
         onClick={this.handleClick}
         onKeyUp={this.handleKeyUp}
         onMouseEnter={this.handleMouseEnter}
-        tabIndex={0}
         role='radio'
       />
     )

--- a/test/specs/modules/Rating/Rating-test.js
+++ b/test/specs/modules/Rating/Rating-test.js
@@ -32,8 +32,7 @@ describe('Rating', () => {
     })
 
     it('if no rating selected no icon should have aria-checked', () => {
-      const icons = mount(<Rating maxRating={3} />)
-        .find('RatingIcon')
+      const icons = mount(<Rating maxRating={3} />).find('RatingIcon')
 
       icons.at(0).should.have.prop('aria-checked', false)
       icons.at(1).should.have.prop('aria-checked', false)
@@ -93,8 +92,7 @@ describe('Rating', () => {
         .last()
         .simulate('mouseEnter')
         .simulate('click')
-      wrapper
-        .should.not.have.className('selected')
+      wrapper.should.not.have.className('selected')
       wrapper
         .find('RatingIcon[selected=true]')
         .should.have.length(0, 'Some RatingIcons did not remove their "selected" prop')
@@ -109,8 +107,7 @@ describe('Rating', () => {
         .find('RatingIcon')
         .first()
         .simulate('mouseEnter')
-      wrapper
-        .should.have.className('selected')
+      wrapper.should.have.className('selected')
     })
 
     it('selects icons up to and including the hovered icon', () => {
@@ -299,7 +296,8 @@ describe('Rating', () => {
       _.times(10, (i) => {
         const maxRating = i + 1
         shallow(<Rating maxRating={maxRating} />)
-          .should.have.exactly(maxRating).descendants('RatingIcon')
+          .should.have.exactly(maxRating)
+          .descendants('RatingIcon')
       })
     })
   })
@@ -329,6 +327,24 @@ describe('Rating', () => {
           .find('RatingIcon[active=true]')
           .should.have.length(rating, `Rating should have ${rating} RatingIcon with "active" prop`)
       })
+    })
+  })
+
+  describe('tabIndex', () => {
+    it('sets icons tabIndex to -1 to prevent focus when element is disabled', () => {
+      shallow(<Rating maxRating={3} />)
+        .find('RatingIcon')
+        .forEach(node => node.should.have.prop('tabIndex', 0))
+
+      shallow(<Rating disabled maxRating={3} />)
+        .find('RatingIcon')
+        .forEach(node => node.should.have.prop('tabIndex', -1))
+    })
+
+    it('sets Rating element tabIndex to 0 to allow focusing the whole group when disabled', () => {
+      shallow(<Rating maxRating={3} />).should.have.prop('tabIndex', -1)
+
+      shallow(<Rating disabled maxRating={3} />).should.have.prop('tabIndex', 0)
     })
   })
 })


### PR DESCRIPTION
As raised in #3252, RatingIcons can be individually focused when navigating with Tab, which doesn't make sense as users cannot select disabled elements anyway.

However, thinking a bit further, still makes sense to be able to focus the whole element so it can still be accessible (i.e.: users with vision impairment can still be aware of its existence).

So the solution was to set `RatingIcon` `tabIndex = -1` ([reference](https://www.w3.org/TR/html5/editing.html#the-tabindex-attribute)) and at the same time keeping `tabIndex = 0` in the `Rating` component, when the whole element is in `disabled` state.

The demo:
![rating-element](https://user-images.githubusercontent.com/15076656/49037761-c6248900-f1c3-11e8-9240-3c3b80c653ca.gif)

Also added test cases.

PS.: I just noticed that some lines in the test file where unintentionally reformatted, I guess we have new lint/prettier rules?

(closes #3252)