### PR TITLE
fix(Dropdown): sets focus to the search input after selection

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -577,7 +577,7 @@ export default class Dropdown extends Component {
     this.makeSelectedItemActive(e)
     this.closeOnChange(e)
     this.clearSearchQuery()
-    if (search && this.searchRef) this.searchRef.focus()
+    if (search) _.invoke(this.searchRef, 'focus')
   }
 
   removeItemOnBackspace = (e) => {
@@ -641,14 +641,14 @@ export default class Dropdown extends Component {
 
     if (!search) return this.toggle(e)
     if (open) {
-      if (this.searchRef) this.searchRef.focus()
+      _.invoke(this.searchRef, 'focus')
       return
     }
     if (searchQuery.length >= minCharacters || minCharacters === 1) {
       this.open(e)
       return
     }
-    if (this.searchRef) this.searchRef.focus()
+    _.invoke(this.searchRef, 'focus')
   }
 
   handleIconClick = (e) => {
@@ -695,7 +695,7 @@ export default class Dropdown extends Component {
     // Notify the onAddItem prop if this is a new value
     if (isAdditionItem) _.invoke(this.props, 'onAddItem', e, { ...this.props, value })
 
-    if (search && this.searchRef) this.searchRef.focus()
+    if (search) _.invoke(this.searchRef, 'focus')
   }
 
   handleFocus = (e) => {
@@ -1119,7 +1119,7 @@ export default class Dropdown extends Component {
     debug('open()', { disabled, open, search })
 
     if (disabled) return
-    if (search && this.searchRef) this.searchRef.focus()
+    if (search) _.invoke(this.searchRef, 'focus')
 
     _.invoke(this.props, 'onOpen', e, this.props)
 

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -746,7 +746,7 @@ export default class Dropdown extends Component {
     // Notify the onAddItem prop if this is a new value
     if (isAdditionItem) _.invoke(this.props, 'onAddItem', e, { ...this.props, value })
 
-    if (multiple && search && this.searchRef) this.searchRef.focus()
+    if (search && this.searchRef) this.searchRef.focus()
   }
 
   handleFocus = (e) => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -2106,6 +2106,24 @@ describe('Dropdown', () => {
 
       dropdownMenuIsOpen()
     })
+
+    it('sets focus to the search input after selection', () => {
+      wrapperMount(<Dropdown open options={options} selection search />)
+
+      // random item, skip the first as it's selected by default
+      const randomIndex = 1 + _.random(options.length - 2)
+
+      wrapper
+        .find('DropdownItem')
+        .at(randomIndex)
+        .simulate('click')
+
+      const activeElement = document.activeElement
+      const searchIsFocused = activeElement === document.querySelector('input.search')
+      searchIsFocused.should.be.true(
+        `Expected "input.search" to be the active element but found ${activeElement} instead.`,
+      )
+    })
   })
 
   describe('searchInput', () => {


### PR DESCRIPTION
Addresses #3349.

![focus-after-selection](https://user-images.githubusercontent.com/1697150/52639457-b0e40e80-2f17-11e9-921d-0d12733cd38b.gif)
