### PR TITLE
docs(misc): fix typos in props descriptions + make minor text change

### DIFF
--- a/docs/src/examples/collections/Table/Variations/index.js
+++ b/docs/src/examples/collections/Table/Variations/index.js
@@ -79,7 +79,7 @@ const Variations = () => (
 
     <ComponentExample
       title='Celled'
-      description='A table may be divided each row into separate cells.'
+      description='A table may be divided into individual cells.'
       examplePath='collections/Table/Variations/TableExampleCelled'
     />
 

--- a/src/collections/Grid/Grid.d.ts
+++ b/src/collections/Grid/Grid.d.ts
@@ -36,7 +36,7 @@ export interface StrictGridProps {
   /** Represents column count per row in Grid. */
   columns?: SemanticWIDTHS | 'equal'
 
-  /** A grid can be combined with a container to use avaiable layout and alignment. */
+  /** A grid can be combined with a container to use available layout and alignment. */
   container?: boolean
 
   /** A grid can have dividers between its columns. */
@@ -60,7 +60,7 @@ export interface StrictGridProps {
   /** A grid can have its columns stack on-top of each other after reaching mobile breakpoints. */
   stackable?: boolean
 
-  /** An can stretch its contents to take up the entire grid height. */
+  /** A grid can stretch its contents to take up the entire grid height. */
   stretched?: boolean
 
   /** A grid can specify its text alignment. */

--- a/src/collections/Grid/GridColumn.d.ts
+++ b/src/collections/Grid/GridColumn.d.ts
@@ -48,13 +48,13 @@ export interface StrictGridColumnProps {
   /** A column can appear only for a specific device, or screen sizes. */
   only?: GridOnlyProp
 
-  /** An can stretch its contents to take up the entire grid or row height. */
+  /** A column can stretch its contents to take up the entire grid or row height. */
   stretched?: boolean
 
   /** A column can specify a width for a tablet device. */
   tablet?: SemanticWIDTHS
 
-  /** A row can specify its text alignment. */
+  /** A column can specify its text alignment. */
   textAlign?: SemanticTEXTALIGNMENTS
 
   /** A column can specify its vertical alignment to have all its columns vertically centered. */

--- a/src/collections/Grid/GridRow.d.ts
+++ b/src/collections/Grid/GridRow.d.ts
@@ -38,10 +38,10 @@ export interface StrictGridRowProps {
   /** A row can appear only for a specific device, or screen sizes. */
   only?: GridOnlyProp
 
-  /** A  row can specify that its columns should reverse order at different device sizes. */
+  /** A row can specify that its columns should reverse order at different device sizes. */
   reversed?: GridReversedProp
 
-  /** An can stretch its contents to take up the entire column height. */
+  /** A row can stretch its contents to take up the entire column height. */
   stretched?: boolean
 
   /** A row can specify its text alignment. */

--- a/src/collections/Table/Table.d.ts
+++ b/src/collections/Table/Table.d.ts
@@ -28,7 +28,7 @@ export interface StrictTableProps {
   /** A table can reduce its complexity to increase readability. */
   basic?: boolean | 'very'
 
-  /** A table may be divided each row into separate cells. */
+  /** A table may be divided into individual cells. */
   celled?: boolean | 'internally'
 
   /** Primary content. */

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -129,7 +129,7 @@ Table.propTypes = {
   /** A table can reduce its complexity to increase readability. */
   basic: PropTypes.oneOfType([PropTypes.oneOf(['very']), PropTypes.bool]),
 
-  /** A table may be divided each row into separate cells. */
+  /** A table may be divided into individual cells. */
   celled: PropTypes.bool,
 
   /** Primary content. */


### PR DESCRIPTION
Fix typos in props descriptions, and minor text change to improve understanding of prop usage.