### PR TITLE
feat(Sidebar): support object refs as value for `target` prop

### DIFF
--- a/docs/src/examples/modules/Sidebar/Usage/SidebarExampleTarget.js
+++ b/docs/src/examples/modules/Sidebar/Usage/SidebarExampleTarget.js
@@ -1,15 +1,20 @@
-import React, { Component } from 'react'
-import { Button, Header, Image, Menu, Ref, Segment, Sidebar } from 'semantic-ui-react'
+import React, { Component, createRef } from 'react'
+import {
+  Button,
+  Header,
+  Image,
+  Menu,
+  Ref,
+  Segment,
+  Sidebar,
+} from 'semantic-ui-react'
 
 export default class VisibilityExampleTarget extends Component {
   state = {}
+  segmentRef = createRef()
 
   handleHideClick = () => this.setState({ visible: false })
   handleShowClick = () => this.setState({ visible: true })
-
-  handleSegmentRef = (c) => {
-    this.segmentRef = c
-  }
 
   handleSidebarHide = () => this.setState({ visible: false })
 
@@ -28,25 +33,23 @@ export default class VisibilityExampleTarget extends Component {
         </Button.Group>
 
         <Sidebar.Pushable as={Segment.Group} raised>
-          {this.segmentRef && (
-            <Sidebar
-              as={Menu}
-              animation='overlay'
-              icon='labeled'
-              inverted
-              onHide={this.handleSidebarHide}
-              vertical
-              target={this.segmentRef}
-              visible={visible}
-              width='thin'
-            >
-              <Menu.Item as='a'>Home</Menu.Item>
-              <Menu.Item as='a'>Games</Menu.Item>
-              <Menu.Item as='a'>Channels</Menu.Item>
-            </Sidebar>
-          )}
+          <Sidebar
+            as={Menu}
+            animation='overlay'
+            icon='labeled'
+            inverted
+            onHide={this.handleSidebarHide}
+            vertical
+            target={this.segmentRef}
+            visible={visible}
+            width='thin'
+          >
+            <Menu.Item as='a'>Home</Menu.Item>
+            <Menu.Item as='a'>Games</Menu.Item>
+            <Menu.Item as='a'>Channels</Menu.Item>
+          </Sidebar>
 
-          <Ref innerRef={this.handleSegmentRef}>
+          <Ref innerRef={this.segmentRef}>
             <Segment>
               <Header as='h3'>Clickable area</Header>
               <p>When you will click there, the sidebar will be closed.</p>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "homepage": "https://github.com/Semantic-Org/Semantic-UI-React#readme",
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "@semantic-ui-react/event-stack": "^3.0.1",
+    "@semantic-ui-react/event-stack": "^3.1.0",
     "classnames": "^2.2.6",
     "keyboard-key": "^1.0.4",
     "lodash": "^4.17.11",

--- a/src/modules/Sidebar/Sidebar.d.ts
+++ b/src/modules/Sidebar/Sidebar.d.ts
@@ -60,7 +60,7 @@ export interface StrictSidebarProps {
   onVisible?: (event: React.MouseEvent<HTMLElement>, data: SidebarProps) => void
 
   /** A sidebar can handle clicks on the passed element. */
-  target?: object
+  target?: object | React.RefObject<HTMLElement>
 
   /** Controls whether or not the sidebar is visible on the page. */
   visible?: boolean

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -79,7 +79,7 @@ class Sidebar extends Component {
     onVisible: PropTypes.func,
 
     /** A sidebar can handle clicks on the passed element. */
-    target: PropTypes.object,
+    target: PropTypes.oneOfType([customPropTypes.domNode, customPropTypes.refObject]),
 
     /** Controls whether or not the sidebar is visible on the page. */
     visible: PropTypes.bool,

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,9 +878,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@semantic-ui-react/event-stack@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@semantic-ui-react/event-stack/-/event-stack-3.0.1.tgz#41d0b095ac94cc5e1607a4fed4d0f8860d0d2e60"
+"@semantic-ui-react/event-stack@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@semantic-ui-react/event-stack/-/event-stack-3.1.0.tgz#aadbe4a28b0dd7703c5f451640d0fefe66dd9208"
+  integrity sha512-WHtU9wutZByZtFZxzj4BVEk+rvWldZpZhRcyv6d84+XLSolm83zLHYJLTACGuSl6Xa/xpgVXquvm9GyMudkJYg==
   dependencies:
     exenv "^1.2.2"
     prop-types "^15.6.2"


### PR DESCRIPTION
Changes similar to #3448.

So, `Sidebar` now accepts a refs created with `React.createRef()` into `target` prop, it's really great simplification 👍