### PR TITLE
chore(Transition): remove deprecated lifecycle methods

### DIFF
--- a/docs/src/examples/modules/Transition/Types/TransitionExampleTransition.js
+++ b/docs/src/examples/modules/Transition/Types/TransitionExampleTransition.js
@@ -17,7 +17,7 @@ export default class TransitionExampleTransition extends Component {
           onClick={this.toggleVisibility}
         />
         <Divider hidden />
-        <Transition visible={visible} animation='scale' duration={3000}>
+        <Transition visible={visible} animation='scale' duration={500}>
           <Image size='small' src='/images/leaves/1.png' />
         </Transition>
       </div>

--- a/docs/src/examples/modules/Transition/Types/TransitionExampleTransition.js
+++ b/docs/src/examples/modules/Transition/Types/TransitionExampleTransition.js
@@ -17,7 +17,7 @@ export default class TransitionExampleTransition extends Component {
           onClick={this.toggleVisibility}
         />
         <Divider hidden />
-        <Transition visible={visible} animation='scale' duration={500}>
+        <Transition visible={visible} animation='scale' duration={3000}>
           <Image size='small' src='/images/leaves/1.png' />
         </Transition>
       </div>

--- a/src/addons/TransitionablePortal/TransitionablePortal.js
+++ b/src/addons/TransitionablePortal/TransitionablePortal.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 
 import Portal from '../Portal'
 import Transition from '../../modules/Transition'
+import { TRANSITION_STATUS_ENTERING } from '../../modules/Transition/utils/computeStatuses'
 import { getUnhandledProps, makeDebugger } from '../../lib'
 
 const debug = makeDebugger('transitionable_portal')
@@ -117,7 +118,7 @@ export default class TransitionablePortal extends Component {
     debug('handleTransitionStart()')
     const { portalOpen } = this.state
     const { status } = data
-    const transitionVisible = status === Transition.ENTERING
+    const transitionVisible = status === TRANSITION_STATUS_ENTERING
 
     _.invoke(this.props, 'onStart', null, { ...data, portalOpen, transitionVisible })
 
@@ -134,7 +135,7 @@ export default class TransitionablePortal extends Component {
 
   render() {
     debug('render()', this.state)
-    // console.log('render', this.state)
+
     const { children, transition } = this.props
     const { portalOpen, transitionVisible } = this.state
 

--- a/src/modules/Transition/Transition.js
+++ b/src/modules/Transition/Transition.js
@@ -5,12 +5,25 @@ import { cloneElement, Component } from 'react'
 
 import { makeDebugger, normalizeTransitionDuration, SUI, useKeyOnly } from '../../lib'
 import TransitionGroup from './TransitionGroup'
+import {
+  computeStatuses,
+  TRANSITION_STATUS_ENTERED,
+  TRANSITION_STATUS_ENTERING,
+  TRANSITION_STATUS_EXITED,
+  TRANSITION_STATUS_EXITING,
+  TRANSITION_STATUS_INITIAL,
+  TRANSITION_STATUS_UNMOUNTED,
+} from './utils/computeStatuses'
 
 const debug = makeDebugger('transition')
 
-const TRANSITION_TYPE = {
-  ENTERING: 'show',
-  EXITING: 'hide',
+const TRANSITION_CALLBACK_TYPE = {
+  [TRANSITION_STATUS_ENTERED]: 'show',
+  [TRANSITION_STATUS_EXITED]: 'hide',
+}
+const TRANSITION_STYLE_TYPE = {
+  [TRANSITION_STATUS_ENTERING]: 'show',
+  [TRANSITION_STATUS_EXITING]: 'hide',
 }
 
 /**
@@ -94,51 +107,50 @@ export default class Transition extends Component {
     unmountOnHide: false,
   }
 
-  static ENTERED = 'ENTERED'
-  static ENTERING = 'ENTERING'
-  static EXITED = 'EXITED'
-  static EXITING = 'EXITING'
-  static UNMOUNTED = 'UNMOUNTED'
+  /** @deprecated Static properties will be removed in v1 */
+  static INITIAL = TRANSITION_STATUS_INITIAL
+  static ENTERED = TRANSITION_STATUS_ENTERED
+  static ENTERING = TRANSITION_STATUS_ENTERING
+  static EXITED = TRANSITION_STATUS_EXITED
+  static EXITING = TRANSITION_STATUS_EXITING
+  static UNMOUNTED = TRANSITION_STATUS_UNMOUNTED
 
   static Group = TransitionGroup
 
-  constructor(...args) {
-    super(...args)
-
-    const { initial: status, next } = this.computeInitialStatuses()
-    this.nextStatus = next
-    this.state = { status }
+  state = {
+    status: TRANSITION_STATUS_INITIAL,
   }
 
   // ----------------------------------------
   // Lifecycle
   // ----------------------------------------
 
+  static getDerivedStateFromProps(props, state) {
+    const derivedState = computeStatuses({
+      mountOnShow: props.mountOnShow,
+      status: state.status,
+      transitionOnMount: props.transitionOnMount,
+      visible: props.visible,
+      unmountOnHide: props.unmountOnHide,
+    })
+
+    debug('getDerivedStateFromProps()', props, state, derivedState)
+
+    return derivedState
+  }
+
   componentDidMount() {
     debug('componentDidMount()')
-
-    this.updateStatus()
+    this.updateStatus({})
   }
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    debug('componentWillReceiveProps()')
-
-    const { current: status, next } = this.computeStatuses(nextProps)
-
-    this.nextStatus = next
-    if (status) this.setState({ status })
-  }
-
-  componentDidUpdate() {
+  componentDidUpdate(prevProps, prevState) {
     debug('componentDidUpdate()')
-
-    this.updateStatus()
+    this.updateStatus(prevState)
   }
 
   componentWillUnmount() {
     debug('componentWillUnmount()')
-
     clearTimeout(this.timeoutId)
   }
 
@@ -146,44 +158,33 @@ export default class Transition extends Component {
   // Callback handling
   // ----------------------------------------
 
-  handleStart = () => {
+  handleStart = (nextStatus) => {
     const { duration } = this.props
-    const status = this.nextStatus
 
-    this.nextStatus = null
-    this.setState({ status, animating: true }, () => {
-      const durationType = TRANSITION_TYPE[status]
-      const durationValue = normalizeTransitionDuration(duration, durationType)
+    const durationType = TRANSITION_CALLBACK_TYPE[nextStatus]
+    const durationValue = normalizeTransitionDuration(duration, durationType)
 
-      _.invoke(this.props, 'onStart', null, { ...this.props, status })
-      this.timeoutId = setTimeout(this.handleComplete, durationValue)
-    })
+    clearTimeout(this.timeoutId)
+    this.timeoutId = setTimeout(
+      () => this.setState((state) => ({ status: state.nextStatus })),
+      durationValue,
+    )
   }
 
-  handleComplete = () => {
-    const { status: current } = this.state
-
-    _.invoke(this.props, 'onComplete', null, { ...this.props, status: current })
-
-    if (this.nextStatus) {
-      this.handleStart()
-      return
+  updateStatus = (prevState) => {
+    if (this.state.status !== this.state.nextStatus && this.state.nextStatus) {
+      this.handleStart(this.state.nextStatus)
     }
 
-    const status = this.computeCompletedStatus()
-    const callback = current === Transition.ENTERING ? 'onShow' : 'onHide'
+    if (!prevState.animating && this.state.animating) {
+      _.invoke(this.props, 'onStart', null, { ...this.props, status: this.state.status })
+    }
 
-    this.setState({ status, animating: false }, () => {
-      _.invoke(this.props, callback, null, { ...this.props, status })
-    })
-  }
+    if (prevState.animating && !this.state.animating) {
+      const callback = this.state.status === TRANSITION_STATUS_ENTERED ? 'onShow' : 'onHide'
 
-  updateStatus = () => {
-    const { animating } = this.state
-
-    if (this.nextStatus) {
-      this.nextStatus = this.computeNextStatus()
-      if (!animating) this.handleStart()
+      _.invoke(this.props, 'onComplete', null, { ...this.props, status: this.state.status })
+      _.invoke(this.props, callback, null, { ...this.props, status: this.state.status })
     }
   }
 
@@ -205,10 +206,10 @@ export default class Transition extends Component {
         animation,
         childClasses,
         useKeyOnly(animating, 'animating'),
-        useKeyOnly(status === Transition.ENTERING, 'in'),
-        useKeyOnly(status === Transition.EXITING, 'out'),
-        useKeyOnly(status === Transition.EXITED, 'hidden'),
-        useKeyOnly(status !== Transition.EXITED, 'visible'),
+        useKeyOnly(status === TRANSITION_STATUS_ENTERING, 'in'),
+        useKeyOnly(status === TRANSITION_STATUS_EXITING, 'out'),
+        useKeyOnly(status === TRANSITION_STATUS_EXITED, 'hidden'),
+        useKeyOnly(status !== TRANSITION_STATUS_EXITED, 'visible'),
         'transition',
       )
     }
@@ -216,61 +217,12 @@ export default class Transition extends Component {
     return cx(animation, childClasses, useKeyOnly(animating, 'animating transition'))
   }
 
-  computeCompletedStatus = () => {
-    const { unmountOnHide } = this.props
-    const { status } = this.state
-
-    if (status === Transition.ENTERING) return Transition.ENTERED
-    return unmountOnHide ? Transition.UNMOUNTED : Transition.EXITED
-  }
-
-  computeInitialStatuses = () => {
-    const { visible, mountOnShow, transitionOnMount, unmountOnHide } = this.props
-
-    if (visible) {
-      if (transitionOnMount) {
-        return {
-          initial: Transition.EXITED,
-          next: Transition.ENTERING,
-        }
-      }
-      return { initial: Transition.ENTERED }
-    }
-
-    if (mountOnShow || unmountOnHide) return { initial: Transition.UNMOUNTED }
-    return { initial: Transition.EXITED }
-  }
-
-  computeNextStatus = () => {
-    const { animating, status } = this.state
-
-    if (animating) return status === Transition.ENTERING ? Transition.EXITING : Transition.ENTERING
-    return status === Transition.ENTERED ? Transition.EXITING : Transition.ENTERING
-  }
-
-  computeStatuses = (props) => {
-    const { status } = this.state
-    const { visible } = props
-
-    if (visible) {
-      return {
-        current: status === Transition.UNMOUNTED && Transition.EXITED,
-        next:
-          status !== Transition.ENTERING && status !== Transition.ENTERED && Transition.ENTERING,
-      }
-    }
-
-    return {
-      next: (status === Transition.ENTERING || status === Transition.ENTERED) && Transition.EXITING,
-    }
-  }
-
   computeStyle = () => {
     const { children, duration } = this.props
     const { status } = this.state
 
     const childStyle = _.get(children, 'props.style')
-    const type = TRANSITION_TYPE[status]
+    const type = TRANSITION_STYLE_TYPE[status]
     const animationDuration = type && `${normalizeTransitionDuration(duration, type)}ms`
 
     return { ...childStyle, animationDuration }
@@ -281,14 +233,16 @@ export default class Transition extends Component {
   // ----------------------------------------
 
   render() {
-    debug('render()')
-    debug('props', this.props)
-    debug('state', this.state)
+    debug('render(): props', this.props)
+    debug('render(): state', this.state)
 
     const { children } = this.props
     const { status } = this.state
 
-    if (status === Transition.UNMOUNTED) return null
+    if (status === TRANSITION_STATUS_UNMOUNTED) {
+      return null
+    }
+
     return cloneElement(children, {
       className: this.computeClasses(),
       style: this.computeStyle(),

--- a/src/modules/Transition/utils/computeStatuses.js
+++ b/src/modules/Transition/utils/computeStatuses.js
@@ -50,13 +50,10 @@ export function computeStatuses(options) {
     }
 
     if (status === TRANSITION_STATUS_ENTERING) {
-      return {
-        animating: false,
-        status: TRANSITION_STATUS_ENTERED,
-        nextStatus: undefined,
-      }
+      return {}
     }
 
+    /* istanbul ignore else */
     if (status === TRANSITION_STATUS_ENTERED) {
       return {
         animating: false,
@@ -64,8 +61,6 @@ export function computeStatuses(options) {
         nextStatus: undefined,
       }
     }
-
-    return {}
   }
 
   if (status === TRANSITION_STATUS_INITIAL) {
@@ -93,11 +88,7 @@ export function computeStatuses(options) {
   }
 
   if (status === TRANSITION_STATUS_EXITING) {
-    return {
-      animating: false,
-      status: unmountOnHide ? TRANSITION_STATUS_UNMOUNTED : TRANSITION_STATUS_EXITED,
-      nextStatus: undefined,
-    }
+    return {}
   }
 
   if (status === TRANSITION_STATUS_EXITED) {
@@ -108,6 +99,7 @@ export function computeStatuses(options) {
     }
   }
 
+  /* istanbul ignore else */
   if (status === TRANSITION_STATUS_UNMOUNTED) {
     return {
       animating: false,
@@ -116,6 +108,7 @@ export function computeStatuses(options) {
     }
   }
 
+  /* istanbul ignore next */
   throw new Error(
     `Transition:computeStatuses(): an unexpected status transition: { visible: ${visible}, status: ${status} }`,
   )

--- a/src/modules/Transition/utils/computeStatuses.js
+++ b/src/modules/Transition/utils/computeStatuses.js
@@ -1,0 +1,122 @@
+export const TRANSITION_STATUS_INITIAL = 'INITIAL'
+export const TRANSITION_STATUS_ENTERED = 'ENTERED'
+export const TRANSITION_STATUS_ENTERING = 'ENTERING'
+export const TRANSITION_STATUS_EXITED = 'EXITED'
+export const TRANSITION_STATUS_EXITING = 'EXITING'
+export const TRANSITION_STATUS_UNMOUNTED = 'UNMOUNTED'
+
+/**
+ * @param {Object} [options]
+ * @param {String} [options.status]
+ * @param {Boolean} [options.mountOnShow]
+ * @param {Boolean} [options.transitionOnMount]
+ * @param {Boolean} [options.visible]
+ * @param {Boolean} [options.unmountOnHide]
+ */
+export function computeStatuses(options) {
+  const { mountOnShow, status, transitionOnMount, visible, unmountOnHide } = options
+
+  if (visible) {
+    if (status === TRANSITION_STATUS_INITIAL) {
+      if (transitionOnMount) {
+        return {
+          animating: true,
+          status: TRANSITION_STATUS_ENTERING,
+          nextStatus: TRANSITION_STATUS_ENTERED,
+        }
+      }
+
+      return {
+        animating: false,
+        status: TRANSITION_STATUS_ENTERED,
+        nextStatus: undefined,
+      }
+    }
+
+    if (status === TRANSITION_STATUS_UNMOUNTED) {
+      return {
+        animating: true,
+        status: TRANSITION_STATUS_ENTERING,
+        nextStatus: TRANSITION_STATUS_ENTERED,
+      }
+    }
+
+    if (status === TRANSITION_STATUS_EXITED || status === TRANSITION_STATUS_EXITING) {
+      return {
+        animating: true,
+        status: TRANSITION_STATUS_ENTERING,
+        nextStatus: TRANSITION_STATUS_ENTERED,
+      }
+    }
+
+    if (status === TRANSITION_STATUS_ENTERING) {
+      return {
+        animating: false,
+        status: TRANSITION_STATUS_ENTERED,
+        nextStatus: undefined,
+      }
+    }
+
+    if (status === TRANSITION_STATUS_ENTERED) {
+      return {
+        animating: false,
+        status: TRANSITION_STATUS_ENTERED,
+        nextStatus: undefined,
+      }
+    }
+
+    return {}
+  }
+
+  if (status === TRANSITION_STATUS_INITIAL) {
+    if (mountOnShow || unmountOnHide) {
+      return {
+        animating: false,
+        status: TRANSITION_STATUS_UNMOUNTED,
+        nextStatus: undefined,
+      }
+    }
+
+    return {
+      animating: false,
+      status: TRANSITION_STATUS_EXITED,
+      nextStatus: undefined,
+    }
+  }
+
+  if (status === TRANSITION_STATUS_ENTERED || status === TRANSITION_STATUS_ENTERING) {
+    return {
+      animating: true,
+      status: TRANSITION_STATUS_EXITING,
+      nextStatus: unmountOnHide ? TRANSITION_STATUS_UNMOUNTED : TRANSITION_STATUS_EXITED,
+    }
+  }
+
+  if (status === TRANSITION_STATUS_EXITING) {
+    return {
+      animating: false,
+      status: unmountOnHide ? TRANSITION_STATUS_UNMOUNTED : TRANSITION_STATUS_EXITED,
+      nextStatus: undefined,
+    }
+  }
+
+  if (status === TRANSITION_STATUS_EXITED) {
+    return {
+      animating: false,
+      status: TRANSITION_STATUS_EXITED,
+      nextStatus: undefined,
+    }
+  }
+
+  if (status === TRANSITION_STATUS_UNMOUNTED) {
+    return {
+      animating: false,
+      status: TRANSITION_STATUS_UNMOUNTED,
+      nextStatus: undefined,
+    }
+  }
+
+  throw new Error(
+    `Transition:computeStatuses(): an unexpected status transition: { visible: ${visible}, status: ${status} }`,
+  )
+}

--- a/test/specs/modules/Transition/Transition-test.js
+++ b/test/specs/modules/Transition/Transition-test.js
@@ -465,6 +465,29 @@ describe('Transition', () => {
         done()
       }, 200)
     })
+
+    it('will be called once even during rerender', (done) => {
+      const onStart = sandbox.spy()
+
+      wrapperMount(
+        <Transition duration={200} onStart={onStart}>
+          <p />
+        </Transition>,
+      )
+
+      wrapper.setProps({ visible: false })
+
+      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_EXITED)
+
+      wrapper.setProps({})
+
+      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_EXITED)
+
+      onStart.should.have.been.calledOnce()
+      done()
+    })
   })
 
   describe('onShow', () => {
@@ -530,6 +553,27 @@ describe('Transition', () => {
           <p />
         </Transition>,
       )
+    })
+
+    it('will be called once even during rerender', (done) => {
+      const onStart = sandbox.spy()
+
+      wrapperMount(
+        <Transition duration={200} onStart={onStart} transitionOnMount>
+          <p />
+        </Transition>,
+      )
+
+      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_ENTERED)
+
+      wrapper.setProps({})
+
+      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_ENTERED)
+
+      onStart.should.have.been.calledOnce()
+      done()
     })
   })
 


### PR DESCRIPTION
Related to #3919.

Removes the usage of `UNSAFE_componentWillReceiveProps` for `Transition`.