### PR TITLE
feat(FormField): make form field error accessible

### DIFF
--- a/docs/src/examples/collections/Form/Shorthand/FormExampleFieldControlId.js
+++ b/docs/src/examples/collections/Form/Shorthand/FormExampleFieldControlId.js
@@ -38,6 +38,16 @@ const FormExampleFieldControlId = () => (
       placeholder='Opinion'
     />
     <Form.Field
+      id='form-input-control-error-email'
+      control={Input}
+      label='Email'
+      placeholder='joe@schmoe.com'
+      error={{
+        content: 'Please enter a valid email address',
+        pointing: 'below',
+      }}
+    />
+    <Form.Field
       id='form-button-control-public'
       control={Button}
       content='Confirm'

--- a/docs/src/examples/collections/Form/Shorthand/index.js
+++ b/docs/src/examples/collections/Form/Shorthand/index.js
@@ -93,7 +93,7 @@ const FormTypesExamples = () => (
 
     <ComponentExample
       title='Accessible Labels'
-      description='Adding an id to a shorthand Form.Field adds a matching htmlFor prop to the label.'
+      description='Adding an id to a shorthand Form.Field adds a matching htmlFor prop to the label. In case of an error, the aria-describedby prop is used to connect the error label to the form field.'
       examplePath='collections/Form/Shorthand/FormExampleFieldControlId'
     />
 

--- a/docs/src/examples/collections/Form/States/FormExampleFieldErrorLabel.js
+++ b/docs/src/examples/collections/Form/States/FormExampleFieldErrorLabel.js
@@ -8,6 +8,7 @@ const FormExampleFieldErrorLabel = () => (
       fluid
       label='First name'
       placeholder='First name'
+      id='form-input-first-name'
     />
     <Form.Input
       error='Please enter your last name'

--- a/src/collections/Form/FormField.d.ts
+++ b/src/collections/Form/FormField.d.ts
@@ -39,7 +39,7 @@ export interface StrictFormFieldProps {
   error?: boolean | SemanticShorthandItem<LabelProps>
 
   /** The id of the control */
-  id?: string
+  id?: number | string
 
   /** A field can have its label next to instead of above it. */
   inline?: boolean

--- a/src/collections/Form/FormField.d.ts
+++ b/src/collections/Form/FormField.d.ts
@@ -38,6 +38,9 @@ export interface StrictFormFieldProps {
   /** Individual fields may display an error state along with a message. */
   error?: boolean | SemanticShorthandItem<LabelProps>
 
+  /** The id of the control */
+  id?: string
+
   /** A field can have its label next to instead of above it. */
   inline?: boolean
 

--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -63,6 +63,8 @@ function FormField(props) {
       prompt: true,
       pointing: errorPointing,
       id: id ? `${id}-error-message` : undefined,
+      role: 'alert',
+      'aria-atomic': true,
     },
   })
 

--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -41,6 +41,7 @@ function FormField(props) {
     required,
     type,
     width,
+    id,
   } = props
 
   const classes = cx(
@@ -58,7 +59,11 @@ function FormField(props) {
   const errorPointing = _.get(error, 'pointing', 'above')
   const errorLabel = Label.create(error, {
     autoGenerateKey: false,
-    defaultProps: { prompt: true, pointing: errorPointing },
+    defaultProps: {
+      prompt: true,
+      pointing: errorPointing,
+      id: id ? `${id}-error-message` : undefined,
+    },
   })
 
   const errorLabelBefore = (errorPointing === 'below' || errorPointing === 'right') && errorLabel
@@ -89,7 +94,13 @@ function FormField(props) {
   // ----------------------------------------
   // Checkbox/Radio Control
   // ----------------------------------------
-  const controlProps = { ...rest, content, children, disabled, required, type }
+
+  const ariaDescribedBy = id && error ? `${id}-error-message` : null
+  const ariaAttrs = {
+    'aria-describedby': ariaDescribedBy,
+    'aria-invalid': error !== undefined ? true : undefined,
+  }
+  const controlProps = { ...rest, content, children, disabled, required, type, id }
 
   // wrap HTML checkboxes/radios in the label
   if (control === 'input' && (type === 'checkbox' || type === 'radio')) {
@@ -97,7 +108,7 @@ function FormField(props) {
       <ElementType className={classes}>
         <label>
           {errorLabelBefore}
-          {createElement(control, controlProps)} {label}
+          {createElement(control, { ...ariaAttrs, ...controlProps })} {label}
           {errorLabelAfter}
         </label>
       </ElementType>
@@ -109,7 +120,7 @@ function FormField(props) {
     return (
       <ElementType className={classes}>
         {errorLabelBefore}
-        {createElement(control, { ...controlProps, label })}
+        {createElement(control, { ...ariaAttrs, ...controlProps, label })}
         {errorLabelAfter}
       </ElementType>
     )
@@ -122,11 +133,11 @@ function FormField(props) {
   return (
     <ElementType className={classes}>
       {createHTMLLabel(label, {
-        defaultProps: { htmlFor: _.get(controlProps, 'id') },
+        defaultProps: { htmlFor: id },
         autoGenerateKey: false,
       })}
       {errorLabelBefore}
-      {createElement(control, controlProps)}
+      {createElement(control, { ...ariaAttrs, ...controlProps })}
       {errorLabelAfter}
     </ElementType>
   )
@@ -160,6 +171,9 @@ FormField.propTypes = {
 
   /** Individual fields may display an error state along with a message. */
   error: PropTypes.oneOfType([PropTypes.bool, customPropTypes.itemShorthand]),
+
+  /** The id of the control */
+  id: PropTypes.string,
 
   /** A field can have its label next to instead of above it. */
   inline: PropTypes.bool,

--- a/test/specs/collections/Form/FormField-test.js
+++ b/test/specs/collections/Form/FormField-test.js
@@ -41,25 +41,45 @@ describe('FormField', () => {
       autoGenerateKey: false,
       propKey: 'error',
       requiredProps: { label: faker.lorem.word() },
-      shorthandDefaultProps: { prompt: true, pointing: 'above' },
+      shorthandDefaultProps: {
+        prompt: true,
+        pointing: 'above',
+        role: 'alert',
+        'aria-atomic': true,
+      },
     })
     common.implementsLabelProp(FormField, {
       autoGenerateKey: false,
       propKey: 'error',
       requiredProps: { control: 'radio' },
-      shorthandDefaultProps: { prompt: true, pointing: 'above' },
+      shorthandDefaultProps: {
+        prompt: true,
+        pointing: 'above',
+        role: 'alert',
+        'aria-atomic': true,
+      },
     })
     common.implementsLabelProp(FormField, {
       autoGenerateKey: false,
       propKey: 'error',
       requiredProps: { control: Checkbox },
-      shorthandDefaultProps: { prompt: true, pointing: 'above' },
+      shorthandDefaultProps: {
+        prompt: true,
+        pointing: 'above',
+        role: 'alert',
+        'aria-atomic': true,
+      },
     })
     common.implementsLabelProp(FormField, {
       autoGenerateKey: false,
       propKey: 'error',
       requiredProps: { control: 'input' },
-      shorthandDefaultProps: { prompt: true, pointing: 'above' },
+      shorthandDefaultProps: {
+        prompt: true,
+        pointing: 'above',
+        role: 'alert',
+        'aria-atomic': true,
+      },
     })
 
     it('positioned in DOM according to passed "pointing" prop', () => {


### PR DESCRIPTION
Fixes #3821 

Form fields should have an id attribute in order for it to work (since aria-describedby needs an id).

Relates to: https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=331#error-identification. More specifically, it relates to techniques: [ARIA19](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA19.html) and [ARIA21](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA21.html)