### PR TITLE
fix(Popup): update `hideOnScroll` description in typings

### DIFF
--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -37,7 +37,7 @@ export interface StrictPopupProps extends StrictPortalProps {
   /** Header displayed above the content in bold. */
   header?: SemanticShorthandItem<PopupHeaderProps>
 
-  /** The node where the popup should mount. */
+  /** Hide the Popup when scrolling the window. */
   hideOnScroll?: boolean
 
   /** Whether the popup should not close on hover. */


### PR DESCRIPTION
- hideOnScroll had an incorrect description that pops up in IDEs

![Screenshot 2019-06-26 at 8 11 04 AM](https://user-images.githubusercontent.com/25174717/60147562-8e2e0480-97eb-11e9-927d-8f0608a76cb9.png)
