### PR TITLE
fix(Item): actually make `content` a shorthand prop for `ItemContent`

### DIFF
--- a/src/views/Item/Item.d.ts
+++ b/src/views/Item/Item.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
-import ItemContent from './ItemContent'
+import { SemanticShorthandItem } from '../../generic'
+import ItemContent, { ItemContentProps } from './ItemContent'
 import ItemDescription, { ItemDescriptionProps } from './ItemDescription'
 import ItemExtra, { ItemExtraProps } from './ItemExtra'
 import ItemGroup from './ItemGroup'
@@ -24,7 +24,7 @@ export interface StrictItemProps {
   className?: string
 
   /** Shorthand for ItemContent component. */
-  content?: SemanticShorthandContent
+  content?: SemanticShorthandItem<ItemContentProps>
 
   /** Shorthand for ItemDescription component. */
   description?: SemanticShorthandItem<ItemDescriptionProps>

--- a/src/views/Item/Item.js
+++ b/src/views/Item/Item.js
@@ -1,4 +1,5 @@
 import cx from 'clsx'
+import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -29,17 +30,22 @@ function Item(props) {
     )
   }
 
+  let contentShorthandValue = content
+  if (
+    contentShorthandValue === undefined &&
+    [description, extra, header, meta].some((prop) => !_.isNil(prop))
+  ) {
+    contentShorthandValue = {}
+  }
+
   return (
     <ElementType {...rest} className={classes}>
       {ItemImage.create(image, { autoGenerateKey: false })}
 
-      <ItemContent
-        content={content}
-        description={description}
-        extra={extra}
-        header={header}
-        meta={meta}
-      />
+      {ItemContent.create(contentShorthandValue, {
+        autoGenerateKey: false,
+        overrideProps: { description, extra, header, meta },
+      })}
     </ElementType>
   )
 }
@@ -63,7 +69,7 @@ Item.propTypes = {
   className: PropTypes.string,
 
   /** Shorthand for ItemContent component. */
-  content: customPropTypes.contentShorthand,
+  content: customPropTypes.itemShorthand,
 
   /** Shorthand for ItemDescription component. */
   description: customPropTypes.itemShorthand,

--- a/src/views/Item/ItemContent.js
+++ b/src/views/Item/ItemContent.js
@@ -4,6 +4,7 @@ import React from 'react'
 
 import {
   childrenUtils,
+  createShorthandFactory,
   customPropTypes,
   getElementType,
   getUnhandledProps,
@@ -72,5 +73,7 @@ ItemContent.propTypes = {
   /** Content can specify its vertical alignment. */
   verticalAlign: PropTypes.oneOf(SUI.VERTICAL_ALIGNMENTS),
 }
+
+ItemContent.create = createShorthandFactory(ItemContent, (content) => ({ content }))
 
 export default ItemContent

--- a/test/specs/views/Item/Item-test.js
+++ b/test/specs/views/Item/Item-test.js
@@ -33,6 +33,13 @@ describe('Item', () => {
     mapValueToProps: (val) => ({ src: val }),
   })
 
+  common.implementsShorthandProp(Item, {
+    autoGenerateKey: false,
+    propKey: 'content',
+    ShorthandComponent: ItemContent,
+    mapValueToProps: (val) => ({ content: val }),
+  })
+
   describe('content prop', () => {
     it('renders ItemContent component', () => {
       shallow(<Item content={faker.hacker.phrase()} />).should.have.descendants('ItemContent')


### PR DESCRIPTION
It *says* it is in the docs, but actually `Item` currently just forwards the `content` prop to `ItemContent` like a typical content prop. This PR will allow use of `as`, `className` and `verticalAlign` via shorthand, and is especially useful when providing the `items` array shorthand to `ItemGroup`. 

With this PR nothing changes for people who were using a primitive value, but it might be a breaking change if people were supplying an element or array, they would need to change it to `content={ content: <element /> }` or similar to match previous behaviour.

Also with this change `ItemContent` will no longer unconditionally render, at least one of the shorthands has to be present.