### PR TITLE
fix(Pagination): set a default activePage in Pagination's state

### DIFF
--- a/src/addons/Pagination/Pagination.js
+++ b/src/addons/Pagination/Pagination.js
@@ -15,6 +15,10 @@ import PaginationItem from './PaginationItem'
  * A component to render a pagination.
  */
 export default class Pagination extends Component {
+  getInitialAutoControlledState() {
+    return { activePage: 1 }
+  }
+
   handleItemClick = (e, { value: nextActivePage }) => {
     const { activePage: prevActivePage } = this.state
 

--- a/test/specs/addons/Pagination/Pagination-test.js
+++ b/test/specs/addons/Pagination/Pagination-test.js
@@ -78,4 +78,25 @@ describe('Pagination', () => {
       onPageChange.should.have.not.been.called()
     })
   })
+
+  describe('activePage', () => {
+    it('defaults to "1"', () => {
+      const wrapper = mount(<Pagination totalPages={3} />)
+
+      wrapper.find('PaginationItem').at(1).prop('value').should.equal(1)
+      wrapper.find('PaginationItem').at(5).prop('value').should.equal(2)
+    })
+
+    it('can be set via "defaultActivePage"', () => {
+      const wrapper = mount(<Pagination defaultActivePage={2} totalPages={3} />)
+
+      wrapper.find('PaginationItem').at(3).should.have.prop('active')
+    })
+
+    it('can be set via "activePage"', () => {
+      const wrapper = mount(<Pagination activePage={2} totalPages={3} />)
+
+      wrapper.find('PaginationItem').at(3).should.have.prop('active')
+    })
+  })
 })


### PR DESCRIPTION
Fixes #4035 

On the first render of a Pagination, if there was no activePage or defaultActivePage value specified, activePage is undefined for "Previous Item" and "Next Item" PaginationItems. This PR sets an initial state for activePage.