### PR TITLE
Fix: Icon onClick callback event disbled for 'disabled' props

### DIFF
--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -74,6 +74,13 @@ class Icon extends PureComponent {
 
     /** Icon can have an aria label. */
     'aria-label': PropTypes.string,
+
+     /**
+     * Called after user's click.
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    onClick: PropTypes.func,
   }
 
   static defaultProps = {
@@ -97,6 +104,18 @@ class Icon extends PureComponent {
     }
 
     return ariaOptions
+  }
+
+  handleClick = (e) => {
+    const { disabled, onClick } = this.props
+
+    if (disabled) {
+      e.preventDefault()
+      return
+    }
+    if (onClick) {
+      _.invoke(this.props, 'onClick', e, this.props)
+    }
   }
 
   render() {
@@ -138,7 +157,7 @@ class Icon extends PureComponent {
     const ElementType = getElementType(Icon, this.props)
     const ariaOptions = this.getIconAriaOptions()
 
-    return <ElementType {...rest} {...ariaOptions} className={classes} />
+    return <ElementType {...rest} {...ariaOptions} className={classes} onClick={this.handleClick}/>
   }
 }
 

--- a/test/specs/elements/Icon/Icon-test.js
+++ b/test/specs/elements/Icon/Icon-test.js
@@ -68,4 +68,25 @@ describe('Icon', () => {
       wrapper.should.have.prop('aria-label', 'icon')
     })
   })
+
+  describe('onClick', () => {
+    it('is called with (e, data) when clicked', () => {
+      const onClick = sandbox.spy()
+
+      shallow(<Icon onClick={onClick} />).simulate('click', syntheticEvent)
+
+      onClick.should.have.been.calledOnce()
+      onClick.should.have.been.calledWithExactly(syntheticEvent, {
+        onClick,
+        ...Icon.defaultProps,
+      })
+    })
+
+    it('is not called when is disabled', () => {
+      const onClick = sandbox.spy()
+
+      shallow(<Icon disabled onClick={onClick} />).simulate('click', syntheticEvent)
+      onClick.should.have.callCount(0)
+    })
+  })
 })


### PR DESCRIPTION
As requested in issue #3341, I have added fix for that issue.