### PR TITLE
fix(ComponentExample): fix crash on show HTML

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/prettierrc",
+  "jsxSingleQuote": true,
   "printWidth": 100,
   "tabWidth": 2,
   "semi": false,

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleRenderHtml.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleRenderHtml.js
@@ -24,7 +24,7 @@ export default class ComponentExampleRenderHtml extends PureComponent {
     const { editorId, value } = this.props
 
     // remove new line at eof after formatting for a tighter fit
-    const formattedCode = formatCode(value).replace(/\s+$/, '')
+    const formattedCode = formatCode(value, 'html').replace(/\s+$/, '')
 
     return (
       <div style={rootStyle}>

--- a/docs/src/components/Document.js
+++ b/docs/src/components/Document.js
@@ -40,6 +40,10 @@ const Document = ({ Body, children, Head, Html, siteData: { dev, versions } }) =
         src={`https://unpkg.com/prettier@${versions.prettier}/parser-babylon.js`}
       />
       <script
+        crossOrigin='true'
+        src={`https://unpkg.com/prettier@${versions.prettier}/parser-html.js`}
+      />
+      <script
         src={`https://cdnjs.cloudflare.com/ajax/libs/prop-types/${versions.propTypes}/prop-types${
           siteData.dev ? '' : '.min'
         }.js`}

--- a/docs/src/utils/formatCode.js
+++ b/docs/src/utils/formatCode.js
@@ -8,18 +8,16 @@ delete prettierConfig.overrides
 // Please use this function directly and don't reexport it in utils.
 // https://github.com/prettier/prettier/issues/4959
 
-const formatCode = (code) => {
+const formatCode = (code, parser = 'babylon') => {
   if (!code) return ''
 
   const formatted = prettier.format(code, {
     ...prettierConfig,
-    parser: 'babylon',
+    parser,
     plugins: window.prettierPlugins,
   })
 
-  return formatted
-    .replace(/^;</, '<') // remove beginning comma in JSX/HTML
-    .replace(/="([\s\S]*?)?"/gm, "='$1'") // single quote JSX
+  return formatted.replace(/^;</, '<') // remove beginning comma in JSX/HTML
 }
 
 export default formatCode

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
       "eslint --fix",
       "git add"
     ],
+    "**/*.mdx": [
+      "prettier --parser mdx --write",
+      "git add"
+    ],
     "**/*.{ts,tsx}": [
       "prettier --write",
       "tslint --fix",
@@ -133,7 +137,7 @@
     "leven": "^2.1.0",
     "lint-staged": "^7.2.2",
     "mocha": "^5.2.0",
-    "prettier": "^1.14.2",
+    "prettier": "^1.15.3",
     "puppeteer": "^1.7.0",
     "raw-loader": "^0.5.1",
     "react": "^16.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10366,10 +10366,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.14.2:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
-  integrity sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==
+prettier@^1.15.3:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
+  integrity sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==
 
 pretty-error@^2.0.2, pretty-error@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Fixes #3283.

This PR:
- updates Prettier
- fixes HTML preview via adding new parser for Prettier
- adds prettier config for `.mdx` files
- adds `jsxSingleQuote` for Prettier
