### PR TITLE
fix(Popup): do not throw if `context` & `trigger` are missing

### DIFF
--- a/docs/src/examples/modules/Popup/Usage/PopupExampleContext.js
+++ b/docs/src/examples/modules/Popup/Usage/PopupExampleContext.js
@@ -1,23 +1,21 @@
-import React, { createRef } from 'react'
+import React from 'react'
 import { Button, Popup } from 'semantic-ui-react'
 
-class PopupExampleContextControlled extends React.Component {
-  contextRef = createRef()
+function PopupExampleContext() {
+  const contextRef = React.useRef()
 
-  render() {
-    return (
-      <>
-        <Popup
-          trigger={<Button content='Trigger Popup' />}
-          context={this.contextRef}
-          content='Hello'
-          position='top center'
-        />
-        ---------->
-        <strong ref={this.contextRef}>here</strong>
-      </>
-    )
-  }
+  return (
+    <>
+      <Popup
+        trigger={<Button content='Trigger Popup' />}
+        context={contextRef}
+        content='Hello'
+        position='top center'
+      />
+      ---------->
+      <strong ref={contextRef}>here</strong>
+    </>
+  )
 }
 
-export default PopupExampleContextControlled
+export default PopupExampleContext

--- a/docs/src/examples/modules/Popup/Usage/PopupExampleContextControlled.js
+++ b/docs/src/examples/modules/Popup/Usage/PopupExampleContextControlled.js
@@ -1,27 +1,26 @@
 import React from 'react'
 import { Button, Popup } from 'semantic-ui-react'
 
-class PopupExampleContextControlled extends React.Component {
-  state = {}
-  contextRef = React.createRef()
+function PopupExampleContextControlled() {
+  const contextRef = React.useRef()
+  const [open, setOpen] = React.useState(false)
 
-  toggle = () => this.setState((prevState) => ({ open: !prevState.open }))
-
-  render() {
-    return (
-      <>
-        <Button content='Open controlled Popup' onClick={this.toggle} />
-        <Popup
-          context={this.contextRef}
-          content='Hello'
-          position='top center'
-          open={this.state.open}
-        />
-        ---------->
-        <strong ref={this.contextRef}>here</strong>
-      </>
-    )
-  }
+  return (
+    <>
+      <Button
+        content='Open controlled Popup'
+        onClick={() => setOpen((prevOpen) => !prevOpen)}
+      />
+      <Popup
+        context={contextRef}
+        content='Hello'
+        position='top center'
+        open={open}
+      />
+      ---------->
+      <strong ref={contextRef}>here</strong>
+    </>
+  )
 }
 
 export default PopupExampleContextControlled

--- a/docs/src/examples/modules/Popup/Usage/PopupExampleContextMenu.js
+++ b/docs/src/examples/modules/Popup/Usage/PopupExampleContextMenu.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import { Menu, Popup, Segment } from 'semantic-ui-react'
+
+function createContextFromEvent(e) {
+  const left = e.clientX
+  const top = e.clientY
+  const right = left + 1
+  const bottom = top + 1
+
+  return {
+    getBoundingClientRect: () => ({
+      left,
+      top,
+      right,
+      bottom,
+
+      height: 0,
+      width: 0,
+    }),
+  }
+}
+
+function PopupExampleContextMenu() {
+  const contextRef = React.useRef()
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <>
+      <Segment
+        onContextMenu={(e) => {
+          e.preventDefault()
+
+          contextRef.current = createContextFromEvent(e)
+          setOpen(true)
+        }}
+        secondary
+        style={{ height: 200 }}
+        tabIndex={0}
+      >
+        Press Context Menu button or perform a right click in this area to open
+        a popup
+      </Segment>
+
+      <Popup
+        basic
+        context={contextRef}
+        onClose={() => setOpen(false)}
+        open={open}
+      >
+        <Menu
+          items={[
+            { key: 'copy', content: 'Copy', icon: 'copy' },
+            { key: 'code', content: 'View source code', icon: 'code' },
+          ]}
+          onItemClick={() => setOpen(false)}
+          secondary
+          vertical
+        />
+      </Popup>
+    </>
+  )
+}
+
+export default PopupExampleContextMenu

--- a/docs/src/examples/modules/Popup/Usage/index.js
+++ b/docs/src/examples/modules/Popup/Usage/index.js
@@ -97,6 +97,11 @@ const PopupUsageExamples = () => (
       examplePath='modules/Popup/Usage/PopupExampleContextControlled'
     />
     <ComponentExample
+      title='Context Menu'
+      description='A popup can open over a DOM node as used as a context menu.'
+      examplePath='modules/Popup/Usage/PopupExampleContextMenu'
+    />
+    <ComponentExample
       title='Hide on scroll'
       description='A popup can be hidden on a scroll event.'
       examplePath='modules/Popup/Usage/PopupExampleHideOnScroll'

--- a/src/modules/Popup/lib/createReferenceProxy.js
+++ b/src/modules/Popup/lib/createReferenceProxy.js
@@ -7,7 +7,7 @@ class ReferenceProxy {
   }
 
   getBoundingClientRect() {
-    return _.invoke(this.ref.current, 'getBoundingClientRect', {})
+    return _.invoke(this.ref.current, 'getBoundingClientRect') || {}
   }
 
   get clientWidth() {


### PR DESCRIPTION
Fixes #3896.

This PR adds an example with context menu usage and fixes an issue when `trigger` and `context` are not defined to prevent throwing errors.