### PR TITLE
fix(Popup): fix positioning in scrollable container

### DIFF
--- a/src/modules/Popup/lib/createReferenceProxy.js
+++ b/src/modules/Popup/lib/createReferenceProxy.js
@@ -19,7 +19,7 @@ class ReferenceProxy {
   }
 
   get parentNode() {
-    return this.ref.current.parentNode
+    return this.ref.current ? this.ref.current.parentNode : undefined
   }
 }
 

--- a/src/modules/Popup/lib/createReferenceProxy.js
+++ b/src/modules/Popup/lib/createReferenceProxy.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import { isRefObject } from '../../../lib/refUtils'
 
-class CreateReferenceProxy {
+class ReferenceProxy {
   constructor(refObject) {
     this.ref = refObject
   }
@@ -32,7 +32,7 @@ class CreateReferenceProxy {
  */
 const createReferenceProxy = _.memoize(
   (reference) =>
-    new CreateReferenceProxy(
+    new ReferenceProxy(
       // TODO: use toRefObject from Stardust
       // https://github.com/stardust-ui/react/issues/998
       isRefObject(reference) ? reference : { current: reference },

--- a/src/modules/Popup/lib/createReferenceProxy.js
+++ b/src/modules/Popup/lib/createReferenceProxy.js
@@ -17,6 +17,10 @@ class CreateReferenceProxy {
   get clientHeight() {
     return this.getBoundingClientRect().height
   }
+
+  get parentNode() {
+    return this.ref.current.parentNode
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #3569.

`Popper.JS` relies on [`getScrollParent()`](https://github.com/FezVrasta/popper.js/blob/master/packages/popper/src/utils/getScrollParent.js) function which recursively uses [`getParentNode()`](https://github.com/FezVrasta/popper.js/blob/master/packages/popper/src/utils/getParentNode.js) under hood. `getParentNode()` uses `parentNode` field and our `ReferenceProxy` doesn't have it before 😢 

### Before

![popup-bug](https://user-images.githubusercontent.com/14183168/57651284-1e621280-75cd-11e9-81dc-bf482fa92e03.gif)


### After

![popup-update](https://user-images.githubusercontent.com/14183168/57651198-f4105500-75cc-11e9-86ee-380f76a6a336.gif)
