### PR TITLE
fix(Pagination): update handling of `onClick` for `ellipsisItem`

### DIFF
--- a/src/addons/Pagination/Pagination.js
+++ b/src/addons/Pagination/Pagination.js
@@ -108,7 +108,7 @@ export default class Pagination extends Component {
     key: `${type}-${value}`,
     onClick: (e, itemProps) => {
       _.invoke(predefinedProps, 'onClick', e, itemProps)
-      this.handleItemClick(e, itemProps)
+      if (itemProps.type !== 'ellipsisItem') this.handleItemClick(e, itemProps)
     },
   })
 

--- a/src/addons/Pagination/PaginationItem.js
+++ b/src/addons/Pagination/PaginationItem.js
@@ -45,9 +45,7 @@ class PaginationItem extends Component {
   }
 
   handleClick = (e) => {
-    const { type } = this.props
-
-    if (type !== 'ellipsisItem') _.invoke(this.props, 'onClick', e, this.props)
+    _.invoke(this.props, 'onClick', e, this.props)
   }
 
   handleKeyDown = (e) => {

--- a/test/specs/addons/Pagination/Pagination-test.js
+++ b/test/specs/addons/Pagination/Pagination-test.js
@@ -64,5 +64,24 @@ describe('Pagination', () => {
         .simulate('click')
       onPageChange.should.have.not.been.called()
     })
+
+    it('will be omitted when item "type" is "ellipsisItem"', () => {
+      const onPageChange = sandbox.spy()
+      const wrapper = mount(
+        <Pagination
+          activePage={5}
+          firstItem={null}
+          onPageChange={onPageChange}
+          prevItem={null}
+          totalPages={10}
+        />,
+      )
+
+      wrapper
+        .find('PaginationItem')
+        .at(1)
+        .simulate('click')
+      onPageChange.should.have.not.been.called()
+    })
   })
 })

--- a/test/specs/addons/Pagination/PaginationItem-test.js
+++ b/test/specs/addons/Pagination/PaginationItem-test.js
@@ -74,15 +74,6 @@ describe('PaginationItem', () => {
       onClick.should.have.been.calledOnce()
       onClick.should.have.been.calledWithMatch(event, { onClick })
     })
-
-    it('is omitted when "type" is "ellipsisItem"', () => {
-      const event = { target: null }
-      const onClick = sandbox.spy()
-
-      shallow(<PaginationItem onClick={onClick} type='ellipsisItem' />).simulate('click', event)
-
-      onClick.should.have.been.not.called()
-    })
   })
 
   describe('onKeyDown', () => {


### PR DESCRIPTION
Fixes #3490.

Allows to correctly handle `onClick` on `ellipsisItem`:
```jsx
<Pagination
  defaultActivePage={5}
  ellipsisItem={{
    content: '...',
    onClick: (e, props) => console.log('ellipsisItem click', props),
  }}
  totalPages={10}
/>
```