### PR TITLE
BREAKING (Sidebar): remove `duration` prop

### DIFF
--- a/src/modules/Sidebar/Sidebar.d.ts
+++ b/src/modules/Sidebar/Sidebar.d.ts
@@ -27,9 +27,6 @@ export interface StrictSidebarProps {
   /** Direction the sidebar should appear on. */
   direction?: 'top' | 'right' | 'bottom' | 'left'
 
-  /** Duration of sidebar animation. */
-  duration?: number | string
-
   /**
    * Called before a sidebar begins to animate out.
    *

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -117,7 +117,7 @@ class Sidebar extends Component {
 
     this.setState({ animating: true }, () => {
       clearTimeout(this.animationTimer)
-      this.animationTimer = setTimeout(this.handleAnimationEnd, this.animationDuration)
+      this.animationTimer = setTimeout(this.handleAnimationEnd, Sidebar.animationDuration)
 
       if (this.skipNextCallback) {
         this.skipNextCallback = false

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -46,9 +46,6 @@ class Sidebar extends Component {
     /** Direction the sidebar should appear on. */
     direction: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
-    /** Duration of sidebar animation. */
-    duration: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-
     /**
      * Called before a sidebar begins to animate out.
      *
@@ -93,9 +90,9 @@ class Sidebar extends Component {
 
   static defaultProps = {
     direction: 'left',
-    duration: 500,
   }
 
+  static animationDuration = 500
   static autoControlledProps = ['visible']
 
   static Pushable = SidebarPushable
@@ -115,12 +112,12 @@ class Sidebar extends Component {
   }
 
   handleAnimationStart = () => {
-    const { duration, visible } = this.props
+    const { visible } = this.props
     const callback = visible ? 'onVisible' : 'onHide'
 
     this.setState({ animating: true }, () => {
       clearTimeout(this.animationTimer)
-      this.animationTimer = setTimeout(this.handleAnimationEnd, duration)
+      this.animationTimer = setTimeout(this.handleAnimationEnd, this.animationDuration)
 
       if (this.skipNextCallback) {
         this.skipNextCallback = false

--- a/test/specs/modules/Sidebar/Sidebar-test.js
+++ b/test/specs/modules/Sidebar/Sidebar-test.js
@@ -88,6 +88,7 @@ describe('Sidebar', () => {
 
   describe('onHidden', () => {
     it('is called when the "visible" prop was changed to "false"', (done) => {
+      Sidebar.animationDuration = 0
       const onHidden = sandbox.spy()
       const wrapper = mount(<Sidebar onHidden={onHidden} visible />)
 
@@ -105,6 +106,7 @@ describe('Sidebar', () => {
 
   describe('onShow', () => {
     it('is called when the "visible" prop was changed to "true"', (done) => {
+      Sidebar.animationDuration = 0
       const onShow = sandbox.spy()
       const wrapper = mount(<Sidebar onShow={onShow} />)
 

--- a/test/specs/modules/Sidebar/Sidebar-test.js
+++ b/test/specs/modules/Sidebar/Sidebar-test.js
@@ -89,14 +89,14 @@ describe('Sidebar', () => {
   describe('onHidden', () => {
     it('is called when the "visible" prop was changed to "false"', (done) => {
       const onHidden = sandbox.spy()
-      const wrapper = mount(<Sidebar duration={0} onHidden={onHidden} visible />)
+      const wrapper = mount(<Sidebar onHidden={onHidden} visible />)
 
       onHidden.should.have.not.been.called()
       wrapper.setProps({ visible: false })
 
       setTimeout(() => {
         onHidden.should.have.been.calledOnce()
-        onHidden.should.have.been.calledWithMatch(null, { duration: 0, visible: false })
+        onHidden.should.have.been.calledWithMatch(null, { visible: false })
 
         done()
       }, 0)
@@ -106,14 +106,14 @@ describe('Sidebar', () => {
   describe('onShow', () => {
     it('is called when the "visible" prop was changed to "true"', (done) => {
       const onShow = sandbox.spy()
-      const wrapper = mount(<Sidebar duration={0} onShow={onShow} />)
+      const wrapper = mount(<Sidebar onShow={onShow} />)
 
       onShow.should.have.not.been.called()
       wrapper.setProps({ visible: true })
 
       setTimeout(() => {
         onShow.should.have.been.calledOnce()
-        onShow.should.have.been.calledWithMatch(null, { duration: 0, visible: true })
+        onShow.should.have.been.calledWithMatch(null, { visible: true })
 
         done()
       }, 0)


### PR DESCRIPTION
`duration` prop has been removed from the `Sidebar` component. However I've maintained a static variable in the `Sidebar` class to still provide the default duration of 500 ms that is used to manage the callback cycle when showing and hiding the sidebar.

@layershifter, as `animationDuration` is now a static prop it can actually be assigned externally (like I've done in the modified tests for this PR). If that's ok, should we add that to the type definitions? It could be done as easily as modifying the `Sidebar` type declaration in the end of `Sidebar.d.ts` to something like:

```ts
declare const Sidebar: SidebarComponent & { animationDuration: number }
```
Cheers!
(Closes #3328)