### PR TITLE
fix(elements): allow 'right' on iconPosition for Label

### DIFF
--- a/src/elements/Input/Input.d.ts
+++ b/src/elements/Input/Input.d.ts
@@ -38,8 +38,8 @@ export interface StrictInputProps {
   /** Optional Icon to display inside the Input. */
   icon?: any | SemanticShorthandItem<InputProps>
 
-  /** An Icon can appear inside an Input on the left. */
-  iconPosition?: 'left'
+  /** An Icon can appear inside an Input on the left or right. */
+  iconPosition?: 'left' | 'right'
 
   /** Shorthand for creating the HTML Input. */
   input?: SemanticShorthandItem<HtmlInputrops>

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -59,7 +59,7 @@ class Input extends Component {
     icon: PropTypes.oneOfType([PropTypes.bool, customPropTypes.itemShorthand]),
 
     /** An Icon can appear inside an Input on the left or right. */
-    iconPosition: PropTypes.oneOf(['left']),
+    iconPosition: PropTypes.oneOf(['left', 'right']),
 
     /** Shorthand for creating the HTML Input. */
     input: customPropTypes.itemShorthand,


### PR DESCRIPTION
Using 'right' as iconPosition currently produces a warning for failed prop type.