### PR TITLE
 fix(Dropdown): sets focus to the search input after selection

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1,5 +1,6 @@
 import cx from 'classnames'
 import keyboardKey from 'keyboard-key'
+
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { Children, cloneElement } from 'react'

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -1,6 +1,5 @@
 import cx from 'classnames'
 import keyboardKey from 'keyboard-key'
-
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { Children, cloneElement } from 'react'

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -746,7 +746,7 @@ export default class Dropdown extends Component {
     // Notify the onAddItem prop if this is a new value
     if (isAdditionItem) _.invoke(this.props, 'onAddItem', e, { ...this.props, value })
 
-    if (multiple && search && this.searchRef) this.searchRef.focus()
+    if (search && this.searchRef) this.searchRef.focus()
   }
 
   handleFocus = (e) => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -2117,6 +2117,24 @@ describe('Dropdown', () => {
 
       dropdownMenuIsOpen()
     })
+
+    it('sets focus to the search input after selection', () => {
+      wrapperMount(<Dropdown open options={options} selection search />)
+
+      // random item, skip the first as it's selected by default
+      const randomIndex = 1 + _.random(options.length - 2)
+
+      wrapper
+        .find('DropdownItem')
+        .at(randomIndex)
+        .simulate('click')
+
+      const activeElement = document.activeElement
+      const searchIsFocused = activeElement === document.querySelector('input.search')
+      searchIsFocused.should.be.true(
+        `Expected "input.search" to be the active element but found ${activeElement} instead.`,
+      )
+    })
   })
 
   describe('searchInput', () => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1963,6 +1963,27 @@ describe('Dropdown', () => {
       )
     })
 
+    it('sets focus to the search input on click Dropdown When open', () => {
+      wrapperMount(
+        <Dropdown
+          minCharacters={3}
+          options={options}
+          placeholder='foo'
+          multiple
+          selection
+          search
+          open
+        />,
+      )
+      wrapper.simulate('click')
+
+      const activeElement = document.activeElement
+      const searchIsFocused = activeElement === document.querySelector('input.search')
+      searchIsFocused.should.be.true(
+        `Expected "input.search" to be the active element but found ${activeElement} instead.`,
+      )
+    })
+
     it('clears the search query when an item is selected', () => {
       // search for random item
       const searchQuery = _.sample(options).text

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -1963,18 +1963,8 @@ describe('Dropdown', () => {
       )
     })
 
-    it('sets focus to the search input on click Dropdown When open', () => {
-      wrapperMount(
-        <Dropdown
-          minCharacters={3}
-          options={options}
-          placeholder='foo'
-          multiple
-          selection
-          search
-          open
-        />,
-      )
+    it('sets focus to the search input on click Dropdown when is opened', () => {
+      wrapperMount(<Dropdown open options={options} multiple selection search />)
       wrapper.simulate('click')
 
       const activeElement = document.activeElement


### PR DESCRIPTION
fixes #3349

![focus-after-selection](https://user-images.githubusercontent.com/1697150/52637261-1df4a580-2f12-11e9-8ced-745e4729ad21.gif)
 

