### PR TITLE
docs(Portal): fix controlled Portal usage

### DIFF
--- a/docs/src/examples/addons/Portal/Types/PortalExampleControlled.js
+++ b/docs/src/examples/addons/Portal/Types/PortalExampleControlled.js
@@ -4,9 +4,8 @@ import { Button, Grid, Header, Segment, Portal } from 'semantic-ui-react'
 export default class PortalExampleControlled extends Component {
   state = { open: false }
 
-  handleClick = () => this.setState({ open: !this.state.open })
-
   handleClose = () => this.setState({ open: false })
+  handleOpen = () => this.setState({ open: true })
 
   render() {
     const { open } = this.state
@@ -14,18 +13,14 @@ export default class PortalExampleControlled extends Component {
     return (
       <Grid columns={2}>
         <Grid.Column>
-          <Portal
-            onClose={this.handleClose}
-            open={open}
-            trigger={
-              <Button
-                content={open ? 'Close Portal' : 'Open Portal'}
-                negative={open}
-                positive={!open}
-                onClick={this.handleClick}
-              />
-            }
-          >
+          <Button
+            content='Open Portal'
+            disabled={open}
+            positive
+            onClick={this.handleOpen}
+          />
+
+          <Portal onClose={this.handleClose} open={open}>
             <Segment
               style={{
                 left: '40%',
@@ -37,6 +32,12 @@ export default class PortalExampleControlled extends Component {
               <Header>This is a controlled portal</Header>
               <p>Portals have tons of great callback functions to hook into.</p>
               <p>To close, simply click the close button or click away</p>
+
+              <Button
+                content='Close Portal'
+                negative
+                onClick={this.handleClose}
+              />
             </Segment>
           </Portal>
         </Grid.Column>

--- a/docs/src/examples/addons/Portal/Types/PortalExampleControlled.js
+++ b/docs/src/examples/addons/Portal/Types/PortalExampleControlled.js
@@ -14,15 +14,26 @@ export default class PortalExampleControlled extends Component {
     return (
       <Grid columns={2}>
         <Grid.Column>
-          <Button
-            content={open ? 'Close Portal' : 'Open Portal'}
-            negative={open}
-            positive={!open}
-            onClick={this.handleClick}
-          />
-
-          <Portal onClose={this.handleClose} open={open}>
-            <Segment style={{ left: '40%', position: 'fixed', top: '50%', zIndex: 1000 }}>
+          <Portal
+            onClose={this.handleClose}
+            open={open}
+            trigger={
+              <Button
+                content={open ? 'Close Portal' : 'Open Portal'}
+                negative={open}
+                positive={!open}
+                onClick={this.handleClick}
+              />
+            }
+          >
+            <Segment
+              style={{
+                left: '40%',
+                position: 'fixed',
+                top: '50%',
+                zIndex: 1000,
+              }}
+            >
               <Header>This is a controlled portal</Header>
               <p>Portals have tons of great callback functions to hook into.</p>
               <p>To close, simply click the close button or click away</p>


### PR DESCRIPTION
As discussed in #3408 the usage of `Portal` as a controlled component was wrong in the docs creating a false positive bug. The proper way puts the control inside the `Portal`'s `trigger`:

![image](https://user-images.githubusercontent.com/15076656/52463718-a5dc5780-2b80-11e9-8617-ed44262f5a34.png)

(Closes #3408)