### PR TITLE
fix(Checkbox): preventDefault() in mouseDown should prevent focus

### DIFF
--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -208,7 +208,10 @@ export default class Checkbox extends Component {
       indeterminate: !!indeterminate,
     })
 
-    _.invoke(this.inputRef.current, 'focus')
+    if (!e.defaultPrevented) {
+      _.invoke(this.inputRef.current, 'focus')
+    }
+
     // Heads up!
     // We need to call "preventDefault" to keep element focused.
     e.preventDefault()

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -304,6 +304,13 @@ describe('Checkbox', () => {
       domEvent.fire(input, 'mousedown')
       document.activeElement.should.equal(input)
     })
+
+    it('will not set focus to container, if default is prevented', () => {
+      wrapperMount(<Checkbox onMouseDown={(e) => e.preventDefault()} />)
+
+      domEvent.fire('.ui.checkbox input', 'mousedown')
+      document.activeElement.should.equal(document.body)
+    })
   })
 
   describe('onMouseUp', () => {


### PR DESCRIPTION
Fixes #3402.

`Checkbox` component should behave as native `input[type=checkbox]`. `preventDefault()` in `onMouseDown` should prevent `Checkbox` from focusing:

With changes in this PR, the code below now works properly:
```jsx
<Checkbox onMouseDown={(e) => e.preventDefault()} />
```