### PR TITLE
fix(typings): add missing `StrictMenuProps` type export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -140,7 +140,7 @@ export {
   StrictGridRowProps,
 } from './dist/commonjs/collections/Grid/GridRow'
 
-export { default as Menu, MenuProps } from './dist/commonjs/collections/Menu'
+export { default as Menu, MenuProps, StrictMenuProps } from './dist/commonjs/collections/Menu'
 export {
   default as MenuHeader,
   MenuHeaderProps,


### PR DESCRIPTION
The type definition was missing an export for StrictMenuprops in the top level type definition file.