### PR TITLE
fix(Dropdown): update search prop typing

### DIFF
--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -246,7 +246,7 @@ export interface StrictDropdownProps {
    * A selection dropdown can allow a user to search through a large list of choices.
    * Pass a function here to replace the default search.
    */
-  search?: (options: DropdownItemProps[], value: string) => DropdownItemProps[] | boolean
+  search?: boolean | ((options: DropdownItemProps[], value: string) => DropdownItemProps[])
 
   /** A shorthand for a search input. */
   searchInput?: any


### PR DESCRIPTION
Fixes #4013. Reverted the Dropdown.search prop typing to the previous version as per #4013 