### PR TITLE
feat(Button) : Add aria-pressed attribute for toggle button

### DIFF
--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -268,6 +268,7 @@ class Button extends Component {
           {labelPosition === 'left' && labelElement}
           <button
             className={buttonClasses}
+            aria-pressed={toggle ? (!!active) : undefined}
             disabled={disabled}
             ref={this.handleRef}
             tabIndex={tabIndex}
@@ -287,6 +288,7 @@ class Button extends Component {
       <ElementType
         {...rest}
         className={classes}
+        aria-pressed={toggle ? (!!active) : undefined}
         disabled={(disabled && ElementType === 'button') || undefined}
         onClick={this.handleClick}
         ref={this.handleRef}

--- a/test/specs/elements/Button/Button-test.js
+++ b/test/specs/elements/Button/Button-test.js
@@ -113,6 +113,24 @@ describe('Button', () => {
     })
   })
 
+  describe('toggle', () => {
+    it('is not set by default', () => {
+      shallow(<Button />).should.not.have.prop('toggle')
+    })
+
+    it('should have aria-pressed', () => {
+      shallow(<Button toggle />).should.have.prop('aria-pressed')
+    })
+
+    it('aria-pressed should be true when active', () => {
+      shallow(<Button toggle active />).should.have.prop('aria-pressed', true)
+    })
+
+    it('aria-pressed should be false when inactive', () => {
+      shallow(<Button toggle />).should.have.prop('aria-pressed', false)
+    })
+  })
+
   describe('icon', () => {
     it('adds className icon', () => {
       shallow(<Button icon='user' />).should.have.className('icon')


### PR DESCRIPTION
This adds the `aria-pressed` attribute for toggle button. #3329 

The value of `active` prop determines the value of `aria-pressed` when `toggle` is set. Otherwise `aria-pressed` is left undefined.

A few test cases have been added to verify functionality.