### PR TITLE
docs(Modal): fix Modal.Description description

### DIFF
--- a/src/modules/Modal/ModalDescription.js
+++ b/src/modules/Modal/ModalDescription.js
@@ -5,7 +5,7 @@ import React from 'react'
 import { childrenUtils, customPropTypes, getElementType, getUnhandledProps } from '../../lib'
 
 /**
- * A modal can have a header.
+ * A modal can contain a description with one or more paragraphs.
  */
 function ModalDescription(props) {
   const { children, className, content } = props


### PR DESCRIPTION
Change description of Modal.Description from "A modal can have a header" to "A modal can contain a description with one or more paragraphs", which is consistent with Card.Description's docs