### PR TITLE
fix(Image): pass `loading` attribute to an `img` element

### DIFF
--- a/src/lib/htmlPropsUtils.js
+++ b/src/lib/htmlPropsUtils.js
@@ -81,7 +81,7 @@ export const htmlInputEvents = [
 
 export const htmlInputProps = [...htmlInputAttrs, ...htmlInputEvents]
 
-export const htmlImageProps = ['alt', 'height', 'src', 'srcSet', 'width']
+export const htmlImageProps = ['alt', 'height', 'src', 'srcSet', 'width', 'loading']
 
 /**
  * Returns an array of objects consisting of: props of html input element and rest.


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading (it's part of the WHATWG spec now, not just experimental)

This allows use of the attribute when the image uses a wrapping element, e.g: `<Image loading="lazy" wrapped />`  
Currently it gets set on the wrapper `div` which is useless.