### PR TITLE
fix(Input): add `select` to type definitions

### DIFF
--- a/src/elements/Input/Input.d.ts
+++ b/src/elements/Input/Input.d.ts
@@ -83,6 +83,7 @@ export interface InputOnChangeData extends InputProps {
 
 declare class Input extends React.Component<InputProps, {}> {
   focus: () => void
+  select: () => void
 }
 
 export default Input


### PR DESCRIPTION
`select` was added in 0.82 but the type definition wasn't updated 😞 