### PR TITLE
fix(customProptypes): add a check for Element existance

### DIFF
--- a/src/lib/customPropTypes.js
+++ b/src/lib/customPropTypes.js
@@ -10,6 +10,8 @@ const typeOf = (...args) => Object.prototype.toString.call(...args)
 export const domNode = (props, propName) => {
   // skip if prop is undefined
   if (props[propName] === undefined) return
+  // short circle for SSR env
+  if (typeof Element === 'undefined') return
   // skip if prop is valid
   if (props[propName] instanceof Element) return
 


### PR DESCRIPTION
Fixes #3864.

The fix is a similar to https://github.com/reactjs/react-transition-group/pull/619 and will stop warnings for SSR envs.