### PR TITLE
feat(Accordion): add `icon` shorthand for AccordionTitle

### DIFF
--- a/docs/src/examples/modules/Accordion/Advanced/AccordionExampleIconShorthand.js
+++ b/docs/src/examples/modules/Accordion/Advanced/AccordionExampleIconShorthand.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { Accordion } from 'semantic-ui-react'
+
+const panels = [
+  {
+    key: 'acquire-dog',
+    title: {
+      content: 'How do you acquire a dog?',
+      icon: 'question',
+    },
+    content: {
+      content: (
+        <span>
+          Three common ways for a prospective owner to acquire a dog is from pet
+          shops, private owners, or shelters.
+        </span>
+      ),
+    },
+  },
+  {
+    key: 'care-for-dogs',
+    title: {
+      content: 'How do I care for a dog?',
+      icon: 'question',
+    },
+    content: {
+      content: (
+        <span>
+          It is entirely acceptable to feed your dog a pure kibble diet. Or you
+          can mix their diet up with some cooked or raw meat, fish, vegetables
+          and rice.
+        </span>
+      ),
+    },
+  },
+]
+
+const AccordionExampleIconShorthand = () => (
+  <Accordion defaultActiveIndex={0} panels={panels} />
+)
+
+export default AccordionExampleIconShorthand

--- a/docs/src/examples/modules/Accordion/Advanced/index.js
+++ b/docs/src/examples/modules/Accordion/Advanced/index.js
@@ -28,6 +28,11 @@ const AccordionAdvancedExamples = () => (
       description='Panels of Accordion can be rendered via shorthand prop.'
       examplePath='modules/Accordion/Advanced/AccordionExampleShorthand'
     />
+    <ComponentExample
+      title='Icon shorthand'
+      description='An accordion title can have a customizable icon.'
+      examplePath='modules/Accordion/Advanced/AccordionExampleIconShorthand'
+    />
   </ExampleSection>
 )
 

--- a/docs/src/examples/modules/Accordion/Types/AccordionExampleStandardShorthand.js
+++ b/docs/src/examples/modules/Accordion/Types/AccordionExampleStandardShorthand.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Accordion } from 'semantic-ui-react'
+import { Accordion, Icon } from 'semantic-ui-react'
 
 const panels = [
   {
@@ -25,14 +25,15 @@ const panels = [
       content: (
         <div>
           <p>
-            Three common ways for a prospective owner to acquire a dog is from pet shops, private
-            owners, or shelters.
+            Three common ways for a prospective owner to acquire a dog is from
+            pet shops, private owners, or shelters.
           </p>
           <p>
-            A pet shop may be the most convenient way to buy a dog. Buying a dog from a private
-            owner allows you to assess the pedigree and upbringing of your dog before choosing to
-            take it home. Lastly, finding your dog from a shelter, helps give a good home to a dog
-            who may not find one so readily.
+            A pet shop may be the most convenient way to buy a dog. Buying a dog
+            from a private owner allows you to assess the pedigree and
+            upbringing of your dog before choosing to take it home. Lastly,
+            finding your dog from a shelter, helps give a good home to a dog who
+            may not find one so readily.
           </p>
         </div>
       ),
@@ -40,10 +41,10 @@ const panels = [
   },
   {
     key: 'care-for-dogs',
-    title:{
-      children:(
+    title: {
+      children: (
         <div>
-          <Icon name='question'/> How do I care for a dog?
+          <Icon name='question' /> How do I care for a dog?
         </div>
       ),
     },
@@ -51,15 +52,18 @@ const panels = [
       content: (
         <div>
           <p>
-            It is entirely acceptable to feed your dog a pure kibble diet.
-            Or you can mix their diet up with some cooked or raw meat, fish, vegetables and rice. 
+            It is entirely acceptable to feed your dog a pure kibble diet. Or
+            you can mix their diet up with some cooked or raw meat, fish,
+            vegetables and rice.
           </p>
         </div>
       ),
-    },   
+    },
   },
 ]
 
-const AccordionExampleStandardShorthand = () => <Accordion defaultActiveIndex={0} panels={panels} />
+const AccordionExampleStandardShorthand = () => (
+  <Accordion defaultActiveIndex={0} panels={panels} />
+)
 
 export default AccordionExampleStandardShorthand

--- a/docs/src/examples/modules/Accordion/Types/AccordionExampleStandardShorthand.js
+++ b/docs/src/examples/modules/Accordion/Types/AccordionExampleStandardShorthand.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Accordion, Icon } from 'semantic-ui-react'
+import { Accordion } from 'semantic-ui-react'
 
 const panels = [
   {
@@ -34,27 +34,6 @@ const panels = [
             upbringing of your dog before choosing to take it home. Lastly,
             finding your dog from a shelter, helps give a good home to a dog who
             may not find one so readily.
-          </p>
-        </div>
-      ),
-    },
-  },
-  {
-    key: 'care-for-dogs',
-    title: {
-      children: (
-        <div>
-          <Icon name='question' /> How do I care for a dog?
-        </div>
-      ),
-    },
-    content: {
-      content: (
-        <div>
-          <p>
-            It is entirely acceptable to feed your dog a pure kibble diet. Or
-            you can mix their diet up with some cooked or raw meat, fish,
-            vegetables and rice.
           </p>
         </div>
       ),

--- a/docs/src/examples/modules/Accordion/Types/AccordionExampleStandardShorthand.js
+++ b/docs/src/examples/modules/Accordion/Types/AccordionExampleStandardShorthand.js
@@ -38,6 +38,26 @@ const panels = [
       ),
     },
   },
+  {
+    key: 'care-for-dogs',
+    title:{
+      children:(
+        <div>
+          <Icon name='question'/> How do I care for a dog?
+        </div>
+      ),
+    },
+    content: {
+      content: (
+        <div>
+          <p>
+            It is entirely acceptable to feed your dog a pure kibble diet.
+            Or you can mix their diet up with some cooked or raw meat, fish, vegetables and rice. 
+          </p>
+        </div>
+      ),
+    },   
+  },
 ]
 
 const AccordionExampleStandardShorthand = () => <Accordion defaultActiveIndex={0} panels={panels} />

--- a/src/modules/Accordion/AccordionTitle.d.ts
+++ b/src/modules/Accordion/AccordionTitle.d.ts
@@ -1,4 +1,6 @@
 import * as React from 'react'
+
+import { IconProps } from '../../elements/Icon'
 import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 
 export interface AccordionTitleProps extends StrictAccordionTitleProps {
@@ -22,7 +24,7 @@ export interface StrictAccordionTitleProps {
   content?: SemanticShorthandContent
 
   /** Shorthand for Icon. */
-  icon?: SemanticShorthandItem
+  icon?: SemanticShorthandItem<IconProps>
 
   /** AccordionTitle index inside Accordion. */
   index?: number | string

--- a/src/modules/Accordion/AccordionTitle.d.ts
+++ b/src/modules/Accordion/AccordionTitle.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 
 export interface AccordionTitleProps extends StrictAccordionTitleProps {
   [key: string]: any
@@ -20,6 +20,9 @@ export interface StrictAccordionTitleProps {
 
   /** Shorthand for primary content. */
   content?: SemanticShorthandContent
+
+  /** Shorthand for Icon. */
+  icon?: SemanticShorthandItem
 
   /** AccordionTitle index inside Accordion. */
   index?: number | string

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -55,6 +55,7 @@ export default class AccordionTitle extends Component {
     const classes = cx(useKeyOnly(active, 'active'), 'title', className)
     const rest = getUnhandledProps(AccordionTitle, this.props)
     const ElementType = getElementType(AccordionTitle, this.props)
+    const iconValue = _.isNil(icon) ? 'dropdown' : icon
 
     if (_.isNil(content)) {
       return (
@@ -66,7 +67,7 @@ export default class AccordionTitle extends Component {
 
     return (
       <ElementType {...rest} className={classes} onClick={this.handleClick}>
-        {Icon.create(_.isNil(icon) ? 'dropdown' : icon, { autoGenerateKey: false })}
+        {Icon.create(iconValue, { autoGenerateKey: false })}
         {content}
       </ElementType>
     )

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -32,6 +32,9 @@ export default class AccordionTitle extends Component {
     /** Shorthand for primary content. */
     content: customPropTypes.contentShorthand,
 
+    /** Shorthand for Icon. */
+    icon: customPropTypes.itemShorthand,
+
     /** AccordionTitle index inside Accordion. */
     index: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
@@ -47,7 +50,7 @@ export default class AccordionTitle extends Component {
   handleClick = e => _.invoke(this.props, 'onClick', e, this.props)
 
   render() {
-    const { active, children, className, content } = this.props
+    const { active, children, className, content, icon } = this.props
 
     const classes = cx(useKeyOnly(active, 'active'), 'title', className)
     const rest = getUnhandledProps(AccordionTitle, this.props)
@@ -63,7 +66,7 @@ export default class AccordionTitle extends Component {
 
     return (
       <ElementType {...rest} className={classes} onClick={this.handleClick}>
-        <Icon name='dropdown' />
+        {Icon.create(_.isNil(icon) ? 'dropdown' : icon, { autoGenerateKey: false })}
         {content}
       </ElementType>
     )

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
 import {
+  childrenUtils,
   createShorthandFactory,
   customPropTypes,
   getElementType,
@@ -57,7 +58,7 @@ export default class AccordionTitle extends Component {
     const ElementType = getElementType(AccordionTitle, this.props)
     const iconValue = _.isNil(icon) ? 'dropdown' : icon
 
-    if (_.isNil(content)) {
+    if (!childrenUtils.isNil(children)) {
       return (
         <ElementType {...rest} className={classes} onClick={this.handleClick}>
           {children}

--- a/test/specs/modules/Accordion/AccordionTitle-test.js
+++ b/test/specs/modules/Accordion/AccordionTitle-test.js
@@ -9,6 +9,7 @@ describe('AccordionTitle', () => {
   common.rendersChildren(AccordionTitle)
 
   common.implementsCreateMethod(AccordionTitle)
+  common.implementsIconProp(AccordionTitle, { autoGenerateKey: false })
 
   common.propKeyOnlyToClassName(AccordionTitle, 'active')
 
@@ -18,8 +19,7 @@ describe('AccordionTitle', () => {
       const event = { target: null }
       const props = { content: 'title', index: 0 }
 
-      shallow(<AccordionTitle onClick={spy} {...props} />)
-        .simulate('click', event)
+      shallow(<AccordionTitle onClick={spy} {...props} />).simulate('click', event)
 
       spy.should.have.been.calledOnce()
       spy.should.have.been.calledWithMatch(event, props)

--- a/test/specs/modules/Accordion/AccordionTitle-test.js
+++ b/test/specs/modules/Accordion/AccordionTitle-test.js
@@ -9,7 +9,10 @@ describe('AccordionTitle', () => {
   common.rendersChildren(AccordionTitle)
 
   common.implementsCreateMethod(AccordionTitle)
-  common.implementsIconProp(AccordionTitle, { autoGenerateKey: false })
+  common.implementsIconProp(AccordionTitle, {
+    alwaysPresent: true,
+    autoGenerateKey: false,
+  })
 
   common.propKeyOnlyToClassName(AccordionTitle, 'active')
 


### PR DESCRIPTION
Added an example on how to add a custom icon via the standard Shorthand