### PR TITLE
fix(Dropdown): aria-live region needs aria-atomic

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -769,8 +769,8 @@ export default class Dropdown extends Component {
   // Getters
   // ----------------------------------------
 
-  getKeyAndValues = options =>
-    (options ? options.map(option => _.pick(option, ['key', 'value'])) : options)
+  getKeyAndValues = (options) =>
+    options ? options.map((option) => _.pick(option, ['key', 'value'])) : options
 
   // There are times when we need to calculate the options based on a value
   // that hasn't yet been persisted to state.
@@ -782,7 +782,7 @@ export default class Dropdown extends Component {
 
     // filter out active options
     if (multiple) {
-      filteredOptions = _.filter(filteredOptions, opt => !_.includes(value, opt.value))
+      filteredOptions = _.filter(filteredOptions, (opt) => !_.includes(value, opt.value))
     }
 
     // filter by search query
@@ -795,7 +795,7 @@ export default class Dropdown extends Component {
 
         const re = new RegExp(_.escapeRegExp(strippedQuery), 'i')
 
-        filteredOptions = _.filter(filteredOptions, opt =>
+        filteredOptions = _.filter(filteredOptions, (opt) =>
           re.test(deburr ? _.deburr(opt.text) : opt.text),
         )
       }
@@ -1056,7 +1056,7 @@ export default class Dropdown extends Component {
     return _.isNil(tabIndex) ? 0 : tabIndex
   }
 
-  handleSearchInputOverrides = predefinedProps => ({
+  handleSearchInputOverrides = (predefinedProps) => ({
     onChange: (e, inputProps) => {
       _.invoke(predefinedProps, 'onChange', e, inputProps)
       this.handleSearchChange(e, inputProps)
@@ -1157,7 +1157,7 @@ export default class Dropdown extends Component {
     this.setState({ focus: hasFocus })
   }
 
-  toggle = e => (this.state.open ? this.close(e) : this.open(e))
+  toggle = (e) => (this.state.open ? this.close(e) : this.open(e))
 
   // ----------------------------------------
   // Render
@@ -1185,7 +1185,7 @@ export default class Dropdown extends Component {
     }
 
     return (
-      <div className={classes} role='alert' aria-live='polite'>
+      <div className={classes} role='alert' aria-live='polite' aria-atomic>
         {_text}
       </div>
     )
@@ -1257,8 +1257,8 @@ export default class Dropdown extends Component {
     }
 
     const isActive = multiple
-      ? optValue => _.includes(value, optValue)
-      : optValue => optValue === value
+      ? (optValue) => _.includes(value, optValue)
+      : (optValue) => optValue === value
 
     return _.map(options, (opt, i) =>
       DropdownItem.create({

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -102,7 +102,7 @@ describe('Dropdown', () => {
     autoGenerateKey: false,
     propKey: 'header',
     ShorthandComponent: DropdownHeader,
-    mapValueToProps: val => ({ content: val }),
+    mapValueToProps: (val) => ({ content: val }),
   })
 
   common.propKeyOnlyToClassName(Dropdown, 'disabled')
@@ -292,6 +292,13 @@ describe('Dropdown', () => {
         .find('div')
         .at(0)
         .should.have.prop('role', 'listbox')
+    })
+    it('should render an aria-live region with aria-atomic', () => {
+      wrapperMount(<Dropdown />)
+      wrapper
+        .find('div')
+        .at(1)
+        .should.have.props({ 'aria-live': 'polite', 'aria-atomic': true, role: 'alert' })
     })
     it('should label search dropdown as a combobox', () => {
       wrapperMount(<Dropdown search />)
@@ -704,7 +711,7 @@ describe('Dropdown', () => {
         .should.have.prop('selected', true)
     })
     it('is null when all options disabled', () => {
-      const disabledOptions = options.map(o => ({ ...o, disabled: true }))
+      const disabledOptions = options.map((o) => ({ ...o, disabled: true }))
 
       wrapperRender(<Dropdown options={disabledOptions} selection />).should.not.have.descendants(
         '.selected',
@@ -1877,7 +1884,7 @@ describe('Dropdown', () => {
     it('adds the onClick handler to all items', () => {
       wrapperShallow(<Dropdown options={options} selection />)
         .find('DropdownItem')
-        .everyWhere(item => item.should.have.prop('onClick'))
+        .everyWhere((item) => item.should.have.prop('onClick'))
     })
     it('calls handleItemClick when an item is clicked', () => {
       wrapperMount(<Dropdown options={options} selection />)
@@ -1927,7 +1934,7 @@ describe('Dropdown', () => {
       ]
       wrapperShallow(<Dropdown options={customOptions} selection />)
         .find('DropdownItem')
-        .everyWhere(item => item.should.have.prop('data-foo', 'someValue'))
+        .everyWhere((item) => item.should.have.prop('data-foo', 'someValue'))
     })
 
     it('handles keys correctly', () => {


### PR DESCRIPTION
Did an audit of our site with NVDA and ran into a problem where dropdowns act kind of funny depending on the order of the values in the dropdown. Apparently aria-live regions only read what changes in the region unless you specify aria-atomic to read the entire area aloud. This means that if you have a dropdown like this

```
Within 25 miles
Within 50 miles
Within 125 miles
Within 250 miles
Within 500 miles
More than 500 miles
```

The screen reader reads these options as 'Within 25 miles', '50', '125', '0'

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#Advanced_live_regions