### PR TITLE
fix(Dropdown): handle `text` as a content in `renderLabel`

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -41,9 +41,9 @@ const getKeyAndValues = (options) =>
 function renderItemContent(item) {
   const { flag, image, text } = item
 
-  // TODO: remove this in v2
+  // TODO: remove this in v3
   // This maintains compatibility with Shorthand API in v1 as this might be called in "Label.create()"
-  if (React.isValidElement(text) || _.isFunction(text)) {
+  if (_.isFunction(text)) {
     return text
   }
 


### PR DESCRIPTION
Fixes #4046.

---

This PR fixes a regression from #4003 ([v1.1.0](https://github.com/Semantic-Org/Semantic-UI-React/releases/tag/v1.1.0)).

That change affected `renderLabel` prop in `Dropdown` (will be used to render labels with `multiple`). In #4003 I decided to avoid breaking changes and keep the existing behavior via this condition:

```js
if (React.isValidElement(text) || _.isFunction(text)) {
```

However, I can't consider the previous behavior as valid as it will break the layout once `text` will be a JSX element (see behaviors below).

## test snippet

```jsx
<Grid columns={2}>
  <Grid.Column>
    <Dropdown
      placeholder="Select Friend"
      fluid
      selection
      multiple
      options={[
        {
          key: "Jenny Hess",
          text: <span>Jenny Hess</span>,
          value: "Jenny Hess"
        },
        {
          key: "Elliot Fu",
          text: "Elliot Fu",
          value: "Elliot Fu"
        }
      ]}
    />
  </Grid.Column>
  <Grid.Column>
    <Dropdown
      placeholder="Select Friend"
      fluid
      selection
      options={[
        {
          key: "Jenny Hess",
          text: <span>Jenny Hess</span>,
          value: "Jenny Hess"
        },
        {
          key: "Elliot Fu",
          text: "Elliot Fu",
          value: "Elliot Fu"
        }
      ]}
    />
  </Grid.Column>
</Grid>
```

Mention that in the first case `text` is a JSX element.

## pre v1.1.0 behavior

![image](https://user-images.githubusercontent.com/14183168/91288054-d39fe600-e790-11ea-9af8-23d3419d73fb.png)

https://codesandbox.io/s/busy-hooks-5p5pq

## v1.1.0 behavior

![image](https://user-images.githubusercontent.com/14183168/91288219-077b0b80-e791-11ea-973e-3f229e2b0018.png)
https://codesandbox.io/s/distracted-dawn-xg28c

## fix in this PR

![image](https://user-images.githubusercontent.com/14183168/91288419-44df9900-e791-11ea-897c-5e59b2362636.png)

---

To keep previous behavior use:

```jsx
<Dropdown renderLabel={({ text }) => text} />
```