### PR TITLE
fix(Dropdown): handle keyboard events for arrows, space and enter keys locally

### DIFF
--- a/docs/src/examples/modules/Dropdown/States/DropdownExampleDisabledItem.js
+++ b/docs/src/examples/modules/Dropdown/States/DropdownExampleDisabledItem.js
@@ -8,7 +8,7 @@ const options = [
 ]
 
 const DropdownExampleDisabledItem = () => (
-  <Dropdown text='Dropdown' options={options} open />
+  <Dropdown text='Dropdown' options={options} />
 )
 
 export default DropdownExampleDisabledItem

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -254,7 +254,7 @@ export default class Dropdown extends Component {
     // prevent selecting null if there was no selected item value
     // prevent selecting duplicate items when the dropdown is closed
     if (_.isNil(selectedValue) || !open) {
-      return [value, selectedIndex]
+      return
     }
 
     // state value may be undefined
@@ -272,8 +272,6 @@ export default class Dropdown extends Component {
         _.invoke(this.props, 'onAddItem', e, { ...this.props, value: selectedValue })
       }
     }
-
-    return [newValue]
   }
 
   selectItemOnEnter = (e) => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -638,6 +638,24 @@ describe('Dropdown', () => {
       wrapper.simulate('click')
       wrapper.should.have.state('selectedIndex', 4)
     })
+
+    it('keeps "selectedIndex" when the same item was selected', () => {
+      const option = _.last(options)
+
+      wrapperMount(<Dropdown options={options} search selection />)
+      const input = wrapper.find('input.search')
+
+      // simulate search and select option
+      input.simulate('change', { target: { value: option.text } })
+      wrapper.simulate('keydown', { key: 'Enter' })
+
+      wrapper.should.have.state('selectedIndex', 4)
+
+      // select the same option again
+      input.simulate('change', { target: { value: option.text } })
+      wrapper.simulate('keydown', { key: 'Enter' })
+      wrapper.should.have.state('selectedIndex', 4)
+    })
   })
 
   describe('isMouseDown', () => {

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -72,7 +72,7 @@ const dropdownMenuIsOpen = () => {
 
 const nativeEvent = { nativeEvent: { stopImmediatePropagation: _.noop } }
 
-describe.only('Dropdown', () => {
+describe('Dropdown', () => {
   beforeEach(() => {
     attachTo = undefined
     wrapper = undefined


### PR DESCRIPTION
Fixes #3994.

---

This PR is focused on the single thing to move event handling from `document` (i.e. `EventStack`) to `Dropdown`s scope as it creates various issues when multiple `Dropdown` are opened. And there are no reasons to have these listeners globally.