### PR TITLE
feat(Popup): add `positionFixed` to support fixed mode in `Popper.JS`

### DIFF
--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -107,7 +107,7 @@ export interface StrictPopupProps extends StrictPortalProps {
     | 'top center'
     | 'bottom center'
 
-  /** Enables the popper position 'fixed' mode */
+  /** Tells `Popper.js` to use the `position: fixed` strategy to position the popover. */
   positionFixed?: boolean
 
   /** An object containing custom settings for the Popper.js modifiers. */

--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -107,6 +107,9 @@ export interface StrictPopupProps extends StrictPortalProps {
     | 'top center'
     | 'bottom center'
 
+  /** Enables the popper position 'fixed' mode */
+  positionFixed?: boolean
+
   /** An object containing custom settings for the Popper.js modifiers. */
   popperModifiers?: object
 

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -156,7 +156,6 @@ export default class Popup extends Component {
     on: ['click', 'hover'],
     pinned: false,
     position: 'top left',
-    positionFixed: false,
   }
 
   static Content = PopupContent

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -127,7 +127,7 @@ export default class Popup extends Component {
     /** Position for the popover. */
     position: PropTypes.oneOf(positions),
 
-    /** Enables the popper position 'fixed' mode */
+    /** Tells `Popper.js` to use the `position: fixed` strategy to position the popover. */
     positionFixed: PropTypes.bool,
 
     /** An object containing custom settings for the Popper.js modifiers. */

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -127,6 +127,9 @@ export default class Popup extends Component {
     /** Position for the popover. */
     position: PropTypes.oneOf(positions),
 
+    /** Enables the popper position 'fixed' mode */
+    positionFixed: PropTypes.bool,
+
     /** An object containing custom settings for the Popper.js modifiers. */
     popperModifiers: PropTypes.object,
 
@@ -153,6 +156,7 @@ export default class Popup extends Component {
     on: ['click', 'hover'],
     pinned: false,
     position: 'top left',
+    positionFixed: false,
   }
 
   static Content = PopupContent
@@ -333,6 +337,7 @@ export default class Popup extends Component {
       pinned,
       popperModifiers,
       position,
+      positionFixed,
       trigger,
     } = this.props
     const { closed, portalRestProps } = this.state
@@ -369,6 +374,7 @@ export default class Popup extends Component {
           eventsEnabled={eventsEnabled}
           modifiers={modifiers}
           placement={positionsMapping[position]}
+          positionFixed={positionFixed}
           referenceElement={referenceElement}
         >
           {this.renderContent}

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -1,15 +1,14 @@
-import * as common from 'test/specs/commonTests'
-
-import { domEvent, sandbox } from 'test/utils'
-
-import Popup from 'src/modules/Popup/Popup'
-import PopupContent from 'src/modules/Popup/PopupContent'
-import PopupHeader from 'src/modules/Popup/PopupHeader'
-import Portal from 'src/addons/Portal/Portal'
-import React from 'react'
-import { SUI } from 'src/lib'
 import _ from 'lodash'
-import { positionsMapping } from 'src/modules/Popup/lib/positions.js'
+import React from 'react'
+
+import Portal from 'src/addons/Portal/Portal'
+import { SUI } from 'src/lib'
+import Popup from 'src/modules/Popup/Popup'
+import { positionsMapping } from 'src/modules/Popup/lib/positions'
+import PopupHeader from 'src/modules/Popup/PopupHeader'
+import PopupContent from 'src/modules/Popup/PopupContent'
+import * as common from 'test/specs/commonTests'
+import { domEvent, sandbox } from 'test/utils'
 
 // ----------------------------------------
 // Wrapper

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -1,14 +1,15 @@
-import _ from 'lodash'
-import React from 'react'
-
-import Portal from 'src/addons/Portal/Portal'
-import { SUI } from 'src/lib'
-import Popup from 'src/modules/Popup/Popup'
-import { positionsMapping } from 'src/modules/Popup/lib/positions.js'
-import PopupHeader from 'src/modules/Popup/PopupHeader'
-import PopupContent from 'src/modules/Popup/PopupContent'
 import * as common from 'test/specs/commonTests'
+
 import { domEvent, sandbox } from 'test/utils'
+
+import Popup from 'src/modules/Popup/Popup'
+import PopupContent from 'src/modules/Popup/PopupContent'
+import PopupHeader from 'src/modules/Popup/PopupHeader'
+import Portal from 'src/addons/Portal/Portal'
+import React from 'react'
+import { SUI } from 'src/lib'
+import _ from 'lodash'
+import { positionsMapping } from 'src/modules/Popup/lib/positions.js'
 
 // ----------------------------------------
 // Wrapper
@@ -290,11 +291,11 @@ describe('Popup', () => {
   })
 
   describe('positionFixed', () => {
-    it(`is "false" by default`, () => {
+    it(`is not defiend by default`, () => {
       wrapperMount(<Popup open />)
 
-      wrapper.should.have.prop('positionFixed', false)
-      wrapper.find('Popper').should.have.prop('positionFixed', false)
+      wrapper.should.not.have.prop('positionFixed')
+      wrapper.find('Popper').should.not.have.prop('positionFixed')
     })
 
     it(`can be set to "true"`, () => {

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -289,6 +289,20 @@ describe('Popup', () => {
     })
   })
 
+  describe('positionFixed', () => {
+    it(`is "false" by default`, () => {
+      wrapperMount(<Popup open />)
+
+      wrapper.should.have.prop('positionFixed', false)
+      wrapper.find('Popper').should.have.prop('positionFixed', false)
+    })
+
+    it(`can be set to "true"`, () => {
+      wrapperMount(<Popup positionFixed open />)
+      wrapper.find('Popper').should.have.prop('positionFixed', true)
+    })
+  })
+
   describe('popperModifiers', () => {
     it('are passed to Popper', () => {
       const modifiers = {


### PR DESCRIPTION
Fixes #3718.

Add support for popper.js to position the popup correctly if used with a mountNode inside a `position: fixed` container