### PR TITLE
docs(ComponentDoc): replace deprecated lifecycle methods

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentDoc.js
+++ b/docs/src/components/ComponentDoc/ComponentDoc.js
@@ -34,15 +34,18 @@ class ComponentDoc extends Component {
   state = {}
   examplesRef = createRef()
 
-  getChildContext() {
+  static getDerivedStateFromProps(props, state) {
+    const { displayName } = props
+
     return {
-      onPassed: this.handleExamplePassed,
+      displayName,
+      activePath: displayName === state.displayName ? state.activePath : undefined,
     }
   }
 
-  componentWillReceiveProps({ displayName }) {
-    if (displayName !== this.props.displayName) {
-      this.setState({ activePath: undefined })
+  getChildContext() {
+    return {
+      onPassed: this.handleExamplePassed,
     }
   }
 

--- a/docs/src/components/ComponentDoc/ComponentDoc.js
+++ b/docs/src/components/ComponentDoc/ComponentDoc.js
@@ -35,11 +35,9 @@ class ComponentDoc extends Component {
   examplesRef = createRef()
 
   static getDerivedStateFromProps(props, state) {
-    const { displayName } = props
-
     return {
-      displayName,
-      activePath: displayName === state.displayName ? state.activePath : undefined,
+      displayName: props.displayName,
+      activePath: props.displayName === state.displayName ? state.activePath : undefined,
     }
   }
 


### PR DESCRIPTION
Relates to #2732  Replace `componentWillReceiveProps` by constructor and `getDerivedStateFromProps`.