### PR TITLE
fix(Search): use result.id for SearchResult key

### DIFF
--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -559,7 +559,7 @@ export default class Search extends Component {
 
     return (
       <SearchResult
-        key={childKey || result.key || result.id || result.title}
+        key={childKey || result.id || result.title}
         active={selectedIndex === offsetIndex}
         onClick={this.handleItemClick}
         onMouseDown={this.handleItemMouseDown}

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -559,7 +559,7 @@ export default class Search extends Component {
 
     return (
       <SearchResult
-        key={childKey || result.title}
+        key={childKey || result.key || result.id || result.title}
         active={selectedIndex === offsetIndex}
         onClick={this.handleItemClick}
         onMouseDown={this.handleItemMouseDown}


### PR DESCRIPTION
In many cases, the title value is not unique, which leads to the SearchResult never got updated. The solution is taking a new `key` property or the `id` property as the component key.