### PR TITLE
fix(Portal): throw an error if React.Fragment passed as `trigger`

### DIFF
--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -3,7 +3,7 @@ import { handleRef, Ref } from '@stardust-ui/react-component-ref'
 import keyboardKey from 'keyboard-key'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { cloneElement, createRef, Fragment } from 'react'
+import React from 'react'
 
 import {
   ModernAutoControlledComponent as Component,
@@ -11,6 +11,7 @@ import {
   doesNodeContainClick,
   makeDebugger,
 } from '../../lib'
+import validateTrigger from './utils/validateTrigger'
 import PortalInner from './PortalInner'
 
 const debug = makeDebugger('portal')
@@ -126,8 +127,8 @@ class Portal extends Component {
 
   static Inner = PortalInner
 
-  contentRef = createRef()
-  triggerRef = createRef()
+  contentRef = React.createRef()
+  triggerRef = React.createRef()
   latestDocumentMouseDownEvent = null
 
   componentWillUnmount() {
@@ -335,10 +336,15 @@ class Portal extends Component {
     const { children, eventPool, mountNode, trigger } = this.props
     const { open } = this.state
 
+    /* istanbul ignore else */
+    if (process.env.NODE_ENV !== 'production') {
+      validateTrigger(trigger)
+    }
+
     return (
-      <Fragment>
+      <>
         {open && (
-          <Fragment>
+          <>
             <PortalInner
               innerRef={this.contentRef}
               mountNode={mountNode}
@@ -363,11 +369,11 @@ class Portal extends Component {
             <EventStack name='mousedown' on={this.handleDocumentMouseDown} pool={eventPool} />
             <EventStack name='click' on={this.handleDocumentClick} pool={eventPool} />
             <EventStack name='keydown' on={this.handleEscape} pool={eventPool} />
-          </Fragment>
+          </>
         )}
         {trigger && (
           <Ref innerRef={this.handleTriggerRef}>
-            {cloneElement(trigger, {
+            {React.cloneElement(trigger, {
               onBlur: this.handleTriggerBlur,
               onClick: this.handleTriggerClick,
               onFocus: this.handleTriggerFocus,
@@ -376,7 +382,7 @@ class Portal extends Component {
             })}
           </Ref>
         )}
-      </Fragment>
+      </>
     )
   }
 }

--- a/src/addons/Portal/utils/validateTrigger.js
+++ b/src/addons/Portal/utils/validateTrigger.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import * as ReactIs from 'react-is'
+
+/**
+ * Asserts that a passed element can be used cloned a props will be applied properly.
+ */
+export default function validateTrigger(element) {
+  if (element) {
+    React.Children.only(element)
+
+    if (ReactIs.isFragment(element)) {
+      throw new Error('An "React.Fragment" cannot be used as a `trigger`.')
+    }
+  }
+}

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -341,7 +341,9 @@ export default class Popup extends Component {
     } = this.props
     const { closed, portalRestProps } = this.state
 
-    if (closed || disabled) return trigger
+    if (closed || disabled) {
+      return trigger
+    }
 
     const modifiers = _.merge(
       {

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React from 'react'
 
 import * as common from 'test/specs/commonTests'
 import { domEvent, sandbox } from 'test/utils'
@@ -10,7 +10,7 @@ import PortalInner from 'src/addons/Portal/PortalInner'
 let wrapper
 
 const createHandlingComponent = (eventName) =>
-  class HandlingComponent extends Component {
+  class HandlingComponent extends React.Component {
     static propTypes = {
       handler: PropTypes.func,
     }

--- a/test/specs/addons/Portal/utils/validateTrigger-test.js
+++ b/test/specs/addons/Portal/utils/validateTrigger-test.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import validateTrigger from 'src/addons/Portal/utils/validateTrigger'
+
+describe('validateTrigger', () => {
+  it('throws on multiple elements passed', () => {
+    expect(() => validateTrigger([<button key='trigger1' />, <button key='trigger2' />])).to.throw()
+  })
+
+  it('throws on React.Fragment passed', () => {
+    expect(() => validateTrigger(React.createElement(React.Fragment))).to.throw()
+  })
+})


### PR DESCRIPTION
Fixes #3928.

Now we will throw errors in two additional cases:
- when an array of elements is passed, `<Popup trigger={[<b />, <b />]} />`
- when a `React.Fragment` is passed `<Popup trigger={[<><b /></>} />` as it impossible to use `React.cloneElement()` with it to assign props

This change is not a breaking as previously these scenarios were impossible, so this PR just adds only meaningful errors.