### PR TITLE
test(Checkbox): remove incorrect event combinations

### DIFF
--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -53,7 +53,7 @@ describe('Checkbox', () => {
   })
 
   describe('aria', () => {
-    ['aria-label', 'role'].forEach((propName) => {
+    ;['aria-label', 'role'].forEach((propName) => {
       it(`passes "${propName}" to the <input>`, () => {
         shallow(<Checkbox {...{ [propName]: 'foo' }} />)
           .find('input')
@@ -377,36 +377,30 @@ describe('Checkbox', () => {
         description: 'click on label: fires on mouse click',
         events: {
           label: ['mouseup', 'click'],
-          input: ['click'],
         },
       },
       {
         description: 'click on input: fires on mouse click',
         events: {
-          label: ['mouseup', 'click'],
           input: ['click'],
         },
       },
       {
         description: 'key on input: fires on space key',
         events: {
-          label: ['mouseup', 'click'],
           input: ['click'],
         },
       },
-
       {
         description: 'click on label with "id": fires on mouse click',
         events: {
           label: ['mouseup', 'click'],
-          input: ['click'],
         },
         id: 'foo',
       },
       {
         description: 'click on input with "id": fires on mouse click',
         events: {
-          label: ['mouseup', 'click'],
           input: ['click'],
         },
         id: 'foo',
@@ -435,8 +429,10 @@ describe('Checkbox', () => {
           { attachTo },
         )
 
-        _.forEach(events, (event, target) => {
-          domEvent.fire(`[data-id=${dataId}] ${target}`, event)
+        _.forEach(events, (targetEvents, target) => {
+          _.forEach(targetEvents, (targetEvent) => {
+            domEvent.fire(`[data-id=${dataId}] ${target}`, targetEvent)
+          })
         })
 
         onClick.should.have.been.calledOnce()
@@ -449,10 +445,10 @@ describe('Checkbox', () => {
   })
 
   describe('Controlled component', () => {
-    const getControlledCheckbox = isOnClick =>
+    const getControlledCheckbox = (isOnClick) =>
       class ControlledCheckbox extends React.Component {
         state = { checked: false }
-        toggle = () => this.setState(prevState => ({ checked: !prevState.checked }))
+        toggle = () => this.setState((prevState) => ({ checked: !prevState.checked }))
 
         render() {
           const handler = isOnClick ? { onClick: this.toggle } : { onChange: this.toggle }


### PR DESCRIPTION
In #3435 we introduced changes to `Checkbox` tests, but these was a mistake in cycles.

We should pass event names instead of array to `simulant.fire()`.