### PR TITLE
fix(Dropdown): clear searchQuery on item selection by mouse click

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import keyboardKey from 'keyboard-key'
-import _ from 'lodash'
+import _ from 'lodash' 
 import PropTypes from 'prop-types'
 import React, { Children, cloneElement } from 'react'
 import shallowEqual from 'shallowequal'

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -729,8 +729,7 @@ export default class Dropdown extends Component {
     this.setValue(newValue)
     this.setSelectedIndex(value)
 
-    const optionSize = _.size(this.getMenuOptions())
-    if (!multiple || isAdditionItem || optionSize === 1) this.clearSearchQuery()
+    this.clearSearchQuery()
 
     this.handleChange(e, newValue)
     this.closeOnChange(e)

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import keyboardKey from 'keyboard-key'
-import _ from 'lodash' 
+import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { Children, cloneElement } from 'react'
 import shallowEqual from 'shallowequal'


### PR DESCRIPTION
 - Remove check to have consistent behavior with `selectItemOnEnter`

Fixes #3306.