### PR TITLE
fix(Input): update supported values for the `size` prop

### DIFF
--- a/src/elements/Input/Input.d.ts
+++ b/src/elements/Input/Input.d.ts
@@ -65,7 +65,7 @@ export interface StrictInputProps {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>, data: InputOnChangeData) => void
 
   /** An Input can vary in size. */
-  size?: SemanticSIZES
+  size?: 'mini' | 'small' | 'large' | 'big' | 'huge' | 'massive'
 
   /** An Input can receive focus. */
   tabIndex?: number | string

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -12,7 +12,6 @@ import {
   getUnhandledProps,
   handleRef,
   partitionHTMLProps,
-  SUI,
   useKeyOnly,
   useValueAndKey,
 } from '../../lib'
@@ -86,7 +85,7 @@ class Input extends Component {
     onChange: PropTypes.func,
 
     /** An Input can vary in size. */
-    size: PropTypes.oneOf(SUI.SIZES),
+    size: PropTypes.oneOf(['mini', 'small', 'large', 'big', 'huge', 'massive']),
 
     /** An Input can receive focus. */
     tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/test/specs/elements/Input/Input-test.js
+++ b/test/specs/elements/Input/Input-test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import Input from 'src/elements/Input/Input'
-import { htmlInputProps, SUI } from 'src/lib'
+import { htmlInputProps } from 'src/lib'
 import * as common from 'test/specs/commonTests'
 import { sandbox } from 'test/utils'
 
@@ -95,7 +95,14 @@ describe('Input', () => {
   common.propKeyOnlyToClassName(Input, 'transparent')
   common.propKeyOnlyToClassName(Input, 'icon')
 
-  common.propValueOnlyToClassName(Input, 'size', SUI.SIZES)
+  common.propValueOnlyToClassName(Input, 'size', [
+    'mini',
+    'small',
+    'large',
+    'big',
+    'huge',
+    'massive',
+  ])
 
   it('renders with conditional children', () => {
     shallow(


### PR DESCRIPTION
Fixes #3439.

This PR updates supported values for the `size` prop, see [`input.css`](https://github.com/Semantic-Org/UI-Input/blob/master/input.css#L487).