### PR TITLE
docs(elements/Icon/Variations/IconExampleColored): add white

### DIFF
--- a/docs/src/examples/elements/Icon/Variations/IconExampleColored.js
+++ b/docs/src/examples/elements/Icon/Variations/IconExampleColored.js
@@ -16,6 +16,7 @@ const IconExampleColored = () => (
     <Icon color='brown' name='users' />
     <Icon color='grey' name='users' />
     <Icon color='black' name='users' />
+    <Icon color='white' name='users' />
   </div>
 )
 


### PR DESCRIPTION
Adding white color to the icon colors.
Why we don't have a white color for icons?