### PR TITLE
fix(Dropdown): correctly handle `focus` value in state

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -379,7 +379,7 @@ export default class Dropdown extends Component {
   static SearchInput = DropdownSearchInput
 
   getInitialAutoControlledState() {
-    return { searchQuery: '' }
+    return { focus: false, searchQuery: '' }
   }
 
   componentWillMount() {
@@ -1141,15 +1141,15 @@ export default class Dropdown extends Component {
     debug('handleClose()')
 
     const hasSearchFocus = document.activeElement === this.searchRef
-    const hasDropdownFocus = document.activeElement === this.ref
-    const hasFocus = hasSearchFocus || hasDropdownFocus
-
     // https://github.com/Semantic-Org/Semantic-UI-React/issues/627
     // Blur the Dropdown on close so it is blurred after selecting an item.
     // This is to prevent it from re-opening when switching tabs after selecting an item.
     if (!hasSearchFocus) {
       this.ref.blur()
     }
+
+    const hasDropdownFocus = document.activeElement === this.ref
+    const hasFocus = hasSearchFocus || hasDropdownFocus
 
     // We need to keep the virtual model in sync with the browser focus change
     // https://github.com/Semantic-Org/Semantic-UI-React/issues/692

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -421,13 +421,13 @@ describe('Dropdown', () => {
 
   describe('handleBlur', () => {
     it('passes the event to the onBlur prop', () => {
-      const spy = sandbox.spy()
+      const onBlur = sandbox.spy()
       const event = { foo: 'bar' }
 
-      wrapperShallow(<Dropdown onBlur={spy} />).simulate('blur', event)
+      wrapperShallow(<Dropdown onBlur={onBlur} />).simulate('blur', event)
 
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(event)
+      onBlur.should.have.been.calledOnce()
+      onBlur.should.have.been.calledWithMatch(event)
     })
 
     it('calls handleChange with the selected option on blur', () => {
@@ -474,14 +474,14 @@ describe('Dropdown', () => {
     })
 
     it('does not call onBlur when the mouse is down', () => {
-      const spy = sandbox.spy()
+      const onBlur = sandbox.spy()
 
-      wrapperShallow(<Dropdown onBlur={spy} selectOnBlur />)
+      wrapperShallow(<Dropdown onBlur={onBlur} selectOnBlur />)
 
       wrapper.simulate('mousedown')
       wrapper.simulate('blur')
 
-      spy.should.not.have.been.called()
+      onBlur.should.not.have.been.called()
     })
 
     it('does not call makeSelectedItemActive when the mouse is down', () => {
@@ -1290,6 +1290,19 @@ describe('Dropdown', () => {
       // click outside
       domEvent.click(document.body)
       dropdownMenuIsClosed()
+    })
+
+    it('handles focus correctly', () => {
+      wrapperMount(<Dropdown options={options} selection />)
+      wrapper.should.have.state('focus', false)
+
+      // focus
+      wrapper.getDOMNode().focus()
+      wrapper.should.have.state('focus', true)
+
+      // click outside
+      domEvent.click(document.body)
+      wrapper.should.have.state('focus', false)
     })
 
     it('closes on esc key', () => {


### PR DESCRIPTION
Fixes a regression introduced in #3428.

---

### Regression

The value of `focus` in a state wasn't handled correctly previously.

![regress](https://user-images.githubusercontent.com/14183168/52913182-20654f80-32c4-11e9-8c92-0e32a5aa209b.gif)

### After 

![rec1](https://user-images.githubusercontent.com/14183168/52913229-ba2cfc80-32c4-11e9-8ede-9a3baf2175fa.gif)
![rec2](https://user-images.githubusercontent.com/14183168/52913230-bbf6c000-32c4-11e9-9446-24fd7b43b6ee.gif)
