### PR TITLE
fix(docs): remove component page hash replacement

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentDoc.js
+++ b/docs/src/components/ComponentDoc/ComponentDoc.js
@@ -5,8 +5,7 @@ import { withRouteData } from 'react-static'
 import { Grid, Header, Icon } from 'semantic-ui-react'
 
 import DocsLayout from 'docs/src/components/DocsLayout'
-import { docTypes, examplePathToHash, getFormattedHash, scrollToAnchor } from 'docs/src/utils'
-import { isBrowser } from 'src/lib'
+import { docTypes, examplePathToHash, scrollToAnchor } from 'docs/src/utils'
 import ComponentDocLinks from './ComponentDocLinks'
 import ComponentDocSee from './ComponentDocSee'
 import ComponentExamples from './ComponentExamples'
@@ -35,19 +34,6 @@ class ComponentDoc extends Component {
 
   state = {}
   examplesRef = createRef()
-
-  componentWillMount() {
-    const { exampleKeys, history } = this.props
-    const { pathname, hash } = window.location
-
-    if (isBrowser() && hash) {
-      const activePath = getFormattedHash(exampleKeys, hash)
-      if (activePath && activePath !== hash) {
-        history.replace({ pathname, hash: activePath })
-      }
-      this.setState({ activePath })
-    }
-  }
 
   getChildContext() {
     return {

--- a/docs/src/components/ComponentDoc/ComponentDoc.js
+++ b/docs/src/components/ComponentDoc/ComponentDoc.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { Component, createRef } from 'react'
 import { withRouteData } from 'react-static'
+
 import { Grid, Header, Icon } from 'semantic-ui-react'
 
 import DocsLayout from 'docs/src/components/DocsLayout'

--- a/docs/src/components/ComponentDoc/ComponentDoc.js
+++ b/docs/src/components/ComponentDoc/ComponentDoc.js
@@ -38,10 +38,13 @@ class ComponentDoc extends Component {
 
   componentWillMount() {
     const { exampleKeys, history } = this.props
+    const { pathname, hash } = window.location
 
-    if (isBrowser() && window.location.hash) {
-      const activePath = getFormattedHash(exampleKeys, window.location.hash)
-      history.replace(`${window.location.pathname}#${activePath}`)
+    if (isBrowser() && hash) {
+      const activePath = getFormattedHash(exampleKeys, hash)
+      if (activePath && activePath !== hash) {
+        history.replace({ pathname, hash: activePath })
+      }
       this.setState({ activePath })
     }
   }

--- a/docs/src/components/ComponentDoc/ComponentDoc.js
+++ b/docs/src/components/ComponentDoc/ComponentDoc.js
@@ -2,7 +2,6 @@ import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { Component, createRef } from 'react'
 import { withRouteData } from 'react-static'
-
 import { Grid, Header, Icon } from 'semantic-ui-react'
 
 import DocsLayout from 'docs/src/components/DocsLayout'


### PR DESCRIPTION
Closes #3527 and affects #2732 (removes `componentWillMount` from `ComponentDoc`).