### PR TITLE
 fix(Popup): transfer zIndex & fix floated elements

### DIFF
--- a/cypress/integration/Popup/Popup.visual.js
+++ b/cypress/integration/Popup/Popup.visual.js
@@ -8,6 +8,7 @@ describe('Popup: visual', () => {
     cy.get('[data-tid="button-popup"]').click()
     cy.get('[data-tid="popup-content"]').should('be.visible')
 
+    // This screenshot contains invalid position of an unknown reason
     cy.percySnapshot('Popup: inside a Modal')
   })
 
@@ -18,5 +19,23 @@ describe('Popup: visual', () => {
     cy.get('[data-tid="popup-content"]').should('be.visible')
 
     cy.percySnapshot('Popup: floating Button')
+  })
+
+  it('flowing', () => {
+    cy.visit('/maximize/popup-example-flowing')
+
+    cy.get('.ui.button').click()
+    cy.get('.ui.popup').should('be.visible')
+
+    cy.percySnapshot('Popup: flowing')
+  })
+
+  it('positionFixed', () => {
+    cy.visit('/maximize/popup-example-position-fixed')
+
+    cy.get('.ui.button').click()
+    cy.get('.ui.popup').should('be.visible')
+
+    cy.percySnapshot('Popup: positionFixed')
   })
 })

--- a/docs/src/examples/modules/Popup/Usage/PopupExamplePopper.js
+++ b/docs/src/examples/modules/Popup/Usage/PopupExamplePopper.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const PopupExamplePopper = () => (
+  <Popup
+    content={
+      <>
+        A wrapping element in this Popup will have custom <code>id</code> &{' '}
+        <code>zIndex</code>.
+      </>
+    }
+    on='click'
+    popper={{ id: 'popper-container', style: { zIndex: 2000 } }}
+    trigger={<Button>Open a popup</Button>}
+  />
+)
+
+export default PopupExamplePopper

--- a/docs/src/examples/modules/Popup/Usage/PopupExamplePositionFixed.js
+++ b/docs/src/examples/modules/Popup/Usage/PopupExamplePositionFixed.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Button, Popup } from 'semantic-ui-react'
+
+const PopupExamplePositionFixed = () => (
+  <Popup
+    content={
+      <>
+        This Popup is positioned with <code>position: fixed</code>
+      </>
+    }
+    on='click'
+    positionFixed
+    trigger={<Button>Open a popup</Button>}
+  />
+)
+
+export default PopupExamplePositionFixed

--- a/docs/src/examples/modules/Popup/Usage/index.js
+++ b/docs/src/examples/modules/Popup/Usage/index.js
@@ -95,6 +95,40 @@ const PopupUsageExamples = () => (
       renderHtml={false}
     />
     <ComponentExample
+      title={
+        <>
+          <code>popper</code> element
+        </>
+      }
+      description={
+        <>
+          From <code>semantic-ui-react@2.0.0</code> we are using an additional
+          wrapping element around <code>Popup</code> for positioning, see{' '}
+          <a href='https://github.com/Semantic-Org/Semantic-UI-React/pull/3947'>
+            Semantic-Org/Semantic-UI-React#3947
+          </a>{' '}
+          for more details. To pass props to this element <code>popper</code>{' '}
+          shorthand can be used.
+        </>
+      }
+      examplePath='modules/Popup/Usage/PopupExamplePopper'
+    />
+    <ComponentExample
+      title={
+        <>
+          Positioning via <code>position: fixed</code>
+        </>
+      }
+      description={
+        <>
+          If your reference element is in a <code>fixed</code> container, use{' '}
+          <code>positionFixed</code>. This will prevent any jumpiness since no
+          repositioning is needed.
+        </>
+      }
+      examplePath='modules/Popup/Usage/PopupExamplePositionFixed'
+    />
+    <ComponentExample
       title='Actions'
       description='A popup can be triggered on hover, click, focus or multiple actions.'
       examplePath='modules/Popup/Usage/PopupExampleActions'

--- a/docs/src/pages/MigrationGuide.mdx
+++ b/docs/src/pages/MigrationGuide.mdx
@@ -32,6 +32,12 @@ The `popperModifiers` prop should be defined as an array with changed format (se
 +<Popup popperModifiers={[{ name: 'preventOverflow', options: { padding: 0 } }]} />
 ```
 
+### a wrapping element around `Popup`
+
+We started to use an additional wrapping element around `Popup` for positioning, see [Semantic-Org/Semantic-UI-React#3947](https://github.com/Semantic-Org/Semantic-UI-React/pull/3947) for more details. To pass props to this element `popper` shorthand can be used, see [an example](/modules/popup/#usage-position-fixed).
+
+⚠️We also made a fix in [Semantic-Org/Semantic-UI-React#4094](https://github.com/Semantic-Org/Semantic-UI-React/pull/4094) to transfer `zIndex` value to avoid any breaks.
+
 ## `Responsive` component was removed
 
 `Responsive` component was deprecated in 1.1.0. There are two main reasons for the removal: there is no connection between breakpoints and pure SSR (server side rendering) support.

--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -119,6 +119,9 @@ export interface StrictPopupProps extends StrictPortalProps {
   /** Tells `Popper.js` to use the `position: fixed` strategy to position the popover. */
   positionFixed?: boolean
 
+  /** A wrapping element for an actual content that will be used for positioning. */
+  popper?: SemanticShorthandItem<React.HTMLAttributes<HTMLDivElement>>
+
   /** An array containing custom settings for the Popper.js modifiers. */
   popperModifiers?: any[]
 

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -343,6 +343,50 @@ describe('Popup', () => {
     })
   })
 
+  describe('popper', () => {
+    it('passes a zIndex value from .popup', (done) => {
+      wrapperMount(<Popup open style={{ zIndex: 5000 }} />)
+
+      const popperElement = wrapper.find('Popper').childAt(0)
+      const popperNode = popperElement.getDOMNode()
+
+      setTimeout(() => {
+        // zIndex transfer is done in a Popper modifier which will be executed in next frame
+        popperNode.style.zIndex.should.be.equal('5000')
+        done()
+      }, 0)
+    })
+
+    it('zIndex passed to a shorthand wins', (done) => {
+      wrapperMount(<Popup open popper={{ style: { zIndex: 100 } }} style={{ zIndex: 5000 }} />)
+
+      const popperElement = wrapper.find('Popper').childAt(0)
+      const popperNode = popperElement.getDOMNode()
+
+      setTimeout(() => {
+        // zIndex transfer is done in a Popper modifier which will be executed in next frame
+        popperNode.style.zIndex.should.be.equal('100')
+        done()
+      }, 0)
+    })
+
+    it('additional props can be passed via shorthand', () => {
+      wrapperMount(<Popup open popper={{ className: 'foo', id: 'bar' }} />)
+      const popperElement = wrapper.find('Popper').childAt(0)
+
+      popperElement.should.have.prop('className', 'foo')
+      popperElement.should.have.prop('id', 'bar')
+    })
+
+    it('"style" prop is merged', () => {
+      wrapperMount(<Popup open popper={{ style: { color: 'red', display: 'block' } }} />)
+      const popperElement = wrapper.find('Popper').childAt(0)
+
+      popperElement.should.have.style('color', 'red')
+      popperElement.should.have.style('display', 'flex')
+    })
+  })
+
   describe('popperModifiers', () => {
     it('are passed to Popper', () => {
       const modifierOffset = { name: 'offset', options: { offset: [0, 10] } }


### PR DESCRIPTION
### `zIndex` transfering

Fixes #4083.

In #3947 a wrapping element was added around `.popup` to avoid Popper.js warnings and position arrows properly. However, that created an issue with `zIndex` as it was defined inside a nested element:

```html
<div>
  <!-- Oops, zIndex was defined in `.popup` CSS -->
  <div class="ui popup">A popup content</div>
</div>
```

There were multiple proposals in #4083, however I decided to go with syncing `zIndex` and avoid hardcoded values in JS code:

```html
<!-- 1900 is a value defined in `.popup` CSS -->
<div style="zIndex: 1900">
  <div class="ui popup">A popup content</div>
</div>
```

### floated elements

Fixes #4092. As was reported in that issue elements that have `float` CSS properly were breaking layout, this was fixed by adding `display: flex` to a wrapping element.

### `popper` shorthand

A wrapping element is accessible as a shorthand now, this allows to apply custom props and styling:

```jsx
  <Popup
    content={
      <>
        A wrapping element in this Popup will have custom <code>id</code> &{' '}
        <code>zIndex</code>.
      </>
    }
    popper={{ id: 'popper-container', style: { zIndex: 2000 } }}
    trigger={<Button>Open a popup</Button>}
  />
)
```

✅ An example to docs was also added.
