### PR TITLE
chore(package): remove `browser` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",
   "types": "index.d.ts",
+  "unpkg": "dist/umd/semantic-ui-react.min.js",
   "files": [
     "src",
     "dist",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "jsnext:main": "dist/es/index.js",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",
-  "browser": "dist/umd/semantic-ui-react.min.js",
   "types": "index.d.ts",
   "files": [
     "src",


### PR DESCRIPTION
Reverts changes introduced in #3566, fixes #3597.
Similar issue: https://github.com/blockstack/blockstack.js/pull/621