### PR TITLE
docs(Popup): add example for `delay` prop in Popup

### DIFF
--- a/docs/src/examples/modules/Popup/Usage/PopupExampleDelay.js
+++ b/docs/src/examples/modules/Popup/Usage/PopupExampleDelay.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const PopupExampleDelay = () => (
+  <Popup
+    mouseEnterDelay={400}
+    mouseLeaveDelay={300}
+    openOnTriggerClick={false} // Disable opening it on click
+    content='Popup will hide in 300ms after leaving mouse.'
+    trigger={<Button>Open After 400ms</Button>}
+  />
+)
+
+export default PopupExampleDelay

--- a/docs/src/examples/modules/Popup/Usage/PopupExampleDelay.js
+++ b/docs/src/examples/modules/Popup/Usage/PopupExampleDelay.js
@@ -3,11 +3,11 @@ import { Button, Popup } from 'semantic-ui-react'
 
 const PopupExampleDelay = () => (
   <Popup
-    mouseEnterDelay={400}
-    mouseLeaveDelay={300}
-    openOnTriggerClick={false} // Disable opening it on click
-    content='Popup will hide in 300ms after leaving mouse.'
-    trigger={<Button>Open After 400ms</Button>}
+    content='Popup will hide in 500ms after leaving mouse.'
+    mouseEnterDelay={500}
+    mouseLeaveDelay={500}
+    on='hover'
+    trigger={<Button>Open After 500ms</Button>}
   />
 )
 

--- a/docs/src/examples/modules/Popup/Usage/index.js
+++ b/docs/src/examples/modules/Popup/Usage/index.js
@@ -107,6 +107,11 @@ const PopupUsageExamples = () => (
       examplePath='modules/Popup/Usage/PopupExampleDefaultOpen'
       renderHtml={false}
     />
+    <ComponentExample
+      title='Delay'
+      description='A popup can have delay in showing and hiding. This avoids accidental popup visibility.'
+      examplePath='modules/Popup/Usage/PopupExampleDelay'
+    />
   </ExampleSection>
 )
 


### PR DESCRIPTION
Added new example to use show/hide delay with the Popup component. This example showcases how to avoid accidental popup visibility.