### PR TITLE
chore(Step): use React.forwardRef()

### DIFF
--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React from 'react'
 
 import {
   childrenUtils,
@@ -10,6 +10,7 @@ import {
   getElementType,
   getUnhandledProps,
   useKeyOnly,
+  useEventCallback,
 } from '../../lib'
 import Icon from '../Icon'
 import StepContent from './StepContent'
@@ -20,70 +21,69 @@ import StepTitle from './StepTitle'
 /**
  * A step shows the completion status of an activity in a series of activities.
  */
-class Step extends Component {
-  computeElementType = () => {
-    const { onClick } = this.props
+const Step = React.forwardRef(function StepInner(props, ref) {
+  const {
+    active,
+    children,
+    className,
+    completed,
+    content,
+    description,
+    disabled,
+    href,
+    onClick,
+    icon,
+    link,
+    title,
+  } = props
 
-    if (onClick) return 'a'
-  }
-
-  handleClick = (e) => {
-    const { disabled } = this.props
-
-    if (!disabled) _.invoke(this.props, 'onClick', e, this.props)
-  }
-
-  render() {
-    const {
-      active,
-      children,
-      className,
-      completed,
-      content,
-      description,
-      disabled,
-      href,
-      icon,
-      link,
-      title,
-    } = this.props
-
-    const classes = cx(
-      useKeyOnly(active, 'active'),
-      useKeyOnly(completed, 'completed'),
-      useKeyOnly(disabled, 'disabled'),
-      useKeyOnly(link, 'link'),
-      'step',
-      className,
-    )
-    const rest = getUnhandledProps(Step, this.props)
-    const ElementType = getElementType(Step, this.props, this.computeElementType)
-
-    if (!childrenUtils.isNil(children)) {
-      return (
-        <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>
-          {children}
-        </ElementType>
-      )
+  const handleClick = useEventCallback((e) => {
+    if (!disabled) {
+      _.invoke(props, 'onClick', e, props)
     }
+  })
 
-    if (!childrenUtils.isNil(content)) {
-      return (
-        <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>
-          {content}
-        </ElementType>
-      )
+  const classes = cx(
+    useKeyOnly(active, 'active'),
+    useKeyOnly(completed, 'completed'),
+    useKeyOnly(disabled, 'disabled'),
+    useKeyOnly(link, 'link'),
+    'step',
+    className,
+  )
+
+  const rest = getUnhandledProps(Step, props)
+  const ElementType = getElementType(Step, props, () => {
+    if (onClick) {
+      return 'a'
     }
+  })
 
+  if (!childrenUtils.isNil(children)) {
     return (
-      <ElementType {...rest} className={classes} href={href} onClick={this.handleClick}>
-        {Icon.create(icon, { autoGenerateKey: false })}
-        {StepContent.create({ description, title }, { autoGenerateKey: false })}
+      <ElementType {...rest} className={classes} href={href} onClick={handleClick} ref={ref}>
+        {children}
       </ElementType>
     )
   }
-}
 
+  if (!childrenUtils.isNil(content)) {
+    return (
+      <ElementType {...rest} className={classes} href={href} onClick={handleClick} ref={ref}>
+        {content}
+      </ElementType>
+    )
+  }
+
+  return (
+    <ElementType {...rest} className={classes} href={href} onClick={handleClick} ref={ref}>
+      {Icon.create(icon, { autoGenerateKey: false })}
+      {StepContent.create({ description, title }, { autoGenerateKey: false })}
+    </ElementType>
+  )
+})
+
+Step.displayName = 'Step'
 Step.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/elements/Step/StepContent.js
+++ b/src/elements/Step/StepContent.js
@@ -15,7 +15,7 @@ import StepTitle from './StepTitle'
 /**
  * A step can contain a content.
  */
-function StepContent(props) {
+const StepContent = React.forwardRef(function StepContentInner(props, ref) {
   const { children, className, content, description, title } = props
   const classes = cx('content', className)
   const rest = getUnhandledProps(StepContent, props)
@@ -23,27 +23,29 @@ function StepContent(props) {
 
   if (!childrenUtils.isNil(children)) {
     return (
-      <ElementType {...rest} className={classes}>
+      <ElementType {...rest} className={classes} ref={ref}>
         {children}
       </ElementType>
     )
   }
+
   if (!childrenUtils.isNil(content)) {
     return (
-      <ElementType {...rest} className={classes}>
+      <ElementType {...rest} className={classes} ref={ref}>
         {content}
       </ElementType>
     )
   }
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {StepTitle.create(title, { autoGenerateKey: false })}
       {StepDescription.create(description, { autoGenerateKey: false })}
     </ElementType>
   )
-}
+})
 
+StepContent.displayName = 'StepContent'
 StepContent.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/elements/Step/StepDescription.js
+++ b/src/elements/Step/StepDescription.js
@@ -10,19 +10,20 @@ import {
   getUnhandledProps,
 } from '../../lib'
 
-function StepDescription(props) {
+const StepDescription = React.forwardRef(function StepDescriptionInner(props, ref) {
   const { children, className, content } = props
   const classes = cx('description', className)
   const rest = getUnhandledProps(StepDescription, props)
   const ElementType = getElementType(StepDescription, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {childrenUtils.isNil(children) ? content : children}
     </ElementType>
   )
-}
+})
 
+StepDescription.displayName = 'StepDescription'
 StepDescription.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/elements/Step/StepGroup.js
+++ b/src/elements/Step/StepGroup.js
@@ -22,7 +22,7 @@ const numberMap = _.pickBy(numberToWordMap, (val, key) => key <= 8)
 /**
  * A set of steps.
  */
-function StepGroup(props) {
+const StepGroup = React.forwardRef(function StepGroupInner(props, ref) {
   const {
     attached,
     children,
@@ -55,26 +55,27 @@ function StepGroup(props) {
 
   if (!childrenUtils.isNil(children)) {
     return (
-      <ElementType {...rest} className={classes}>
+      <ElementType {...rest} className={classes} ref={ref}>
         {children}
       </ElementType>
     )
   }
   if (!childrenUtils.isNil(content)) {
     return (
-      <ElementType {...rest} className={classes}>
+      <ElementType {...rest} className={classes} ref={ref}>
         {content}
       </ElementType>
     )
   }
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {_.map(items, (item) => Step.create(item))}
     </ElementType>
   )
-}
+})
 
+StepGroup.displayName = 'StepGroup'
 StepGroup.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/elements/Step/StepTitle.js
+++ b/src/elements/Step/StepTitle.js
@@ -13,19 +13,20 @@ import {
 /**
  * A step can contain a title.
  */
-function StepTitle(props) {
+const StepTitle = React.forwardRef(function StepTitleInner(props, ref) {
   const { children, className, content } = props
   const classes = cx('title', className)
   const rest = getUnhandledProps(StepTitle, props)
   const ElementType = getElementType(StepTitle, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {childrenUtils.isNil(children) ? content : children}
     </ElementType>
   )
-}
+})
 
+StepTitle.displayName = 'StepTitle'
 StepTitle.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/lib/hooks/useEventCallback.js
+++ b/src/lib/hooks/useEventCallback.js
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect'
+
+/**
+ * https://reactjs.org/docs/hooks-faq.html#how-to-read-an-often-changing-value-from-usecallback
+ *
+ * Modified `useCallback` that can be used when dependencies change too frequently. Can occur when:
+ * e.g. user props are depedencies which could change on every render
+ * e.g. volatile values (i.e. useState/useDispatch) are dependencies which could change frequently
+ *
+ * This should not be used often, but can be a useful re-render optimization since the callback is
+ * a ref and will not be invalidated between rerenders.
+ *
+ * @param {Function} fn The callback function that will be used
+ */
+export default function useEventCallback(fn) {
+  const callbackRef = React.useRef(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      throw new Error('Cannot call an event handler while rendering...')
+    }
+  })
+
+  useIsomorphicLayoutEffect(() => {
+    callbackRef.current = fn
+  }, [fn])
+
+  return React.useCallback(
+    (...args) => {
+      const callback = callbackRef.current
+
+      return callback(...args)
+    },
+    [callbackRef],
+  )
+}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -47,3 +47,4 @@ export { makeDebugger }
 //
 
 export useClassNamesOnNode from './hooks/useClassNamesOnNode'
+export useEventCallback from './hooks/useEventCallback'

--- a/test/specs/addons/Confirm/Confirm-test.js
+++ b/test/specs/addons/Confirm/Confirm-test.js
@@ -26,7 +26,7 @@ describe('Confirm', () => {
     if (wrapper && wrapper.unmount) wrapper.unmount()
   })
 
-  common.isConformant(Confirm)
+  common.isConformant(Confirm, { rendersPortal: true })
 
   common.implementsShorthandProp(Confirm, {
     autoGenerateKey: false,

--- a/test/specs/addons/TransitionablePortal/TransitionablePortal-test.js
+++ b/test/specs/addons/TransitionablePortal/TransitionablePortal-test.js
@@ -10,7 +10,10 @@ const requiredProps = {
 }
 
 describe('TransitionablePortal', () => {
-  common.isConformant(TransitionablePortal, { requiredProps })
+  common.isConformant(TransitionablePortal, {
+    rendersPortal: true,
+    requiredProps,
+  })
 
   describe('children', () => {
     it('renders a Transition', () => {

--- a/test/specs/collections/Form/FormInput-test.js
+++ b/test/specs/collections/Form/FormInput-test.js
@@ -6,6 +6,48 @@ import * as common from 'test/specs/commonTests'
 
 describe('FormInput', () => {
   common.isConformant(FormInput, {
+    eventTargets: {
+      // keyboard
+      onKeyDown: 'input',
+      onKeyPress: 'input',
+      onKeyUp: 'input',
+
+      // focus
+      onFocus: 'input',
+      onBlur: 'input',
+
+      // form
+      onChange: 'input',
+      onInput: 'input',
+
+      // mouse
+      onClick: 'input',
+      onContextMenu: 'input',
+      onDrag: 'input',
+      onDragEnd: 'input',
+      onDragEnter: 'input',
+      onDragExit: 'input',
+      onDragLeave: 'input',
+      onDragOver: 'input',
+      onDragStart: 'input',
+      onDrop: 'input',
+      onMouseDown: 'input',
+      onMouseEnter: 'input',
+      onMouseLeave: 'input',
+      onMouseMove: 'input',
+      onMouseOut: 'input',
+      onMouseOver: 'input',
+      onMouseUp: 'input',
+
+      // selection
+      onSelect: 'input',
+
+      // touch
+      onTouchCancel: 'input',
+      onTouchEnd: 'input',
+      onTouchMove: 'input',
+      onTouchStart: 'input',
+    },
     ignoredTypingsProps: ['label', 'error'],
   })
   common.labelImplementsHtmlForProp(FormInput)

--- a/test/specs/commonTests/forwardsRef.js
+++ b/test/specs/commonTests/forwardsRef.js
@@ -1,14 +1,20 @@
-import React from 'react'
+import * as React from 'react'
+import * as ReactIs from 'react-is'
+
 import { consoleUtil, sandbox } from 'test/utils'
 
 /**
  * Assert a Component correctly implements a shorthand create method.
- * @param {React.Component} Component The component to test
+ * @param {React.ElementType} Component The component to test
  * @param {{ requiredProps?: Object, tagName?: string }} options Options for a test
  */
 export default function forwardsRef(Component, options = {}) {
   describe('forwardsRef', () => {
     const { requiredProps = {}, tagName = 'div' } = options
+
+    it('is produced by React.forwardRef() call', () => {
+      expect(ReactIs.isForwardRef(<Component {...requiredProps} />)).to.equal(true)
+    })
 
     it(`forwards ref to "${tagName}"`, () => {
       const ref = sandbox.spy()

--- a/test/specs/elements/Step/Step-test.js
+++ b/test/specs/elements/Step/Step-test.js
@@ -10,6 +10,9 @@ import { sandbox } from 'test/utils'
 
 describe('Step', () => {
   common.isConformant(Step)
+  common.forwardsRef(Step)
+  common.forwardsRef(Step, { requiredProps: { content: faker.lorem.word() } })
+  common.forwardsRef(Step, { requiredProps: { content: <span /> } })
   common.hasSubcomponents(Step, [StepContent, StepDescription, StepTitle])
   common.rendersChildren(Step)
 
@@ -53,7 +56,7 @@ describe('Step', () => {
       const event = { target: null }
       const onClick = sandbox.spy()
 
-      shallow(<Step onClick={onClick} />).simulate('click', event)
+      mount(<Step onClick={onClick} />).simulate('click', event)
 
       onClick.should.have.been.calledOnce()
       onClick.should.have.been.calledWithMatch(event, { onClick })
@@ -62,7 +65,7 @@ describe('Step', () => {
     it('is not called when is disabled', () => {
       const onClick = sandbox.spy()
 
-      shallow(<Step disabled onClick={onClick} />).simulate('click')
+      mount(<Step disabled onClick={onClick} />).simulate('click')
       onClick.should.have.not.been.called()
     })
 

--- a/test/specs/elements/Step/StepContent-test.js
+++ b/test/specs/elements/Step/StepContent-test.js
@@ -2,9 +2,14 @@ import StepContent from 'src/elements/Step/StepContent'
 import StepDescription from 'src/elements/Step/StepDescription'
 import StepTitle from 'src/elements/Step/StepTitle'
 import * as common from 'test/specs/commonTests'
+import faker from 'faker'
+import React from 'react'
 
 describe('StepContent', () => {
   common.isConformant(StepContent)
+  common.forwardsRef(StepContent)
+  common.forwardsRef(StepContent, { requiredProps: { content: faker.lorem.word() } })
+  common.forwardsRef(StepContent, { requiredProps: { children: <span /> } })
   common.rendersChildren(StepContent)
 
   common.implementsCreateMethod(StepContent)

--- a/test/specs/elements/Step/StepDescription-test.js
+++ b/test/specs/elements/Step/StepDescription-test.js
@@ -3,6 +3,7 @@ import * as common from 'test/specs/commonTests'
 
 describe('StepDescription', () => {
   common.isConformant(StepDescription)
+  common.forwardsRef(StepDescription)
   common.implementsCreateMethod(StepDescription)
   common.rendersChildren(StepDescription)
 })

--- a/test/specs/elements/Step/StepGroup-test.js
+++ b/test/specs/elements/Step/StepGroup-test.js
@@ -1,3 +1,4 @@
+import faker from 'faker'
 import _ from 'lodash'
 import React from 'react'
 
@@ -9,6 +10,9 @@ const numberMap = _.pickBy(numberToWordMap, (val, key) => key <= 8)
 
 describe('StepGroup', () => {
   common.isConformant(StepGroup)
+  common.forwardsRef(StepGroup)
+  common.forwardsRef(StepGroup, { requiredProps: { content: faker.lorem.word() } })
+  common.forwardsRef(StepGroup, { requiredProps: { children: <span /> } })
   common.hasUIClassName(StepGroup)
   common.rendersChildren(StepGroup)
 

--- a/test/specs/elements/Step/StepTitle-test.js
+++ b/test/specs/elements/Step/StepTitle-test.js
@@ -3,6 +3,7 @@ import * as common from 'test/specs/commonTests'
 
 describe('StepTitle', () => {
   common.isConformant(StepTitle)
+  common.forwardsRef(StepTitle)
   common.implementsCreateMethod(StepTitle)
   common.rendersChildren(StepTitle)
 })


### PR DESCRIPTION
Similarly to #4234, adds native ref forwarding to `Step` and all subcomponents.

- `Step` became functional component
  - `useEventCallback` hook was added to keep event listeners stable
- `isConformant()` was modified to use `mount()`
- fixes to affected unit tests