### PR TITLE
fix(TransitionablePortal): fixed deprecated lifecycle method #2732

### DIFF
--- a/src/addons/TransitionablePortal/TransitionablePortal.js
+++ b/src/addons/TransitionablePortal/TransitionablePortal.js
@@ -76,11 +76,10 @@ export default class TransitionablePortal extends Component {
   // Lifecycle
   // ----------------------------------------
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps({ open }) {
-    debug('componentWillReceiveProps()', { open })
-
-    this.setState({ portalOpen: open })
+  componentDidUpdate(prevProps) {
+    if (this.props.open !== prevProps.open) {
+      this.setState({ portalOpen: this.props.open })
+    }
   }
 
   // ----------------------------------------

--- a/test/specs/addons/TransitionablePortal/TransitionablePortal-test.js
+++ b/test/specs/addons/TransitionablePortal/TransitionablePortal-test.js
@@ -43,7 +43,7 @@ describe('TransitionablePortal', () => {
     })
   })
 
-  describe('componentWillReceiveProps', () => {
+  describe('componentDidUpdate', () => {
     it('passes `open` prop to `portalOpen` when defined', () => {
       wrapperMount(<TransitionablePortal {...requiredProps} />)
 


### PR DESCRIPTION
* removed deprecated componentWillReceiveProps lifecycle

* changed it to componentDidUpdate

* changed test description to componentDidUpdate

it is worth mentioning that it is not advised to use getDerivedStateFromProps in this case due to the different time this hook is getting called in contrast to componentDidUpdate which also does not require change from any of the test