### PR TITLE
fix(Textarea): fix broken ctrl-z on firefox

### DIFF
--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -89,9 +89,9 @@ class TextArea extends Component {
     const { minHeight, borderBottomWidth, borderTopWidth } = window.getComputedStyle(this.ref)
 
     const borderHeight = _.sum([borderBottomWidth, borderTopWidth].map(x => parseFloat(x)))
+    const scrollHeight = this.ref.scrollHeight
 
     // Measure the scrollHeight and update the height to match.
-    const scrollHeight = this.ref.scrollHeight
     this.ref.style.height = 'auto'
     this.ref.style.overflowY = 'hidden'
     this.ref.style.height = `${Math.max(

--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -91,11 +91,12 @@ class TextArea extends Component {
     const borderHeight = _.sum([borderBottomWidth, borderTopWidth].map(x => parseFloat(x)))
 
     // Measure the scrollHeight and update the height to match.
+    const scrollHeight = this.ref.scrollHeight
     this.ref.style.height = 'auto'
     this.ref.style.overflowY = 'hidden'
     this.ref.style.height = `${Math.max(
       parseFloat(minHeight),
-      Math.ceil(this.ref.scrollHeight + borderHeight),
+      Math.ceil(scrollHeight + borderHeight),
     )}px`
     this.ref.style.overflowY = ''
   }


### PR DESCRIPTION
In TextArea ctrl-z is currently broken on firefox if autoHeight is enabled.

I feel like it might be a firefox bug but this workaround will make it work.