### PR TITLE
chore(Dropdown): use createRef() internally

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -3,7 +3,7 @@ import cx from 'classnames'
 import keyboardKey from 'keyboard-key'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { Children, cloneElement } from 'react'
+import React, { Children, cloneElement, createRef } from 'react'
 import shallowEqual from 'shallowequal'
 
 import {
@@ -18,6 +18,7 @@ import {
   useKeyOnly,
   useKeyOrValueAndKey,
 } from '../../lib'
+import Ref from '../../addons/Ref'
 import Icon from '../../elements/Icon'
 import Label from '../../elements/Label'
 import DropdownDivider from './DropdownDivider'
@@ -378,6 +379,10 @@ export default class Dropdown extends Component {
   static Menu = DropdownMenu
   static SearchInput = DropdownSearchInput
 
+  searchRef = createRef()
+  sizerRef = createRef()
+  ref = createRef()
+
   getInitialAutoControlledState() {
     return { focus: false, searchQuery: '' }
   }
@@ -577,7 +582,7 @@ export default class Dropdown extends Component {
     this.makeSelectedItemActive(e)
     this.closeOnChange(e)
     this.clearSearchQuery()
-    if (search) _.invoke(this.searchRef, 'focus')
+    if (search) _.invoke(this.searchRef.current, 'focus')
   }
 
   removeItemOnBackspace = (e) => {
@@ -605,7 +610,7 @@ export default class Dropdown extends Component {
     if (!this.props.closeOnBlur) return
 
     // If event happened in the dropdown, ignore it
-    if (this.ref && doesNodeContainClick(this.ref, e)) return
+    if (this.ref.current && doesNodeContainClick(this.ref.current, e)) return
 
     this.close()
   }
@@ -641,14 +646,14 @@ export default class Dropdown extends Component {
 
     if (!search) return this.toggle(e)
     if (open) {
-      _.invoke(this.searchRef, 'focus')
+      _.invoke(this.searchRef.current, 'focus')
       return
     }
     if (searchQuery.length >= minCharacters || minCharacters === 1) {
       this.open(e)
       return
     }
-    _.invoke(this.searchRef, 'focus')
+    _.invoke(this.searchRef.current, 'focus')
   }
 
   handleIconClick = (e) => {
@@ -695,7 +700,7 @@ export default class Dropdown extends Component {
     // Notify the onAddItem prop if this is a new value
     if (isAdditionItem) _.invoke(this.props, 'onAddItem', e, { ...this.props, value })
 
-    if (search) _.invoke(this.searchRef, 'focus')
+    if (search) _.invoke(this.searchRef.current, 'focus')
   }
 
   handleFocus = (e) => {
@@ -1002,16 +1007,6 @@ export default class Dropdown extends Component {
   }
 
   // ----------------------------------------
-  // Refs
-  // ----------------------------------------
-
-  handleSearchRef = c => (this.searchRef = c)
-
-  handleSizerRef = c => (this.sizerRef = c)
-
-  handleRef = c => (this.ref = c)
-
-  // ----------------------------------------
   // Helpers
   // ----------------------------------------
 
@@ -1034,13 +1029,13 @@ export default class Dropdown extends Component {
   computeSearchInputWidth = () => {
     const { searchQuery } = this.state
 
-    if (this.sizerRef && searchQuery) {
+    if (this.sizerRef.current && searchQuery) {
       // resize the search input, temporarily show the sizer so we can measure it
 
-      this.sizerRef.style.display = 'inline'
-      this.sizerRef.textContent = searchQuery
-      const searchWidth = Math.ceil(this.sizerRef.getBoundingClientRect().width)
-      this.sizerRef.style.removeProperty('display')
+      this.sizerRef.current.style.display = 'inline'
+      this.sizerRef.current.textContent = searchQuery
+      const searchWidth = Math.ceil(this.sizerRef.current.getBoundingClientRect().width)
+      this.sizerRef.current.style.removeProperty('display')
 
       return searchWidth
     }
@@ -1075,8 +1070,8 @@ export default class Dropdown extends Component {
 
   scrollSelectedItemIntoView = () => {
     debug('scrollSelectedItemIntoView()')
-    if (!this.ref) return
-    const menu = this.ref.querySelector('.menu.visible')
+    if (!this.ref.current) return
+    const menu = this.ref.current.querySelector('.menu.visible')
     if (!menu) return
     const item = menu.querySelector('.item.selected')
     if (!item) return
@@ -1094,13 +1089,13 @@ export default class Dropdown extends Component {
   }
 
   setOpenDirection = () => {
-    if (!this.ref) return
+    if (!this.ref.current) return
 
-    const menu = this.ref.querySelector('.menu.visible')
+    const menu = this.ref.current.querySelector('.menu.visible')
 
     if (!menu) return
 
-    const dropdownRect = this.ref.getBoundingClientRect()
+    const dropdownRect = this.ref.current.getBoundingClientRect()
     const menuHeight = menu.clientHeight
     const spaceAtTheBottom =
       document.documentElement.clientHeight - dropdownRect.top - dropdownRect.height - menuHeight
@@ -1119,7 +1114,7 @@ export default class Dropdown extends Component {
     debug('open()', { disabled, open, search })
 
     if (disabled) return
-    if (search) _.invoke(this.searchRef, 'focus')
+    if (search) _.invoke(this.searchRef.current, 'focus')
 
     _.invoke(this.props, 'onOpen', e, this.props)
 
@@ -1140,15 +1135,15 @@ export default class Dropdown extends Component {
   handleClose = () => {
     debug('handleClose()')
 
-    const hasSearchFocus = document.activeElement === this.searchRef
+    const hasSearchFocus = document.activeElement === this.searchRef.current
     // https://github.com/Semantic-Org/Semantic-UI-React/issues/627
     // Blur the Dropdown on close so it is blurred after selecting an item.
     // This is to prevent it from re-opening when switching tabs after selecting an item.
     if (!hasSearchFocus) {
-      this.ref.blur()
+      this.ref.current.blur()
     }
 
-    const hasDropdownFocus = document.activeElement === this.ref
+    const hasDropdownFocus = document.activeElement === this.ref.current
     const hasFocus = hasSearchFocus || hasDropdownFocus
 
     // We need to keep the virtual model in sync with the browser focus change
@@ -1194,23 +1189,26 @@ export default class Dropdown extends Component {
     const { search, searchInput } = this.props
     const { searchQuery } = this.state
 
-    if (!search) return null
-    return DropdownSearchInput.create(searchInput, {
-      defaultProps: {
-        inputRef: this.handleSearchRef,
-        style: { width: this.computeSearchInputWidth() },
-        tabIndex: this.computeSearchInputTabIndex(),
-        value: searchQuery,
-      },
-      overrideProps: this.handleSearchInputOverrides,
-    })
+    return (
+      search && (
+        <Ref innerRef={this.searchRef}>
+          {DropdownSearchInput.create(searchInput, {
+            defaultProps: {
+              style: { width: this.computeSearchInputWidth() },
+              tabIndex: this.computeSearchInputTabIndex(),
+              value: searchQuery,
+            },
+            overrideProps: this.handleSearchInputOverrides,
+          })}
+        </Ref>
+      )
+    )
   }
 
   renderSearchSizer = () => {
     const { search, multiple } = this.props
 
-    if (!(search && multiple)) return null
-    return <span className='sizer' ref={this.handleSizerRef} />
+    return search && multiple && <span className='sizer' ref={this.sizerRef} />
   }
 
   renderLabels = () => {
@@ -1365,7 +1363,7 @@ export default class Dropdown extends Component {
         onFocus={this.handleFocus}
         onChange={this.handleChange}
         tabIndex={this.computeTabIndex()}
-        ref={this.handleRef}
+        ref={this.ref}
       >
         {this.renderLabels()}
         {this.renderSearchInput()}

--- a/src/modules/Dropdown/DropdownSearchInput.d.ts
+++ b/src/modules/Dropdown/DropdownSearchInput.d.ts
@@ -14,9 +14,6 @@ export interface StrictDropdownSearchInputProps {
   /** Additional classes. */
   className?: string
 
-  /** A ref handler for input. */
-  inputRef?: React.Ref<HTMLInputElement>
-
   /** An input can receive focus. */
   tabIndex?: number | string
 

--- a/src/modules/Dropdown/DropdownSearchInput.js
+++ b/src/modules/Dropdown/DropdownSearchInput.js
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
-import { createShorthandFactory, customPropTypes, getUnhandledProps, handleRef } from '../../lib'
+import { createShorthandFactory, customPropTypes, getUnhandledProps } from '../../lib'
 
 /**
  * A search item sub-component for Dropdown component.
@@ -18,9 +18,6 @@ class DropdownSearchInput extends Component {
 
     /** Additional classes. */
     className: PropTypes.string,
-
-    /** A ref handler for input. */
-    inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
     /** An input can receive focus. */
     tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -43,10 +40,6 @@ class DropdownSearchInput extends Component {
     _.invoke(this.props, 'onChange', e, { ...this.props, value })
   }
 
-  handleRef = (c) => {
-    handleRef(this.props.inputRef, c)
-  }
-
   render() {
     const { autoComplete, className, tabIndex, type, value } = this.props
     const classes = cx('search', className)
@@ -59,7 +52,6 @@ class DropdownSearchInput extends Component {
         autoComplete={autoComplete}
         className={classes}
         onChange={this.handleChange}
-        ref={this.handleRef}
         tabIndex={tabIndex}
         type={type}
         value={value}

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -162,33 +162,33 @@ describe('Dropdown', () => {
     wrapperMount(<Dropdown options={options} selection defaultOpen />)
 
     const instance = wrapper.instance()
-    sandbox.spy(instance.ref, 'blur')
+    sandbox.spy(instance.ref.current, 'blur')
 
     dropdownMenuIsOpen()
     wrapper.simulate('click')
     dropdownMenuIsClosed()
 
-    instance.ref.blur.should.have.been.calledOnce()
+    instance.ref.current.blur.should.have.been.calledOnce()
   })
 
   it('blurs the Dropdown node on close by clicking outside component', () => {
     wrapperMount(<Dropdown options={options} selection defaultOpen />)
 
     const instance = wrapper.instance()
-    sandbox.spy(instance.ref, 'blur')
+    sandbox.spy(instance.ref.current, 'blur')
 
     dropdownMenuIsOpen()
     document.body.click()
     dropdownMenuIsClosed()
 
-    instance.ref.blur.should.have.been.calledOnce()
+    instance.ref.current.blur.should.have.been.calledOnce()
   })
 
   it('does not close on click when search is true and options are empty', () => {
     wrapperMount(<Dropdown options={[]} search selection defaultOpen />)
 
     const instance = wrapper.instance()
-    sandbox.spy(instance.ref, 'blur')
+    sandbox.spy(instance.ref.current, 'blur')
 
     dropdownMenuIsOpen()
     wrapper.simulate('click')
@@ -1558,7 +1558,7 @@ describe('Dropdown', () => {
           .at(randomIndex)
           .simulate('click', nativeEvent)
 
-        wrapper.instance().searchRef.should.eq(document.activeElement)
+        wrapper.instance().searchRef.current.should.eq(document.activeElement)
       })
     })
     describe('removing items', () => {

--- a/test/specs/modules/Dropdown/DropdownSearchInput-test.js
+++ b/test/specs/modules/Dropdown/DropdownSearchInput-test.js
@@ -38,23 +38,6 @@ describe('DropdownSearchInput', () => {
     })
   })
 
-  describe('inputRef', () => {
-    it('maintains ref on input', () => {
-      const inputRef = sandbox.spy()
-      const mountNode = document.createElement('div')
-      document.body.appendChild(mountNode)
-
-      const wrapper = mount(<DropdownSearchInput inputRef={inputRef} />, { attachTo: mountNode })
-      const input = document.querySelector('input')
-
-      inputRef.should.have.been.calledOnce()
-      inputRef.should.have.been.calledWithMatch(input)
-
-      wrapper.detach()
-      document.body.removeChild(mountNode)
-    })
-  })
-
   describe('tabIndex', () => {
     it('is not set by default', () => {
       shallow(<DropdownSearchInput />).should.not.have.prop('tabIndex')


### PR DESCRIPTION
This PR continues adoption of `createRef()`, no user-facing changes.