### PR TITLE
perf(docs): improve doc examples performance

### DIFF
--- a/docs/public/style.css
+++ b/docs/public/style.css
@@ -54,6 +54,18 @@ code:not(.hljs)::after {
   content: '\00a0';
 }
 
+.docs-example {
+  position: relative;
+  background: #fff;
+  box-shadow: 0 1px 2px #ccc;
+}
+.docs-example:hover {
+  box-shadow: 0 2px 8px #bbb;
+}
+.docs-example.active {
+  box-shadow: 0 8px 32px #aaa;
+}
+
 .docs-icon-set-column {
   cursor: pointer;
 }

--- a/docs/public/style.css
+++ b/docs/public/style.css
@@ -118,6 +118,7 @@ code:not(.hljs)::after {
   font-size: 10px;
   color: #fff;
   opacity: 0.5;
+  white-space: nowrap;
 }
 .carbon-poweredby:hover {
   color: #ddd;

--- a/docs/src/components/CarbonAd/CarbonAdNative.js
+++ b/docs/src/components/CarbonAd/CarbonAdNative.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
 import { Label } from 'semantic-ui-react'
@@ -6,7 +6,7 @@ import { makeDebugger } from '../../../../src/lib'
 
 const debug = makeDebugger('carbon-ad-native')
 
-class CarbonAdNative extends Component {
+class CarbonAdNative extends PureComponent {
   static propTypes = {
     inverted: PropTypes.bool,
   }

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import copyToClipboard from 'copy-to-clipboard'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
@@ -68,8 +69,6 @@ class ComponentExample extends PureComponent {
     this.anchorName = examplePathToHash(examplePath)
 
     this.setState({
-      handleMouseLeave: this.handleMouseLeave,
-      handleMouseMove: this.handleMouseMove,
       showCode: this.isActiveHash(),
       sourceCode: this.getOriginalSourceCode(),
     })
@@ -122,22 +121,6 @@ class ComponentExample extends PureComponent {
   handleDirectLinkClick = () => {
     this.setHashAndScroll()
     copyToClipboard(window && window.location.href)
-  }
-
-  handleMouseLeave = () => {
-    this.setState({
-      isHovering: false,
-      handleMouseLeave: null,
-      handleMouseMove: this.handleMouseMove,
-    })
-  }
-
-  handleMouseMove = () => {
-    this.setState({
-      isHovering: true,
-      handleMouseLeave: this.handleMouseLeave,
-      handleMouseMove: null,
-    })
   }
 
   handleShowCodeClick = (e) => {
@@ -207,31 +190,9 @@ class ComponentExample extends PureComponent {
       suiVersion,
       title,
     } = this.props
-    const {
-      error,
-      handleMouseLeave,
-      handleMouseMove,
-      htmlMarkup,
-      isHovering,
-      showCode,
-      showHTML,
-      sourceCode,
-    } = this.state
+    const { error, htmlMarkup, showCode, showHTML, sourceCode } = this.state
 
     const isActive = this.isActiveHash() || this.isActiveState()
-
-    const exampleStyle = {
-      position: 'relative',
-      background: '#fff',
-      boxShadow: '0 1px 2px #ccc',
-      ...(isActive
-        ? {
-          boxShadow: '0 8px 32px #aaa',
-        }
-        : isHovering && {
-          boxShadow: '0 2px 8px #bbb',
-        }),
-    }
 
     return (
       <Visibility
@@ -242,13 +203,7 @@ class ComponentExample extends PureComponent {
       >
         {/* Ensure anchor links don't occlude card shadow effect */}
         <div id={this.anchorName} style={{ paddingTop: '1rem' }}>
-          <Grid
-            className='docs-example'
-            padded='vertically'
-            onMouseLeave={handleMouseLeave}
-            onMouseMove={handleMouseMove}
-            style={exampleStyle}
-          >
+          <Grid className={cx('docs-example', { active: isActive })} padded='vertically'>
             <Grid.Row columns='equal'>
               <Grid.Column>
                 <ComponentExampleTitle

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleTitle.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleTitle.js
@@ -1,16 +1,20 @@
 import PropTypes from 'prop-types'
-import React, { PureComponent } from 'react'
+import React, { Component } from 'react'
 import { Header, Label } from 'semantic-ui-react'
 
 const titleStyle = {
   margin: 0,
 }
 
-export default class ComponentExampleTitle extends PureComponent {
+export default class ComponentExampleTitle extends Component {
   static propTypes = {
     description: PropTypes.node,
     title: PropTypes.node,
     suiVersion: PropTypes.string,
+  }
+
+  shouldComponentUpdate() {
+    return false
   }
 
   render() {

--- a/docs/src/components/ComponentDoc/ComponentSidebar/ComponentSidebar.js
+++ b/docs/src/components/ComponentDoc/ComponentSidebar/ComponentSidebar.js
@@ -16,7 +16,7 @@ const sidebarStyle = {
 }
 
 const ComponentSidebar = ({ activePath, examplesRef, onItemClick, sections }) => (
-  <Sticky context={examplesRef} offset={15}>
+  <Sticky context={examplesRef} offset={14}>
     <Menu as={Accordion} fluid style={sidebarStyle} text vertical>
       {_.map(sections, ({ examples, sectionName }) => (
         <ComponentSidebarSection


### PR DESCRIPTION
Doc example pages were getting a bit sluggish.  This improves performance a bit by removing some listeners and moving styles to the CSS sheet and implementing more shouldComponentUpdate.