### PR TITLE
docs(Composition|Shorthand): improve pages

### DIFF
--- a/docs/src/components/Sidebar/Sidebar.js
+++ b/docs/src/components/Sidebar/Sidebar.js
@@ -218,7 +218,7 @@ class Sidebar extends Component {
                   Get Started
                 </Menu.Item>
                 <Menu.Item as={Link} exact to='/augmentation' activeClassName='active'>
-                  Augmentation
+                  Composition
                 </Menu.Item>
                 <Menu.Item as={Link} exact to='/shorthand-props' activeClassName='active'>
                   Shorthand Props

--- a/docs/src/pages/Augmentation.mdx
+++ b/docs/src/pages/Augmentation.mdx
@@ -22,7 +22,7 @@ Semantic UI React provides a way to compose React components through the `as` pr
 
 ## Unhandled props & DOM attributes
 
-Our components handle only props that are defined in their interfaces, all unhandled props are passed to the component you are rendering `as`. It means that all HTML props are supported on all components.
+Our components handle only props that are defined in their `propTypes`, all unhandled props are passed to the component you are rendering `as`. It means that all HTML props are supported on all components.
 
 ```jsx
 // `type` is an unhandled prop on `Button` and will be passed through ⬇️

--- a/docs/src/pages/Augmentation.mdx
+++ b/docs/src/pages/Augmentation.mdx
@@ -30,7 +30,7 @@ Our components handle only props that are defined in their `propTypes`, all unha
 <Button type='submit' />
 ```
 
-This is also essential for working with third party libraries like `react-router`.
+This is also essential for composing with third party libraries like `react-router`.
 
 ```jsx
 import { Link } from 'react-router-dom'

--- a/docs/src/pages/Augmentation.mdx
+++ b/docs/src/pages/Augmentation.mdx
@@ -1,34 +1,43 @@
 import { Message } from 'semantic-ui-react'
 
 export const meta = {
-  title: 'Augmentation',
+  title: 'Composition',
   prevPage: { title: 'Get Started', href: '/usage' },
   nextPage: { title: 'Shorthand Props', href: '/shorthand-props' },
 }
 
-React components are inherently composable. Semantic UI React makes them even more so with the `as` prop feature: you can control the rendered HTML tag, or render one component as another component.
+## `as` prop
+
+Semantic UI React provides a way to compose React components through the `as` prop. It allows to compose component features and props without adding extra nested components.
 
 ```jsx
 <>
-  // will produce <button class='ui button' />
+  {/* 🔨  Each Semantic UI React component has a default value for `as` prop */}
+  {/* Will output: <button class='ui button' /> */}
   <Button />
-  // 🔨 will produce <a class='ui button' />
+  {/* Uses another tag: <a class='ui button' /> */}
   <Button as='a' />
 </>
 ```
 
-Augmentation is powerful. You can compose component features and props without adding extra nested components. This is essential for working with `MenuLink`s and `react-router`.
+## Unhandled props & DOM attributes
 
-<Message info size='mini'>
-  Unhandled props by a component are passed to the component you are rendering <code>as</code>.
-</Message>
+Our components handle only props that are defined in their interfaces, all unhandled props are passed to the component you are rendering `as`. It means that all HTML props are supported on all components.
+
+```jsx
+// `type` is an unhandled prop on `Button` and will be passed through ⬇️
+// Will output: <button class="ui button" type="submit" />
+<Button type='submit' />
+```
+
+This is also essential for working with third party libraries like `react-router`.
 
 ```jsx
 import { Link } from 'react-router-dom'
-;<Menu>
-  // 💡 `to` does not belong to `Menu.Item` props and will be passed to `Link`
-  <Menu.Item as={Link} to='/home'>
-    Home
-  </Menu.Item>
-</Menu>
+import { Button } from 'semantic-ui-react'
+
+// 💡 `to` prop is not handled in `Button` and will be passed to `Link` component
+;<Button as={Link} to='/home'>
+  To homepage
+</Button>
 ```

--- a/docs/src/pages/ShorthandProps.mdx
+++ b/docs/src/pages/ShorthandProps.mdx
@@ -2,7 +2,7 @@ import { Icon, Message } from 'semantic-ui-react'
 
 export const meta = {
   title: 'Shorthand Props',
-  prevPage: { title: 'Augmentation', href: '/augmentation' },
+  prevPage: { title: 'Composition', href: '/augmentation' },
   nextPage: { title: 'Theming', href: '/theming' },
 }
 
@@ -30,7 +30,7 @@ There is even shorter way to define default element's props - by using a primiti
 ```jsx
 <>
   <Button content='Like' icon='like' />
-  // 💡 has identical effect to the previous one
+  {/* 💡 has identical effect to the previous one */}
   <Button content='Like' icon={{ name: 'like' }} />
 </>
 ```
@@ -40,9 +40,9 @@ This works because `name` is the default prop of shorthand's `<Icon />` element.
 ```jsx
 <>
   <Modal trigger={<Button>Show</Button>} content='Content' />
-  // 💡 has identical effect to the previous one
+  {/* 💡 has identical effect to the previous one */}
   <Modal trigger={<Button>Show</Button>} content={{ content: 'Content' }} />
-  // ⛔ example below has broken styling, see section about React Element
+  {/* ⛔ example below has broken styling, see section about React Element */}
   <Modal trigger={<Button>Show</Button>} content={<div>Content</div>} />
 </>
 ```

--- a/docs/src/pages/Usage.mdx
+++ b/docs/src/pages/Usage.mdx
@@ -6,7 +6,7 @@ import { semanticUIDocsURL, semanticUIRepoURL, semanticUICSSRepoURL } from 'docs
 
 export const meta = {
   title: 'Get Started',
-  nextPage: { title: 'Augmentation', href: '/augmentation' },
+  nextPage: { title: 'Composition', href: '/augmentation' },
 }
 
 ## Install
@@ -49,9 +49,7 @@ Choose a theme and delivery method that suits your needs:
             value={`
               <link
                 rel="stylesheet"
-                href="//cdn.jsdelivr.net/npm/semantic-ui@${
-                  props.versions.sui
-                }/dist/semantic.min.css"
+                href="//cdn.jsdelivr.net/npm/semantic-ui@${props.versions.sui}/dist/semantic.min.css"
               />
             `}
           />

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@babel/register": "^7.4.4",
     "@babel/standalone": "^7.4.5",
     "@mdx-js/loader": "^0.20.3",
-    "@stardust-ui/docs-components": "^0.33.0",
+    "@stardust-ui/docs-components": "^0.34.1",
     "@types/react": "^16.4.14",
     "anchor-js": "^4.2.0",
     "babel-eslint": "^10.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,10 +980,10 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@stardust-ui/docs-components@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@stardust-ui/docs-components/-/docs-components-0.33.0.tgz#7b921a73e947c72a2523bf544577067b41477489"
-  integrity sha512-BJEw3qxuooBihdEiS/O+DjejPDvg2T49qnrLUl7DYbzOXDItrkbf37h0EoBYinWTuwNkGxLGexNT5FT876Dn4Q==
+"@stardust-ui/docs-components@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@stardust-ui/docs-components/-/docs-components-0.34.1.tgz#d7cf5f67f32beb3c29dbf3ce5f3c41d9592ee7fb"
+  integrity sha512-BdDILhG3G5+Uw9h6gf3EjmuZCI7BO8MYz3Wus8Ova/T5CrMCi1rkEXkFB6UzgKsncEU+2D3XRilihWul93DAxg==
   dependencies:
     "@babel/runtime" "^7.1.2"
     copy-to-clipboard "^3.2.0"


### PR DESCRIPTION
This PR:
- renames `Augmentation` page to `Composition` because previous name it's not clear
- adds a section about unhandled props to `Composition` page 
- updates comments on `Shorthand Props` page