### PR TITLE
Add support for data-testid attribute to Input

### DIFF
--- a/src/lib/htmlPropsUtils.js
+++ b/src/lib/htmlPropsUtils.js
@@ -78,7 +78,9 @@ export const htmlInputEvents = [
   'onTouchStart',
 ]
 
-export const htmlInputProps = [...htmlInputAttrs, ...htmlInputEvents]
+export const testAttributes = ['data-testid']
+
+export const htmlInputProps = [...htmlInputAttrs, ...htmlInputEvents, ...testAttributes]
 
 export const htmlImageProps = ['alt', 'height', 'src', 'srcSet', 'width']
 


### PR DESCRIPTION
We rely on `data-testid` attributes for our automated e2e and integration tests. We can't set the attribute value to the correct `input` element since setting that as a prop on an `Input` will set the attribute value on the wrapping `div` instead of the child `input`.

I've browsed the codebase and I've also come across this issue:
https://github.com/Semantic-Org/Semantic-UI-React/issues/2979

Not sure if this is the best way to solve it, so please comment if there's anything you want me to change. Thanks!