### PR TITLE
fix(Feed|CardGroup|ItemGroup|Search): change key checks from falsy to nullish semantics

### DIFF
--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -411,7 +411,7 @@ export default class Search extends Component {
 
     return (
       <SearchResult
-        key={childKey || result.id || result.title}
+        key={childKey ?? (result.id || result.title)}
         active={selectedIndex === offsetIndex}
         onClick={this.handleItemClick}
         onMouseDown={this.handleItemMouseDown}
@@ -436,7 +436,7 @@ export default class Search extends Component {
 
     return _.map(categories, ({ childKey, ...category }) => {
       const categoryProps = {
-        key: childKey || category.name,
+        key: childKey ?? category.name,
         active: _.inRange(selectedIndex, count, count + category.results.length),
         layoutRenderer: categoryLayoutRenderer,
         renderer: categoryRenderer,

--- a/src/views/Card/CardGroup.js
+++ b/src/views/Card/CardGroup.js
@@ -60,7 +60,7 @@ function CardGroup(props) {
   }
 
   const itemsJSX = _.map(items, (item) => {
-    const key = item.key || [item.header, item.description].join('-')
+    const key = item.key ?? [item.header, item.description].join('-')
     return <Card key={key} {...item} />
   })
 

--- a/src/views/Feed/Feed.js
+++ b/src/views/Feed/Feed.js
@@ -34,7 +34,7 @@ function Feed(props) {
 
   const eventElements = _.map(events, (eventProps) => {
     const { childKey, date, meta, summary, ...eventData } = eventProps
-    const finalKey = childKey || [date, meta, summary].join('-')
+    const finalKey = childKey ?? [date, meta, summary].join('-')
 
     return <FeedEvent date={date} key={finalKey} meta={meta} summary={summary} {...eventData} />
   })

--- a/src/views/Item/ItemGroup.js
+++ b/src/views/Item/ItemGroup.js
@@ -49,7 +49,7 @@ function ItemGroup(props) {
   const itemsJSX = _.map(items, (item) => {
     const { childKey, ...itemProps } = item
     const finalKey =
-      childKey ||
+      childKey ??
       [itemProps.content, itemProps.description, itemProps.header, itemProps.meta].join('-')
 
     return <Item {...itemProps} key={finalKey} />


### PR DESCRIPTION
Fixes #4111.

The nullish coalescing operator has been available in @babel/preset-env since v7.8, so it should be safe to use (build/tests passed).