### PR TITLE
feat(Popup): add pinned and popperModifiers prop

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
@@ -214,7 +214,10 @@ const Wrapper = (props) => {
       {...rest}
       /* eslint-disable-next-line react/prop-types */
       sourceCode={sourceCode}
-    />
+    >
+      {/* eslint-disable-next-line react/prop-types */}
+      {props.children}
+    </ComponentExample>
   )
 }
 

--- a/docs/src/examples/modules/Popup/States/PopupExamplePinned.js
+++ b/docs/src/examples/modules/Popup/States/PopupExamplePinned.js
@@ -4,6 +4,7 @@ import { Button, Popup } from 'semantic-ui-react'
 const PopupExamplePinned = () => (
   <Popup
     content='I will not flip!'
+    on='click'
     pinned
     trigger={<Button content='Button' />}
   />

--- a/docs/src/examples/modules/Popup/States/PopupExamplePinned.js
+++ b/docs/src/examples/modules/Popup/States/PopupExamplePinned.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const PopupExamplePinned = () => (
+  <Popup
+    content='I will not flip!'
+    pinned
+    trigger={<Button content='Button' />}
+  />
+)
+
+export default PopupExamplePinned

--- a/docs/src/examples/modules/Popup/States/index.js
+++ b/docs/src/examples/modules/Popup/States/index.js
@@ -9,6 +9,11 @@ const PopupStatesExamples = () => (
       description='A disabled popup only renders its trigger.'
       examplePath='modules/Popup/States/PopupExampleDisabled'
     />
+    <ComponentExample
+      title='Pinned'
+      description='Disables automatic repositioning of the component, it will always be placed according to the position value.'
+      examplePath='modules/Popup/States/PopupExamplePinned'
+    />
   </ExampleSection>
 )
 

--- a/docs/src/examples/modules/Popup/Usage/index.js
+++ b/docs/src/examples/modules/Popup/Usage/index.js
@@ -45,6 +45,18 @@ const PopupUsageExamples = () => (
       />
     </ComponentExample>
     <ComponentExample
+      title='Popper Modifiers'
+      description='You can also deeply configure PopperJS with passing down modifiers.'
+      examplePath='modules/Popup/Usage/PopupExamplePopperModifiers'
+    >
+      <Button
+        content='Popper.JS: modifiers'
+        href='https://popper.js.org/popper-documentation.html#modifiers'
+        icon='book'
+        target='_blank'
+      />
+    </ComponentExample>
+    <ComponentExample
       title='Actions'
       description='A popup can be triggered on hover, click, focus or multiple actions.'
       examplePath='modules/Popup/Usage/PopupExampleActions'

--- a/docs/src/examples/modules/Popup/Usage/index.js
+++ b/docs/src/examples/modules/Popup/Usage/index.js
@@ -45,18 +45,6 @@ const PopupUsageExamples = () => (
       />
     </ComponentExample>
     <ComponentExample
-      title='Popper Modifiers'
-      description='You can also deeply configure PopperJS with passing down modifiers.'
-      examplePath='modules/Popup/Usage/PopupExamplePopperModifiers'
-    >
-      <Button
-        content='Popper.JS: modifiers'
-        href='https://popper.js.org/popper-documentation.html#modifiers'
-        icon='book'
-        target='_blank'
-      />
-    </ComponentExample>
-    <ComponentExample
       title='Actions'
       description='A popup can be triggered on hover, click, focus or multiple actions.'
       examplePath='modules/Popup/Usage/PopupExampleActions'

--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -90,6 +90,12 @@ export interface StrictPopupProps extends StrictPortalProps {
    */
   onUnmount?: (nothing: null, data: PopupProps) => void
 
+  /** Disables automatic repositioning of the component, it will always be placed according to the position value. */
+  pinned?: boolean
+
+  /** An object containing custom settings for the Popper.js modifiers. */
+  popperModifiers?: object
+
   /** Position for the popover. */
   position?:
     | 'top left'

--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -93,9 +93,6 @@ export interface StrictPopupProps extends StrictPortalProps {
   /** Disables automatic repositioning of the component, it will always be placed according to the position value. */
   pinned?: boolean
 
-  /** An object containing custom settings for the Popper.js modifiers. */
-  popperModifiers?: object
-
   /** Position for the popover. */
   position?:
     | 'top left'
@@ -106,6 +103,9 @@ export interface StrictPopupProps extends StrictPortalProps {
     | 'left center'
     | 'top center'
     | 'bottom center'
+
+  /** An object containing custom settings for the Popper.js modifiers. */
+  popperModifiers?: object
 
   /** Popup size. */
   size?: 'mini' | 'tiny' | 'small' | 'large' | 'huge'

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -117,8 +117,14 @@ export default class Popup extends Component {
      */
     onUnmount: PropTypes.func,
 
+    /** Disables automatic repositioning of the component, it will always be placed according to the position value. */
+    pinned: PropTypes.bool,
+
     /** Position for the popover. */
     position: PropTypes.oneOf(positions),
+
+    /** An object containing custom settings for the Popper.js modifiers. */
+    popperModifiers: PropTypes.object,
 
     /** Popup size. */
     size: PropTypes.oneOf(_.without(SUI.SIZES, 'medium', 'big', 'massive')),
@@ -285,15 +291,16 @@ export default class Popup extends Component {
   }
 
   render() {
-    const { context, disabled, offset, position, trigger } = this.props
+    const { context, disabled, offset, pinned, popperModifiers, position, trigger } = this.props
     const { closed, portalRestProps } = this.state
 
     if (closed || disabled) return trigger
 
-    const modifiers = {
+    const modifiers = _.merge(popperModifiers, {
       arrow: { enabled: false },
+      flip: { enabled: !pinned },
       offset: { offset },
-    }
+    })
     const referenceElement = createReferenceProxy(_.isNil(context) ? this.triggerRef : context)
 
     const mergedPortalProps = { ...this.getPortalProps(), ...portalRestProps }

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -297,11 +297,17 @@ export default class Popup extends Component {
 
     if (closed || disabled) return trigger
 
-    const modifiers = _.merge(popperModifiers, {
-      arrow: { enabled: false },
-      flip: { enabled: !pinned },
-      offset: { offset },
-    })
+    const modifiers = _.merge(
+      {
+        arrow: { enabled: false },
+        flip: { enabled: !pinned },
+        // There are issues with `keepTogether` and `offset`
+        // https://github.com/FezVrasta/popper.js/issues/557
+        keepTogether: { enabled: !!offset },
+        offset: { offset },
+      },
+      popperModifiers,
+    )
     const referenceElement = createReferenceProxy(_.isNil(context) ? this.triggerRef : context)
 
     const mergedPortalProps = { ...this.getPortalProps(), ...portalRestProps }

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -143,6 +143,7 @@ export default class Popup extends Component {
     disabled: false,
     offset: 0,
     on: 'hover',
+    pinned: false,
     position: 'top left',
   }
 

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -239,13 +239,54 @@ describe('Popup', () => {
     })
   })
 
+  describe('pinned', () => {
+    it(`is "false" by default`, () => {
+      wrapperMount(<Popup open />)
+
+      wrapper.should.have.prop('pinned', false)
+    })
+
+    it(`disables "flip" modifier in PopperJS when is "true"`, () => {
+      wrapperMount(<Popup open pinned />)
+
+      wrapper
+        .find('Popper')
+        .should.have.prop('modifiers')
+        .deep.include({ flip: { enabled: false } })
+    })
+
+    it(`enables "flip" modifier in PopperJS when is "false"`, () => {
+      wrapperMount(<Popup open pinned={false} />)
+
+      wrapper
+        .find('Popper')
+        .should.have.prop('modifiers')
+        .deep.include({ flip: { enabled: true } })
+    })
+  })
+
   describe('position', () => {
     _.forEach(positionsMapping, (placement, position) => {
       it(`passes the "${position}" as "${placement}" to Popper`, () => {
         wrapperMount(<Popup open position={position} />)
 
-        wrapper.find('Popper').prop('placement', placement)
+        wrapper.find('Popper').should.have.prop('placement', placement)
       })
+    })
+  })
+
+  describe('popperModifiers', () => {
+    it(`are passed to Popper`, () => {
+      const modifiers = {
+        keepTogether: { enabled: false },
+        preventOverflow: { padding: 0 },
+      }
+      wrapperMount(<Popup popperModifiers={modifiers} open />)
+
+      wrapper
+        .find('Popper')
+        .should.have.prop('modifiers')
+        .deep.include(modifiers)
     })
   })
 


### PR DESCRIPTION
Fixes #3615.

## `pinned`

Will stop flipping of opened Popup.

![popup-pinned](https://user-images.githubusercontent.com/14183168/59213547-6e74ca80-8bb5-11e9-85d0-09686c2562bf.gif)

## `popperModifiers`

We can't map all PopperJS modifiers to component's props, so it will be better to just export them to allow customize them.

### Restore rending `children` in `ComponentExample`

I just noticed that we're are missing helpful descriptions in docs:

![image](https://user-images.githubusercontent.com/14183168/59213789-f955c500-8bb5-11e9-8e8f-7dd67acd19bd.png)

Fixed 💥 