### PR TITLE
Use string enums rather than string unions to define types

### DIFF
--- a/src/generic.d.ts
+++ b/src/generic.d.ts
@@ -73,20 +73,21 @@ export type SemanticShorthandItem<TProps> =
 // Styling
 // ======================================================
 
-export type SemanticCOLORS =
-  | 'red'
-  | 'orange'
-  | 'yellow'
-  | 'olive'
-  | 'green'
-  | 'teal'
-  | 'blue'
-  | 'violet'
-  | 'purple'
-  | 'pink'
-  | 'brown'
-  | 'grey'
-  | 'black'
+export enum SemanticCOLORS {
+  red = 'red',
+  orange = 'orange',
+  yellow = 'yellow',
+  olivde = 'olive',
+  green = 'green',
+  teal = 'teal',
+  blue = 'blue',
+  violet = 'violet',
+  purple = 'purple',
+  pink = 'pink',
+  brown = 'brown',
+  grey = 'grey',
+  black = 'black'
+}
 export type SemanticSIZES =
   | 'mini'
   | 'tiny'


### PR DESCRIPTION
Specifying the value of `color` on a `Progress` component yields a TypeScript error, even if passing in a defined string constant (such as `green`). Is there any reason the union types such as `SemanticCOLORS` and `SemanticDIRECTIONALTRANSITIONS` aren't defined as string enums?

I've included a proposed fix for the `SemanticCOLORS` type. By turning it into an enum, you get an inferred type definition as well as string values that can be used at runtime. Happy to submit a complete PR including a bunch of enums if this seems to be interesting to the maintainers. I'm not sure where such enums should live, and whether they should be made accessible to regular JavaScript.