### PR TITLE
docs(FormExampleSubcomponentControl): gender neutral option

### DIFF
--- a/docs/src/examples/collections/Form/Shorthand/FormExampleSubcomponentControl.js
+++ b/docs/src/examples/collections/Form/Shorthand/FormExampleSubcomponentControl.js
@@ -4,6 +4,7 @@ import { Form } from 'semantic-ui-react'
 const options = [
   { key: 'm', text: 'Male', value: 'male' },
   { key: 'f', text: 'Female', value: 'female' },
+  { key: 'n', text: 'Neutral', value: 'neutral' },
 ]
 
 class FormExampleSubcomponentControl extends Component {


### PR DESCRIPTION
I added a gender neutral option in the example as I felt some communities might be impacted by the binary choice here.