### PR TITLE
fix(Tab): panes type definition

### DIFF
--- a/src/modules/Tab/Tab.d.ts
+++ b/src/modules/Tab/Tab.d.ts
@@ -49,7 +49,7 @@ export interface StrictTabProps {
    * }
    */
   panes?: {
-    content?: SemanticShorthandItem<TabPaneProps>;
+    pane?: SemanticShorthandItem<TabPaneProps>;
     menuItem?: any;
     render?: () => React.ReactNode;
   }[]


### PR DESCRIPTION
Type definition for Tab prop pane is incorrect.

In reference to #3495 