### PR TITLE
docs(Responsive): update ResponsiveExampleMaxWidth.js (added two words to clarify)

### DIFF
--- a/docs/src/examples/addons/Responsive/Types/ResponsiveExampleMaxWidth.js
+++ b/docs/src/examples/addons/Responsive/Types/ResponsiveExampleMaxWidth.js
@@ -7,7 +7,7 @@ const ResponsiveExampleMaxWidth = () => (
       Visible only if display has <code>767px</code> width and lower
     </Responsive>
     <Responsive as={Segment} maxWidth={2569}>
-      Visible only if display has <code>2569px</code> width
+      Visible only if display has <code>2569px</code> width and lower
     </Responsive>
   </Segment.Group>
 )


### PR DESCRIPTION
Added "and lower" to the 2569px width example, because that's what it does and the wording was confusing on first sight.