### PR TITLE
chore(AutoControlledComponent): align API of trySetState() with React's

### DIFF
--- a/src/lib/AutoControlledComponent.js
+++ b/src/lib/AutoControlledComponent.js
@@ -181,39 +181,18 @@ export default class AutoControlledComponent extends Component {
   /**
    * Safely attempt to set state for props that might be controlled by the user.
    * Second argument is a state object that is always passed to setState.
-   * @param {object} maybeState State that corresponds to controlled props.
-   * @param {object} [state] Actual state, useful when you also need to setState.
+   * @param {object} state State that corresponds to controlled props.
+   * @param {function} [callback] Callback which is called after setState applied.
    */
-  trySetState = (maybeState, state) => {
-    const { autoControlledProps } = this.constructor
-    if (process.env.NODE_ENV !== 'production') {
-      const { name } = this.constructor
-      // warn about failed attempts to setState for keys not listed in autoControlledProps
-      const illegalKeys = _.difference(_.keys(maybeState), autoControlledProps)
-      if (!_.isEmpty(illegalKeys)) {
-        console.error(
-          [
-            `${name} called trySetState() with controlled props: "${illegalKeys}".`,
-            'State will not be set.',
-            'Only props in static autoControlledProps will be set on state.',
-          ].join(' '),
-        )
-      }
-    }
-
-    let newState = Object.keys(maybeState).reduce((acc, prop) => {
+  trySetState = (state, callback) => {
+    const newState = Object.keys(state).reduce((acc, prop) => {
       // ignore props defined by the parent
       if (this.props[prop] !== undefined) return acc
 
-      // ignore props not listed in auto controlled props
-      if (autoControlledProps.indexOf(prop) === -1) return acc
-
-      acc[prop] = maybeState[prop]
+      acc[prop] = state[prop]
       return acc
     }, {})
 
-    if (state) newState = { ...newState, ...state }
-
-    if (Object.keys(newState).length > 0) this.setState(newState)
+    if (Object.keys(newState).length > 0) this.setState(newState, callback)
   }
 }

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -761,7 +761,7 @@ export default class Dropdown extends Component {
     const newQuery = value
 
     _.invoke(this.props, 'onSearchChange', e, { ...this.props, searchQuery: newQuery })
-    this.trySetState({ searchQuery: newQuery }, { selectedIndex: 0 })
+    this.trySetState({ searchQuery: newQuery, selectedIndex: 0 })
 
     // open search dropdown on search query
     if (!open && newQuery.length >= minCharacters) {

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -83,7 +83,7 @@ export default class Rating extends Component {
     }
 
     // set rating
-    this.trySetState({ rating: newRating }, { isSelecting: false })
+    this.trySetState({ rating: newRating, isSelecting: false })
     if (onRate) onRate(e, { ...this.props, rating: newRating })
   }
 

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -448,7 +448,7 @@ export default class Search extends Component {
 
     const { selectFirstResult } = this.props
 
-    this.trySetState({ value }, { selectedIndex: selectFirstResult ? 0 : -1 })
+    this.trySetState({ value, selectedIndex: selectFirstResult ? 0 : -1 })
   }
 
   moveSelectionBy = (e, offset) => {

--- a/test/specs/lib/AutoControlledComponent-test.js
+++ b/test/specs/lib/AutoControlledComponent-test.js
@@ -65,17 +65,6 @@ describe('extending AutoControlledComponent', () => {
       wrapper.should.have.state(randomProp, randomValue)
     })
 
-    it('does not set state for non autoControlledProps', () => {
-      consoleUtil.disableOnce()
-
-      TestClass = createTestClass({ autoControlledProps: [], state: {} })
-      const wrapper = shallow(<TestClass />)
-
-      wrapper.instance().trySetState({ [faker.hacker.noun()]: faker.hacker.verb() })
-
-      wrapper.state().should.be.empty()
-    })
-
     it('does not set state for props defined by the parent', () => {
       consoleUtil.disableOnce()
 


### PR DESCRIPTION
This PR is a slice of changes for `AutoControlledComponent` from #3452. The same changes were applied for Stardust UI, too.

---

This PR updates the `trySetState()` method of `AutoControlledComponent` to have the same API as `setState()` in React class components.