### PR TITLE
chore(lib): remove `customPropTypes.as`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -486,7 +486,7 @@ A docblock should appear above each prop in `propTypes` to describe them:
 ```js
 Label.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A label can reduce its complexity. */
   basic: PropTypes.bool,

--- a/src/addons/Responsive/Responsive.js
+++ b/src/addons/Responsive/Responsive.js
@@ -2,13 +2,7 @@ import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
-import {
-  customPropTypes,
-  eventStack,
-  getElementType,
-  getUnhandledProps,
-  isBrowser,
-} from '../../lib'
+import { eventStack, getElementType, getUnhandledProps, isBrowser } from '../../lib'
 import isVisible from './lib/isVisible'
 
 /**
@@ -17,7 +11,7 @@ import isVisible from './lib/isVisible'
 export default class Responsive extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Primary content. */
     children: PropTypes.node,

--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React, { Component, createRef } from 'react'
 
 import Ref from '../Ref'
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 
 /**
  * A TextArea can be used to allow for extended user input.
@@ -12,7 +12,7 @@ import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
 class TextArea extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /**
      * Called on change.

--- a/src/behaviors/Visibility/Visibility.js
+++ b/src/behaviors/Visibility/Visibility.js
@@ -5,7 +5,6 @@ import React, { Component, createRef } from 'react'
 import Ref from '../../addons/Ref'
 import {
   eventStack,
-  customPropTypes,
   getElementType,
   getUnhandledProps,
   normalizeOffset,
@@ -18,7 +17,7 @@ import {
 export default class Visibility extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Primary content. */
     children: PropTypes.node,

--- a/src/collections/Breadcrumb/Breadcrumb.js
+++ b/src/collections/Breadcrumb/Breadcrumb.js
@@ -48,7 +48,7 @@ function Breadcrumb(props) {
 
 Breadcrumb.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Breadcrumb/BreadcrumbDivider.js
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.js
@@ -46,7 +46,7 @@ function BreadcrumbDivider(props) {
 
 BreadcrumbDivider.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -18,7 +18,7 @@ import {
 export default class BreadcrumbSection extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Style as the currently active section. */
     active: PropTypes.bool,

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -3,14 +3,7 @@ import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
-import {
-  customPropTypes,
-  getElementType,
-  getUnhandledProps,
-  SUI,
-  useKeyOnly,
-  useWidthProp,
-} from '../../lib'
+import { getElementType, getUnhandledProps, SUI, useKeyOnly, useWidthProp } from '../../lib'
 import FormButton from './FormButton'
 import FormCheckbox from './FormCheckbox'
 import FormDropdown from './FormDropdown'
@@ -35,7 +28,7 @@ import FormTextArea from './FormTextArea'
 class Form extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** The HTML form action */
     action: PropTypes.string,

--- a/src/collections/Form/FormButton.js
+++ b/src/collections/Form/FormButton.js
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 import Button from '../../elements/Button'
 import FormField from './FormField'
 
@@ -19,7 +20,7 @@ function FormButton(props) {
 
 FormButton.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A FormField control prop. */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormCheckbox.js
+++ b/src/collections/Form/FormCheckbox.js
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 import Checkbox from '../../modules/Checkbox'
 import FormField from './FormField'
 
@@ -19,7 +20,7 @@ function FormCheckbox(props) {
 
 FormCheckbox.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A FormField control prop. */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormDropdown.js
+++ b/src/collections/Form/FormDropdown.js
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 import Dropdown from '../../modules/Dropdown'
 import FormField from './FormField'
 
@@ -19,7 +20,7 @@ function FormDropdown(props) {
 
 FormDropdown.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A FormField control prop. */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -134,7 +134,7 @@ function FormField(props) {
 
 FormField.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Form/FormGroup.js
+++ b/src/collections/Form/FormGroup.js
@@ -38,7 +38,7 @@ function FormGroup(props) {
 
 FormGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Form/FormInput.js
+++ b/src/collections/Form/FormInput.js
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 import Input from '../../elements/Input'
 import FormField from './FormField'
 
@@ -19,7 +20,7 @@ function FormInput(props) {
 
 FormInput.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A FormField control prop. */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormRadio.js
+++ b/src/collections/Form/FormRadio.js
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 import Radio from '../../addons/Radio'
 import FormField from './FormField'
 
@@ -19,7 +20,7 @@ function FormRadio(props) {
 
 FormRadio.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A FormField control prop. */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormSelect.js
+++ b/src/collections/Form/FormSelect.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 import Select from '../../addons/Select'
 import Dropdown from '../../modules/Dropdown'
 import FormField from './FormField'
@@ -21,7 +21,7 @@ function FormSelect(props) {
 
 FormSelect.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A FormField control prop. */
   control: FormField.propTypes.control,

--- a/src/collections/Form/FormTextArea.js
+++ b/src/collections/Form/FormTextArea.js
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 import TextArea from '../../addons/TextArea'
 import FormField from './FormField'
 
@@ -19,7 +20,7 @@ function FormTextArea(props) {
 
 FormTextArea.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A FormField control prop. */
   control: FormField.propTypes.control,

--- a/src/collections/Grid/Grid.js
+++ b/src/collections/Grid/Grid.js
@@ -74,7 +74,7 @@ Grid.Row = GridRow
 
 Grid.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A grid can have rows divided into cells. */
   celled: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['internally'])]),

--- a/src/collections/Grid/GridColumn.js
+++ b/src/collections/Grid/GridColumn.js
@@ -65,7 +65,7 @@ function GridColumn(props) {
 
 GridColumn.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Grid/GridRow.js
+++ b/src/collections/Grid/GridRow.js
@@ -57,7 +57,7 @@ function GridRow(props) {
 
 GridRow.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A row can have its columns centered. */
   centered: PropTypes.bool,

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -27,7 +27,7 @@ import MenuMenu from './MenuMenu'
 class Menu extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Index of the currently active item. */
     activeIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/src/collections/Menu/MenuHeader.js
+++ b/src/collections/Menu/MenuHeader.js
@@ -22,7 +22,7 @@ function MenuHeader(props) {
 
 MenuHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -21,7 +21,7 @@ import Icon from '../../elements/Icon'
 export default class MenuItem extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** A menu item can be active. */
     active: PropTypes.bool,

--- a/src/collections/Menu/MenuMenu.js
+++ b/src/collections/Menu/MenuMenu.js
@@ -23,7 +23,7 @@ function MenuMenu(props) {
 
 MenuMenu.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Message/Message.js
+++ b/src/collections/Message/Message.js
@@ -26,7 +26,7 @@ import MessageItem from './MessageItem'
 export default class Message extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** A message can be formatted to attach itself to other content. */
     attached: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['bottom', 'top'])]),

--- a/src/collections/Message/MessageContent.js
+++ b/src/collections/Message/MessageContent.js
@@ -22,7 +22,7 @@ function MessageContent(props) {
 
 MessageContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Message/MessageHeader.js
+++ b/src/collections/Message/MessageHeader.js
@@ -28,7 +28,7 @@ function MessageHeader(props) {
 
 MessageHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Message/MessageItem.js
+++ b/src/collections/Message/MessageItem.js
@@ -28,7 +28,7 @@ function MessageItem(props) {
 
 MessageItem.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Message/MessageList.js
+++ b/src/collections/Message/MessageList.js
@@ -30,7 +30,7 @@ function MessageList(props) {
 
 MessageList.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -121,7 +121,7 @@ Table.defaultProps = {
 
 Table.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Attach table to other content */
   attached: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['top', 'bottom'])]),

--- a/src/collections/Table/TableBody.js
+++ b/src/collections/Table/TableBody.js
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 
 function TableBody(props) {
   const { children, className } = props
@@ -23,7 +23,7 @@ TableBody.defaultProps = {
 
 TableBody.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Table/TableCell.js
+++ b/src/collections/Table/TableCell.js
@@ -80,7 +80,7 @@ TableCell.defaultProps = {
 
 TableCell.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A cell can be active or selected by a user. */
   active: PropTypes.bool,

--- a/src/collections/Table/TableFooter.js
+++ b/src/collections/Table/TableFooter.js
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getUnhandledProps } from '../../lib'
+import { getUnhandledProps } from '../../lib'
 import TableHeader from './TableHeader'
 
 /**
@@ -15,7 +16,7 @@ function TableFooter(props) {
 
 TableFooter.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 }
 
 TableFooter.defaultProps = {

--- a/src/collections/Table/TableHeader.js
+++ b/src/collections/Table/TableHeader.js
@@ -32,7 +32,7 @@ TableHeader.defaultProps = {
 
 TableHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/collections/Table/TableHeaderCell.js
+++ b/src/collections/Table/TableHeaderCell.js
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getUnhandledProps, useValueAndKey } from '../../lib'
+import { getUnhandledProps, useValueAndKey } from '../../lib'
 import TableCell from './TableCell'
 
 /**
@@ -18,7 +18,7 @@ function TableHeaderCell(props) {
 
 TableHeaderCell.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Additional classes. */
   className: PropTypes.string,

--- a/src/collections/Table/TableRow.js
+++ b/src/collections/Table/TableRow.js
@@ -71,13 +71,13 @@ TableRow.defaultProps = {
 
 TableRow.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A row can be active or selected by a user. */
   active: PropTypes.bool,
 
   /** An element type to render as (string or function). */
-  cellAs: customPropTypes.as,
+  cellAs: PropTypes.elementType,
 
   /** Shorthand array of props for TableCell. */
   cells: customPropTypes.collectionShorthand,

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -30,7 +30,7 @@ import ButtonOr from './ButtonOr'
 class Button extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** A button can show it is currently the active user selection. */
     active: PropTypes.bool,

--- a/src/elements/Button/ButtonContent.js
+++ b/src/elements/Button/ButtonContent.js
@@ -33,7 +33,7 @@ function ButtonContent(props) {
 
 ButtonContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Button/ButtonGroup.js
+++ b/src/elements/Button/ButtonGroup.js
@@ -86,7 +86,7 @@ function ButtonGroup(props) {
 
 ButtonGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Groups can be attached to other content. */
   attached: PropTypes.oneOfType([

--- a/src/elements/Button/ButtonOr.js
+++ b/src/elements/Button/ButtonOr.js
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 
 /**
  * Button groups can contain conditionals.
@@ -18,7 +18,7 @@ function ButtonOr(props) {
 
 ButtonOr.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Additional classes. */
   className: PropTypes.string,

--- a/src/elements/Container/Container.js
+++ b/src/elements/Container/Container.js
@@ -37,7 +37,7 @@ function Container(props) {
 
 Container.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Divider/Divider.js
+++ b/src/elements/Divider/Divider.js
@@ -51,7 +51,7 @@ function Divider(props) {
 
 Divider.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -510,7 +510,7 @@ export const names = [
 class Flag extends PureComponent {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Additional classes. */
     className: PropTypes.string,

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -99,7 +99,7 @@ function Header(props) {
 
 Header.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Attach header  to other content, like a segment. */
   attached: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['top', 'bottom'])]),

--- a/src/elements/Header/HeaderContent.js
+++ b/src/elements/Header/HeaderContent.js
@@ -22,7 +22,7 @@ function HeaderContent(props) {
 
 HeaderContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Header/HeaderSubheader.js
+++ b/src/elements/Header/HeaderSubheader.js
@@ -28,7 +28,7 @@ function HeaderSubheader(props) {
 
 HeaderSubheader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -22,7 +22,7 @@ import IconGroup from './IconGroup'
 class Icon extends PureComponent {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Formatted to appear bordered. */
     bordered: PropTypes.bool,

--- a/src/elements/Icon/IconGroup.js
+++ b/src/elements/Icon/IconGroup.js
@@ -23,7 +23,7 @@ function IconGroup(props) {
 
 IconGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -112,7 +112,7 @@ Image.Group = ImageGroup
 
 Image.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** An image may be formatted to appear inline with text as an avatar. */
   avatar: PropTypes.bool,

--- a/src/elements/Image/ImageGroup.js
+++ b/src/elements/Image/ImageGroup.js
@@ -22,7 +22,7 @@ function ImageGroup(props) {
 
 ImageGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -29,7 +29,7 @@ import Label from '../Label'
 class Input extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** An Input can be formatted to alert the user to an action they may perform. */
     action: PropTypes.oneOfType([PropTypes.bool, customPropTypes.itemShorthand]),

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -25,7 +25,7 @@ import LabelGroup from './LabelGroup'
 export default class Label extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** A label can be active. */
     active: PropTypes.bool,

--- a/src/elements/Label/LabelDetail.js
+++ b/src/elements/Label/LabelDetail.js
@@ -25,7 +25,7 @@ function LabelDetail(props) {
 
 LabelDetail.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Label/LabelGroup.js
+++ b/src/elements/Label/LabelGroup.js
@@ -38,7 +38,7 @@ function LabelGroup(props) {
 
 LabelGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/List/List.js
+++ b/src/elements/List/List.js
@@ -27,7 +27,7 @@ import ListList from './ListList'
 class List extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** A list can animate to set the current item apart from the list. */
     animated: PropTypes.bool,

--- a/src/elements/List/ListContent.js
+++ b/src/elements/List/ListContent.js
@@ -49,7 +49,7 @@ function ListContent(props) {
 
 ListContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/List/ListDescription.js
+++ b/src/elements/List/ListDescription.js
@@ -28,7 +28,7 @@ function ListDescription(props) {
 
 ListDescription.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/List/ListHeader.js
+++ b/src/elements/List/ListHeader.js
@@ -28,7 +28,7 @@ function ListHeader(props) {
 
 ListHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/List/ListItem.js
+++ b/src/elements/List/ListItem.js
@@ -23,7 +23,7 @@ import ListIcon from './ListIcon'
 class ListItem extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** A list item can active. */
     active: PropTypes.bool,

--- a/src/elements/List/ListList.js
+++ b/src/elements/List/ListList.js
@@ -29,7 +29,7 @@ function ListList(props) {
 
 ListList.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Loader/Loader.js
+++ b/src/elements/Loader/Loader.js
@@ -53,7 +53,7 @@ function Loader(props) {
 
 Loader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A loader can be active or visible. */
   active: PropTypes.bool,

--- a/src/elements/Placeholder/Placeholder.js
+++ b/src/elements/Placeholder/Placeholder.js
@@ -38,7 +38,7 @@ function Placeholder(props) {
 
 Placeholder.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Placeholder/PlaceholderHeader.js
+++ b/src/elements/Placeholder/PlaceholderHeader.js
@@ -28,7 +28,7 @@ function PlaceholderHeader(props) {
 
 PlaceholderHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Placeholder/PlaceholderImage.js
+++ b/src/elements/Placeholder/PlaceholderImage.js
@@ -23,7 +23,7 @@ function PlaceholderImage(props) {
 
 PlaceholderImage.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Additional classes. */
   className: PropTypes.string,

--- a/src/elements/Placeholder/PlaceholderLine.js
+++ b/src/elements/Placeholder/PlaceholderLine.js
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 
 /**
  * A placeholder can contain have lines of text.
@@ -18,7 +18,7 @@ function PlaceholderLine(props) {
 
 PlaceholderLine.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Additional classes. */
   className: PropTypes.string,

--- a/src/elements/Placeholder/PlaceholderParagraph.js
+++ b/src/elements/Placeholder/PlaceholderParagraph.js
@@ -22,7 +22,7 @@ function PlaceholderParagraph(props) {
 
 PlaceholderParagraph.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Rail/Rail.js
+++ b/src/elements/Rail/Rail.js
@@ -52,7 +52,7 @@ function Rail(props) {
 
 Rail.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A rail can appear attached to the main viewport. */
   attached: PropTypes.bool,

--- a/src/elements/Reveal/Reveal.js
+++ b/src/elements/Reveal/Reveal.js
@@ -38,7 +38,7 @@ function Reveal(props) {
 
 Reveal.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** An active reveal displays its hidden content. */
   active: PropTypes.bool,

--- a/src/elements/Reveal/RevealContent.js
+++ b/src/elements/Reveal/RevealContent.js
@@ -35,7 +35,7 @@ function RevealContent(props) {
 
 RevealContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Segment/Segment.js
+++ b/src/elements/Segment/Segment.js
@@ -87,7 +87,7 @@ Segment.Inline = SegmentInline
 
 Segment.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Attach segment to other content, like a header. */
   attached: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['top', 'bottom'])]),

--- a/src/elements/Segment/SegmentGroup.js
+++ b/src/elements/Segment/SegmentGroup.js
@@ -41,7 +41,7 @@ function SegmentGroup(props) {
 
 SegmentGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Segment/SegmentInline.js
+++ b/src/elements/Segment/SegmentInline.js
@@ -22,7 +22,7 @@ function SegmentInline(props) {
 
 SegmentInline.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -23,7 +23,7 @@ import StepTitle from './StepTitle'
 class Step extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** A step can be highlighted as active. */
     active: PropTypes.bool,

--- a/src/elements/Step/StepContent.js
+++ b/src/elements/Step/StepContent.js
@@ -46,7 +46,7 @@ function StepContent(props) {
 
 StepContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Step/StepDescription.js
+++ b/src/elements/Step/StepDescription.js
@@ -25,7 +25,7 @@ function StepDescription(props) {
 
 StepDescription.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/elements/Step/StepGroup.js
+++ b/src/elements/Step/StepGroup.js
@@ -77,7 +77,7 @@ function StepGroup(props) {
 
 StepGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Steps can be attached to other elements. */
   attached: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['top', 'bottom'])]),

--- a/src/elements/Step/StepTitle.js
+++ b/src/elements/Step/StepTitle.js
@@ -28,7 +28,7 @@ function StepTitle(props) {
 
 StepTitle.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -5,14 +5,6 @@ import leven from './leven'
 const typeOf = (...args) => Object.prototype.toString.call(...args)
 
 /**
- * Ensure a component can render as a give prop value.
- */
-export const as = (...args) =>
-  PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.string, PropTypes.symbol])(
-    ...args,
-  )
-
-/**
  * Ensure a prop is a valid DOM node.
  */
 export const domNode = (props, propName) => {

--- a/src/modules/Accordion/AccordionAccordion.js
+++ b/src/modules/Accordion/AccordionAccordion.js
@@ -32,7 +32,7 @@ const warnIfPropsAreInvalid = (props, state) => {
 export default class AccordionAccordion extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Index of the currently active panel. */
     activeIndex: customPropTypes.every([

--- a/src/modules/Accordion/AccordionContent.js
+++ b/src/modules/Accordion/AccordionContent.js
@@ -29,7 +29,7 @@ function AccordionContent(props) {
 
 AccordionContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Whether or not the content is visible. */
   active: PropTypes.bool,

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -19,7 +19,7 @@ import Icon from '../../elements/Icon'
 export default class AccordionTitle extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Whether or not the title is in the open state. */
     active: PropTypes.bool,

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -26,7 +26,7 @@ const debug = makeDebugger('checkbox')
 export default class Checkbox extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Whether or not checkbox is checked. */
     checked: PropTypes.bool,

--- a/src/modules/Dimmer/DimmerDimmable.js
+++ b/src/modules/Dimmer/DimmerDimmable.js
@@ -34,7 +34,7 @@ function DimmerDimmable(props) {
 
 DimmerDimmable.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A dimmable element can blur its contents. */
   blurring: PropTypes.bool,

--- a/src/modules/Dimmer/DimmerInner.js
+++ b/src/modules/Dimmer/DimmerInner.js
@@ -20,7 +20,7 @@ import {
 export default class DimmerInner extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** An active dimmer will dim its parent container. */
     active: PropTypes.bool,

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -40,7 +40,7 @@ const getKeyOrValue = (key, value) => (_.isNil(key) ? value : key)
 export default class Dropdown extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Label prefixed to an option added by a user. */
     additionLabel: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),

--- a/src/modules/Dropdown/DropdownDivider.js
+++ b/src/modules/Dropdown/DropdownDivider.js
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps } from '../../lib'
+import { getElementType, getUnhandledProps } from '../../lib'
 
 /**
  * A dropdown menu can contain dividers to separate related content.
@@ -18,7 +18,7 @@ function DropdownDivider(props) {
 
 DropdownDivider.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Additional classes. */
   className: PropTypes.string,

--- a/src/modules/Dropdown/DropdownHeader.js
+++ b/src/modules/Dropdown/DropdownHeader.js
@@ -39,7 +39,7 @@ function DropdownHeader(props) {
 
 DropdownHeader.propTypes = {
   /** An element type to render as (string or function) */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -23,7 +23,7 @@ import Label from '../../elements/Label'
 class DropdownItem extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Style as the currently chosen item. */
     active: PropTypes.bool,

--- a/src/modules/Dropdown/DropdownMenu.js
+++ b/src/modules/Dropdown/DropdownMenu.js
@@ -34,7 +34,7 @@ function DropdownMenu(props) {
 
 DropdownMenu.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/modules/Dropdown/DropdownSearchInput.js
+++ b/src/modules/Dropdown/DropdownSearchInput.js
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
-import { createShorthandFactory, customPropTypes, getUnhandledProps } from '../../lib'
+import { createShorthandFactory, getUnhandledProps } from '../../lib'
 
 /**
  * A search item sub-component for Dropdown component.
@@ -11,7 +11,7 @@ import { createShorthandFactory, customPropTypes, getUnhandledProps } from '../.
 class DropdownSearchInput extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** An input can have the auto complete. */
     autoComplete: PropTypes.string,

--- a/src/modules/Embed/Embed.js
+++ b/src/modules/Embed/Embed.js
@@ -19,7 +19,7 @@ import Icon from '../../elements/Icon'
 export default class Embed extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** An embed can be active. */
     active: PropTypes.bool,

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -36,7 +36,7 @@ const debug = makeDebugger('modal')
 class Modal extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Shorthand for Modal.Actions. Typically an array of button shorthand. */
     actions: customPropTypes.itemShorthand,

--- a/src/modules/Modal/ModalActions.js
+++ b/src/modules/Modal/ModalActions.js
@@ -18,7 +18,7 @@ import Button from '../../elements/Button'
 export default class ModalActions extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Array of shorthand buttons. */
     actions: customPropTypes.collectionShorthand,

--- a/src/modules/Modal/ModalContent.js
+++ b/src/modules/Modal/ModalContent.js
@@ -35,7 +35,7 @@ function ModalContent(props) {
 
 ModalContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/modules/Modal/ModalDescription.js
+++ b/src/modules/Modal/ModalDescription.js
@@ -22,7 +22,7 @@ function ModalDescription(props) {
 
 ModalDescription.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/modules/Modal/ModalHeader.js
+++ b/src/modules/Modal/ModalHeader.js
@@ -28,7 +28,7 @@ function ModalHeader(props) {
 
 ModalHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -32,7 +32,7 @@ const debug = makeDebugger('popup')
 export default class Popup extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Display the popup without the pointing arrow. */
     basic: PropTypes.bool,

--- a/src/modules/Popup/PopupContent.js
+++ b/src/modules/Popup/PopupContent.js
@@ -28,7 +28,7 @@ export default function PopupContent(props) {
 
 PopupContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** The content of the Popup */
   children: PropTypes.node,

--- a/src/modules/Popup/PopupHeader.js
+++ b/src/modules/Popup/PopupHeader.js
@@ -28,7 +28,7 @@ export default function PopupHeader(props) {
 
 PopupHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -20,7 +20,7 @@ import {
 class Progress extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** A progress bar can show activity. */
     active: PropTypes.bool,

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -5,7 +5,6 @@ import React from 'react'
 
 import {
   AutoControlledComponent as Component,
-  customPropTypes,
   getElementType,
   getUnhandledProps,
   SUI,
@@ -19,7 +18,7 @@ import RatingIcon from './RatingIcon'
 export default class Rating extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Additional classes. */
     className: PropTypes.string,

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
-import { customPropTypes, getElementType, getUnhandledProps, useKeyOnly } from '../../lib'
+import { getElementType, getUnhandledProps, useKeyOnly } from '../../lib'
 
 /**
  * An internal icon sub-component for Rating component
@@ -12,7 +12,7 @@ import { customPropTypes, getElementType, getUnhandledProps, useKeyOnly } from '
 export default class RatingIcon extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Indicates activity of an icon. */
     active: PropTypes.bool,

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -33,7 +33,7 @@ const debug = makeDebugger('search')
 export default class Search extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     // ------------------------------------
     // Behavior

--- a/src/modules/Search/SearchCategory.js
+++ b/src/modules/Search/SearchCategory.js
@@ -30,7 +30,7 @@ SearchCategory.defaultProps = {
 
 SearchCategory.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** The item currently selected by keyboard shortcut. */
   active: PropTypes.bool,

--- a/src/modules/Search/SearchResult.js
+++ b/src/modules/Search/SearchResult.js
@@ -33,7 +33,7 @@ const defaultRenderer = ({ image, price, title, description }) => [
 export default class SearchResult extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** The item currently selected by keyboard shortcut. */
     active: PropTypes.bool,

--- a/src/modules/Search/SearchResults.js
+++ b/src/modules/Search/SearchResults.js
@@ -19,7 +19,7 @@ function SearchResults(props) {
 
 SearchResults.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -22,7 +22,7 @@ import SidebarPusher from './SidebarPusher'
 class Sidebar extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Animation style. */
     animation: PropTypes.oneOf([

--- a/src/modules/Sidebar/SidebarPushable.js
+++ b/src/modules/Sidebar/SidebarPushable.js
@@ -22,7 +22,7 @@ function SidebarPushable(props) {
 
 SidebarPushable.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/modules/Sidebar/SidebarPusher.js
+++ b/src/modules/Sidebar/SidebarPusher.js
@@ -29,7 +29,7 @@ function SidebarPusher(props) {
 
 SidebarPusher.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/modules/Sticky/Sticky.js
+++ b/src/modules/Sticky/Sticky.js
@@ -18,7 +18,7 @@ import {
 export default class Sticky extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** A Sticky can be active. */
     active: PropTypes.bool,

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -21,7 +21,7 @@ import TabPane from './TabPane'
 class Tab extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** The initial activeIndex. */
     defaultActiveIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/src/modules/Tab/TabPane.js
+++ b/src/modules/Tab/TabPane.js
@@ -41,7 +41,7 @@ TabPane.defaultProps = {
 
 TabPane.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A tab pane can be active. */
   active: PropTypes.bool,

--- a/src/modules/Transition/TransitionGroup.js
+++ b/src/modules/Transition/TransitionGroup.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import React, { cloneElement, Fragment } from 'react'
 
 import {
-  customPropTypes,
   getChildMapping,
   getElementType,
   getUnhandledProps,
@@ -21,7 +20,7 @@ const debug = makeDebugger('transition_group')
 export default class TransitionGroup extends React.Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** Named animation event to used. Must be defined in CSS. */
     animation: PropTypes.oneOfType([PropTypes.oneOf(SUI.TRANSITIONS), PropTypes.string]),

--- a/src/views/Advertisement/Advertisement.js
+++ b/src/views/Advertisement/Advertisement.js
@@ -36,7 +36,7 @@ function Advertisement(props) {
 
 Advertisement.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Center the advertisement. */
   centered: PropTypes.bool,

--- a/src/views/Card/Card.js
+++ b/src/views/Card/Card.js
@@ -23,7 +23,7 @@ import CardMeta from './CardMeta'
 export default class Card extends Component {
   static propTypes = {
     /** An element type to render as (string or function). */
-    as: customPropTypes.as,
+    as: PropTypes.elementType,
 
     /** A Card can center itself inside its container. */
     centered: PropTypes.bool,

--- a/src/views/Card/CardContent.js
+++ b/src/views/Card/CardContent.js
@@ -55,7 +55,7 @@ function CardContent(props) {
 
 CardContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Card/CardDescription.js
+++ b/src/views/Card/CardDescription.js
@@ -30,7 +30,7 @@ function CardDescription(props) {
 
 CardDescription.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Card/CardGroup.js
+++ b/src/views/Card/CardGroup.js
@@ -73,7 +73,7 @@ function CardGroup(props) {
 
 CardGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** A group of cards can center itself inside its container. */
   centered: PropTypes.bool,

--- a/src/views/Card/CardHeader.js
+++ b/src/views/Card/CardHeader.js
@@ -30,7 +30,7 @@ function CardHeader(props) {
 
 CardHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Card/CardMeta.js
+++ b/src/views/Card/CardMeta.js
@@ -30,7 +30,7 @@ function CardMeta(props) {
 
 CardMeta.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Comment/Comment.js
+++ b/src/views/Comment/Comment.js
@@ -37,7 +37,7 @@ function Comment(props) {
 
 Comment.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Comment/CommentAction.js
+++ b/src/views/Comment/CommentAction.js
@@ -33,7 +33,7 @@ CommentAction.defaultProps = {
 
 CommentAction.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Style as the currently active action. */
   active: PropTypes.bool,

--- a/src/views/Comment/CommentActions.js
+++ b/src/views/Comment/CommentActions.js
@@ -22,7 +22,7 @@ function CommentActions(props) {
 
 CommentActions.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Comment/CommentAuthor.js
+++ b/src/views/Comment/CommentAuthor.js
@@ -22,7 +22,7 @@ function CommentAuthor(props) {
 
 CommentAuthor.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Comment/CommentAvatar.js
+++ b/src/views/Comment/CommentAvatar.js
@@ -4,7 +4,6 @@ import React from 'react'
 
 import {
   createHTMLImage,
-  customPropTypes,
   getElementType,
   getUnhandledProps,
   htmlImageProps,
@@ -31,7 +30,7 @@ function CommentAvatar(props) {
 
 CommentAvatar.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Additional classes. */
   className: PropTypes.string,

--- a/src/views/Comment/CommentContent.js
+++ b/src/views/Comment/CommentContent.js
@@ -22,7 +22,7 @@ function CommentContent(props) {
 
 CommentContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Comment/CommentGroup.js
+++ b/src/views/Comment/CommentGroup.js
@@ -39,7 +39,7 @@ function CommentGroup(props) {
 
 CommentGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Comment/CommentMetadata.js
+++ b/src/views/Comment/CommentMetadata.js
@@ -22,7 +22,7 @@ function CommentMetadata(props) {
 
 CommentMetadata.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Comment/CommentText.js
+++ b/src/views/Comment/CommentText.js
@@ -22,7 +22,7 @@ function CommentText(props) {
 
 CommentText.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Feed/Feed.js
+++ b/src/views/Feed/Feed.js
@@ -48,7 +48,7 @@ function Feed(props) {
 
 Feed.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Feed/FeedContent.js
+++ b/src/views/Feed/FeedContent.js
@@ -49,7 +49,7 @@ function FeedContent(props) {
 
 FeedContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Feed/FeedDate.js
+++ b/src/views/Feed/FeedDate.js
@@ -22,7 +22,7 @@ function FeedDate(props) {
 
 FeedDate.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Feed/FeedEvent.js
+++ b/src/views/Feed/FeedEvent.js
@@ -42,7 +42,7 @@ function FeedEvent(props) {
 
 FeedEvent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Feed/FeedExtra.js
+++ b/src/views/Feed/FeedExtra.js
@@ -51,7 +51,7 @@ function FeedExtra(props) {
 
 FeedExtra.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Feed/FeedLabel.js
+++ b/src/views/Feed/FeedLabel.js
@@ -40,7 +40,7 @@ function FeedLabel(props) {
 
 FeedLabel.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Feed/FeedLike.js
+++ b/src/views/Feed/FeedLike.js
@@ -37,7 +37,7 @@ FeedLike.defaultProps = {
 
 FeedLike.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Feed/FeedMeta.js
+++ b/src/views/Feed/FeedMeta.js
@@ -39,7 +39,7 @@ function FeedMeta(props) {
 
 FeedMeta.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Feed/FeedSummary.js
+++ b/src/views/Feed/FeedSummary.js
@@ -41,7 +41,7 @@ function FeedSummary(props) {
 
 FeedSummary.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Feed/FeedUser.js
+++ b/src/views/Feed/FeedUser.js
@@ -22,7 +22,7 @@ function FeedUser(props) {
 
 FeedUser.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Item/Item.js
+++ b/src/views/Item/Item.js
@@ -54,7 +54,7 @@ Item.Meta = ItemMeta
 
 Item.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Item/ItemContent.js
+++ b/src/views/Item/ItemContent.js
@@ -46,7 +46,7 @@ function ItemContent(props) {
 
 ItemContent.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Item/ItemDescription.js
+++ b/src/views/Item/ItemDescription.js
@@ -28,7 +28,7 @@ function ItemDescription(props) {
 
 ItemDescription.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Item/ItemExtra.js
+++ b/src/views/Item/ItemExtra.js
@@ -28,7 +28,7 @@ function ItemExtra(props) {
 
 ItemExtra.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Item/ItemGroup.js
+++ b/src/views/Item/ItemGroup.js
@@ -64,7 +64,7 @@ function ItemGroup(props) {
 
 ItemGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Item/ItemHeader.js
+++ b/src/views/Item/ItemHeader.js
@@ -28,7 +28,7 @@ function ItemHeader(props) {
 
 ItemHeader.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Item/ItemMeta.js
+++ b/src/views/Item/ItemMeta.js
@@ -28,7 +28,7 @@ function ItemMeta(props) {
 
 ItemMeta.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Statistic/Statistic.js
+++ b/src/views/Statistic/Statistic.js
@@ -76,7 +76,7 @@ function Statistic(props) {
 
 Statistic.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Statistic/StatisticGroup.js
+++ b/src/views/Statistic/StatisticGroup.js
@@ -57,7 +57,7 @@ function StatisticGroup(props) {
 
 StatisticGroup.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Statistic/StatisticLabel.js
+++ b/src/views/Statistic/StatisticLabel.js
@@ -28,7 +28,7 @@ function StatisticLabel(props) {
 
 StatisticLabel.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,

--- a/src/views/Statistic/StatisticValue.js
+++ b/src/views/Statistic/StatisticValue.js
@@ -30,7 +30,7 @@ function StatisticValue(props) {
 
 StatisticValue.propTypes = {
   /** An element type to render as (string or function). */
-  as: customPropTypes.as,
+  as: PropTypes.elementType,
 
   /** Primary content. */
   children: PropTypes.node,


### PR DESCRIPTION
We don't need anymore `customPropTypes.as` because it exists in `prop-types` as `PropTypes.elementType` 🎉 