### PR TITLE
chore: remove .state() assertions in tests

### DIFF
--- a/src/modules/Embed/Embed.js
+++ b/src/modules/Embed/Embed.js
@@ -1,4 +1,5 @@
 import cx from 'clsx'
+import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -57,10 +58,9 @@ export default class Embed extends Component {
   }
 
   handleClick = (e) => {
-    const { onClick } = this.props
     const { active } = this.state
 
-    if (onClick) onClick(e, { ...this.props, active: true })
+    _.invoke(this.props, 'onClick', e, { ...this.props, active: true })
     if (!active) this.setState({ active: true })
   }
 

--- a/src/modules/Transition/Transition.js
+++ b/src/modules/Transition/Transition.js
@@ -87,7 +87,11 @@ export default class Transition extends Component {
     const durationType = TRANSITION_CALLBACK_TYPE[nextStatus]
     const durationValue = normalizeTransitionDuration(duration, durationType)
 
-    this.timeoutId = setTimeout(() => this.setState({ status: nextStatus }), durationValue)
+    if (durationValue === 0) {
+      this.setState({ status: nextStatus })
+    } else {
+      this.timeoutId = setTimeout(() => this.setState({ status: nextStatus }), durationValue)
+    }
   }
 
   updateStatus = (prevState) => {
@@ -161,7 +165,7 @@ export default class Transition extends Component {
     debug('render(): state', this.state)
 
     const { children } = this.props
-    const { status } = this.state
+    const { nextStatus, status } = this.state
 
     if (status === TRANSITION_STATUS_UNMOUNTED) {
       return null
@@ -170,6 +174,10 @@ export default class Transition extends Component {
     return cloneElement(children, {
       className: this.computeClasses(),
       style: this.computeStyle(),
+      ...(process.env.NODE_ENV !== 'production' && {
+        'data-test-status': status,
+        'data-test-next-status': nextStatus,
+      }),
     })
   }
 }

--- a/test/specs/modules/Accordion/AccordionAccordion-test.js
+++ b/test/specs/modules/Accordion/AccordionAccordion-test.js
@@ -6,7 +6,7 @@ import AccordionTitle from 'src/modules/Accordion/AccordionTitle'
 import * as common from 'test/specs/commonTests'
 import { consoleUtil, sandbox } from 'test/utils'
 
-describe.only('AccordionAccordion', () => {
+describe('AccordionAccordion', () => {
   common.isConformant(AccordionAccordion)
   common.rendersChildren(AccordionAccordion, {
     rendersContent: false,

--- a/test/specs/modules/Accordion/AccordionAccordion-test.js
+++ b/test/specs/modules/Accordion/AccordionAccordion-test.js
@@ -6,7 +6,7 @@ import AccordionTitle from 'src/modules/Accordion/AccordionTitle'
 import * as common from 'test/specs/commonTests'
 import { consoleUtil, sandbox } from 'test/utils'
 
-describe('AccordionAccordion', () => {
+describe.only('AccordionAccordion', () => {
   common.isConformant(AccordionAccordion)
   common.rendersChildren(AccordionAccordion, {
     rendersContent: false,
@@ -21,89 +21,74 @@ describe('AccordionAccordion', () => {
       { key: 'C', title: 'C', content: 'Something C' },
     ]
 
-    it('defaults to -1', () => {
-      shallow(<AccordionAccordion />).should.have.state('activeIndex', -1)
+    it('there is no active items by default', () => {
+      mount(<AccordionAccordion />).should.not.have.descendants('.active')
     })
 
-    it('defaults to -1 when "exclusive" is false', () => {
-      shallow(<AccordionAccordion exclusive={false} />)
-        .should.have.state('activeIndex')
-        .that.is.empty()
+    it('there is no active items by default when "exclusive" is false', () => {
+      mount(<AccordionAccordion exclusive={false} />).should.not.have.descendants('.active')
     })
 
-    it('makes Accordion.Content at activeIndex - 0 "active"', () => {
-      const wrapper = shallow(<AccordionAccordion activeIndex={0} panels={panels} />)
+    it('activates an item', () => {
+      const wrapper = mount(<AccordionAccordion activeIndex={0} panels={panels} />)
 
-      wrapper.childAt(0).should.have.prop('active', true)
-      wrapper.childAt(1).should.have.prop('active', false)
-      wrapper.childAt(2).should.have.prop('active', false)
+      wrapper.find('.title').at(0).should.have.className('active')
+      wrapper.find('.title').at(1).should.not.have.className('active')
+      wrapper.find('.title').at(2).should.not.have.className('active')
     })
 
-    it('is toggled to -1 when clicking Title a second time', () => {
+    it('items can be toggled by a click', () => {
       const wrapper = mount(<AccordionAccordion panels={panels} />)
 
-      wrapper.find(AccordionTitle).at(0).simulate('click')
-      wrapper.should.have.state('activeIndex', 0)
+      wrapper.find('.title').at(0).simulate('click')
+      wrapper.find('.title').at(0).should.have.className('active')
 
-      wrapper.find(AccordionTitle).at(0).simulate('click')
-      wrapper.should.have.state('activeIndex', -1)
+      wrapper.find('.title').at(0).simulate('click')
+      wrapper.find('.title').at(0).should.not.have.className('active')
     })
 
-    it('sets the correct panel active', () => {
-      const wrapper = shallow(<AccordionAccordion activeIndex={0} panels={panels} />)
-
-      wrapper.childAt(0).should.have.prop('active', true)
-      wrapper.childAt(1).should.have.prop('active', false)
-      wrapper.childAt(2).should.have.prop('active', false)
+    it('activates a proper item', () => {
+      const wrapper = mount(<AccordionAccordion activeIndex={0} panels={panels} />)
 
       wrapper.setProps({ activeIndex: 1 })
-      wrapper.childAt(0).should.have.prop('active', false)
-      wrapper.childAt(1).should.have.prop('active', true)
-      wrapper.childAt(2).should.have.prop('active', false)
+      wrapper.find('.title').at(0).should.not.have.className('active')
+      wrapper.find('.title').at(1).should.have.className('active')
+      wrapper.find('.title').at(2).should.not.have.className('active')
     })
 
-    it('can be an array', () => {
-      const wrapper = shallow(
-        <AccordionAccordion activeIndex={[0, 1]} exclusive={false} panels={panels} />,
-      )
-      wrapper.childAt(0).should.have.prop('active', true)
-      wrapper.childAt(1).should.have.prop('active', true)
-      wrapper.childAt(2).should.have.prop('active', false)
-
-      wrapper.setProps({ activeIndex: [1, 2] })
-      wrapper.childAt(0).should.have.prop('active', false)
-      wrapper.childAt(1).should.have.prop('active', true)
-      wrapper.childAt(2).should.have.prop('active', true)
-    })
-
-    it('can be inclusive and makes Accordion.Content at activeIndex - 1 "active"', () => {
-      const wrapper = shallow(
+    it('can activate a single item when "exclusive" is false', () => {
+      const wrapper = mount(
         <AccordionAccordion activeIndex={[0]} exclusive={false} panels={panels} />,
       )
 
-      wrapper.childAt(0).should.have.prop('active', true)
-      wrapper.childAt(1).should.have.prop('active', false)
-      wrapper.childAt(2).should.have.prop('active', false)
+      wrapper.find('.title').at(0).should.have.className('active')
+      wrapper.find('.title').at(1).should.not.have.className('active')
+      wrapper.find('.title').at(2).should.not.have.className('active')
     })
 
-    it('can be inclusive and allows multiple open', () => {
-      const wrapper = shallow(
+    it('can activate multiple items when "exclusive" is false', () => {
+      const wrapper = mount(
         <AccordionAccordion activeIndex={[0, 1]} exclusive={false} panels={panels} />,
       )
+      wrapper.find('.title').at(0).should.have.className('active')
+      wrapper.find('.title').at(1).should.have.className('active')
+      wrapper.find('.title').at(2).should.not.have.className('active')
 
-      wrapper.childAt(0).should.have.prop('active', true)
-      wrapper.childAt(1).should.have.prop('active', true)
-      wrapper.childAt(2).should.have.prop('active', false)
+      wrapper.setProps({ activeIndex: [1, 2] })
+      wrapper.find('.title').at(0).should.not.have.className('active')
+      wrapper.find('.title').at(1).should.have.className('active')
+      wrapper.find('.title').at(2).should.have.className('active')
     })
 
     it('can be inclusive and can open multiple panels by clicking', () => {
       const wrapper = mount(<AccordionAccordion exclusive={false} panels={panels} />)
 
-      wrapper.find(AccordionTitle).at(0).simulate('click')
-      wrapper.should.have.state('activeIndex').that.includes(0)
+      wrapper.find('.title').at(0).simulate('click')
+      wrapper.find('.title').at(0).should.have.className('active')
 
-      wrapper.find(AccordionTitle).at(1).simulate('click')
-      wrapper.should.have.state('activeIndex').that.includes(0, 1)
+      wrapper.find('.title').at(1).simulate('click')
+      wrapper.find('.title').at(0).should.have.className('active')
+      wrapper.find('.title').at(1).should.have.className('active')
     })
 
     it('can be inclusive and close multiple panels by clicking', () => {
@@ -111,11 +96,13 @@ describe('AccordionAccordion', () => {
         <AccordionAccordion defaultActiveIndex={[0, 1]} exclusive={false} panels={panels} />,
       )
 
-      wrapper.find(AccordionTitle).at(0).simulate('click')
-      wrapper.should.have.state('activeIndex').that.includes(1)
+      wrapper.find('.title').at(0).simulate('click')
+      wrapper.find('.title').at(0).should.not.have.className('active')
+      wrapper.find('.title').at(1).should.have.className('active')
 
-      wrapper.find(AccordionTitle).at(1).simulate('click')
-      wrapper.should.have.state('activeIndex').that.is.empty()
+      wrapper.find('.title').at(1).simulate('click')
+      wrapper.find('.title').at(0).should.not.have.className('active')
+      wrapper.find('.title').at(1).should.not.have.className('active')
     })
 
     it('warns if is `exclusive` and is given an array', () => {
@@ -139,7 +126,18 @@ describe('AccordionAccordion', () => {
 
   describe('defaultActiveIndex', () => {
     it('sets the initial activeIndex state', () => {
-      shallow(<AccordionAccordion defaultActiveIndex={123} />).should.have.state('activeIndex', 123)
+      const wrapper = mount(
+        <AccordionAccordion
+          defaultActiveIndex={1}
+          panels={[
+            { key: 'A', title: 'A', content: 'Something A' },
+            { key: 'B', title: 'B', content: 'Something B' },
+          ]}
+        />,
+      )
+
+      wrapper.find('.title').at(0).should.not.have.className('active')
+      wrapper.find('.title').at(1).should.have.className('active')
     })
   })
 
@@ -153,14 +151,11 @@ describe('AccordionAccordion', () => {
     ]
 
     it('is called with (e, titleProps) when clicked', () => {
-      mount(<AccordionAccordion panels={panels} onTitleClick={onTitleClick} />)
-        .find(AccordionTitle)
-        .at(0)
-        .simulate('click', event)
+      const wrapper = mount(<AccordionAccordion panels={panels} onTitleClick={onTitleClick} />)
 
+      wrapper.find('.title').at(0).simulate('click', event)
       onClick.should.have.been.calledOnce()
       onClick.should.have.been.calledWithMatch(event, { index: 0, content: 'A' })
-
       onTitleClick.should.have.been.calledOnce()
       onTitleClick.should.have.been.calledWithMatch(event, { index: 0, content: 'A' })
     })

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -22,7 +22,7 @@ const wrapperMount = (element, opts) => {
 }
 const wrapperShallow = (...args) => (wrapper = shallow(...args))
 
-describe.only('Checkbox', () => {
+describe('Checkbox', () => {
   common.isConformant(Checkbox)
   common.hasUIClassName(Checkbox)
 

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -22,7 +22,7 @@ const wrapperMount = (element, opts) => {
 }
 const wrapperShallow = (...args) => (wrapper = shallow(...args))
 
-describe('Checkbox', () => {
+describe.only('Checkbox', () => {
   common.isConformant(Checkbox)
   common.hasUIClassName(Checkbox)
 
@@ -482,22 +482,32 @@ describe('Checkbox', () => {
 
         render() {
           const handler = isOnClick ? { onClick: this.toggle } : { onChange: this.toggle }
-          return <Checkbox label='Check this box' checked={this.state.checked} {...handler} />
+
+          return (
+            <Checkbox
+              data-checked={this.state.checked}
+              label='Check this box'
+              checked={this.state.checked}
+              {...handler}
+            />
+          )
         }
       }
 
     it('toggles state on "change" with "setState" as function', () => {
-      const ControlledCheckbox = getControlledCheckbox(false)
-      wrapperMount(<ControlledCheckbox />)
-      domEvent.fire(document.querySelector('input'), 'click')
-      wrapper.state().should.eql({ checked: true })
+      const TestComponent = getControlledCheckbox(false)
+      wrapperMount(<TestComponent />)
+
+      domEvent.click('input')
+      wrapper.should.not.have.descendants('[data-checked=true]')
     })
 
     it('toggles state on "click" with "setState" as function', () => {
-      const ControlledCheckbox = getControlledCheckbox(true)
-      wrapperMount(<ControlledCheckbox />)
-      domEvent.fire(document.querySelector('input'), 'click')
-      wrapper.state().should.eql({ checked: true })
+      const TestComponent = getControlledCheckbox(true)
+      wrapperMount(<TestComponent />)
+
+      domEvent.click('input')
+      wrapper.should.not.have.descendants('[data-checked=true]')
     })
   })
 })

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -58,6 +58,30 @@ const dropdownMenuIsClosed = () => {
   }
 }
 
+function bodyIsFocused() {
+  const isFocused = document.activeElement === document.body
+
+  isFocused.should.be.true(
+    `Expected Dropdown to be the active element but found ${document.activeElement} instead.`,
+  )
+}
+
+function dropdownIsFocused() {
+  const isFocused = document.activeElement === document.querySelector('div.dropdown')
+
+  isFocused.should.be.true(
+    `Expected Dropdown to be the active element but found ${document.activeElement} instead.`,
+  )
+}
+
+function dropdownInputIsFocused() {
+  const isFocused = document.activeElement === document.querySelector('input.search')
+
+  isFocused.should.be.true(
+    `Expected DropdownSearchInput to be the active element but found ${document.activeElement} instead.`,
+  )
+}
+
 const dropdownMenuIsOpen = () => {
   wrapper.childAt(0).should.have.className('active')
   wrapper.childAt(0).should.have.className('visible')
@@ -141,7 +165,8 @@ describe('Dropdown', () => {
 
   describe('defaultSearchQuery', () => {
     it('changes default value of searchQuery', () => {
-      shallow(<Dropdown defaultSearchQuery='foo' />).should.have.state('searchQuery', 'foo')
+      wrapperMount(<Dropdown defaultSearchQuery='foo' search />)
+      wrapper.find('input.search').should.have.value('foo')
     })
   })
 
@@ -369,14 +394,15 @@ describe('Dropdown', () => {
       const event = { stopPropagation: _.noop }
       const onChange = sandbox.spy()
 
-      wrapperShallow(
+      wrapperMount(
         <Dropdown defaultValue={defaultValue} clearable onChange={onChange} options={options} />,
       )
-      wrapper.find('Icon').simulate('click', event)
+      wrapper.find('i.clear').simulate('click', event)
 
       onChange.should.have.been.calledOnce()
       onChange.should.have.been.calledWithMatch(event, { value: '' })
-      wrapper.should.have.state('selectedIndex', 0)
+      wrapper.should.have.exactly(1).descendants('.selected.item')
+      wrapper.find('.item').at(0).should.have.className('selected')
     })
 
     it('clears when value is multiple and is not empty', () => {
@@ -384,7 +410,7 @@ describe('Dropdown', () => {
       const event = { stopPropagation: _.noop }
       const onChange = sandbox.spy()
 
-      wrapperShallow(
+      wrapperMount(
         <Dropdown
           defaultValue={defaultValue}
           clearable
@@ -393,11 +419,12 @@ describe('Dropdown', () => {
           options={options}
         />,
       )
-      wrapper.find('Icon').simulate('click', event)
+      wrapper.find('i.clear').simulate('click', event)
 
       onChange.should.have.been.calledOnce()
       onChange.should.have.been.calledWithMatch(event, { value: [] })
-      wrapper.should.have.state('selectedIndex', 0)
+      wrapper.should.have.exactly(1).descendants('.selected.item')
+      wrapper.find('.item').at(0).should.have.className('selected')
     })
   })
 
@@ -447,19 +474,11 @@ describe('Dropdown', () => {
       onChange.should.have.been.calledOnce()
     })
 
-    it('sets focus state to false', () => {
-      wrapperShallow(<Dropdown selectOnBlur />)
-
-      wrapper.childAt(0).simulate('blur')
-      wrapper.should.have.state('focus', false)
-    })
-
     it('sets searchQuery state to empty', () => {
-      wrapperShallow(<Dropdown />)
+      wrapperMount(<Dropdown defaultSearchQuery='foo' search />)
 
-      wrapper.setState({ searchQuery: 'foo' })
       wrapper.childAt(0).simulate('blur')
-      wrapper.should.have.state('searchQuery', '')
+      wrapper.find('input.search').should.have.value('')
     })
 
     it('does not call onBlur when the mouse is down', () => {
@@ -485,15 +504,6 @@ describe('Dropdown', () => {
       wrapper.simulate('blur')
 
       instance.makeSelectedItemActive.should.not.have.been.called()
-    })
-
-    it('does not set focus state when the mouse is down', () => {
-      wrapperShallow(<Dropdown />)
-
-      wrapper.setState({ focus: 'foo' })
-      wrapper.simulate('mousedown')
-      wrapper.simulate('blur')
-      wrapper.should.have.state('focus', 'foo')
     })
   })
 
@@ -522,7 +532,7 @@ describe('Dropdown', () => {
       dropdownMenuIsOpen()
 
       wrapper.find('DropdownItem').first().simulate('click')
-      wrapper.should.have.state('value', options[0].value)
+      wrapper.find('.item').at(0).should.have.className('active')
       dropdownMenuIsClosed()
 
       // The dropdown will be still focused after an item will be selected, we should remove
@@ -595,10 +605,11 @@ describe('Dropdown', () => {
 
       wrapper.simulate('click')
       wrapper.simulate('keydown', { key: 'ArrowDown' })
-      wrapper.should.have.state('selectedIndex', 1)
+      wrapper.should.have.exactly(1).descendants('.selected.item')
+      wrapper.find('.item').at(1).should.have.className('selected')
 
       wrapper.setProps({ options: [] })
-      wrapper.should.have.not.state('selectedIndex')
+      wrapper.should.not.have.descendants('.selected.item')
     })
 
     it('will not call setSelectedIndex if options have not changed', () => {
@@ -606,10 +617,10 @@ describe('Dropdown', () => {
 
       wrapper.simulate('click')
       wrapper.simulate('keydown', { key: 'ArrowDown' })
-      wrapper.should.have.state('selectedIndex', 1)
+      wrapper.find('.item').at(1).should.have.className('selected')
 
       wrapper.setProps({ options })
-      wrapper.should.have.state('selectedIndex', 1)
+      wrapper.find('.item').at(1).should.have.className('selected')
     })
   })
 
@@ -623,16 +634,15 @@ describe('Dropdown', () => {
       // open, simulate search and select option
       wrapper.simulate('click')
       wrapper.simulate('keydown', { key: 'ArrowDown' })
-      wrapper.should.have.state('selectedIndex', 1)
+      wrapper.find('.item').at(1).should.have.className('selected')
 
       input.simulate('change', { target: { value: option.text } })
       wrapper.simulate('keydown', { key: 'Enter' })
-
-      wrapper.should.have.state('selectedIndex', 4)
+      wrapper.find('.item').at(4).should.have.className('selected')
 
       // open again
       wrapper.simulate('click')
-      wrapper.should.have.state('selectedIndex', 4)
+      wrapper.find('.item').at(4).should.have.className('selected')
     })
 
     it('keeps "selectedIndex" when the same item was selected', () => {
@@ -644,13 +654,12 @@ describe('Dropdown', () => {
       // simulate search and select option
       input.simulate('change', { target: { value: option.text } })
       wrapper.simulate('keydown', { key: 'Enter' })
-
-      wrapper.should.have.state('selectedIndex', 4)
+      wrapper.find('.item').at(4).should.have.className('selected')
 
       // select the same option again
       input.simulate('change', { target: { value: option.text } })
       wrapper.simulate('keydown', { key: 'Enter' })
-      wrapper.should.have.state('selectedIndex', 4)
+      wrapper.find('.item').at(4).should.have.className('selected')
     })
   })
 
@@ -703,11 +712,13 @@ describe('Dropdown', () => {
 
   describe('searchQuery', () => {
     it('defaults to empty string', () => {
-      shallow(<Dropdown />).should.have.state('searchQuery', '')
+      wrapperMount(<Dropdown search />)
+      wrapper.find('input.search').should.have.value('')
     })
 
     it('passes value to state', () => {
-      shallow(<Dropdown searchQuery='foo' />).should.have.state('searchQuery', 'foo')
+      wrapperMount(<Dropdown search searchQuery='foo' />)
+      wrapper.find('input.search').should.have.value('foo')
     })
   })
 
@@ -1054,7 +1065,7 @@ describe('Dropdown', () => {
       wrapper.simulate('click')
       wrapper.simulate('keydown', { key: 'ArrowDown' })
 
-      wrapper.should.have.state('searchQuery', 'foo')
+      wrapper.find('input.search').should.have.value('foo')
     })
   })
 
@@ -1110,8 +1121,7 @@ describe('Dropdown', () => {
 
       wrapper.simulate('click')
       wrapper.simulate('keydown', { key: 'ArrowDown' })
-
-      wrapper.should.have.state('value', options[1].value)
+      wrapper.find('.item').at(1).should.have.className('active')
     })
 
     it('updates value on up arrow', () => {
@@ -1119,8 +1129,7 @@ describe('Dropdown', () => {
 
       wrapper.simulate('click')
       wrapper.simulate('keydown', { key: 'ArrowUp' })
-
-      wrapper.should.have.state('value', options[4].value)
+      wrapper.find('.item').at(4).should.have.className('active')
     })
   })
 
@@ -1359,15 +1368,15 @@ describe('Dropdown', () => {
 
     it('handles focus correctly', () => {
       wrapperMount(<Dropdown options={options} selection />)
-      wrapper.should.have.state('focus', false)
+      bodyIsFocused()
 
       // focus
       wrapper.getDOMNode().focus()
-      wrapper.should.have.state('focus', true)
+      dropdownIsFocused()
 
       // click outside
       domEvent.click(document.body)
-      wrapper.should.have.state('focus', false)
+      bodyIsFocused()
     })
 
     it('closes on esc key', () => {
@@ -1718,6 +1727,7 @@ describe('Dropdown', () => {
       spy.should.have.been.calledOnce()
       spy.should.have.been.calledWithMatch({}, { value: expected })
     })
+
     it('removes the last item when there is no search query when uncontrolled', () => {
       const value = _.map(options, 'value')
       const expected = _.dropRight(value)
@@ -1734,14 +1744,12 @@ describe('Dropdown', () => {
 
       // open
       wrapper.simulate('click')
-
       domEvent.keyDown(document, { key: 'Backspace' })
 
       spy.should.have.been.calledOnce()
       spy.should.have.been.calledWithMatch({}, { value: expected })
-
-      wrapper.state('value').should.deep.equal(expected)
     })
+
     it('does not remove the last item when there is a search query', () => {
       // search for random item
       const searchQuery = _.sample(options).text
@@ -2099,7 +2107,7 @@ describe('Dropdown', () => {
       wrapper.find('DropdownItem').first().simulate('click')
 
       // bye bye search query
-      wrapper.should.have.state('searchQuery', '')
+      wrapper.find('input.search').should.have.value('')
     })
 
     it('opens the menu on change if there is a query and not already open', () => {
@@ -2173,10 +2181,10 @@ describe('Dropdown', () => {
       // avoid it to prevent false positives
       wrapper.simulate('click')
       wrapper.simulate('keydown', { key: 'ArrowUp' })
-      wrapper.should.have.state('selectedIndex', 3)
+      wrapper.find('.item').at(3).should.have.className('selected')
 
       wrapper.find('input.search').simulate('change', { target: { value: 'baz' } })
-      wrapper.should.have.state('selectedIndex', 0)
+      wrapper.find('.item').at(0).should.have.className('selected')
     })
 
     it('still allows moving selection after blur/focus', () => {
@@ -2226,13 +2234,7 @@ describe('Dropdown', () => {
         .simulate('click', nativeEvent)
 
       dropdownMenuIsClosed()
-
-      const activeElement = document.activeElement
-      const searchIsFocused = activeElement === document.querySelector('input.search')
-      searchIsFocused.should.be.true(
-        `Expected "input.search" to be the active element but found ${activeElement} instead.`,
-      )
-      wrapper.should.have.state('focus', true)
+      dropdownInputIsFocused()
     })
 
     it('sets focus to the dropdown after selection', () => {
@@ -2247,14 +2249,7 @@ describe('Dropdown', () => {
       // TODO: try reenable after Enzyme update
       // https://github.com/Semantic-Org/Semantic-UI-React/pull/3747#issuecomment-522018329
       // dropdownMenuIsClosed()
-
-      const activeElement = document.activeElement
-      const dropdownIsFocused = activeElement === document.querySelector('div.dropdown')
-      dropdownIsFocused.should.be.true(
-        `Expected Dropdown to be the active element but found ${activeElement} instead.`,
-      )
-
-      wrapper.should.have.state('focus', true)
+      dropdownIsFocused()
     })
   })
 
@@ -2687,7 +2682,7 @@ describe('Dropdown', () => {
       search.simulate('change', { target: { value: 'boo' } })
       search.simulate('keydown', { key: 'Enter' })
 
-      wrapper.should.have.state('searchQuery', '')
+      wrapper.find('input.search').should.have.value('')
     })
   })
 
@@ -2755,7 +2750,7 @@ describe('Dropdown', () => {
       wrapper.simulate('keydown', { key: 'ArrowDown' })
 
       onChange.should.have.been.called()
-      wrapper.should.have.state('value', options[1].value)
+      wrapper.find('.item').at(1).should.have.className('active')
     })
 
     it('does not change value when set to false', () => {
@@ -2776,7 +2771,7 @@ describe('Dropdown', () => {
       wrapper.simulate('keydown', { key: 'ArrowDown' })
 
       onChange.should.not.have.been.called()
-      wrapper.should.have.state('value', value)
+      wrapper.find('.item').at(0).should.have.className('active')
     })
   })
 

--- a/test/specs/modules/Embed/Embed-test.js
+++ b/test/specs/modules/Embed/Embed-test.js
@@ -48,17 +48,21 @@ describe('Embed', () => {
 
   describe('active', () => {
     it('defaults to false', () => {
-      shallow(<Embed />).should.have.not.state('active')
+      mount(<Embed />).should.have.not.className('active')
     })
 
-    it('passes to state', () => {
-      shallow(<Embed active />).should.have.state('active', true)
+    it('applies className', () => {
+      mount(<Embed active />).should.have.className('active')
     })
 
     it('renders nothing when false', () => {
-      const children = 'child text'
+      const wrapper = mount(
+        <Embed>
+          <p id='foo' />
+        </Embed>,
+      )
 
-      shallow(<Embed>{children}</Embed>).should.not.contain(<div className='embed'>{children}</div>)
+      wrapper.should.not.have.descendants('#foo')
     })
   })
 
@@ -90,9 +94,8 @@ describe('Embed', () => {
 
   describe('defaultActive', () => {
     it('sets the initial active state', () => {
-      shallow(<Embed defaultActive />).should.have.state('active', true)
-
-      shallow(<Embed defaultActive={false} />).should.have.state('active', false)
+      mount(<Embed defaultActive />).should.have.className('active')
+      mount(<Embed defaultActive={false} />).should.have.not.className('active')
     })
   })
 
@@ -118,23 +121,18 @@ describe('Embed', () => {
   })
 
   describe('onClick', () => {
-    it('omitted when not defined', () => {
-      const click = () => shallow(<Embed />).simulate('click')
-      expect(click).to.not.throw()
-    })
-
-    it('updates state', () => {
+    it('sets to active state', () => {
       const wrapper = mount(<Embed />)
 
       wrapper.simulate('click')
-      wrapper.should.have.state('active', true)
+      wrapper.should.have.className('active')
     })
 
-    it('omits state update if active', () => {
+    it('skips state update if active', () => {
       const wrapper = mount(<Embed active />)
 
       wrapper.simulate('click')
-      wrapper.should.have.state('active', true)
+      wrapper.should.have.className('active')
     })
   })
 

--- a/test/specs/modules/Transition/Transition-test.js
+++ b/test/specs/modules/Transition/Transition-test.js
@@ -17,7 +17,7 @@ let wrapper
 const wrapperMount = (...args) => (wrapper = mount(...args))
 const wrapperShallow = (...args) => (wrapper = shallow(...args))
 
-describe.only('Transition', () => {
+describe('Transition', () => {
   common.hasSubcomponents(Transition, [TransitionGroup])
   common.hasValidTypings(Transition)
 

--- a/test/specs/modules/Transition/Transition-test.js
+++ b/test/specs/modules/Transition/Transition-test.js
@@ -8,7 +8,6 @@ import {
   TRANSITION_STATUS_ENTERING,
   TRANSITION_STATUS_EXITED,
   TRANSITION_STATUS_EXITING,
-  TRANSITION_STATUS_UNMOUNTED,
 } from 'src/modules/Transition/utils/computeStatuses'
 import * as common from 'test/specs/commonTests'
 import { sandbox } from 'test/utils'
@@ -18,7 +17,7 @@ let wrapper
 const wrapperMount = (...args) => (wrapper = mount(...args))
 const wrapperShallow = (...args) => (wrapper = shallow(...args))
 
-describe('Transition', () => {
+describe.only('Transition', () => {
   common.hasSubcomponents(Transition, [TransitionGroup])
   common.hasValidTypings(Transition)
 
@@ -39,12 +38,12 @@ describe('Transition', () => {
           </Transition>,
         )
 
-        wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+        wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
         animation.split(' ').forEach((className) => wrapper.should.have.className(className))
         wrapper.should.have.className('in')
 
         wrapper.setProps({ visible: false })
-        wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+        wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
         animation.split(' ').forEach((className) => wrapper.should.have.className(className))
         wrapper.should.have.className('out')
       })
@@ -58,12 +57,12 @@ describe('Transition', () => {
           </Transition>,
         )
 
-        wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+        wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
         wrapper.should.have.className(animation)
         wrapper.should.not.have.className('in')
 
         wrapper.setProps({ visible: false })
-        wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+        wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
         wrapper.should.have.className(animation)
         wrapper.should.not.have.className('out')
       })
@@ -76,11 +75,11 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
       wrapper.should.have.className('jump')
 
       wrapper.setProps({ visible: false })
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
       wrapper.should.have.className('jump')
     })
   })
@@ -153,11 +152,11 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
       wrapper.should.have.className('in')
 
       wrapper.setProps({ visible: false })
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
       wrapper.should.have.className('out')
     })
 
@@ -168,11 +167,11 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
       wrapper.should.have.not.className('in')
 
       wrapper.setProps({ visible: false })
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
       wrapper.should.have.not.className('out')
     })
   })
@@ -205,8 +204,8 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERED)
-      wrapper.should.have.not.state('nextStatus')
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERED)
+      wrapper.find('p').should.not.have.data('test-next-status')
     })
 
     it('sets statuses when `visible` is false', () => {
@@ -216,8 +215,7 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_UNMOUNTED)
-      wrapper.should.have.not.state('nextStatus')
+      wrapper.should.have.not.descendants('p')
     })
 
     it('sets statuses when mount is disabled', () => {
@@ -227,8 +225,8 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITED)
-      wrapper.should.have.not.state('nextStatus')
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITED)
+      wrapper.find('p').should.not.have.data('test-next-status')
     })
   })
 
@@ -250,7 +248,7 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
       wrapper.should.have.style('animation-duration', '500ms')
     })
 
@@ -261,7 +259,7 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
       wrapper.should.have.style('animation-duration', '1000ms')
     })
 
@@ -272,7 +270,7 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
       wrapper.should.have.style('animation-duration', '2000ms')
     })
 
@@ -283,7 +281,7 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITED)
       wrapper.should.not.have.style('animation-duration')
     })
 
@@ -295,7 +293,7 @@ describe('Transition', () => {
       )
 
       wrapper.setProps({ visible: false })
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
       wrapper.should.have.style('animation-duration')
     })
 
@@ -306,7 +304,7 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
       wrapper.should.have.style('animation-duration', '1000ms')
     })
 
@@ -318,7 +316,7 @@ describe('Transition', () => {
       )
 
       wrapper.setProps({ visible: false })
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
       wrapper.should.have.style('animation-duration', '1000ms')
     })
   })
@@ -331,11 +329,11 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
 
       wrapper.setProps({ visible: false })
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_EXITED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_EXITED)
     })
 
     it('updates status when set to false while ENTERED', () => {
@@ -344,11 +342,11 @@ describe('Transition', () => {
           <p />
         </Transition>,
       )
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERED)
 
       wrapper.setProps({ visible: false })
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_EXITED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_EXITED)
     })
 
     it('updates status when set to true while UNMOUNTED', () => {
@@ -357,12 +355,11 @@ describe('Transition', () => {
           <p />
         </Transition>,
       )
-
-      wrapper.should.have.state('status', TRANSITION_STATUS_UNMOUNTED)
+      wrapper.should.have.not.descendants('p')
 
       wrapper.setProps({ visible: true })
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_ENTERED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_ENTERED)
     })
 
     it('updates next status when set to true while performs an ENTERING transition', (done) => {
@@ -372,11 +369,11 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
 
       wrapper.setProps({ visible: false })
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_EXITED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_EXITED)
     })
 
     it('updates next status when set to true while performs an EXITING transition', (done) => {
@@ -386,15 +383,15 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERED)
 
       wrapper.setProps({ visible: false })
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_EXITED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_EXITED)
 
       wrapper.setProps({ visible: true })
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_ENTERED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_ENTERED)
     })
   })
 
@@ -474,14 +471,14 @@ describe('Transition', () => {
       )
 
       wrapper.setProps({ visible: false })
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
 
       setTimeout(() => {
-        wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
+        wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
       }, 100)
       setTimeout(() => {
         onHide.should.have.been.calledOnce()
-        wrapper.should.have.state('status', TRANSITION_STATUS_EXITED)
+        wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITED)
 
         done()
       }, 200)
@@ -498,13 +495,13 @@ describe('Transition', () => {
 
       wrapper.setProps({ visible: false })
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_EXITED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_EXITED)
 
       wrapper.setProps({})
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_EXITING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_EXITED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_EXITED)
 
       onStart.should.have.been.calledOnce()
       done()
@@ -541,14 +538,14 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
 
       setTimeout(() => {
-        wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
+        wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
       }, 100)
       setTimeout(() => {
         onShow.should.have.been.calledOnce()
-        wrapper.should.have.state('status', TRANSITION_STATUS_ENTERED)
+        wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERED)
         done()
       }, 200)
     })
@@ -585,13 +582,13 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_ENTERED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_ENTERED)
 
       wrapper.setProps({})
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_ENTERED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_ENTERED)
 
       onStart.should.have.been.calledOnce()
       done()
@@ -619,38 +616,34 @@ describe('Transition', () => {
         </Transition>,
       )
 
-      wrapper.should.have.state('status', TRANSITION_STATUS_ENTERING)
-      wrapper.should.have.state('nextStatus', TRANSITION_STATUS_ENTERED)
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_ENTERING)
+      wrapper.find('p').should.have.data('test-next-status', TRANSITION_STATUS_ENTERED)
     })
   })
 
   describe('unmountOnHide', () => {
-    it('unmounts child when true', (done) => {
-      const onHide = () => {
-        wrapper.should.have.state('status', TRANSITION_STATUS_UNMOUNTED)
-        done()
-      }
-
+    it('unmounts child when true', () => {
       wrapperMount(
-        <Transition duration={0} onHide={onHide} transitionOnMount={false} unmountOnHide>
+        <Transition duration={0} transitionOnMount={false} unmountOnHide>
           <p />
         </Transition>,
       )
+
       wrapper.setProps({ visible: false })
+      wrapper.update()
+      wrapper.should.have.not.descendants('p')
     })
 
-    it('lefts mounted when false', (done) => {
-      const onHide = () => {
-        wrapper.should.have.state('status', TRANSITION_STATUS_EXITED)
-        done()
-      }
-
+    it('lefts mounted when false', () => {
       wrapperMount(
-        <Transition duration={5} onHide={onHide} transitionOnMount={false} unmountOnHide={false}>
+        <Transition duration={0} transitionOnMount={false} unmountOnHide={false}>
           <p />
         </Transition>,
       )
+
       wrapper.setProps({ visible: false })
+      wrapper.update()
+      wrapper.find('p').should.have.data('test-status', TRANSITION_STATUS_EXITED)
     })
   })
 })


### PR DESCRIPTION
This PR removes `.state()` assertions by Enzyme from our tests.

This is a required step as all components will become functional and will use native ref forwarding via `React.forwardRef`.