### PR TITLE
chore(package): add `browser` field that points to UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "jsnext:main": "dist/es/index.js",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",
+  "browser": "dist/umd/semantic-ui-react.min.js",
   "types": "index.d.ts",
   "files": [
     "src",


### PR DESCRIPTION
- uses expose-loader to do this
- added the umd build path as the browser property on package.json