### PR TITLE
fix(Checkbox): prevent click propagation from the input element

### DIFF
--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -203,6 +203,12 @@ export default class Checkbox extends Component {
     if (this.inputRef) this.inputRef.indeterminate = !!indeterminate
   }
 
+  handleInputClick = (e) => {
+    e.stopPropagation()
+    // To prevent two clicks from being fired from the component we have to stop the propagation
+    // from the "input" click: https://github.com/Semantic-Org/Semantic-UI-React/issues/3433
+  }
+
   render() {
     const {
       className,
@@ -253,12 +259,12 @@ export default class Checkbox extends Component {
           disabled={disabled}
           id={id}
           name={name}
+          onClick={this.handleInputClick}
           readOnly
           ref={this.handleInputRef}
           tabIndex={this.computeTabIndex()}
           type={type}
           value={value}
-          onClick={e => e.stopPropagation()}
         />
         {/*
          Heads Up!

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -258,6 +258,7 @@ export default class Checkbox extends Component {
           tabIndex={this.computeTabIndex()}
           type={type}
           value={value}
+          onClick={e => e.stopPropagation()}
         />
         {/*
          Heads Up!

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -223,7 +223,7 @@ export default class Checkbox extends Component {
   setIndeterminate = () => {
     const { indeterminate } = this.state
 
-    if (this.inputRef.current) this.inputRef.current.indeterminate = !!indeterminate
+    _.set(this.inputRef, 'current.indeterminate', !!indeterminate)
   }
 
   render() {

--- a/test/specs/commonTests/isConformant.js
+++ b/test/specs/commonTests/isConformant.js
@@ -13,7 +13,6 @@ import hasValidTypings from './hasValidTypings'
  * Assert Component conforms to guidelines that are applicable to all components.
  * @param {React.Component|Function} Component A component that should conform.
  * @param {Object} [options={}]
- * @param {String[]} [options.disabledHandlers=[]] An array of listeners that are disabled.
  * @param {Object} [options.eventTargets={}] Map of events and the child component to target.
  * @param {Number} [options.nestingLevel=0] The nesting level of the component.
  * @param {boolean} [options.rendersChildren=false] Does this component render any children?
@@ -23,7 +22,6 @@ import hasValidTypings from './hasValidTypings'
  */
 export default (Component, options = {}) => {
   const {
-    disabledHandlers = [],
     eventTargets = {},
     nestingLevel = 0,
     requiredProps = {},
@@ -220,7 +218,7 @@ export default (Component, options = {}) => {
       // This test catches the case where a developer forgot to call the event prop
       // after handling it internally. It also catch cases where the synthetic event was not passed back.
       _.each(syntheticEvent.types, ({ eventShape, listeners }) => {
-        _.each(_.without(listeners, ...disabledHandlers), (listenerName) => {
+        _.each(listeners, (listenerName) => {
           // onKeyDown => keyDown
           const eventName = _.camelCase(listenerName.replace('on', ''))
 

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -6,8 +6,6 @@ import Checkbox from 'src/modules/Checkbox/Checkbox'
 import * as common from 'test/specs/commonTests'
 import { domEvent, sandbox } from 'test/utils'
 
-const mockedMouseEvent = { button: 0 }
-
 // ----------------------------------------
 // Wrapper
 // ----------------------------------------
@@ -149,14 +147,16 @@ describe('Checkbox', () => {
     it('cannot be checked', () => {
       wrapperShallow(<Checkbox disabled />)
 
-      wrapper.simulate('mouseup', mockedMouseEvent)
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
       wrapper.find('input').should.not.be.checked()
     })
 
     it('cannot be unchecked', () => {
       wrapperShallow(<Checkbox defaultChecked disabled />)
 
-      wrapper.simulate('mouseup', mockedMouseEvent)
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
       wrapper.find('input').should.be.checked()
     })
 
@@ -243,15 +243,10 @@ describe('Checkbox', () => {
 
     it('is not called when on change when "id" is passed', () => {
       const onChange = sandbox.spy()
-      mount(<Checkbox id='foo' onChange={onChange} />).simulate('mouseup', mockedMouseEvent)
+      wrapperMount(<Checkbox id='foo' onChange={onChange} />)
 
-      onChange.should.have.not.been.called()
-    })
-
-    it('is not called with other button click in mouse up', () => {
-      const onChange = sandbox.spy()
-      mount(<Checkbox id='foo' onChange={onChange} />).simulate('mouseup', { button: 2 })
-
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
       onChange.should.have.not.been.called()
     })
   })
@@ -274,16 +269,10 @@ describe('Checkbox', () => {
 
     it('is not called when "id" is passed', () => {
       const onClick = sandbox.spy()
-      mount(<Checkbox id='foo' onClick={onClick} />).simulate('mouseup', mockedMouseEvent)
+      wrapperMount(<Checkbox id='foo' onClick={onClick} />)
 
-      onClick.should.have.not.been.called()
-    })
-
-    it('is not called with left button click in mouse up', () => {
-      const onClick = sandbox.spy()
-      const mockedMouseRightClickEvent = { button: 2 }
-      mount(<Checkbox id='foo' onClick={onClick} />).simulate('mouseup', mockedMouseRightClickEvent)
-
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
       onClick.should.have.not.been.called()
     })
   })
@@ -311,7 +300,7 @@ describe('Checkbox', () => {
     it('is called with (event, data) on mouse up', () => {
       const onMouseUp = sandbox.spy()
       const props = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
-      mount(<Checkbox onMouseUp={onMouseUp} {...props} />).simulate('mouseup', mockedMouseEvent)
+      mount(<Checkbox onMouseUp={onMouseUp} {...props} />).simulate('mouseup')
 
       onMouseUp.should.have.been.calledOnce()
       onMouseUp.should.have.been.calledWithMatch({}, props)

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -199,6 +199,18 @@ describe('Checkbox', () => {
           .should.have.prop(propName)
       })
     })
+
+    it('does not propagate click', () => {
+      const onClick = sandbox.spy()
+      mount(
+        <div role='presentation' onClick={onClick}>
+          <Checkbox id='foo' />
+        </div>,
+      )
+        .find('input')
+        .simulate('click')
+      onClick.should.not.have.been.called()
+    })
   })
 
   describe('label', () => {

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -202,34 +202,34 @@ describe('Checkbox', () => {
   })
 
   describe('click propagation', () => {
-    const assertions = [
+    const assertMatrix = [
       {
         description: 'propagates once on "label" without "id"',
         id: undefined,
         target: 'label',
-        propagates: true,
+        propagations: 1,
       },
       {
         description: 'does not propagate on "input" without "id"',
         id: undefined,
         target: 'input',
-        propagates: false,
+        propagations: 0,
       },
       {
         description: 'propagates once on "label" with "id"',
         id: 'foo',
         target: 'label',
-        propagates: true,
+        propagations: 1,
       },
       {
         description: 'does not propagate on "input" with "id"',
         id: 'foo',
         target: 'input',
-        propagates: false,
+        propagations: 0,
       },
     ]
 
-    assertions.forEach((assertion) => {
+    assertMatrix.forEach((assertion) => {
       it(assertion.description, () => {
         const onClick = sandbox.spy()
         wrapperMount(
@@ -237,10 +237,8 @@ describe('Checkbox', () => {
             <Checkbox id={assertion.id} />
           </div>,
         )
-        const target = document.querySelector(`.ui.checkbox ${assertion.target}`)
-        domEvent.click(target)
-        if (assertion.propagates) onClick.should.have.been.calledOnce()
-        else onClick.should.not.have.been.called()
+        domEvent.click(`.ui.checkbox ${assertion.target}`)
+        onClick.should.have.been.callCount(assertion.propagations)
       })
     })
   })

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -379,7 +379,6 @@ describe('Checkbox', () => {
           label: ['mouseup', 'click'],
           input: ['click'],
         },
-        target: 'label',
       },
       {
         description: 'click on input: fires on mouse click',
@@ -387,7 +386,6 @@ describe('Checkbox', () => {
           label: ['mouseup', 'click'],
           input: ['click'],
         },
-        target: 'label',
       },
       {
         description: 'key on input: fires on space key',
@@ -395,7 +393,6 @@ describe('Checkbox', () => {
           label: ['mouseup', 'click'],
           input: ['click'],
         },
-        target: 'input',
       },
 
       {

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -68,25 +68,30 @@ describe('Checkbox', () => {
 
   describe('checking', () => {
     it('can be checked and unchecked', () => {
-      wrapperShallow(<Checkbox />)
+      wrapperMount(<Checkbox />)
 
       wrapper.find('input').should.not.be.checked()
 
-      wrapper.simulate('mouseup', mockedMouseEvent)
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
       wrapper.find('input').should.be.checked()
 
-      wrapper.simulate('mouseup', mockedMouseEvent)
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
       wrapper.find('input').should.not.be.checked()
     })
+
     it('can be checked but not unchecked when radio', () => {
-      wrapperShallow(<Checkbox radio />)
+      wrapperMount(<Checkbox radio />)
 
       wrapper.find('input').should.not.be.checked()
 
-      wrapper.simulate('mouseup', mockedMouseEvent)
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
       wrapper.find('input').should.be.checked()
 
-      wrapper.simulate('mouseup', mockedMouseEvent)
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
       wrapper.find('input').should.be.checked()
     })
   })
@@ -201,48 +206,6 @@ describe('Checkbox', () => {
     })
   })
 
-  describe('click propagation', () => {
-    const assertMatrix = [
-      {
-        description: 'propagates once on "label" without "id"',
-        id: undefined,
-        target: 'label',
-        propagations: 1,
-      },
-      {
-        description: 'does not propagate on "input" without "id"',
-        id: undefined,
-        target: 'input',
-        propagations: 0,
-      },
-      {
-        description: 'propagates once on "label" with "id"',
-        id: 'foo',
-        target: 'label',
-        propagations: 1,
-      },
-      {
-        description: 'does not propagate on "input" with "id"',
-        id: 'foo',
-        target: 'input',
-        propagations: 0,
-      },
-    ]
-
-    assertMatrix.forEach((assertion) => {
-      it(assertion.description, () => {
-        const onClick = sandbox.spy()
-        wrapperMount(
-          <div role='presentation' onClick={onClick}>
-            <Checkbox id={assertion.id} />
-          </div>,
-        )
-        domEvent.click(`.ui.checkbox ${assertion.target}`)
-        onClick.should.have.been.callCount(assertion.propagations)
-      })
-    })
-  })
-
   describe('label', () => {
     it('adds the "fitted" class when not present', () => {
       shallow(<Checkbox name='firstName' />).should.have.className('fitted')
@@ -263,7 +226,11 @@ describe('Checkbox', () => {
     it('is called with (e, data) on mouse up', () => {
       const onChange = sandbox.spy()
       const props = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
-      mount(<Checkbox onChange={onChange} {...props} />).simulate('mouseup', mockedMouseEvent)
+
+      wrapperMount(<Checkbox onChange={onChange} {...props} />)
+
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
 
       onChange.should.have.been.calledOnce()
       onChange.should.have.been.calledWithMatch(
@@ -292,10 +259,10 @@ describe('Checkbox', () => {
   })
 
   describe('onClick', () => {
-    it('is called with (event, data) on mouseup', () => {
+    it('is called with (event, data) on click', () => {
       const onClick = sandbox.spy()
       const props = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
-      mount(<Checkbox onClick={onClick} {...props} />).simulate('mouseup', mockedMouseEvent)
+      mount(<Checkbox onClick={onClick} {...props} />).simulate('click')
 
       onClick.should.have.been.calledOnce()
       onClick.should.have.been.calledWithMatch(
@@ -332,13 +299,7 @@ describe('Checkbox', () => {
       onMousedDown.should.have.been.calledOnce()
       onMousedDown.should.have.been.calledWithMatch({}, props)
     })
-    it('prevents default event', () => {
-      const preventDefault = sandbox.spy()
-      wrapperShallow(<Checkbox />)
 
-      wrapper.simulate('mousedown', { preventDefault })
-      preventDefault.should.have.been.calledOnce()
-    })
     it('sets focus to container', () => {
       wrapperMount(<Checkbox />)
       const input = document.querySelector('.ui.checkbox input')
@@ -368,15 +329,17 @@ describe('Checkbox', () => {
 
   describe('readOnly', () => {
     it('cannot be checked', () => {
-      wrapperShallow(<Checkbox readOnly />)
+      wrapperMount(<Checkbox readOnly />)
 
-      wrapper.simulate('click')
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
       wrapper.find('input').should.not.be.checked()
     })
     it('cannot be unchecked', () => {
-      wrapperShallow(<Checkbox defaultChecked readOnly />)
+      wrapperMount(<Checkbox defaultChecked readOnly />)
 
-      wrapper.simulate('click')
+      wrapper.find('label').simulate('mouseup')
+      wrapper.find('label').simulate('click')
       wrapper.find('input').should.be.checked()
     })
   })
@@ -424,40 +387,77 @@ describe('Checkbox', () => {
   describe('comparisons with native DOM', () => {
     const assertMatrix = [
       {
-        description: 'click on label: fires on mouse up',
-        event: 'mouseup',
+        description: 'click on label: fires on mouse click',
+        events: {
+          label: ['mouseup', 'click'],
+          input: ['click'],
+        },
+        target: 'label',
+      },
+      {
+        description: 'click on input: fires on mouse click',
+        events: {
+          label: ['mouseup', 'click'],
+          input: ['click'],
+        },
         target: 'label',
       },
       {
         description: 'key on input: fires on space key',
-        event: 'click',
+        events: {
+          label: ['mouseup', 'click'],
+          input: ['click'],
+        },
         target: 'input',
       },
 
       {
-        description: 'click on label: fires on mouse click',
-        event: 'click',
-        target: 'label',
+        description: 'click on label with "id": fires on mouse click',
+        events: {
+          label: ['mouseup', 'click'],
+          input: ['click'],
+        },
+        id: 'foo',
+      },
+      {
+        description: 'click on input with "id": fires on mouse click',
+        events: {
+          label: ['mouseup', 'click'],
+          input: ['click'],
+        },
+        id: 'foo',
+      },
+      {
+        description: 'key on input with "id: fires on space key',
+        events: {
+          input: ['click'],
+        },
         id: 'foo',
       },
     ]
 
-    assertMatrix.forEach(({ description, event, target, ...props }) => {
+    assertMatrix.forEach(({ description, events, ...props }) => {
       it(description, () => {
         const dataId = _.uniqueId('checkbox')
-        const selector = `[data-id=${dataId}] ${target}`
 
         const onClick = sandbox.spy()
         const onChange = sandbox.spy()
+        const onParentClick = sandbox.spy()
 
         wrapperMount(
-          <Checkbox {...props} data-id={dataId} onClick={onClick} onChange={onChange} />,
+          <div onClick={onParentClick} role='presentation'>
+            <Checkbox {...props} data-id={dataId} onClick={onClick} onChange={onChange} />
+          </div>,
           { attachTo },
         )
-        domEvent.fire(selector, event)
+
+        _.forEach(events, (event, target) => {
+          domEvent.fire(`[data-id=${dataId}] ${target}`, event)
+        })
 
         onClick.should.have.been.calledOnce()
         onChange.should.have.been.calledOnce()
+        onParentClick.should.have.been.calledOnce()
 
         onChange.should.have.been.calledAfter(onClick)
       })
@@ -469,6 +469,7 @@ describe('Checkbox', () => {
       class ControlledCheckbox extends React.Component {
         state = { checked: false }
         toggle = () => this.setState(prevState => ({ checked: !prevState.checked }))
+
         render() {
           const handler = isOnClick ? { onClick: this.toggle } : { onChange: this.toggle }
           return <Checkbox label='Check this box' checked={this.state.checked} {...handler} />

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -199,17 +199,49 @@ describe('Checkbox', () => {
           .should.have.prop(propName)
       })
     })
+  })
 
-    it('does not propagate click', () => {
-      const onClick = sandbox.spy()
-      mount(
-        <div role='presentation' onClick={onClick}>
-          <Checkbox id='foo' />
-        </div>,
-      )
-        .find('input')
-        .simulate('click')
-      onClick.should.not.have.been.called()
+  describe('click propagation', () => {
+    const assertions = [
+      {
+        description: 'propagates once on "label" without "id"',
+        id: undefined,
+        target: 'label',
+        propagates: true,
+      },
+      {
+        description: 'does not propagate on "input" without "id"',
+        id: undefined,
+        target: 'input',
+        propagates: false,
+      },
+      {
+        description: 'propagates once on "label" with "id"',
+        id: 'foo',
+        target: 'label',
+        propagates: true,
+      },
+      {
+        description: 'does not propagate on "input" with "id"',
+        id: 'foo',
+        target: 'input',
+        propagates: false,
+      },
+    ]
+
+    assertions.forEach((assertion) => {
+      it(assertion.description, () => {
+        const onClick = sandbox.spy()
+        wrapperMount(
+          <div role='presentation' onClick={onClick}>
+            <Checkbox id={assertion.id} />
+          </div>,
+        )
+        const target = document.querySelector(`.ui.checkbox ${assertion.target}`)
+        domEvent.click(target)
+        if (assertion.propagates) onClick.should.have.been.calledOnce()
+        else onClick.should.not.have.been.called()
+      })
     })
   })
 

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -25,9 +25,7 @@ const wrapperMount = (element, opts) => {
 const wrapperShallow = (...args) => (wrapper = shallow(...args))
 
 describe('Checkbox', () => {
-  common.isConformant(Checkbox, {
-    disabledHandlers: ['onClick'],
-  })
+  common.isConformant(Checkbox)
   common.hasUIClassName(Checkbox)
 
   common.propKeyOnlyToClassName(Checkbox, 'checked')

--- a/test/utils/domEvent.js
+++ b/test/utils/domEvent.js
@@ -35,6 +35,14 @@ export const click = (node, data) => fire(node, 'click', data)
 export const keyDown = (node, data) => fire(node, 'keydown', data)
 
 /**
+ * Dispatch a 'mousedown' event on a DOM node.
+ * @param {String|Object} node A querySelector string or DOM node.
+ * @param {Object} [data] Additional event data.
+ * @returns {Object} The event
+ */
+export const mouseDown = (node, data) => fire(node, 'mousedown', data)
+
+/**
  * Dispatch a 'mouseenter' event on a DOM node.
  * @param {String|Object} node A querySelector string or DOM node.
  * @param {Object} [data] Additional event data.
@@ -89,6 +97,7 @@ export default {
   mouseEnter,
   mouseLeave,
   mouseOver,
+  mouseDown,
   mouseUp,
   resize,
   scroll,


### PR DESCRIPTION
Initially the click was being fired from both `label` and `input`
![checkbox-antes](https://user-images.githubusercontent.com/15076656/52701258-79f71280-2f82-11e9-974a-b7ac4e25ef7e.gif)

Now it only comes from `label`
![checkbox-depois](https://user-images.githubusercontent.com/15076656/52701274-85e2d480-2f82-11e9-9692-3becacd6a751.gif)

(Closes #3433)
(Closes #3440)