### PR TITLE
fix(TextArea): Make TextArea's height shrink (#3418)

### DIFF
--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -45,6 +45,8 @@ class TextArea extends Component {
     rows: 3,
   }
 
+  initialHeight = null
+
   componentDidMount() {
     this.updateHeight()
   }
@@ -82,11 +84,22 @@ class TextArea extends Component {
     this.ref.style.resize = null
   }
 
+  setInitialHeight(height) {
+    if (!this.initialHeight) {
+      this.initialHeight = height
+    }
+  }
+
   updateHeight = () => {
     const { autoHeight } = this.props
     if (!this.ref || !autoHeight) return
 
-    const { minHeight, borderBottomWidth, borderTopWidth } = window.getComputedStyle(this.ref)
+    const { minHeight, borderBottomWidth, borderTopWidth, height } = window.getComputedStyle(
+      this.ref,
+    )
+
+    this.setInitialHeight(height)
+    this.ref.style.height = this.initialHeight
 
     const borderHeight = _.sum([borderBottomWidth, borderTopWidth].map(x => parseFloat(x)))
     const scrollHeight = this.ref.scrollHeight

--- a/test/specs/addons/TextArea/TextArea-test.js
+++ b/test/specs/addons/TextArea/TextArea-test.js
@@ -82,13 +82,7 @@ describe('TextArea', () => {
     })
 
     it('sets styles when there is a multiline value', () => {
-      wrapperMount(
-        <TextArea
-          autoHeight
-          style={style}
-          value={'line1\nline2\nline3\nline4'}
-        />,
-      )
+      wrapperMount(<TextArea autoHeight style={style} value={'line1\nline2\nline3\nline4'} />)
       assertHeight('40px') // 4 lines
     })
 
@@ -101,6 +95,18 @@ describe('TextArea', () => {
       // update the value and fire a change event
       wrapper.setProps({ value: 'line1\nline2\nline3\nline4' })
       assertHeight('40px') // 4 lines
+    })
+
+    it('shrinks height when new line is deleted', () => {
+      const initialValue = 'line1\nline2\nline3\nline4'
+      wrapperMount(<TextArea autoHeight style={style} value={initialValue} />)
+
+      // initial height
+      assertHeight('40px') // 4 lines
+
+      // update the value and fire a change event
+      wrapper.setProps({ value: 'line1\nline2\nline3' })
+      assertHeight('30px') // 3 lines
     })
 
     it('adds styles when toggled to true', () => {
@@ -158,13 +164,11 @@ describe('TextArea', () => {
 
   describe('rows', () => {
     it('has default value', () => {
-      shallow(<TextArea />)
-        .should.have.prop('rows', 3)
+      shallow(<TextArea />).should.have.prop('rows', 3)
     })
 
     it('sets prop', () => {
-      shallow(<TextArea rows={1} />)
-        .should.have.prop('rows', 1)
+      shallow(<TextArea rows={1} />).should.have.prop('rows', 1)
     })
   })
 


### PR DESCRIPTION
This fixes the issue reported [here](https://github.com/Semantic-Org/Semantic-UI-React/issues/3418)

## Before
![bug](https://user-images.githubusercontent.com/27497967/52735649-69698b00-2fc8-11e9-9bee-a5237934745d.gif)

## After
![fix](https://user-images.githubusercontent.com/27497967/52735723-80a87880-2fc8-11e9-836a-75bb17d0f838.gif)

