### PR TITLE
fix(Checkbox): handle change on root element

### DIFF
--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -148,7 +148,9 @@ export default class Checkbox extends Component {
     const { id } = this.props
     const { checked, indeterminate } = this.state
 
+    const isInputClick = _.invoke(this.inputRef.current, 'contains', e.target)
     const isLabelClick = _.invoke(this.labelRef.current, 'contains', e.target)
+    const isRootClick = !isLabelClick && !isInputClick
 
     const hasId = !_.isNil(id)
     const isLabelClickAndForwardedToInput = isLabelClick && hasId
@@ -169,7 +171,12 @@ export default class Checkbox extends Component {
         this.handleChange(e)
       }
 
-      if (hasId) {
+      // Changes should be triggered for the slider variation
+      if (isRootClick) {
+        this.handleChange(e)
+      }
+
+      if (isLabelClick && hasId) {
         // To prevent two clicks from being fired from the component we have to stop the propagation
         // from the "input" click: https://github.com/Semantic-Org/Semantic-UI-React/issues/3433
         e.stopPropagation()

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -416,9 +416,22 @@ describe('Checkbox', () => {
         id: 'foo',
       },
       {
-        description: 'key on input with "id: fires on space key',
+        description: 'key on input with "id": fires on space key',
         events: {
           input: ['click'],
+        },
+        id: 'foo',
+      },
+      {
+        description: 'click on root: fires on mouse click',
+        events: {
+          '': ['mouseup', 'click'],
+        },
+      },
+      {
+        description: 'click on root with "id": fires on mouse click',
+        events: {
+          '': ['mouseup', 'click'],
         },
         id: 'foo',
       },


### PR DESCRIPTION
Fixes #3502.

In SUI the whole area of `slider` is clickable, previously we had an behavior mismatch. This PR fixes it.

## Before
![before](https://user-images.githubusercontent.com/14183168/60824910-d0bbed80-a1aa-11e9-9ccf-09e497393959.gif)

## After 
![after](https://user-images.githubusercontent.com/14183168/60824906-cdc0fd00-a1aa-11e9-90ee-43aeded5f66d.gif)


