### PR TITLE
fix(Modal): do not close when mouse click was occurred inside

### DIFF
--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -186,13 +186,12 @@ class Modal extends Component {
   handleDocumentClick = (e) => {
     debug('handleDocumentClick()')
     const { closeOnDimmerClick } = this.props
-
-    const previousDocumentMouseDownEvent = this.latestDocumentMouseDownEvent
-    delete this.latestDocumentMouseDownEvent
+    const currentDocumentMouseDownEvent = this.latestDocumentMouseDownEvent
+    this.latestDocumentMouseDownEvent = null
 
     if (
       !closeOnDimmerClick ||
-      doesNodeContainClick(this.ref.current, previousDocumentMouseDownEvent) ||
+      doesNodeContainClick(this.ref.current, currentDocumentMouseDownEvent) ||
       doesNodeContainClick(this.ref.current, e)
     )
       return

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -153,6 +153,7 @@ class Modal extends Component {
 
   ref = createRef()
   dimmerRef = createRef()
+  mouseDownEvent = null
 
   componentWillUnmount() {
     debug('componentWillUnmount()')
@@ -178,11 +179,20 @@ class Modal extends Component {
     this.trySetState({ open: false })
   }
 
-  handleDocumentClick = (e) => {
-    debug('handleDocumentClick()')
+  handleDocumentMouseDown = (e) => {
+    this.mouseDownEvent = e
+  }
+
+  handleDocumentMouseUp = (e) => {
+    debug('handleDocumentMouseUp()')
     const { closeOnDimmerClick } = this.props
 
-    if (!closeOnDimmerClick || doesNodeContainClick(this.ref.current, e)) return
+    if (
+      !closeOnDimmerClick ||
+      doesNodeContainClick(this.ref.current, this.mouseDownEvent) ||
+      doesNodeContainClick(this.ref.current, e)
+    )
+      return
 
     _.invoke(this.props, 'onClose', e, this.props)
     this.trySetState({ open: false })
@@ -209,7 +219,11 @@ class Modal extends Component {
     this.setState({ scrolling: false })
     this.setPositionAndClassNames()
 
-    eventStack.sub('click', this.handleDocumentClick, {
+    eventStack.sub('mousedown', this.handleDocumentMouseDown, {
+      pool: eventPool,
+      target: this.dimmerRef.current,
+    })
+    eventStack.sub('mouseup', this.handleDocumentMouseUp, {
       pool: eventPool,
       target: this.dimmerRef.current,
     })
@@ -221,7 +235,11 @@ class Modal extends Component {
     debug('handlePortalUnmount()', { eventPool })
 
     cancelAnimationFrame(this.animationRequestId)
-    eventStack.unsub('click', this.handleDocumentClick, {
+    eventStack.unsub('mousedown', this.handleDocumentMouseDown, {
+      pool: eventPool,
+      target: this.dimmerRef.current,
+    })
+    eventStack.unsub('mouseup', this.handleDocumentMouseUp, {
       pool: eventPool,
       target: this.dimmerRef.current,
     })

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -153,7 +153,7 @@ class Modal extends Component {
 
   ref = createRef()
   dimmerRef = createRef()
-  mouseDownEvent = null
+  latestDocumentMouseDownEvent = null
 
   componentWillUnmount() {
     debug('componentWillUnmount()')
@@ -180,16 +180,19 @@ class Modal extends Component {
   }
 
   handleDocumentMouseDown = (e) => {
-    this.mouseDownEvent = e
+    this.latestDocumentMouseDownEvent = e
   }
 
-  handleDocumentMouseUp = (e) => {
-    debug('handleDocumentMouseUp()')
+  handleDocumentClick = (e) => {
+    debug('handleDocumentClick()')
     const { closeOnDimmerClick } = this.props
+
+    const previousDocumentMouseDownEvent = this.latestDocumentMouseDownEvent
+    delete this.latestDocumentMouseDownEvent
 
     if (
       !closeOnDimmerClick ||
-      doesNodeContainClick(this.ref.current, this.mouseDownEvent) ||
+      doesNodeContainClick(this.ref.current, previousDocumentMouseDownEvent) ||
       doesNodeContainClick(this.ref.current, e)
     )
       return
@@ -223,7 +226,7 @@ class Modal extends Component {
       pool: eventPool,
       target: this.dimmerRef.current,
     })
-    eventStack.sub('mouseup', this.handleDocumentMouseUp, {
+    eventStack.sub('click', this.handleDocumentClick, {
       pool: eventPool,
       target: this.dimmerRef.current,
     })
@@ -239,7 +242,7 @@ class Modal extends Component {
       pool: eventPool,
       target: this.dimmerRef.current,
     })
-    eventStack.unsub('mouseup', this.handleDocumentMouseUp, {
+    eventStack.unsub('click', this.handleDocumentClick, {
       pool: eventPool,
       target: this.dimmerRef.current,
     })

--- a/test/specs/addons/Confirm/Confirm-test.js
+++ b/test/specs/addons/Confirm/Confirm-test.js
@@ -124,26 +124,22 @@ describe('Confirm', () => {
     })
 
     it('is called on dimmer click', () => {
-      domEvent.mouseDown('.ui.dimmer')
-      domEvent.mouseUp('.ui.dimmer')
+      domEvent.click('.ui.dimmer')
       spy.should.have.been.calledOnce()
     })
 
     it('is called on click outside of the modal', () => {
-      domEvent.mouseDown(document.querySelector('.ui.modal').parentNode)
-      domEvent.mouseUp(document.querySelector('.ui.modal').parentNode)
+      domEvent.click(document.querySelector('.ui.modal').parentNode)
       spy.should.have.been.calledOnce()
     })
 
     it('is not called on click inside of the modal', () => {
-      domEvent.mouseDown(document.querySelector('.ui.modal'))
-      domEvent.mouseUp(document.querySelector('.ui.modal'))
+      domEvent.click(document.querySelector('.ui.modal'))
       spy.should.not.have.been.calledOnce()
     })
 
     it('is not called on body click', () => {
-      domEvent.mouseDown('body')
-      domEvent.mouseUp('body')
+      domEvent.click('body')
       spy.should.not.have.been.calledOnce()
     })
 

--- a/test/specs/addons/Confirm/Confirm-test.js
+++ b/test/specs/addons/Confirm/Confirm-test.js
@@ -32,13 +32,13 @@ describe('Confirm', () => {
     autoGenerateKey: false,
     propKey: 'header',
     ShorthandComponent: Modal.Header,
-    mapValueToProps: content => ({ content }),
+    mapValueToProps: (content) => ({ content }),
   })
   common.implementsShorthandProp(Confirm, {
     autoGenerateKey: false,
     propKey: 'content',
     ShorthandComponent: Modal.Content,
-    mapValueToProps: content => ({ content }),
+    mapValueToProps: (content) => ({ content }),
   })
 
   describe('children', () => {
@@ -124,22 +124,26 @@ describe('Confirm', () => {
     })
 
     it('is called on dimmer click', () => {
-      domEvent.click('.ui.dimmer')
+      domEvent.mouseDown('.ui.dimmer')
+      domEvent.mouseUp('.ui.dimmer')
       spy.should.have.been.calledOnce()
     })
 
     it('is called on click outside of the modal', () => {
-      domEvent.click(document.querySelector('.ui.modal').parentNode)
+      domEvent.mouseDown(document.querySelector('.ui.modal').parentNode)
+      domEvent.mouseUp(document.querySelector('.ui.modal').parentNode)
       spy.should.have.been.calledOnce()
     })
 
     it('is not called on click inside of the modal', () => {
-      domEvent.click(document.querySelector('.ui.modal'))
+      domEvent.mouseDown(document.querySelector('.ui.modal'))
+      domEvent.mouseUp(document.querySelector('.ui.modal'))
       spy.should.not.have.been.calledOnce()
     })
 
     it('is not called on body click', () => {
-      domEvent.click('body')
+      domEvent.mouseDown('body')
+      domEvent.mouseUp('body')
       spy.should.not.have.been.calledOnce()
     })
 

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -319,32 +319,36 @@ describe('Modal', () => {
     it('is called on dimmer click', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen />)
 
-      domEvent.mouseDown('.ui.dimmer')
-      domEvent.mouseUp('.ui.dimmer')
+      domEvent.click('.ui.dimmer')
       spy.should.have.been.calledOnce()
     })
 
     it('is called on click outside of the modal', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen />)
 
-      domEvent.mouseDown(document.querySelector('.ui.modal').parentNode)
-      domEvent.mouseUp(document.querySelector('.ui.modal').parentNode)
+      domEvent.click(document.querySelector('.ui.modal').parentNode)
       spy.should.have.been.calledOnce()
+    })
+
+    it('is not called on mousedown inside and mouseup outside of the modal', () => {
+      wrapperMount(<Modal onClose={spy} defaultOpen />)
+
+      domEvent.mouseDown(document.querySelector('.ui.modal'))
+      domEvent.click(document.querySelector('.ui.modal').parentNode)
+      spy.should.not.have.been.called()
     })
 
     it('is not called on click inside of the modal', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen />)
 
-      domEvent.mouseDown(document.querySelector('.ui.modal'))
-      domEvent.mouseUp(document.querySelector('.ui.modal'))
+      domEvent.click(document.querySelector('.ui.modal'))
       spy.should.not.have.been.called()
     })
 
     it('is not called on body click', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen />)
 
-      domEvent.mouseDown(document.body)
-      domEvent.mouseUp(document.body)
+      domEvent.click(document.body)
       spy.should.not.have.been.calledOnce()
     })
 
@@ -372,16 +376,14 @@ describe('Modal', () => {
     it('is not called on dimmer click when closeOnDimmerClick is false', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen closeOnDimmerClick={false} />)
 
-      domEvent.mouseDown('.ui.dimmer')
-      domEvent.mouseUp('.ui.dimmer')
+      domEvent.click('.ui.dimmer')
       spy.should.not.have.been.called()
     })
 
     it('is not called on body click when closeOnDocumentClick is false', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen closeOnDocumentClick={false} />)
 
-      domEvent.mouseDown(document.body)
-      domEvent.mouseUp(document.body)
+      domEvent.click(document.body)
       spy.should.not.have.been.called()
     })
   })
@@ -547,8 +549,7 @@ describe('Modal', () => {
 
       requestAnimationFrame(() => {
         assertBodyClasses('scrolling')
-        domEvent.mouseDown('.ui.dimmer')
-        domEvent.mouseUp('.ui.dimmer')
+        domEvent.click('.ui.dimmer')
 
         assertBodyClasses('scrolling', false)
 

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -53,13 +53,13 @@ describe('Modal', () => {
     autoGenerateKey: false,
     propKey: 'header',
     ShorthandComponent: ModalHeader,
-    mapValueToProps: content => ({ content }),
+    mapValueToProps: (content) => ({ content }),
   })
   common.implementsShorthandProp(Modal, {
     autoGenerateKey: false,
     propKey: 'content',
     ShorthandComponent: ModalContent,
-    mapValueToProps: content => ({ content }),
+    mapValueToProps: (content) => ({ content }),
   })
 
   // Heads up!
@@ -319,28 +319,32 @@ describe('Modal', () => {
     it('is called on dimmer click', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen />)
 
-      domEvent.click('.ui.dimmer')
+      domEvent.mouseDown('.ui.dimmer')
+      domEvent.mouseUp('.ui.dimmer')
       spy.should.have.been.calledOnce()
     })
 
     it('is called on click outside of the modal', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen />)
 
-      domEvent.click(document.querySelector('.ui.modal').parentNode)
+      domEvent.mouseDown(document.querySelector('.ui.modal').parentNode)
+      domEvent.mouseUp(document.querySelector('.ui.modal').parentNode)
       spy.should.have.been.calledOnce()
     })
 
     it('is not called on click inside of the modal', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen />)
 
-      domEvent.click(document.querySelector('.ui.modal'))
+      domEvent.mouseDown(document.querySelector('.ui.modal'))
+      domEvent.mouseUp(document.querySelector('.ui.modal'))
       spy.should.not.have.been.called()
     })
 
     it('is not called on body click', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen />)
 
-      domEvent.click(document.body)
+      domEvent.mouseDown(document.body)
+      domEvent.mouseUp(document.body)
       spy.should.not.have.been.calledOnce()
     })
 
@@ -368,14 +372,16 @@ describe('Modal', () => {
     it('is not called on dimmer click when closeOnDimmerClick is false', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen closeOnDimmerClick={false} />)
 
-      domEvent.click('.ui.dimmer')
+      domEvent.mouseDown('.ui.dimmer')
+      domEvent.mouseUp('.ui.dimmer')
       spy.should.not.have.been.called()
     })
 
     it('is not called on body click when closeOnDocumentClick is false', () => {
       wrapperMount(<Modal onClose={spy} defaultOpen closeOnDocumentClick={false} />)
 
-      domEvent.click(document.body)
+      domEvent.mouseDown(document.body)
+      domEvent.mouseUp(document.body)
       spy.should.not.have.been.called()
     })
   })
@@ -541,7 +547,8 @@ describe('Modal', () => {
 
       requestAnimationFrame(() => {
         assertBodyClasses('scrolling')
-        domEvent.click('.ui.dimmer')
+        domEvent.mouseDown('.ui.dimmer')
+        domEvent.mouseUp('.ui.dimmer')
 
         assertBodyClasses('scrolling', false)
 


### PR DESCRIPTION
The default modal closes when:

1. When a click starts in the modal but ends in the dimmer
2. When a click starts in the dimmer but ends in the modal

This can be reproduced in the first example
https://react.semantic-ui.com/modules/modal/

This change will only close the Modal if the click starts and ends in the dimmer.