### PR TITLE
fix(Card): fix `image` shorthand

### DIFF
--- a/docs/src/examples/views/Card/Content/CardExampleImageCard.js
+++ b/docs/src/examples/views/Card/Content/CardExampleImageCard.js
@@ -3,11 +3,13 @@ import { Card, Icon, Image } from 'semantic-ui-react'
 
 const CardExampleImageCard = () => (
   <Card>
-    <Image src='/images/avatar/large/daniel.jpg' />
+    <Image src='/images/avatar/large/daniel.jpg' wrapped ui={false} />
     <Card.Content>
       <Card.Header>Daniel</Card.Header>
       <Card.Meta>Joined in 2016</Card.Meta>
-      <Card.Description>Daniel is a comedian living in Nashville.</Card.Description>
+      <Card.Description>
+        Daniel is a comedian living in Nashville.
+      </Card.Description>
     </Card.Content>
     <Card.Content extra>
       <a>

--- a/docs/src/examples/views/Card/Types/CardExampleCard.js
+++ b/docs/src/examples/views/Card/Types/CardExampleCard.js
@@ -3,13 +3,15 @@ import { Card, Icon, Image } from 'semantic-ui-react'
 
 const CardExampleCard = () => (
   <Card>
-    <Image src='/images/avatar/large/matthew.png' />
+    <Image src='/images/avatar/large/matthew.png' wrapped ui={false} />
     <Card.Content>
       <Card.Header>Matthew</Card.Header>
       <Card.Meta>
         <span className='date'>Joined in 2015</span>
       </Card.Meta>
-      <Card.Description>Matthew is a musician living in Nashville.</Card.Description>
+      <Card.Description>
+        Matthew is a musician living in Nashville.
+      </Card.Description>
     </Card.Content>
     <Card.Content extra>
       <a>

--- a/src/views/Card/Card.js
+++ b/src/views/Card/Card.js
@@ -140,7 +140,13 @@ export default class Card extends Component {
 
     return (
       <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>
-        {Image.create(image, { autoGenerateKey: false })}
+        {Image.create(image, {
+          autoGenerateKey: false,
+          defaultProps: {
+            ui: false,
+            wrapped: true,
+          },
+        })}
         {(description || header || meta) && (
           <CardContent description={description} header={header} meta={meta} />
         )}


### PR DESCRIPTION
Fixes #3542.

Updates generated markup by shorthand.

#### Before

```html
<img src="..." class="ui image" />
```

![image](https://user-images.githubusercontent.com/14183168/55513703-a49e4700-5666-11e9-881f-d1ff02c66f22.png)


#### After

```html
<div class="image">
  <img src="..." />
</div>
```

![image](https://user-images.githubusercontent.com/14183168/55513692-9bad7580-5666-11e9-8ec6-536f4093d1aa.png)
