### PR TITLE
fix(Dropdown): allowing a ReactNode for the text prop

### DIFF
--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -273,7 +273,7 @@ export interface StrictDropdownProps {
   tabIndex?: number | string
 
   /** The text displayed in the dropdown, usually for the active item. */
-  text?: string
+  text?: string | React.ReactNode
 
   /** Custom element to trigger the menu to become visible. Takes place of 'text'. */
   trigger?: React.ReactNode

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -332,7 +332,7 @@ export default class Dropdown extends Component {
     tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
     /** The text displayed in the dropdown, usually for the active item. */
-    text: PropTypes.string,
+    text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
     /** Custom element to trigger the menu to become visible. Takes place of 'text'. */
     trigger: customPropTypes.every([
@@ -1193,7 +1193,7 @@ export default class Dropdown extends Component {
       search && searchQuery && 'filtered',
     )
     let _text = placeholder
-    
+
     if (text) {
       _text = text
     } else if (open && !multiple) {


### PR DESCRIPTION
This PR is updating the `PropTypes` of the `Dropdown` module to allow a `ReactNode` for the `text` prop.