### PR TITLE
fix(lib): fully remove debug in production

### DIFF
--- a/.babel-preset.js
+++ b/.babel-preset.js
@@ -48,7 +48,7 @@ const plugins = [
     'filter-imports',
     {
       imports: {
-        debug: ['default'],
+        './makeDebugger': ['default'],
         '../../lib': ['makeDebugger'],
       },
     },

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,3 +1,5 @@
+import makeDebugger from './makeDebugger'
+
 export AutoControlledComponent from './AutoControlledComponent'
 export { getChildMapping, mergeChildMappings } from './childMapping'
 export * as childrenUtils from './childrenUtils'
@@ -13,8 +15,6 @@ export {
 } from './classNameBuilders'
 
 export * as customPropTypes from './customPropTypes'
-
-export { debug, makeDebugger } from './debug'
 export eventStack from './eventStack'
 
 export * from './factories'
@@ -40,3 +40,5 @@ export normalizeOffset from './normalizeOffset'
 export normalizeTransitionDuration from './normalizeTransitionDuration'
 export objectDiff from './objectDiff'
 export { handleRef, isRefObject } from './refUtils'
+
+export { makeDebugger }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -41,4 +41,5 @@ export normalizeTransitionDuration from './normalizeTransitionDuration'
 export objectDiff from './objectDiff'
 export { handleRef, isRefObject } from './refUtils'
 
+// Heads up! We import/export for this module to safely remove it with "babel-plugin-filter-imports"
 export { makeDebugger }

--- a/src/lib/makeDebugger.js
+++ b/src/lib/makeDebugger.js
@@ -1,4 +1,4 @@
-import _debug from 'debug'
+import debug from 'debug'
 import isBrowser from './isBrowser'
 
 if (isBrowser() && process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
@@ -18,7 +18,7 @@ if (isBrowser() && process.env.NODE_ENV !== 'production' && process.env.NODE_ENV
   }
 
   // enable what ever settings we got from storage
-  _debug.enable(DEBUG)
+  debug.enable(DEBUG)
 }
 
 /**
@@ -31,12 +31,6 @@ if (isBrowser() && process.env.NODE_ENV !== 'production' && process.env.NODE_ENV
  * debug('Some message')
  * @returns {Function}
  */
-export const makeDebugger = namespace => _debug(`semanticUIReact:${namespace}`)
+const makeDebugger = namespace => debug(`semanticUIReact:${namespace}`)
 
-/**
- * Default debugger, simple log.
- * @example
- * import { debug } from 'src/lib'
- * debug('Some message')
- */
-export const debug = makeDebugger('log')
+export default makeDebugger


### PR DESCRIPTION
Fixes ##3484. This PR:
- fixes issue with not fully remove debug part in CJS builds, see [lib/index.js](https://cdn.jsdelivr.net/npm/semantic-ui-react@0.85.0/dist/commonjs/lib/index.js), `var _debug = require("./debug");` was present there
- removes `debug()` function as it was never used