### PR TITLE
chore: use ModernAutoControlled component

### DIFF
--- a/src/addons/Pagination/Pagination.js
+++ b/src/addons/Pagination/Pagination.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import {
-  AutoControlledComponent as Component,
+  ModernAutoControlledComponent as Component,
   createPaginationItems,
   customPropTypes,
   getUnhandledProps,
@@ -98,7 +98,7 @@ export default class Pagination extends Component {
     // Heads up! We need the cast to the "number" type there, as `activePage` can be a string
     if (+prevActivePage === +nextActivePage) return
 
-    this.trySetState({ activePage: nextActivePage })
+    this.setState({ activePage: nextActivePage })
     _.invoke(this.props, 'onPageChange', e, { ...this.props, activePage: nextActivePage })
   }
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import React, { cloneElement, createRef, Fragment } from 'react'
 
 import {
-  AutoControlledComponent as Component,
+  ModernAutoControlledComponent as Component,
   customPropTypes,
   doesNodeContainClick,
   makeDebugger,
@@ -285,7 +285,7 @@ class Portal extends Component {
     const { onOpen } = this.props
     if (onOpen) onOpen(e, this.props)
 
-    this.trySetState({ open: true })
+    this.setState({ open: true })
   }
 
   openWithTimeout = (e, delay) => {
@@ -303,7 +303,7 @@ class Portal extends Component {
     const { onClose } = this.props
     if (onClose) onClose(e, this.props)
 
-    this.trySetState({ open: false })
+    this.setState({ open: false })
   }
 
   closeWithTimeout = (e, delay) => {

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import {
-  AutoControlledComponent as Component,
+  ModernAutoControlledComponent as Component,
   childrenUtils,
   customPropTypes,
   createShorthandFactory,
@@ -117,7 +117,7 @@ class Menu extends Component {
     onClick: (e, itemProps) => {
       const { index } = itemProps
 
-      this.trySetState({ activeIndex: index })
+      this.setState({ activeIndex: index })
 
       _.invoke(predefinedProps, 'onClick', e, itemProps)
       _.invoke(this.props, 'onItemClick', e, itemProps)

--- a/src/modules/Accordion/AccordionAccordion.js
+++ b/src/modules/Accordion/AccordionAccordion.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import {
-  AutoControlledComponent as Component,
+  ModernAutoControlledComponent as Component,
   childrenUtils,
   createShorthandFactory,
   customPropTypes,
@@ -110,7 +110,7 @@ export default class AccordionAccordion extends Component {
   handleTitleClick = (e, titleProps) => {
     const { index } = titleProps
 
-    this.trySetState({ activeIndex: this.computeNewIndex(index) })
+    this.setState({ activeIndex: this.computeNewIndex(index) })
     _.invoke(this.props, 'onTitleClick', e, titleProps)
   }
 

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import React, { createRef } from 'react'
 
 import {
-  AutoControlledComponent as Component,
+  ModernAutoControlledComponent as Component,
   createHTMLLabel,
   customPropTypes,
   getElementType,
@@ -195,7 +195,7 @@ export default class Checkbox extends Component {
       checked: !checked,
       indeterminate: false,
     })
-    this.trySetState({ checked: !checked, indeterminate: false })
+    this.setState({ checked: !checked, indeterminate: false })
   }
 
   handleMouseDown = (e) => {

--- a/src/modules/Embed/Embed.js
+++ b/src/modules/Embed/Embed.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import {
-  AutoControlledComponent as Component,
+  ModernAutoControlledComponent as Component,
   childrenUtils,
   createHTMLIframe,
   customPropTypes,
@@ -130,7 +130,7 @@ export default class Embed extends Component {
     const { active } = this.state
 
     if (onClick) onClick(e, { ...this.props, active: true })
-    if (!active) this.trySetState({ active: true })
+    if (!active) this.setState({ active: true })
   }
 
   render() {

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -6,7 +6,7 @@ import React, { createRef, Fragment, isValidElement } from 'react'
 import shallowEqual from 'shallowequal'
 
 import {
-  AutoControlledComponent as Component,
+  ModernAutoControlledComponent as Component,
   childrenUtils,
   customPropTypes,
   doesNodeContainClick,
@@ -179,7 +179,7 @@ class Modal extends Component {
     debug('close()')
 
     _.invoke(this.props, 'onClose', e, this.props)
-    this.trySetState({ open: false })
+    this.setState({ open: false })
   }
 
   handleDocumentMouseDown = (e) => {
@@ -200,7 +200,7 @@ class Modal extends Component {
       return
 
     _.invoke(this.props, 'onClose', e, this.props)
-    this.trySetState({ open: false })
+    this.setState({ open: false })
   }
 
   handleIconOverrides = (predefinedProps) => ({
@@ -214,7 +214,7 @@ class Modal extends Component {
     debug('open()')
 
     _.invoke(this.props, 'onOpen', e, this.props)
-    this.trySetState({ open: true })
+    this.setState({ open: true })
   }
 
   handlePortalMount = (e) => {

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import {
-  AutoControlledComponent as Component,
+  ModernAutoControlledComponent as Component,
   getElementType,
   getUnhandledProps,
   SUI,
@@ -82,7 +82,7 @@ export default class Rating extends Component {
     }
 
     // set rating
-    this.trySetState({ rating: newRating, isSelecting: false })
+    this.setState({ rating: newRating, isSelecting: false })
     if (onRate) onRate(e, { ...this.props, rating: newRating })
   }
 

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import {
-  AutoControlledComponent as Component,
+  ModernAutoControlledComponent as Component,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -84,7 +84,7 @@ class Tab extends Component {
 
   handleItemClick = (e, { index }) => {
     _.invoke(this.props, 'onTabChange', e, { ...this.props, activeIndex: index })
-    this.trySetState({ activeIndex: index })
+    this.setState({ activeIndex: index })
   }
 
   renderItems() {


### PR DESCRIPTION
Related to #3919.

Removes the usage of `UNSAFE_componentWillReceiveProps` for:
- `Pagination`
- `Portal`
- `Menu`
- `AccordionAccordion`
- `Checkbox`
- `Embed`
- `Modal`
- `Rating`
- `Tab`

***

There are only components remaining that are using old `AutoControlledComponent`: `Dropdown` and `Search`. Due complexity with them these usages will be addressed in separate PRs.