### PR TITLE
chore: remove usages of `lodash/fp` in customPropTypes

### DIFF
--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -163,7 +163,7 @@ FormField.propTypes = {
    * Extra FormField props are passed to the control component.
    * Mutually exclusive with children.
    */
-  control: customPropTypes.some([
+  control: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.oneOf(['button', 'input', 'select', 'textarea']),
   ]),

--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -164,7 +164,7 @@ FormField.propTypes = {
    * Mutually exclusive with children.
    */
   control: PropTypes.oneOfType([
-    PropTypes.func,
+    PropTypes.elementType,
     PropTypes.oneOf(['button', 'input', 'select', 'textarea']),
   ]),
 

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -247,7 +247,7 @@ Button.propTypes = {
   fluid: PropTypes.bool,
 
   /** Add an Icon by name, props object, or pass an <Icon />. */
-  icon: customPropTypes.some([
+  icon: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.string,
     PropTypes.object,
@@ -258,7 +258,7 @@ Button.propTypes = {
   inverted: PropTypes.bool,
 
   /** Add a Label by text, props object, or pass a <Label />. */
-  label: customPropTypes.some([PropTypes.string, PropTypes.object, PropTypes.element]),
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.element]),
 
   /** A labeled button can format a Label or Icon to appear on the left or right. */
   labelPosition: PropTypes.oneOf(['right', 'left']),

--- a/test/specs/lib/customPropTypes-test.js
+++ b/test/specs/lib/customPropTypes-test.js
@@ -56,6 +56,19 @@ describe.only('customPropTypes', () => {
         /Invalid name `name` of type `number` supplied/,
       )
     })
+
+    it('should execute all validators including custom', () => {
+      PropTypes.checkPropTypes(
+        {
+          name: customPropTypes.every([customPropTypes.suggest(['foo']), PropTypes.number]),
+        },
+        { name: 'bar' },
+        'name',
+        'FooComponent',
+      )
+
+      console.error.should.have.been.calledWithMatch(/Instead of `bar`, did you mean:/)
+    })
   })
 
   describe('suggest', () => {

--- a/test/specs/lib/customPropTypes-test.js
+++ b/test/specs/lib/customPropTypes-test.js
@@ -5,7 +5,7 @@ import { consoleUtil, sandbox } from 'test/utils'
 
 /* eslint-disable no-console */
 
-describe.only('customPropTypes', () => {
+describe('customPropTypes', () => {
   beforeEach(() => {
     consoleUtil.disable()
     sandbox.spy(console, 'error')

--- a/test/specs/lib/customPropTypes-test.js
+++ b/test/specs/lib/customPropTypes-test.js
@@ -1,42 +1,122 @@
+import PropTypes from 'prop-types'
 import { customPropTypes } from 'src/lib'
 
-describe('suggest prop type', () => {
-  it('should throw error when non-array argument given', () => {
-    expect(() => customPropTypes.suggest('foo')).to.throw(
-      Error,
-      /Invalid argument supplied to suggest, expected an instance of array./,
-    )
+import { consoleUtil, sandbox } from 'test/utils'
+
+/* eslint-disable no-console */
+
+describe.only('customPropTypes', () => {
+  beforeEach(() => {
+    consoleUtil.disable()
+    sandbox.spy(console, 'error')
   })
 
-  it('should return undefined when prop is valid', () => {
-    const propType = customPropTypes.suggest(['foo', 'bar', 'baz'])
-    expect(propType({ name: 'bar' }, 'name', 'FooComponent')).to.equal(undefined)
+  describe('every', () => {
+    it('should throw error when a non-array argument given', () => {
+      PropTypes.checkPropTypes(
+        {
+          name: customPropTypes.every('foo'),
+        },
+        { name: 'foo' },
+        'name',
+        'FooComponent',
+      )
+
+      console.error.should.have.been.calledWithMatch(
+        /Invalid argument supplied to every, expected an instance of array/,
+      )
+    })
+
+    it('should throw error when a non-function argument given', () => {
+      PropTypes.checkPropTypes(
+        {
+          name: customPropTypes.every([{}]),
+        },
+        { name: 'foo' },
+        'name',
+        'FooComponent',
+      )
+
+      console.error.should.have.been.calledWithMatch(
+        /argument "validators" should contain functions/,
+      )
+    })
+
+    it('should execute all validators', () => {
+      PropTypes.checkPropTypes(
+        {
+          name: customPropTypes.every([PropTypes.string]),
+        },
+        { name: 1 },
+        'name',
+        'FooComponent',
+      )
+
+      console.error.should.have.been.calledWithMatch(
+        /Invalid name `name` of type `number` supplied/,
+      )
+    })
   })
 
-  it('should return Error with suggestions when prop is invalid', () => {
-    const propType = customPropTypes.suggest(['foo', 'bar', 'baz'])
-    const props = { name: 'bad', title: 'bat words' }
+  describe('suggest', () => {
+    it('should throw error when non-array argument given', () => {
+      expect(() => customPropTypes.suggest('foo')).to.throw(
+        Error,
+        /Invalid argument supplied to suggest, expected an instance of array./,
+      )
+    })
 
-    const resultFooComponent = propType(props, 'name', 'FooComponent')
-    expect(resultFooComponent).to.be.an.instanceof(Error)
-    expect(resultFooComponent.message).to
-      .equal(`Invalid prop \`name\` of value \`bad\` supplied to \`FooComponent\`.
+    it('should return undefined when prop is valid', () => {
+      PropTypes.checkPropTypes(
+        {
+          name: customPropTypes.suggest(['foo', 'bar', 'baz']),
+        },
+        { name: 'foo' },
+        'name',
+        'FooComponent',
+      )
+
+      console.error.should.have.not.been.called()
+    })
+
+    it('should return Error with suggestions when prop is invalid', () => {
+      PropTypes.checkPropTypes(
+        {
+          name: customPropTypes.suggest(['foo', 'bar', 'baz']),
+        },
+        { name: 'bad' },
+        'name',
+        'FooComponent',
+      )
+
+      console.error.should.have.been
+        .calledWithMatch(`Invalid prop \`name\` of value \`bad\` supplied to \`FooComponent\`.
 
 Instead of \`bad\`, did you mean:
   - bar
   - baz
   - foo
 `)
+    })
 
-    const resultBarComponent = propType(props, 'title', 'BarComponent')
-    expect(resultBarComponent).to.be.an.instanceof(Error)
-    expect(resultBarComponent.message).to
-      .equal(`Invalid prop \`title\` of value \`bat words\` supplied to \`BarComponent\`.
+    it('should return Error with suggestions when prop contains multiple words and is invalid', () => {
+      PropTypes.checkPropTypes(
+        {
+          name: customPropTypes.suggest(['foo', 'bar', 'baz']),
+        },
+        { name: 'bat words' },
+        'name',
+        'FooComponent',
+      )
+
+      console.error.should.have.been
+        .calledWithMatch(`Invalid prop \`name\` of value \`bat words\` supplied to \`FooComponent\`.
 
 Instead of \`bat words\`, did you mean:
   - bar
   - baz
   - foo
 `)
+    })
   })
 })


### PR DESCRIPTION
This PR removes the last usage of `lodash/fp` in distributed code, this will not improve anything as `customPropTypes` are not bundled into production builds. The change is done to unblock #4072.

`customPropTypes.some()` was removed as it can be replaced with `PropTypes.oneOfType()`.