### PR TITLE
docs(VisibilityExampleUpdateOn): Correcting Typo

### DIFF
--- a/docs/src/examples/behaviors/Visibility/Settings/VisibilityExampleUpdateOn.js
+++ b/docs/src/examples/behaviors/Visibility/Settings/VisibilityExampleUpdateOn.js
@@ -77,7 +77,7 @@ export default class VisibilityExampleUpdateOn extends Component {
               <Segment>
                 <Checkbox
                   checked={showWireframe}
-                  label='Show Wifeframe'
+                  label='Show Wireframe'
                   onChange={this.handleWireframe}
                   toggle
                 />


### PR DESCRIPTION
Just a typo - Wifeframe should be Wireframe.