### PR TITLE
docs(Layouts): fix vertical alignment on LoginPage

### DIFF
--- a/docs/src/layouts/LoginLayout.js
+++ b/docs/src/layouts/LoginLayout.js
@@ -2,48 +2,32 @@ import React from 'react'
 import { Button, Form, Grid, Header, Image, Message, Segment } from 'semantic-ui-react'
 
 const LoginForm = () => (
-  <div className='login-form'>
-    {/*
-      Heads up! The styles below are necessary for the correct render of this example.
-      You can do same with CSS, the main idea is that all the elements up to the `Grid`
-      below must have a height of 100%.
-    */}
-    <style>
-      {`
-      body > div,
-      body > div > div,
-      body > div > div > div.login-form {
-        height: 100%;
-      }
-    `}
-    </style>
-    <Grid textAlign='center' style={{ height: '100vh' }} verticalAlign='middle'>
-      <Grid.Column style={{ maxWidth: 450 }}>
-        <Header as='h2' color='teal' textAlign='center'>
-          <Image src='/logo.png' /> Log-in to your account
-        </Header>
-        <Form size='large'>
-          <Segment stacked>
-            <Form.Input fluid icon='user' iconPosition='left' placeholder='E-mail address' />
-            <Form.Input
-              fluid
-              icon='lock'
-              iconPosition='left'
-              placeholder='Password'
-              type='password'
-            />
+  <Grid textAlign='center' style={{ height: '100vh' }} verticalAlign='middle'>
+    <Grid.Column style={{ maxWidth: 450 }}>
+      <Header as='h2' color='teal' textAlign='center'>
+        <Image src='/logo.png' /> Log-in to your account
+      </Header>
+      <Form size='large'>
+        <Segment stacked>
+          <Form.Input fluid icon='user' iconPosition='left' placeholder='E-mail address' />
+          <Form.Input
+            fluid
+            icon='lock'
+            iconPosition='left'
+            placeholder='Password'
+            type='password'
+          />
 
-            <Button color='teal' fluid size='large'>
-              Login
-            </Button>
-          </Segment>
-        </Form>
-        <Message>
-          New to us? <a href='#'>Sign Up</a>
-        </Message>
-      </Grid.Column>
-    </Grid>
-  </div>
+          <Button color='teal' fluid size='large'>
+            Login
+          </Button>
+        </Segment>
+      </Form>
+      <Message>
+        New to us? <a href='#'>Sign Up</a>
+      </Message>
+    </Grid.Column>
+  </Grid>
 )
 
 export default LoginForm

--- a/docs/src/layouts/LoginLayout.js
+++ b/docs/src/layouts/LoginLayout.js
@@ -8,7 +8,8 @@ const LoginForm = () => (
       You can do same with CSS, the main idea is that all the elements up to the `Grid`
       below must have a height of 100%.
     */}
-    <style>{`
+    <style>
+      {`
       body > div,
       body > div > div,
       body > div > div > div.login-form {
@@ -16,7 +17,7 @@ const LoginForm = () => (
       }
     `}
     </style>
-    <Grid textAlign='center' style={{ height: '100%' }} verticalAlign='middle'>
+    <Grid textAlign='center' style={{ height: '100vh' }} verticalAlign='middle'>
       <Grid.Column style={{ maxWidth: 450 }}>
         <Header as='h2' color='teal' textAlign='center'>
           <Image src='/logo.png' /> Log-in to your account


### PR DESCRIPTION
The vertical alignment of login form is fixed. 
Earlier the grid height was given 100% and now I changed grid height to 100vh. Now the login form will be always centered irresective of screen height.
This PR fixes this [issue](https://github.com/Semantic-Org/Semantic-UI-React/issues/3620)

Fixes #3620.