### PR TITLE
feat(Popup): add `eventsEnabled` prop

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
@@ -1,9 +1,10 @@
+import { KnobProvider } from '@stardust-ui/docs-components'
 import cx from 'classnames'
 import copyToClipboard from 'copy-to-clipboard'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import VisibilitySensor from 'react-visibility-sensor'
-import { Grid } from 'semantic-ui-react'
+import { Checkbox, Grid, Label } from 'semantic-ui-react'
 
 import { examplePathToHash, scrollToAnchor } from 'docs/src/utils'
 import CarbonAdNative from 'docs/src/components/CarbonAd/CarbonAdNative'
@@ -11,6 +12,7 @@ import formatCode from 'docs/src/utils/formatCode'
 import ComponentControls from '../ComponentControls'
 import ExampleEditor from '../ExampleEditor'
 import ComponentDocContext from '../ComponentDocContext'
+import ComponentExampleKnobs from './ComponentExampleKnobs'
 import ComponentExampleTitle from './ComponentExampleTitle'
 
 const childrenStyle = {
@@ -22,6 +24,23 @@ const componentControlsStyle = {
   flex: '0 0 auto',
   width: 'auto',
 }
+
+/* eslint-disable react/prop-types */
+const knobComponents = {
+  KnobControl: (props) => (
+    <div style={{ display: 'flex', alignItems: 'center', flexGrow: 0.9 }}>{props.children}</div>
+  ),
+  KnobBoolean: (props) => (
+    <Checkbox
+      checked={props.value}
+      onChange={(e, data) => props.setValue(data.checked)}
+      type='checkbox'
+      value={props.value}
+    />
+  ),
+  KnobLabel: (props) => <Label style={{ fontFamily: 'monospace' }}>{props.name}</Label>,
+}
+/* eslint-enable react/prop-types */
 
 /**
  * Renders a `component` and the raw `code` that produced it.
@@ -78,9 +97,7 @@ class ComponentExample extends Component {
         if (wasCodeChanged) {
           /* eslint-disable-next-line no-console */
           console.warn(
-            `[HMR] the code of example (${
-              props.examplePath
-            }) was not reload because it was modified, please reset your changes.`,
+            `[HMR] the code of example (${props.examplePath}) was not reload because it was modified, please reset your changes.`,
           )
         } else {
           derivedState.originalSourceCode = props.sourceCode
@@ -173,27 +190,31 @@ class ComponentExample extends Component {
                 />
               </Grid.Column>
             </Grid.Row>
+            <KnobProvider components={knobComponents}>
+              <ComponentExampleKnobs />
 
-            {children && (
-              <Grid.Row columns={1} style={childrenStyle}>
-                <Grid.Column>{children}</Grid.Column>
+              {children && (
+                <Grid.Row columns={1} style={childrenStyle}>
+                  <Grid.Column>{children}</Grid.Column>
+                </Grid.Row>
+              )}
+
+              <Grid.Row style={{ paddingBottom: wasEverVisible && 0 }}>
+                <ExampleEditor
+                  examplePath={examplePath}
+                  hasCodeChanged={originalSourceCode !== sourceCode}
+                  onCodeChange={this.handleCodeChange}
+                  onCodeFormat={this.handleCodeFormat}
+                  onCodeReset={this.handleCodeReset}
+                  renderHtml={renderHtml}
+                  showCode={showCode}
+                  sourceCode={sourceCode}
+                  title={title}
+                  visible={wasEverVisible}
+                />
               </Grid.Row>
-            )}
+            </KnobProvider>
 
-            <Grid.Row style={{ paddingBottom: wasEverVisible && 0 }}>
-              <ExampleEditor
-                examplePath={examplePath}
-                hasCodeChanged={originalSourceCode !== sourceCode}
-                onCodeChange={this.handleCodeChange}
-                onCodeFormat={this.handleCodeFormat}
-                onCodeReset={this.handleCodeReset}
-                renderHtml={renderHtml}
-                showCode={showCode}
-                sourceCode={sourceCode}
-                title={title}
-                visible={wasEverVisible}
-              />
-            </Grid.Row>
             {isActiveHash && <CarbonAdNative inverted={showCode} />}
           </Grid>
         </div>

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
@@ -28,7 +28,9 @@ const componentControlsStyle = {
 /* eslint-disable react/prop-types */
 const knobComponents = {
   KnobControl: (props) => (
-    <div style={{ display: 'flex', alignItems: 'center', flexGrow: 0.9 }}>{props.children}</div>
+    <div style={{ display: 'flex', alignItems: 'center', flexGrow: 1, marginLeft: 5 }}>
+      {props.children}
+    </div>
   ),
   KnobBoolean: (props) => (
     <Checkbox
@@ -38,7 +40,11 @@ const knobComponents = {
       value={props.value}
     />
   ),
-  KnobLabel: (props) => <Label style={{ fontFamily: 'monospace' }}>{props.name}</Label>,
+  KnobLabel: (props) => (
+    <Label size='small' style={{ fontFamily: 'monospace' }}>
+      {props.name}
+    </Label>
+  ),
 }
 /* eslint-enable react/prop-types */
 

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleKnobs.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExampleKnobs.js
@@ -1,0 +1,43 @@
+import { CodeSnippet, KnobInspector, useKnobValues } from '@stardust-ui/docs-components'
+import _ from 'lodash'
+import React from 'react'
+import { Grid } from 'semantic-ui-react'
+
+const columnStyles = {
+  padding: 0,
+}
+
+const knobsStyles = {
+  background: 'whitesmoke',
+  color: '#777',
+  lineHeight: '1.5',
+  padding: '1rem',
+}
+
+const rowStyles = {
+  padding: 0,
+}
+
+const ComponentExampleKnobs = () => {
+  const knobValues = useKnobValues()
+  const values = _.fromPairs(knobValues.map((knob) => [knob.name, knob.value]))
+
+  return (
+    <KnobInspector>
+      {(knobs) =>
+        knobs && (
+          <Grid.Row columns={2} stretched style={rowStyles}>
+            <Grid.Column style={columnStyles}>
+              <div style={knobsStyles}> {knobs}</div>
+            </Grid.Column>
+            <Grid.Column style={columnStyles}>
+              <CodeSnippet copyable={false} fitted label='Knobs' mode='json' value={values} />
+            </Grid.Column>
+          </Grid.Row>
+        )
+      }
+    </KnobInspector>
+  )
+}
+
+export default ComponentExampleKnobs

--- a/docs/src/components/ComponentDoc/ExampleEditor/renderConfig.js
+++ b/docs/src/components/ComponentDoc/ExampleEditor/renderConfig.js
@@ -1,3 +1,4 @@
+import * as docsComponents from '@stardust-ui/docs-components'
 import faker from 'faker'
 import React from 'react'
 import PropTypes from 'prop-types'
@@ -16,6 +17,7 @@ export const babelConfig = {
 }
 
 export const externals = {
+  '@stardust-ui/docs-components': docsComponents,
   faker,
   lodash: require('lodash'),
   react: React,

--- a/docs/src/components/ExternalExampleLayout.js
+++ b/docs/src/components/ExternalExampleLayout.js
@@ -1,11 +1,12 @@
+import { KnobProvider } from '@stardust-ui/docs-components'
 import PropTypes from 'prop-types'
-import { createElement } from 'react'
+import React, { createElement } from 'react'
 import { withRouteData } from 'react-static'
 
 const ExternalExampleLayout = (props) => {
   const exampleComponent = require(`docs/src/examples/${props.path}`).default
 
-  return createElement(exampleComponent)
+  return <KnobProvider>{createElement(exampleComponent)}</KnobProvider>
 }
 
 ExternalExampleLayout.propTypes = {

--- a/docs/src/examples/modules/Popup/Usage/PopupExampleActions.js
+++ b/docs/src/examples/modules/Popup/Usage/PopupExampleActions.js
@@ -26,7 +26,7 @@ const PopupExampleActions = () => (
     </Grid.Column>
     <Grid.Column>
       <Popup
-        trigger={<Button icon>Click me or Hover me</Button>}
+        trigger={<Button>Click me or Hover me</Button>}
         header='Movie Search'
         content='Multiple events can trigger a popup'
         on={['hover', 'click']}

--- a/docs/src/examples/modules/Popup/Usage/PopupExampleEventsEnabled.js
+++ b/docs/src/examples/modules/Popup/Usage/PopupExampleEventsEnabled.js
@@ -2,7 +2,7 @@ import { useBooleanKnob } from '@stardust-ui/docs-components'
 import React from 'react'
 import { Button, Popup } from 'semantic-ui-react'
 
-const PopupExampleDefaultOpen = () => {
+const PopupExampleEventsEnabled = () => {
   const [eventsEnabled] = useBooleanKnob({
     name: 'eventsEnabled',
     initialValue: true,
@@ -22,4 +22,4 @@ const PopupExampleDefaultOpen = () => {
   )
 }
 
-export default PopupExampleDefaultOpen
+export default PopupExampleEventsEnabled

--- a/docs/src/examples/modules/Popup/Usage/PopupExampleEventsEnabled.js
+++ b/docs/src/examples/modules/Popup/Usage/PopupExampleEventsEnabled.js
@@ -1,0 +1,25 @@
+import { useBooleanKnob } from '@stardust-ui/docs-components'
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const PopupExampleDefaultOpen = () => {
+  const [eventsEnabled] = useBooleanKnob({
+    name: 'eventsEnabled',
+    initialValue: true,
+  })
+  const [open, setOpen] = useBooleanKnob({ name: 'open' })
+
+  return (
+    <Popup
+      content='Hello'
+      eventsEnabled={eventsEnabled}
+      on='click'
+      onClose={() => setOpen(false)}
+      onOpen={() => setOpen(true)}
+      open={open}
+      trigger={<Button content='A trigger' />}
+    />
+  )
+}
+
+export default PopupExampleDefaultOpen

--- a/docs/src/examples/modules/Popup/Usage/index.js
+++ b/docs/src/examples/modules/Popup/Usage/index.js
@@ -45,6 +45,34 @@ const PopupUsageExamples = () => (
       />
     </ComponentExample>
     <ComponentExample
+      title={<code>eventsEnabled</code>}
+      description={
+        <span>
+          Enables the <code>Popper.js</code> event listeners.
+        </span>
+      }
+      examplePath='modules/Popup/Usage/PopupExampleEventsEnabled'
+    />
+    <ComponentExample
+      title='Popper Dependencies'
+      description={
+        <span>
+          A popup can have dependencies which update will schedule a position
+          update. Should be used in cases when content is changing, behaves like{' '}
+          <a
+            href='https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect'
+            rel='noopener noreferrer'
+            target='_blank'
+          >
+            <code>dependencies</code>
+          </a>{' '}
+          in React Hooks.
+        </span>
+      }
+      examplePath='modules/Popup/Usage/PopupExamplePopperDependencies'
+      renderHtml={false}
+    />
+    <ComponentExample
       title='Actions'
       description='A popup can be triggered on hover, click, focus or multiple actions.'
       examplePath='modules/Popup/Usage/PopupExampleActions'
@@ -77,25 +105,6 @@ const PopupUsageExamples = () => (
       title='Default Open'
       description='A popup can appear open by default.'
       examplePath='modules/Popup/Usage/PopupExampleDefaultOpen'
-      renderHtml={false}
-    />
-    <ComponentExample
-      title='Popper Dependencies'
-      description={
-        <span>
-          A popup can have dependencies which update will schedule a position
-          update. Should be used in cases when content is changing, behaves like{' '}
-          <a
-            href='https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect'
-            rel='noopener noreferrer'
-            target='_blank'
-          >
-            <code>dependencies</code>
-          </a>{' '}
-          in React Hooks.
-        </span>
-      }
-      examplePath='modules/Popup/Usage/PopupExamplePopperDependencies'
       renderHtml={false}
     />
   </ExampleSection>

--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -31,6 +31,9 @@ export interface StrictPopupProps extends StrictPortalProps {
   /** A disabled popup only renders its trigger. */
   disabled?: boolean
 
+  /** Enables the Popper.js event listeners. */
+  eventsEnabled?: boolean
+
   /** A flowing Popup has no maximum width and continues to flow to fit its content. */
   flowing?: boolean
 

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -52,6 +52,9 @@ export default class Popup extends Component {
     /** A disabled popup only renders its trigger. */
     disabled: PropTypes.bool,
 
+    /** Enables the Popper.js event listeners. */
+    eventsEnabled: PropTypes.bool,
+
     /** A flowing Popup has no maximum width and continues to flow to fit its content. */
     flowing: PropTypes.bool,
 
@@ -145,6 +148,7 @@ export default class Popup extends Component {
 
   static defaultProps = {
     disabled: false,
+    eventsEnabled: true,
     offset: 0,
     on: 'hover',
     pinned: false,
@@ -319,7 +323,16 @@ export default class Popup extends Component {
   }
 
   render() {
-    const { context, disabled, offset, pinned, popperModifiers, position, trigger } = this.props
+    const {
+      context,
+      disabled,
+      eventsEnabled,
+      offset,
+      pinned,
+      popperModifiers,
+      position,
+      trigger,
+    } = this.props
     const { closed, portalRestProps } = this.state
 
     if (closed || disabled) return trigger
@@ -351,6 +364,7 @@ export default class Popup extends Component {
         triggerRef={this.triggerRef}
       >
         <Popper
+          eventsEnabled={eventsEnabled}
           modifiers={modifiers}
           placement={positionsMapping[position]}
           referenceElement={referenceElement}

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -110,6 +110,20 @@ describe('Popup', () => {
     })
   })
 
+  describe('eventsEnabled ', () => {
+    it(`is "true" by default`, () => {
+      wrapperMount(<Popup open />)
+
+      wrapper.should.have.prop('eventsEnabled', true)
+      wrapper.find('Popper').should.have.prop('eventsEnabled', true)
+    })
+
+    it(`can be set to "false"`, () => {
+      wrapperMount(<Popup eventsEnabled={false} />)
+      wrapper.find('Popper').should.have.prop('eventsEnabled', false)
+    })
+  })
+
   describe('flowing', () => {
     it('adds flowing to the popup className', () => {
       wrapperMount(<Popup flowing open />)

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -119,7 +119,7 @@ describe('Popup', () => {
     })
 
     it(`can be set to "false"`, () => {
-      wrapperMount(<Popup eventsEnabled={false} />)
+      wrapperMount(<Popup eventsEnabled={false} open />)
       wrapper.find('Popper').should.have.prop('eventsEnabled', false)
     })
   })


### PR DESCRIPTION
Fixes #3700.

This PR adds `eventsEnabled` prop to `Popup` component that allows to disable PopperJS event handlers.