### PR TITLE
Fix(Portal): Modal handles keyboard escape event instead of child dropdown

### DIFF
--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -160,7 +160,7 @@ class Portal extends Component {
   handleEscape = (e) => {
     if (!this.props.closeOnEscape) return
     if (keyboardKey.getCode(e) !== keyboardKey.Escape) return
-    if (e.path.find(element => element.classList && element.classList.contains('dropdown'))) {
+    if (e.target.classList && e.target.classList.contains('dropdown')) {
       return
     }
     debug('handleEscape()')

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -160,7 +160,9 @@ class Portal extends Component {
   handleEscape = (e) => {
     if (!this.props.closeOnEscape) return
     if (keyboardKey.getCode(e) !== keyboardKey.Escape) return
-
+    if (e.path.find(element => element.classList && element.classList.contains('dropdown'))) {
+      return
+    }
     debug('handleEscape()')
     this.close(e)
   }

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react'
 import * as common from 'test/specs/commonTests'
 import { domEvent, sandbox } from 'test/utils'
 import Portal from 'src/addons/Portal/Portal'
+import Dropdown from 'src/modules/Dropdown/Dropdown';
 import PortalInner from 'src/addons/Portal/PortalInner'
 
 let wrapper
@@ -569,6 +570,27 @@ describe('Portal', () => {
       wrapper.should.have.descendants(PortalInner)
 
       domEvent.keyDown(document, { key: 'Escape' })
+      wrapper.update()
+      wrapper.should.have.descendants(PortalInner)
+    })
+
+    it('does not close the portal on escape when dropdown child is focussed', () => {
+      wrapperMount(
+        <Portal closeOnEscape defaultOpen>
+          <Dropdown
+            id='dropdown'
+            placeholder='Skills'
+            options={[
+              { key: 'angular', text: 'Angular', value: 'angular' },
+              { key: 'css', text: 'CSS', value: 'css' },
+            ]}
+          />
+        </Portal>,
+      )
+      wrapper.should.have.descendants(PortalInner)
+
+      domEvent.click('.ui.dropdown')
+      domEvent.keyDown(document.getElementById('dropdown'), { key: 'Escape' })
       wrapper.update()
       wrapper.should.have.descendants(PortalInner)
     })


### PR DESCRIPTION
fixes issue: #3194 Dropdown: closing Dropdown inside a Modal by clicking Escape also closes Modal