### PR TITLE
chore(package): upgrade keyboard-key

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@babel/runtime": "^7.1.2",
     "@semantic-ui-react/event-stack": "^3.0.1",
     "classnames": "^2.2.6",
-    "keyboard-key": "^1.0.2",
+    "keyboard-key": "^1.0.4",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.2",
     "shallowequal": "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6976,9 +6976,10 @@ karma@^3.0.0:
     tmp "0.0.33"
     useragent "2.2.1"
 
-keyboard-key@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/keyboard-key/-/keyboard-key-1.0.2.tgz#212e14dde4c2059814336159bbc5acd0a348ca6b"
+keyboard-key@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/keyboard-key/-/keyboard-key-1.0.4.tgz#52d8fa07b7e17757072aa22a67fb4ae85e4c46b0"
+  integrity sha512-my04dE6BCwPpwoe4KYKfPxWiwgDYQOHrVmtzn1CfzmoEsGG/ef4oZGaXCzi1+iFhG7CN5JkOuxmei5OABY8/ag==
 
 killable@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes #3251

The latest release of `keyboard-key` now respects event objects that already have a `key` property.  This should resolve many bugs like what was noted in the linked issue.

The long term fix there is to add locale support to keyboard-key.  Namely, we'd need to handle the proper <kbd>shift</kbd> values for every keyboard locale.  See the new [Locale Caveat](https://github.com/levithomason/keyboard-key/#locale-caveat) section over at `keyboard-key`.