### PR TITLE
fix(Input): add 'inputMode' attribute to input

### DIFF
--- a/src/lib/htmlPropsUtils.js
+++ b/src/lib/htmlPropsUtils.js
@@ -16,6 +16,7 @@ export const htmlInputAttrs = [
   'disabled',
   'form',
   'id',
+  'inputMode',
   'lang',
   'list',
   'max',


### PR DESCRIPTION
The inputmode attribute provides a hint to browsers for devices with onscreen keyboards to help them decide which keyboard to display.