### PR TITLE
BREAKING(Portal): use createRef() API internally

### DIFF
--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -93,12 +93,8 @@ export interface StrictPortalProps {
   /** Element to be rendered in-place where the portal is defined. */
   trigger?: React.ReactNode
 
-  /**
-   * Called when componentDidMount.
-   *
-   * @param {HTMLElement} node - Referred node.
-   */
-  triggerRef?: (node: HTMLElement) => void
+  /** Called with a ref to the trigger node. */
+  triggerRef?: React.Ref<any>
 }
 
 declare class Portal extends React.Component<PortalProps, {}> {

--- a/src/addons/Portal/PortalInner.d.ts
+++ b/src/addons/Portal/PortalInner.d.ts
@@ -8,6 +8,9 @@ export interface StrictPortalInnerProps {
   /** Primary content. */
   children: React.ReactNode
 
+  /** Called with a ref to the inner node. */
+  innerRef?: React.Ref<any>
+
   /** The node where the portal should mount. */
   mountNode?: any
 

--- a/src/addons/Portal/PortalInner.js
+++ b/src/addons/Portal/PortalInner.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { createPortal } from 'react-dom'
 
-import { isBrowser, makeDebugger } from '../../lib'
+import { customPropTypes, handleRef, isBrowser, makeDebugger } from '../../lib'
 import Ref from '../Ref'
 
 const debug = makeDebugger('portalInner')
@@ -15,6 +15,9 @@ class PortalInner extends Component {
   static propTypes = {
     /** Primary content. */
     children: PropTypes.node.isRequired,
+
+    /** Called with a ref to the inner node. */
+    innerRef: customPropTypes.ref,
 
     /** The node where the portal should mount. */
     mountNode: PropTypes.any,
@@ -38,22 +41,21 @@ class PortalInner extends Component {
 
   componentDidMount() {
     debug('componentDidMount()')
-    _.invoke(this.props, 'onMount', null, { ...this.props, node: this.ref })
+    _.invoke(this.props, 'onMount', null, this.props)
   }
 
   componentWillUnmount() {
     debug('componentWillUnmount()')
-    _.invoke(this.props, 'onUnmount', null, { ...this.props, node: this.ref })
+    _.invoke(this.props, 'onUnmount', null, this.props)
   }
 
   handleRef = (c) => {
-    debug('handleRef')
-    this.ref = c
+    debug('handleRef', c)
+    handleRef(this.props.innerRef, c)
   }
 
   render() {
     if (!isBrowser()) return null
-
     const { children, mountNode = document.body } = this.props
 
     return createPortal(<Ref innerRef={this.handleRef}>{children}</Ref>, mountNode)

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -175,7 +175,7 @@ describe('Portal', () => {
           <p />
         </Portal>,
       )
-      wrapper.instance().portalNode.tagName.should.equal('P')
+      wrapper.instance().contentRef.current.tagName.should.equal('P')
     })
 
     it('maintains ref to DOM node with React component', () => {
@@ -186,7 +186,7 @@ describe('Portal', () => {
           <EmptyComponent />
         </Portal>,
       )
-      wrapper.instance().portalNode.tagName.should.equal('P')
+      wrapper.instance().contentRef.current.tagName.should.equal('P')
     })
   })
 

--- a/test/specs/addons/Portal/PortalInner-test.js
+++ b/test/specs/addons/Portal/PortalInner-test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { createRef } from 'react'
 
 import PortalInner from 'src/addons/Portal/PortalInner'
 import * as common from 'test/specs/commonTests'
@@ -8,6 +8,19 @@ describe('PortalInner', () => {
   common.isConformant(PortalInner, {
     rendersChildren: false,
     requiredProps: { children: <p /> },
+  })
+
+  describe('innerRef', () => {
+    it('returns ref', () => {
+      const innerRef = createRef()
+      const wrapper = mount(
+        <PortalInner innerRef={innerRef}>
+          <p />
+        </PortalInner>,
+      )
+
+      expect(wrapper.getDOMNode()).to.equal(innerRef.current)
+    })
   })
 
   describe('onMount', () => {


### PR DESCRIPTION
This PR continues adoption of `createRef()`.

----

# BREAKING CHANGES

Will affect you **only** if you used the `PortalInner` component directly before.

`PortalInner` returned `node` previously in `onMount`/`onUnmount` callbacks. Now you should use `innerRef`.

#### Before

```js
<PortalInner onMount={(e, data) => console.log(data.node)} />
```

#### After

```js
const innerRef = React.createRef()

<PortalInner innerRef={innerRef} />
console.log(innerRef.current)
```