### PR TITLE
feat(Icon): `disabled` prop disables `onClick`

### DIFF
--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -99,6 +99,17 @@ class Icon extends PureComponent {
     return ariaOptions
   }
 
+  handleClick = (e) => {
+    const { disabled } = this.props
+
+    if (disabled) {
+      e.preventDefault()
+      return
+    }
+
+    _.invoke(this.props, 'onClick', e, this.props)
+  }
+
   render() {
     const {
       bordered,
@@ -138,7 +149,7 @@ class Icon extends PureComponent {
     const ElementType = getElementType(Icon, this.props)
     const ariaOptions = this.getIconAriaOptions()
 
-    return <ElementType {...rest} {...ariaOptions} className={classes} />
+    return <ElementType {...rest} {...ariaOptions} className={classes} onClick={this.handleClick} />
   }
 }
 

--- a/test/specs/elements/Icon/Icon-test.js
+++ b/test/specs/elements/Icon/Icon-test.js
@@ -75,21 +75,19 @@ describe('Icon', () => {
   describe('onClick', () => {
     it('is called with (e, data) when clicked', () => {
       const onClick = sandbox.spy()
-
-      shallow(<Icon onClick={onClick} />).simulate('click', syntheticEvent)
+      mount(<Icon onClick={onClick} />).simulate('click')
 
       onClick.should.have.been.calledOnce()
-      onClick.should.have.been.calledWithExactly(syntheticEvent, {
-        onClick,
-        ...Icon.defaultProps,
-      })
+      onClick.should.have.been.calledWithMatch({ type: 'click' }, { onClick })
     })
 
-    it('is not called when is disabled', () => {
+    it('is not called when "disabled" is true', () => {
       const onClick = sandbox.spy()
+      const preventDefault = sandbox.spy()
+      mount(<Icon disabled onClick={onClick} />).simulate('click', { preventDefault })
 
-      shallow(<Icon disabled onClick={onClick} />).simulate('click', syntheticEvent)
-      onClick.should.have.callCount(0)
+      onClick.should.have.not.been.called()
+      preventDefault.should.have.calledOnce()
     })
   })
 })

--- a/test/specs/elements/Icon/Icon-test.js
+++ b/test/specs/elements/Icon/Icon-test.js
@@ -5,6 +5,9 @@ import Icon from 'src/elements/Icon/Icon'
 import IconGroup from 'src/elements/Icon/IconGroup'
 import { SUI } from 'src/lib'
 import * as common from 'test/specs/commonTests'
+import { sandbox } from 'test/utils'
+
+const syntheticEvent = { preventDefault: () => undefined }
 
 describe('Icon', () => {
   common.isConformant(Icon)
@@ -66,6 +69,27 @@ describe('Icon', () => {
 
       wrapper.should.not.have.prop('aria-hidden')
       wrapper.should.have.prop('aria-label', 'icon')
+    })
+  })
+
+  describe('onClick', () => {
+    it('is called with (e, data) when clicked', () => {
+      const onClick = sandbox.spy()
+
+      shallow(<Icon onClick={onClick} />).simulate('click', syntheticEvent)
+
+      onClick.should.have.been.calledOnce()
+      onClick.should.have.been.calledWithExactly(syntheticEvent, {
+        onClick,
+        ...Icon.defaultProps,
+      })
+    })
+
+    it('is not called when is disabled', () => {
+      const onClick = sandbox.spy()
+
+      shallow(<Icon disabled onClick={onClick} />).simulate('click', syntheticEvent)
+      onClick.should.have.callCount(0)
     })
   })
 })

--- a/test/specs/elements/Icon/Icon-test.js
+++ b/test/specs/elements/Icon/Icon-test.js
@@ -7,8 +7,6 @@ import { SUI } from 'src/lib'
 import * as common from 'test/specs/commonTests'
 import { sandbox } from 'test/utils'
 
-const syntheticEvent = { preventDefault: () => undefined }
-
 describe('Icon', () => {
   common.isConformant(Icon)
   common.hasSubcomponents(Icon, [IconGroup])


### PR DESCRIPTION
Added behaviour of not running `onClick` function when Icon is `disabled`.
Very similar with what is already available in the `Button` component.

Fixes #3341.