### PR TITLE
refactor(Checkbox): remove hardcoded hidden classname

### DIFF
--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -293,7 +293,6 @@ export default class Checkbox extends Component {
           <input
             {...htmlInputProps}
             checked={checked}
-            className='hidden'
             disabled={disabled}
             id={id}
             name={name}


### PR DESCRIPTION
The checkbox has a nonsensical 'hidden' classname which sets a
z-index of -1 for the browser. I don't see any reason for this
documented and it can cause grief in your styles. I removed it
in this commit.