### PR TITLE
chore: add github action to check PR labels

### DIFF
--- a/.github/workflows/pr-health.yml
+++ b/.github/workflows/pr-health.yml
@@ -1,0 +1,14 @@
+name: PR Health
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 1
+          labels: "PR: Breaking Change :boom:, PR: New Feature :rocket:, PR: Bug Fix :bug:, PR: Docs :memo:, PR: Internal :house:"


### PR DESCRIPTION
This PR enables a Github Action to check for PR labels. This will allow to enable [lerna-changelog](https://github.com/lerna/lerna-changelog) usage in future.