### PR TITLE
fix(Popup): fixing the popup position

### DIFF
--- a/src/modules/Popup/lib/positions.js
+++ b/src/modules/Popup/lib/positions.js
@@ -2,12 +2,12 @@ import _ from 'lodash'
 
 export const positionsMapping = {
   'top center': 'top',
-  'top left': 'top-start',
-  'top right': 'top-end',
+  'top left': 'top-end',
+  'top right': 'top-start',
 
   'bottom center': 'bottom',
-  'bottom left': 'bottom-start',
-  'bottom right': 'bottom-end',
+  'bottom left': 'bottom-end',
+  'bottom right': 'bottom-start',
 
   'right center': 'right',
   'left center': 'left',
@@ -15,4 +15,15 @@ export const positionsMapping = {
 
 export const positions = _.keys(positionsMapping)
 
-export const placementMapping = _.invert(positionsMapping)
+export const placementMapping = {
+  top: 'top center',
+  'top-start': 'top left',
+  'top-end': 'top right',
+
+  bottom: 'bottom center',
+  'bottom-end': 'bottom right',
+  'bottom-start': 'bottom left',
+
+  right: 'right center',
+  left: 'left center',
+}


### PR DESCRIPTION
Regarding to issue [#3917](https://github.com/Semantic-Org/Semantic-UI-React/issues/3917)

* Making a new hash that provides the right positions of the placements;
* Changing the position of the popup;

**Before**:
![popup - before](https://user-images.githubusercontent.com/62830392/77855885-136f9b00-71fc-11ea-8b09-4b93f7926024.png)

**After:**
![popup - after](https://user-images.githubusercontent.com/62830392/77855889-1e2a3000-71fc-11ea-8b1e-05a233c02341.png)

