### PR TITLE
chore(Modal|Portal|Popup): use React.forwardRef()

### DIFF
--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -92,6 +92,9 @@ export interface StrictPortalProps {
 
   /** Element to be rendered in-place where the portal is defined. */
   trigger?: React.ReactNode
+
+  /** Called with a ref to the trigger node. */
+  triggerRef?: React.Ref<any>
 }
 
 declare class Portal extends React.Component<PortalProps> {

--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -92,9 +92,6 @@ export interface StrictPortalProps {
 
   /** Element to be rendered in-place where the portal is defined. */
   trigger?: React.ReactNode
-
-  /** Called with a ref to the trigger node. */
-  triggerRef?: React.Ref<any>
 }
 
 declare class Portal extends React.Component<PortalProps> {

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -388,8 +388,6 @@ Portal.defaultProps = {
   openOnTriggerClick: true,
 }
 
-Portal.autoControlledProps = ['open']
-
 Portal.Inner = PortalInner
 
 export default Portal

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import {
+  customPropTypes,
   doesNodeContainClick,
   makeDebugger,
   useAutoControlledValue,
-  useMergedRefs,
 } from '../../lib'
-import validateTrigger from './utils/validateTrigger'
+import useTrigger from './utils/useTrigger'
 import PortalInner from './PortalInner'
 
 const debug = makeDebugger('portal')
@@ -38,13 +38,7 @@ function Portal(props) {
     openOnTriggerClick,
     openOnTriggerFocus,
     openOnTriggerMouseEnter,
-    trigger,
   } = props
-
-  /* istanbul ignore else */
-  if (process.env.NODE_ENV !== 'production') {
-    validateTrigger(trigger)
-  }
 
   const [open, setOpen] = useAutoControlledValue({
     state: props.open,
@@ -53,7 +47,7 @@ function Portal(props) {
   })
 
   const contentRef = React.useRef()
-  const triggerRef = useMergedRefs(trigger?.ref, React.useRef())
+  const [triggerRef, trigger] = useTrigger(props.trigger, props.triggerRef)
 
   const mouseEnterTimer = React.useRef()
   const mouseLeaveTimer = React.useRef()
@@ -379,6 +373,9 @@ Portal.propTypes = {
 
   /** Element to be rendered in-place where the portal is defined. */
   trigger: PropTypes.node,
+
+  /** Called with a ref to the trigger node. */
+  triggerRef: customPropTypes.ref,
 }
 
 Portal.defaultProps = {

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -1,15 +1,14 @@
 import EventStack from '@semantic-ui-react/event-stack'
-import { handleRef, Ref } from '@fluentui/react-component-ref'
 import keyboardKey from 'keyboard-key'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 import {
-  ModernAutoControlledComponent as Component,
-  customPropTypes,
   doesNodeContainClick,
   makeDebugger,
+  useAutoControlledValue,
+  useMergedRefs,
 } from '../../lib'
 import validateTrigger from './utils/validateTrigger'
 import PortalInner from './PortalInner'
@@ -23,263 +22,276 @@ const debug = makeDebugger('portal')
  * @see Dimmer
  * @see Confirm
  */
-class Portal extends Component {
-  contentRef = React.createRef()
-  triggerRef = React.createRef()
-  latestDocumentMouseDownEvent = null
+function Portal(props) {
+  const {
+    children,
+    closeOnDocumentClick,
+    closeOnEscape,
+    closeOnPortalMouseLeave,
+    closeOnTriggerBlur,
+    closeOnTriggerClick,
+    closeOnTriggerMouseLeave,
+    eventPool,
+    mountNode,
+    mouseEnterDelay,
+    mouseLeaveDelay,
+    openOnTriggerClick,
+    openOnTriggerFocus,
+    openOnTriggerMouseEnter,
+    trigger,
+  } = props
 
-  componentWillUnmount() {
-    // Clean up timers
-    clearTimeout(this.mouseEnterTimer)
-    clearTimeout(this.mouseLeaveTimer)
+  /* istanbul ignore else */
+  if (process.env.NODE_ENV !== 'production') {
+    validateTrigger(trigger)
+  }
+
+  const [open, setOpen] = useAutoControlledValue({
+    state: props.open,
+    defaultState: props.defaultOpen,
+    initialState: false,
+  })
+
+  const contentRef = React.useRef()
+  const triggerRef = useMergedRefs(trigger?.ref, React.useRef())
+
+  const mouseEnterTimer = React.useRef()
+  const mouseLeaveTimer = React.useRef()
+  const latestDocumentMouseDownEvent = React.useRef()
+
+  // ----------------------------------------
+  // Behavior
+  // ----------------------------------------
+
+  const openPortal = (e) => {
+    debug('open()')
+
+    _.invoke(props, 'onOpen', e, { ...props, open: true })
+    setOpen(true)
+  }
+
+  const openPortalWithTimeout = (e, delay) => {
+    debug('openWithTimeout()', delay)
+    // React wipes the entire event object and suggests using e.persist() if
+    // you need the event for async access. However, even with e.persist
+    // certain required props (e.g. currentTarget) are null so we're forced to clone.
+    const eventClone = { ...e }
+    return setTimeout(() => openPortal(eventClone), delay || 0)
+  }
+
+  const closePortal = (e) => {
+    debug('close()')
+
+    _.invoke(props, 'onClose', e, { ...props, open: false })
+    setOpen(false)
+  }
+
+  const closePortalWithTimeout = (e, delay) => {
+    debug('closeWithTimeout()', delay)
+    // React wipes the entire event object and suggests using e.persist() if
+    // you need the event for async access. However, even with e.persist
+    // certain required props (e.g. currentTarget) are null so we're forced to clone.
+    const eventClone = { ...e }
+    return setTimeout(() => closePortal(eventClone), delay || 0)
   }
 
   // ----------------------------------------
   // Document Event Handlers
   // ----------------------------------------
 
-  handleDocumentMouseDown = (e) => {
-    this.latestDocumentMouseDownEvent = e
+  React.useEffect(() => {
+    // Clean up timers
+    clearTimeout(mouseEnterTimer.current)
+    clearTimeout(mouseLeaveTimer.current)
+  }, [])
+
+  const handleDocumentMouseDown = (e) => {
+    latestDocumentMouseDownEvent.current = e
   }
 
-  handleDocumentClick = (e) => {
-    const { closeOnDocumentClick } = this.props
-    const currentMouseDownEvent = this.latestDocumentMouseDownEvent
-    this.latestDocumentMouseDownEvent = null
+  const handleDocumentClick = (e) => {
+    const currentMouseDownEvent = latestDocumentMouseDownEvent.current
+    latestDocumentMouseDownEvent.current = null
+
+    // event happened in trigger (delegate to trigger handlers)
+    const isInsideTrigger = doesNodeContainClick(triggerRef.current, e)
+    // event originated in the portal but was ended outside
+    const isOriginatedFromPortal =
+      currentMouseDownEvent && doesNodeContainClick(contentRef.current, currentMouseDownEvent)
+    // event happened in the portal
+    const isInsidePortal = doesNodeContainClick(contentRef.current, e)
 
     if (
-      !this.contentRef.current || // no portal
-      doesNodeContainClick(this.triggerRef.current, e) || // event happened in trigger (delegate to trigger handlers)
-      (currentMouseDownEvent &&
-        doesNodeContainClick(this.contentRef.current, currentMouseDownEvent)) || // event originated in the portal but was ended outside
-      doesNodeContainClick(this.contentRef.current, e) // event happened in the portal
+      !contentRef.current?.contains || // no portal
+      isInsideTrigger ||
+      isOriginatedFromPortal ||
+      isInsidePortal
     ) {
       return
     } // ignore the click
 
     if (closeOnDocumentClick) {
       debug('handleDocumentClick()')
-      this.close(e)
+      closePortal(e)
     }
   }
 
-  handleEscape = (e) => {
-    if (!this.props.closeOnEscape) return
-    if (keyboardKey.getCode(e) !== keyboardKey.Escape) return
+  const handleEscape = (e) => {
+    if (!closeOnEscape) {
+      return
+    }
+    if (keyboardKey.getCode(e) !== keyboardKey.Escape) {
+      return
+    }
 
     debug('handleEscape()')
-    this.close(e)
+    closePortal(e)
   }
 
   // ----------------------------------------
   // Component Event Handlers
   // ----------------------------------------
 
-  handlePortalMouseLeave = (e) => {
-    const { closeOnPortalMouseLeave, mouseLeaveDelay } = this.props
-
-    if (!closeOnPortalMouseLeave) return
+  const handlePortalMouseLeave = (e) => {
+    if (!closeOnPortalMouseLeave) {
+      return
+    }
 
     // Do not close the portal when 'mouseleave' is triggered by children
-    if (e.target !== this.contentRef.current) return
+    if (e.target !== contentRef.current) {
+      return
+    }
 
     debug('handlePortalMouseLeave()')
-    this.mouseLeaveTimer = this.closeWithTimeout(e, mouseLeaveDelay)
+    mouseLeaveTimer.current = closePortalWithTimeout(e, mouseLeaveDelay)
   }
 
-  handlePortalMouseEnter = () => {
+  const handlePortalMouseEnter = () => {
     // In order to enable mousing from the trigger to the portal, we need to
     // clear the mouseleave timer that was set when leaving the trigger.
-    const { closeOnPortalMouseLeave } = this.props
-
-    if (!closeOnPortalMouseLeave) return
+    if (!closeOnPortalMouseLeave) {
+      return
+    }
 
     debug('handlePortalMouseEnter()')
-    clearTimeout(this.mouseLeaveTimer)
+    clearTimeout(mouseLeaveTimer.current)
   }
 
-  handleTriggerBlur = (e, ...rest) => {
-    const { trigger, closeOnTriggerBlur } = this.props
-
+  const handleTriggerBlur = (e, ...rest) => {
     // Call original event handler
     _.invoke(trigger, 'props.onBlur', e, ...rest)
 
     // IE 11 doesn't work with relatedTarget in blur events
     const target = e.relatedTarget || document.activeElement
     // do not close if focus is given to the portal
-    const didFocusPortal = _.invoke(this.contentRef.current, 'contains', target)
+    const didFocusPortal = _.invoke(contentRef.current, 'contains', target)
 
-    if (!closeOnTriggerBlur || didFocusPortal) return
+    if (!closeOnTriggerBlur || didFocusPortal) {
+      return
+    }
 
     debug('handleTriggerBlur()')
-    this.close(e)
+    closePortal(e)
   }
 
-  handleTriggerClick = (e, ...rest) => {
-    const { trigger, closeOnTriggerClick, openOnTriggerClick } = this.props
-    const { open } = this.state
-
+  const handleTriggerClick = (e, ...rest) => {
     // Call original event handler
     _.invoke(trigger, 'props.onClick', e, ...rest)
 
     if (open && closeOnTriggerClick) {
       debug('handleTriggerClick() - close')
 
-      this.close(e)
+      closePortal(e)
     } else if (!open && openOnTriggerClick) {
       debug('handleTriggerClick() - open')
-
-      this.open(e)
+      openPortal(e)
     }
   }
 
-  handleTriggerFocus = (e, ...rest) => {
-    const { trigger, openOnTriggerFocus } = this.props
-
+  const handleTriggerFocus = (e, ...rest) => {
     // Call original event handler
     _.invoke(trigger, 'props.onFocus', e, ...rest)
 
-    if (!openOnTriggerFocus) return
+    if (!openOnTriggerFocus) {
+      return
+    }
 
     debug('handleTriggerFocus()')
-    this.open(e)
+    openPortal(e)
   }
 
-  handleTriggerMouseLeave = (e, ...rest) => {
-    clearTimeout(this.mouseEnterTimer)
-
-    const { trigger, closeOnTriggerMouseLeave, mouseLeaveDelay } = this.props
+  const handleTriggerMouseLeave = (e, ...rest) => {
+    clearTimeout(mouseEnterTimer)
 
     // Call original event handler
     _.invoke(trigger, 'props.onMouseLeave', e, ...rest)
 
-    if (!closeOnTriggerMouseLeave) return
+    if (!closeOnTriggerMouseLeave) {
+      return
+    }
 
     debug('handleTriggerMouseLeave()')
-    this.mouseLeaveTimer = this.closeWithTimeout(e, mouseLeaveDelay)
+    mouseLeaveTimer.current = closePortalWithTimeout(e, mouseLeaveDelay)
   }
 
-  handleTriggerMouseEnter = (e, ...rest) => {
-    clearTimeout(this.mouseLeaveTimer)
-
-    const { trigger, mouseEnterDelay, openOnTriggerMouseEnter } = this.props
+  const handleTriggerMouseEnter = (e, ...rest) => {
+    clearTimeout(mouseLeaveTimer)
 
     // Call original event handler
     _.invoke(trigger, 'props.onMouseEnter', e, ...rest)
 
-    if (!openOnTriggerMouseEnter) return
-
-    debug('handleTriggerMouseEnter()')
-    this.mouseEnterTimer = this.openWithTimeout(e, mouseEnterDelay)
-  }
-
-  // ----------------------------------------
-  // Behavior
-  // ----------------------------------------
-
-  open = (e) => {
-    debug('open()')
-
-    _.invoke(this.props, 'onOpen', e, { ...this.props, open: true })
-    this.setState({ open: true })
-  }
-
-  openWithTimeout = (e, delay) => {
-    debug('openWithTimeout()', delay)
-    // React wipes the entire event object and suggests using e.persist() if
-    // you need the event for async access. However, even with e.persist
-    // certain required props (e.g. currentTarget) are null so we're forced to clone.
-    const eventClone = { ...e }
-    return setTimeout(() => this.open(eventClone), delay || 0)
-  }
-
-  close = (e) => {
-    debug('close()')
-
-    _.invoke(this.props, 'onClose', e, { ...this.props, open: false })
-    this.setState({ open: false })
-  }
-
-  closeWithTimeout = (e, delay) => {
-    debug('closeWithTimeout()', delay)
-    // React wipes the entire event object and suggests using e.persist() if
-    // you need the event for async access. However, even with e.persist
-    // certain required props (e.g. currentTarget) are null so we're forced to clone.
-    const eventClone = { ...e }
-    return setTimeout(() => this.close(eventClone), delay || 0)
-  }
-
-  handleMount = () => {
-    debug('handleMount()')
-    _.invoke(this.props, 'onMount', null, this.props)
-  }
-
-  handleUnmount = () => {
-    debug('handleUnmount()')
-    _.invoke(this.props, 'onUnmount', null, this.props)
-  }
-
-  handleTriggerRef = (c) => {
-    debug('handleTriggerRef()')
-    this.triggerRef.current = c
-    handleRef(this.props.triggerRef, c)
-  }
-
-  render() {
-    const { children, eventPool, mountNode, trigger } = this.props
-    const { open } = this.state
-
-    /* istanbul ignore else */
-    if (process.env.NODE_ENV !== 'production') {
-      validateTrigger(trigger)
+    if (!openOnTriggerMouseEnter) {
+      return
     }
 
-    return (
-      <>
-        {open && (
-          <>
-            <PortalInner
-              innerRef={this.contentRef}
-              mountNode={mountNode}
-              onMount={this.handleMount}
-              onUnmount={this.handleUnmount}
-            >
-              {children}
-            </PortalInner>
-
-            <EventStack
-              name='mouseleave'
-              on={this.handlePortalMouseLeave}
-              pool={eventPool}
-              target={this.contentRef}
-            />
-            <EventStack
-              name='mouseenter'
-              on={this.handlePortalMouseEnter}
-              pool={eventPool}
-              target={this.contentRef}
-            />
-            <EventStack name='mousedown' on={this.handleDocumentMouseDown} pool={eventPool} />
-            <EventStack name='click' on={this.handleDocumentClick} pool={eventPool} />
-            <EventStack name='keydown' on={this.handleEscape} pool={eventPool} />
-          </>
-        )}
-        {trigger && (
-          <Ref innerRef={this.handleTriggerRef}>
-            {React.cloneElement(trigger, {
-              onBlur: this.handleTriggerBlur,
-              onClick: this.handleTriggerClick,
-              onFocus: this.handleTriggerFocus,
-              onMouseLeave: this.handleTriggerMouseLeave,
-              onMouseEnter: this.handleTriggerMouseEnter,
-            })}
-          </Ref>
-        )}
-      </>
-    )
+    debug('handleTriggerMouseEnter()')
+    mouseEnterTimer.current = openPortalWithTimeout(e, mouseEnterDelay)
   }
+
+  return (
+    <>
+      {open && (
+        <>
+          <PortalInner
+            mountNode={mountNode}
+            onMount={() => _.invoke(props, 'onMount', null, props)}
+            onUnmount={() => _.invoke(props, 'onUnmount', null, props)}
+            ref={contentRef}
+          >
+            {children}
+          </PortalInner>
+
+          <EventStack
+            name='mouseleave'
+            on={handlePortalMouseLeave}
+            pool={eventPool}
+            target={contentRef}
+          />
+          <EventStack
+            name='mouseenter'
+            on={handlePortalMouseEnter}
+            pool={eventPool}
+            target={contentRef}
+          />
+          <EventStack name='mousedown' on={handleDocumentMouseDown} pool={eventPool} />
+          <EventStack name='click' on={handleDocumentClick} pool={eventPool} />
+          <EventStack name='keydown' on={handleEscape} pool={eventPool} />
+        </>
+      )}
+      {trigger &&
+        React.cloneElement(trigger, {
+          onBlur: handleTriggerBlur,
+          onClick: handleTriggerClick,
+          onFocus: handleTriggerFocus,
+          onMouseLeave: handleTriggerMouseLeave,
+          onMouseEnter: handleTriggerMouseEnter,
+          ref: triggerRef,
+        })}
+    </>
+  )
 }
 
+Portal.displayName = 'Portal'
 Portal.propTypes = {
   /** Primary content. */
   children: PropTypes.node.isRequired,
@@ -367,9 +379,6 @@ Portal.propTypes = {
 
   /** Element to be rendered in-place where the portal is defined. */
   trigger: PropTypes.node,
-
-  /** Called with a ref to the trigger node. */
-  triggerRef: customPropTypes.ref,
 }
 
 Portal.defaultProps = {

--- a/src/addons/Portal/usePortalElement.js
+++ b/src/addons/Portal/usePortalElement.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import ReactIs from 'react-is'
+
+import { useMergedRefs } from '../../lib'
+
+/**
+ * Assigns merged ref to an existing element is possible or wraps it with an additional "div".
+ *
+ * @param {React.ReactNode} node
+ * @param {React.Ref} userRef
+ */
+export default function usePortalElement(node, userRef) {
+  const ref = useMergedRefs(node.ref, userRef)
+
+  if (React.isValidElement(node)) {
+    if (ReactIs.isForwardRef(node)) {
+      return React.cloneElement(node, { ref })
+    }
+
+    if (typeof node.type === 'string') {
+      return React.cloneElement(node, { ref })
+    }
+  }
+
+  return (
+    <div data-suir-portal='true' ref={ref}>
+      {node}
+    </div>
+  )
+}

--- a/src/addons/Portal/utils/useTrigger.js
+++ b/src/addons/Portal/utils/useTrigger.js
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import { useMergedRefs } from '../../../lib'
+import validateTrigger from './validateTrigger'
+
+/**
+ * @param {React.ReactNode} trigger
+ * @param {React.Ref} triggerRef
+ */
+function useTrigger(trigger, triggerRef) {
+  const ref = useMergedRefs(trigger?.ref, triggerRef)
+
+  if (trigger) {
+    /* istanbul ignore else */
+    if (process.env.NODE_ENV !== 'production') {
+      validateTrigger(trigger)
+    }
+
+    return [ref, React.cloneElement(trigger, { ref })]
+  }
+
+  return [ref, null]
+}
+
+export default useTrigger

--- a/src/addons/Portal/utils/validateTrigger.js
+++ b/src/addons/Portal/utils/validateTrigger.js
@@ -5,11 +5,9 @@ import * as ReactIs from 'react-is'
  * Asserts that a passed element can be used cloned a props will be applied properly.
  */
 export default function validateTrigger(element) {
-  if (element) {
-    React.Children.only(element)
+  React.Children.only(element)
 
-    if (ReactIs.isFragment(element)) {
-      throw new Error('An "React.Fragment" cannot be used as a `trigger`.')
-    }
+  if (ReactIs.isFragment(element)) {
+    throw new Error('An "React.Fragment" cannot be used as a `trigger`.')
   }
 }

--- a/src/lib/doesNodeContainClick.js
+++ b/src/lib/doesNodeContainClick.js
@@ -10,7 +10,9 @@ import _ from 'lodash'
  * @returns {boolean}
  */
 const doesNodeContainClick = (node, e) => {
-  if (_.some([e, node], _.isNil)) return false
+  if (_.some([e, node], _.isNil)) {
+    return false
+  }
 
   // if there is an e.target and it is in the document, use a simple node.contains() check
   if (e.target) {
@@ -18,7 +20,10 @@ const doesNodeContainClick = (node, e) => {
 
     if (document.querySelector('[data-suir-click-target=true]')) {
       _.invoke(e.target, 'removeAttribute', 'data-suir-click-target')
-      return node.contains(e.target)
+
+      if (typeof node.contains === 'function') {
+        return node.contains(e.target)
+      }
     }
   }
 
@@ -29,18 +34,31 @@ const doesNodeContainClick = (node, e) => {
   // return early if the event properties aren't available
   // prevent measuring the node and repainting if we don't need to
   const { clientX, clientY } = e
-  if (_.some([clientX, clientY], _.isNil)) return false
+
+  if (_.some([clientX, clientY], _.isNil)) {
+    return false
+  }
+
+  if (typeof node.getClientRects !== 'function') {
+    return false
+  }
 
   // false if the node is not visible
   const clientRects = node.getClientRects()
+
   // Heads Up!
   // getClientRects returns a DOMRectList, not an array nor a plain object
   // We explicitly avoid _.isEmpty and check .length to cover all possible shapes
-  if (!node.offsetWidth || !node.offsetHeight || !clientRects || !clientRects.length) return false
+  if (!node.offsetWidth || !node.offsetHeight || !clientRects || !clientRects.length) {
+    return false
+  }
 
   // false if the node doesn't have a valid bounding rect
   const { top, bottom, left, right } = _.first(clientRects)
-  if (_.some([top, bottom, left, right], _.isNil)) return false
+
+  if (_.some([top, bottom, left, right], _.isNil)) {
+    return false
+  }
 
   // we add a small decimal to the upper bound just to make it inclusive
   // don't add an whole pixel (1) as the event/node values may be decimal sensitive

--- a/src/lib/hooks/useAutoControlledValue.js
+++ b/src/lib/hooks/useAutoControlledValue.js
@@ -1,42 +1,6 @@
 import * as React from 'react'
 
 /**
- * Helper hook to handle previous comparison of controlled/uncontrolled. Prints an error when "isControlled" value
- * switches between subsequent renders.
- */
-function useIsControlled(controlledValue) {
-  const [isControlled] = React.useState(controlledValue !== undefined)
-
-  if (process.env.NODE_ENV !== 'production') {
-    // We don't want these warnings in production even though it is against native behaviour
-    React.useEffect(() => {
-      if (isControlled !== (controlledValue !== undefined)) {
-        const error = new Error()
-
-        const controlWarning = isControlled
-          ? 'a controlled value to be uncontrolled'
-          : 'an uncontrolled value to be controlled'
-        const undefinedWarning = isControlled ? 'defined to an undefined' : 'undefined to a defined'
-
-        // eslint-disable-next-line no-console
-        console.error(
-          [
-            // Default react error
-            `A component is changing ${controlWarning}'. This is likely caused by the value changing from `,
-            `${undefinedWarning} value, which should not happen. Decide between using a controlled or uncontrolled `,
-            'input element for the lifetime of the component.',
-            'More info: https://reactjs.org/link/controlled-components',
-            error.stack,
-          ].join(' '),
-        )
-      }
-    }, [isControlled, controlledValue])
-  }
-
-  return isControlled
-}
-
-/**
  * A hook that allows optional user control, implements an interface similar to `React.useState()`.
  * Useful for components which allow uncontrolled and controlled behaviours for users.
  *
@@ -50,12 +14,11 @@ function useIsControlled(controlledValue) {
  * @see https://reactjs.org/docs/hooks-state.html
  */
 function useAutoControlledValue(options) {
-  const isControlled = useIsControlled(options.state)
   const initialState =
     typeof options.defaultState === 'undefined' ? options.initialState : options.defaultState
-
   const [internalState, setInternalState] = React.useState(initialState)
-  const state = isControlled ? options.state : internalState
+
+  const state = typeof options.state === 'undefined' ? internalState : options.state
   const stateRef = React.useRef(state)
 
   React.useEffect(() => {

--- a/src/lib/hooks/usePrevious.js
+++ b/src/lib/hooks/usePrevious.js
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+/**
+ * Hook keeping track of a given value from a previous execution of the component the Hook is used in.
+ *
+ * @see https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+ */
+function usePrevious(value) {
+  const ref = React.useRef()
+
+  React.useEffect(() => {
+    ref.current = value
+  })
+
+  return ref.current
+}
+
+export default usePrevious

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -48,5 +48,6 @@ export { makeDebugger }
 
 export useAutoControlledValue from './hooks/useAutoControlledValue'
 export useClassNamesOnNode from './hooks/useClassNamesOnNode'
+export useMergedRefs from './hooks/useMergedRefs'
 export useEventCallback from './hooks/useEventCallback'
 export useMergedRefs from './hooks/useMergedRefs'

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -48,6 +48,7 @@ export { makeDebugger }
 
 export useAutoControlledValue from './hooks/useAutoControlledValue'
 export useClassNamesOnNode from './hooks/useClassNamesOnNode'
-export useMergedRefs from './hooks/useMergedRefs'
 export useEventCallback from './hooks/useEventCallback'
+export useIsomorphicLayoutEffect from './hooks/useIsomorphicLayoutEffect'
 export useMergedRefs from './hooks/useMergedRefs'
+export usePrevious from './hooks/usePrevious'

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -1,12 +1,10 @@
-import { Ref } from '@fluentui/react-component-ref'
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { createRef, isValidElement } from 'react'
+import React from 'react'
 import shallowEqual from 'shallowequal'
 
 import {
-  ModernAutoControlledComponent as Component,
   childrenUtils,
   customPropTypes,
   doesNodeContainClick,
@@ -16,6 +14,8 @@ import {
   isBrowser,
   makeDebugger,
   useKeyOnly,
+  useAutoControlledValue,
+  useMergedRefs,
 } from '../../lib'
 import Icon from '../../elements/Icon'
 import Portal from '../../addons/Portal'
@@ -33,246 +33,262 @@ const debug = makeDebugger('modal')
  * @see Confirm
  * @see Portal
  */
-class Modal extends Component {
-  legacy = isBrowser() && isLegacy()
-  ref = createRef()
-  dimmerRef = createRef()
-  latestDocumentMouseDownEvent = null
-
-  componentWillUnmount() {
-    debug('componentWillUnmount()')
-    this.handlePortalUnmount()
-  }
-
+const Modal = React.forwardRef(function (props, ref) {
+  const {
+    actions,
+    basic,
+    centered,
+    children,
+    className,
+    closeIcon,
+    closeOnDimmerClick,
+    closeOnDocumentClick,
+    content,
+    dimmer,
+    eventPool,
+    header,
+    size,
+    style,
+    trigger,
+  } = props
   // Do not access document when server side rendering
-  getMountNode = () => (isBrowser() ? this.props.mountNode || document.body : null)
+  const mountNode = isBrowser() ? props.mountNode || document.body : null
 
-  handleActionsOverrides = (predefinedProps) => ({
-    onActionClick: (e, actionProps) => {
-      _.invoke(predefinedProps, 'onActionClick', e, actionProps)
-      _.invoke(this.props, 'onActionClick', e, this.props)
-
-      this.handleClose(e)
-    },
+  const [open, setOpen] = useAutoControlledValue({
+    state: props.open,
+    defaultState: props.defaultOpen,
+    initialState: false,
   })
 
-  handleClose = (e) => {
-    debug('close()')
+  const [legacyStyles, setLegacyStyles] = React.useState({})
+  const [scrolling, setScrolling] = React.useState(false)
 
-    _.invoke(this.props, 'onClose', e, { ...this.props, open: false })
-    this.setState({ open: false })
-  }
+  const [legacy] = React.useState(() => isBrowser() && isLegacy())
 
-  handleDocumentMouseDown = (e) => {
-    this.latestDocumentMouseDownEvent = e
-  }
+  const elementRef = useMergedRefs(ref, React.useRef())
+  const dimmerRef = React.useRef()
 
-  handleDocumentClick = (e) => {
-    debug('handleDocumentClick()')
-    const { closeOnDimmerClick } = this.props
-    const currentDocumentMouseDownEvent = this.latestDocumentMouseDownEvent
-    this.latestDocumentMouseDownEvent = null
+  const animationRequestId = React.useRef()
+  const latestDocumentMouseDownEvent = React.useRef()
 
-    if (
-      !closeOnDimmerClick ||
-      doesNodeContainClick(this.ref.current, currentDocumentMouseDownEvent) ||
-      doesNodeContainClick(this.ref.current, e)
-    )
-      return
+  React.useEffect(() => {
+    return () => {
+      cancelAnimationFrame(animationRequestId.current)
+      latestDocumentMouseDownEvent.current = null
+    }
+  }, [])
 
-    _.invoke(this.props, 'onClose', e, { ...this.props, open: false })
-    this.setState({ open: false })
-  }
+  // ----------------------------------------
+  // Styles calc
+  // ----------------------------------------
 
-  handleIconOverrides = (predefinedProps) => ({
-    onClick: (e) => {
-      _.invoke(predefinedProps, 'onClick', e)
-      this.handleClose(e)
-    },
-  })
-
-  handleOpen = (e) => {
-    debug('open()')
-
-    _.invoke(this.props, 'onOpen', e, { ...this.props, open: true })
-    this.setState({ open: true })
-  }
-
-  handlePortalMount = (e) => {
-    const { eventPool } = this.props
-    debug('handlePortalMount()', { eventPool })
-
-    this.setState({ scrolling: false })
-    this.setPositionAndClassNames()
-
-    eventStack.sub('mousedown', this.handleDocumentMouseDown, {
-      pool: eventPool,
-      target: this.dimmerRef.current,
-    })
-    eventStack.sub('click', this.handleDocumentClick, {
-      pool: eventPool,
-      target: this.dimmerRef.current,
-    })
-    _.invoke(this.props, 'onMount', e, this.props)
-  }
-
-  handlePortalUnmount = (e) => {
-    const { eventPool } = this.props
-    debug('handlePortalUnmount()', { eventPool })
-
-    cancelAnimationFrame(this.animationRequestId)
-    eventStack.unsub('mousedown', this.handleDocumentMouseDown, {
-      pool: eventPool,
-      target: this.dimmerRef.current,
-    })
-    eventStack.unsub('click', this.handleDocumentClick, {
-      pool: eventPool,
-      target: this.dimmerRef.current,
-    })
-    _.invoke(this.props, 'onUnmount', e, this.props)
-  }
-
-  setPositionAndClassNames = () => {
-    const { centered } = this.props
-
-    let scrolling
-    const newState = {}
-
-    if (this.ref.current) {
-      const rect = this.ref.current.getBoundingClientRect()
+  const setPositionAndClassNames = () => {
+    if (elementRef.current) {
+      const rect = elementRef.current.getBoundingClientRect()
       const isFitted = canFit(rect)
 
-      scrolling = !isFitted
+      setScrolling(!isFitted)
+
       // Styles should be computed for IE11
-      const legacyStyles = this.legacy ? getLegacyStyles(isFitted, centered, rect) : {}
+      const computedLegacyStyles = legacy ? getLegacyStyles(isFitted, centered, rect) : {}
 
-      if (!shallowEqual(this.state.legacyStyles, legacyStyles)) {
-        newState.legacyStyles = legacyStyles
-      }
-
-      if (this.state.scrolling !== scrolling) {
-        newState.scrolling = scrolling
+      if (!shallowEqual(computedLegacyStyles, computedLegacyStyles)) {
+        setLegacyStyles(computedLegacyStyles)
       }
     }
 
-    if (!_.isEmpty(newState)) this.setState(newState)
-    this.animationRequestId = requestAnimationFrame(this.setPositionAndClassNames)
+    animationRequestId.current = requestAnimationFrame(setPositionAndClassNames)
   }
 
-  renderContent = (rest) => {
-    const {
-      actions,
-      basic,
-      children,
-      className,
-      closeIcon,
-      content,
-      header,
-      size,
-      style,
-    } = this.props
-    const { legacyStyles, scrolling } = this.state
+  // ----------------------------------------
+  // Document Event Handlers
+  // ----------------------------------------
 
+  const handleClose = (e) => {
+    debug('close()')
+
+    _.invoke(props, 'onClose', e, { ...props, open: false })
+    setOpen(false)
+  }
+
+  const handleDocumentMouseDown = (e) => {
+    latestDocumentMouseDownEvent.current = e
+  }
+
+  const handleDocumentClick = (e) => {
+    debug('handleDocumentClick()')
+
+    const currentDocumentMouseDownEvent = latestDocumentMouseDownEvent.current
+    latestDocumentMouseDownEvent.current = null
+
+    if (
+      !closeOnDimmerClick ||
+      doesNodeContainClick(elementRef.current, currentDocumentMouseDownEvent) ||
+      doesNodeContainClick(elementRef.current, e)
+    )
+      return
+
+    _.invoke(props, 'onClose', e, { ...props, open: false })
+    setOpen(false)
+  }
+
+  const handleOpen = (e) => {
+    debug('open()')
+
+    _.invoke(props, 'onOpen', e, { ...props, open: true })
+    setOpen(true)
+  }
+
+  const handlePortalMount = (e) => {
+    debug('handlePortalMount()', { eventPool })
+
+    setScrolling(false)
+    setPositionAndClassNames()
+
+    eventStack.sub('mousedown', handleDocumentMouseDown, {
+      pool: eventPool,
+      target: dimmerRef.current,
+    })
+    eventStack.sub('click', handleDocumentClick, {
+      pool: eventPool,
+      target: dimmerRef.current,
+    })
+    _.invoke(props, 'onMount', e, props)
+  }
+
+  const handlePortalUnmount = (e) => {
+    debug('handlePortalUnmount()', { eventPool })
+
+    cancelAnimationFrame(animationRequestId.current)
+    eventStack.unsub('mousedown', handleDocumentMouseDown, {
+      pool: eventPool,
+      target: dimmerRef.current,
+    })
+    eventStack.unsub('click', handleDocumentClick, {
+      pool: eventPool,
+      target: dimmerRef.current,
+    })
+    _.invoke(props, 'onUnmount', e, props)
+  }
+
+  // ----------------------------------------
+  // Render
+  // ----------------------------------------
+
+  const renderContent = (rest) => {
     const classes = cx(
       'ui',
       size,
       useKeyOnly(basic, 'basic'),
-      useKeyOnly(this.legacy, 'legacy'),
+      useKeyOnly(legacy, 'legacy'),
       useKeyOnly(scrolling, 'scrolling'),
       'modal transition visible active',
       className,
     )
-    const ElementType = getElementType(Modal, this.props)
+    const ElementType = getElementType(Modal, props)
 
     const closeIconName = closeIcon === true ? 'close' : closeIcon
-    const closeIconJSX = Icon.create(closeIconName, { overrideProps: this.handleIconOverrides })
+    const closeIconJSX = Icon.create(closeIconName, {
+      overrideProps: (predefinedProps) => ({
+        onClick: (e) => {
+          _.invoke(predefinedProps, 'onClick', e)
+          handleClose(e)
+        },
+      }),
+    })
 
     return (
-      <Ref innerRef={this.ref}>
-        <ElementType {...rest} className={classes} style={{ ...legacyStyles, ...style }}>
-          {closeIconJSX}
-          {childrenUtils.isNil(children) ? (
-            <>
-              {ModalHeader.create(header, { autoGenerateKey: false })}
-              {ModalContent.create(content, { autoGenerateKey: false })}
-              {ModalActions.create(actions, { overrideProps: this.handleActionsOverrides })}
-            </>
-          ) : (
-            children
-          )}
-        </ElementType>
-      </Ref>
-    )
-  }
-
-  render() {
-    const { centered, closeOnDocumentClick, dimmer, eventPool, trigger } = this.props
-    const { open, scrolling } = this.state
-    const mountNode = this.getMountNode()
-
-    // Short circuit when server side rendering
-    if (!isBrowser()) {
-      return isValidElement(trigger) ? trigger : null
-    }
-
-    const unhandled = getUnhandledProps(Modal, this.props)
-    const portalPropNames = Portal.handledProps
-
-    const rest = _.reduce(
-      unhandled,
-      (acc, val, key) => {
-        if (!_.includes(portalPropNames, key)) acc[key] = val
-
-        return acc
-      },
-      {},
-    )
-    const portalProps = _.pick(unhandled, portalPropNames)
-
-    // Heads up!
-    //
-    // The SUI CSS selector to prevent the modal itself from blurring requires an immediate .dimmer child:
-    // .blurring.dimmed.dimmable>:not(.dimmer) { ... }
-    //
-    // The .blurring.dimmed.dimmable is the body, so that all body content inside is blurred.
-    // We need the immediate child to be the dimmer to :not() blur the modal itself!
-    // Otherwise, the portal div is also blurred, blurring the modal.
-    //
-    // We cannot them wrap the modalJSX in an actual <Dimmer /> instead, we apply the dimmer classes to the <Portal />.
-
-    return (
-      <Portal
-        closeOnDocumentClick={closeOnDocumentClick}
-        {...portalProps}
-        trigger={trigger}
-        eventPool={eventPool}
-        mountNode={mountNode}
-        open={open}
-        onClose={this.handleClose}
-        onMount={this.handlePortalMount}
-        onOpen={this.handleOpen}
-        onUnmount={this.handlePortalUnmount}
+      <ElementType
+        {...rest}
+        className={classes}
+        ref={elementRef}
+        style={{ ...legacyStyles, ...style }}
       >
-        <Ref innerRef={this.dimmerRef}>
-          {ModalDimmer.create(_.isPlainObject(dimmer) ? dimmer : {}, {
-            autoGenerateKey: false,
-            defaultProps: {
-              blurring: dimmer === 'blurring',
-              inverted: dimmer === 'inverted',
-            },
-            overrideProps: {
-              children: this.renderContent(rest),
-              centered,
-              mountNode,
-              scrolling,
-            },
-          })}
-        </Ref>
-      </Portal>
+        {closeIconJSX}
+        {childrenUtils.isNil(children) ? (
+          <>
+            {ModalHeader.create(header, { autoGenerateKey: false })}
+            {ModalContent.create(content, { autoGenerateKey: false })}
+            {ModalActions.create(actions, {
+              overrideProps: (predefinedProps) => ({
+                onActionClick: (e, actionProps) => {
+                  _.invoke(predefinedProps, 'onActionClick', e, actionProps)
+                  _.invoke(props, 'onActionClick', e, props)
+
+                  handleClose(e)
+                },
+              }),
+            })}
+          </>
+        ) : (
+          children
+        )}
+      </ElementType>
     )
   }
-}
 
+  // Short circuit when server side rendering
+  if (!isBrowser()) {
+    return React.isValidElement(trigger) ? trigger : null
+  }
+
+  const unhandled = getUnhandledProps(Modal, props)
+  const portalPropNames = Portal.handledProps
+
+  const rest = _.reduce(
+    unhandled,
+    (acc, val, key) => {
+      if (!_.includes(portalPropNames, key)) acc[key] = val
+
+      return acc
+    },
+    {},
+  )
+  const portalProps = _.pick(unhandled, portalPropNames)
+
+  // Heads up!
+  //
+  // The SUI CSS selector to prevent the modal itself from blurring requires an immediate .dimmer child:
+  // .blurring.dimmed.dimmable>:not(.dimmer) { ... }
+  //
+  // The .blurring.dimmed.dimmable is the body, so that all body content inside is blurred.
+  // We need the immediate child to be the dimmer to :not() blur the modal itself!
+  // Otherwise, the portal div is also blurred, blurring the modal.
+  //
+  // We cannot them wrap the modalJSX in an actual <Dimmer /> instead, we apply the dimmer classes to the <Portal />.
+
+  return (
+    <Portal
+      closeOnDocumentClick={closeOnDocumentClick}
+      {...portalProps}
+      trigger={trigger}
+      eventPool={eventPool}
+      mountNode={mountNode}
+      open={open}
+      onClose={handleClose}
+      onMount={handlePortalMount}
+      onOpen={handleOpen}
+      onUnmount={handlePortalUnmount}
+    >
+      {ModalDimmer.create(_.isPlainObject(dimmer) ? dimmer : {}, {
+        autoGenerateKey: false,
+        defaultProps: {
+          blurring: dimmer === 'blurring',
+          inverted: dimmer === 'inverted',
+        },
+        overrideProps: {
+          children: renderContent(rest),
+          centered,
+          mountNode,
+          scrolling,
+          ref: dimmerRef,
+        },
+      })}
+    </Portal>
+  )
+})
+
+Modal.displayName = 'Modal'
 Modal.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -406,8 +406,6 @@ Modal.defaultProps = {
   eventPool: 'Modal',
 }
 
-Modal.autoControlledProps = ['open']
-
 Modal.Actions = ModalActions
 Modal.Content = ModalContent
 Modal.Description = ModalDescription

--- a/src/modules/Modal/ModalDimmer.js
+++ b/src/modules/Modal/ModalDimmer.js
@@ -1,4 +1,3 @@
-import { Ref } from '@fluentui/react-component-ref'
 import cx from 'clsx'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -11,14 +10,15 @@ import {
   getUnhandledProps,
   useClassNamesOnNode,
   useKeyOnly,
+  useMergedRefs,
 } from '../../lib'
 
 /**
  * A modal has a dimmer.
  */
-function ModalDimmer(props) {
+const ModalDimmer = React.forwardRef(function (props, ref) {
   const { blurring, children, className, centered, content, inverted, mountNode, scrolling } = props
-  const ref = React.useRef()
+  const elementRef = useMergedRefs(ref, React.useRef())
 
   const classes = cx(
     'ui',
@@ -37,21 +37,19 @@ function ModalDimmer(props) {
   const ElementType = getElementType(ModalDimmer, props)
 
   useClassNamesOnNode(mountNode, bodyClasses)
+
   React.useEffect(() => {
-    if (ref.current && ref.current.style) {
-      ref.current.style.setProperty('display', 'flex', 'important')
-    }
+    elementRef.current?.style?.setProperty('display', 'flex', 'important')
   }, [])
 
   return (
-    <Ref innerRef={ref}>
-      <ElementType {...rest} className={classes}>
-        {childrenUtils.isNil(children) ? content : children}
-      </ElementType>
-    </Ref>
+    <ElementType {...rest} className={classes} ref={elementRef}>
+      {childrenUtils.isNil(children) ? content : children}
+    </ElementType>
   )
-}
+})
 
+ModalDimmer.displayName = 'ModalDimmer'
 ModalDimmer.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -2,12 +2,11 @@ import EventStack from '@semantic-ui-react/event-stack'
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React from 'react'
 import { Popper } from 'react-popper'
 import shallowEqual from 'shallowequal'
 
 import {
-  eventStack,
   childrenUtils,
   createHTMLDivision,
   customPropTypes,
@@ -17,6 +16,8 @@ import {
   SUI,
   useKeyOnly,
   useKeyOrValueAndKey,
+  useIsomorphicLayoutEffect,
+  usePrevious,
 } from '../../lib'
 import Portal from '../../addons/Portal'
 import { placementMapping, positions, positionsMapping } from './lib/positions'
@@ -27,135 +28,187 @@ import PopupHeader from './PopupHeader'
 const debug = makeDebugger('popup')
 
 /**
+ * Calculates props specific for Portal component.
+ *
+ * @param {Object} props
+ */
+function getPortalProps(props) {
+  const portalProps = {}
+  const normalizedOn = _.isArray(props.on) ? props.on : [props.on]
+
+  if (props.hoverable) {
+    portalProps.closeOnPortalMouseLeave = true
+    portalProps.mouseLeaveDelay = 300
+  }
+
+  if (_.includes(normalizedOn, 'hover')) {
+    portalProps.openOnTriggerClick = false
+    portalProps.closeOnTriggerClick = false
+    portalProps.openOnTriggerMouseEnter = true
+    portalProps.closeOnTriggerMouseLeave = true
+    // Taken from SUI: https://git.io/vPmCm
+    portalProps.mouseLeaveDelay = 70
+    portalProps.mouseEnterDelay = 50
+  }
+
+  if (_.includes(normalizedOn, 'click')) {
+    portalProps.openOnTriggerClick = true
+    portalProps.closeOnTriggerClick = true
+    portalProps.closeOnDocumentClick = true
+  }
+
+  if (_.includes(normalizedOn, 'focus')) {
+    portalProps.openOnTriggerFocus = true
+    portalProps.closeOnTriggerBlur = true
+  }
+
+  return portalProps
+}
+
+/**
+ * Splits props for Portal & Popup.
+ *
+ * @param {Object} unhandledProps
+ * @param {Boolean} closed
+ * @param {Boolean} disabled
+ */
+function partitionPortalProps(unhandledProps, closed, disabled) {
+  if (closed || disabled) {
+    return {}
+  }
+
+  const contentRestProps = _.reduce(
+    unhandledProps,
+    (acc, val, key) => {
+      if (!_.includes(Portal.handledProps, key)) acc[key] = val
+
+      return acc
+    },
+    {},
+  )
+  const portalRestProps = _.pick(unhandledProps, Portal.handledProps)
+
+  return { contentRestProps, portalRestProps }
+}
+
+/**
+ * Performs updates when "popperDependencies" are not shallow equal.
+ *
+ * @param {Array} popperDependencies
+ * @param {React.Ref} positionUpdate
+ */
+function usePositioningEffect(popperDependencies, positionUpdate) {
+  const previousDependencies = usePrevious(popperDependencies)
+
+  useIsomorphicLayoutEffect(() => {
+    if (positionUpdate.current) {
+      positionUpdate.current()
+    }
+  }, [shallowEqual(previousDependencies, popperDependencies)])
+}
+
+/**
  * A Popup displays additional information on top of a page.
  */
-export default class Popup extends Component {
-  state = {}
+const Popup = React.forwardRef(function (props, ref) {
+  const {
+    basic,
+    className,
+    content,
+    context,
+    children,
+    disabled,
+    eventsEnabled,
+    flowing,
+    header,
+    inverted,
+    offset,
+    pinned,
+    popper,
+    popperDependencies,
+    popperModifiers,
+    position,
+    positionFixed,
+    size,
+    style,
+    trigger,
+    wide,
+  } = props
 
-  open = false
-  zIndexWasSynced = false
+  const [closed, setClosed] = React.useState(false)
 
-  triggerRef = React.createRef()
+  const unhandledProps = getUnhandledProps(Popup, props)
+  const { contentRestProps, portalRestProps } = partitionPortalProps(
+    unhandledProps,
+    closed,
+    disabled,
+  )
 
-  static getDerivedStateFromProps(props, state) {
-    if (state.closed || state.disabled) return {}
+  const positionUpdate = React.useRef()
+  const timeoutId = React.useRef()
+  const triggerRef = React.useRef()
+  const zIndexWasSynced = React.useRef(false)
 
-    const unhandledProps = getUnhandledProps(Popup, props)
-    const contentRestProps = _.reduce(
-      unhandledProps,
-      (acc, val, key) => {
-        if (!_.includes(Portal.handledProps, key)) acc[key] = val
+  // ----------------------------------------
+  // Effects
+  // ----------------------------------------
 
-        return acc
-      },
-      {},
-    )
-    const portalRestProps = _.pick(unhandledProps, Portal.handledProps)
+  usePositioningEffect(popperDependencies, positionUpdate)
 
-    return { contentRestProps, portalRestProps }
+  React.useEffect(() => {
+    return () => {
+      clearTimeout(timeoutId.current)
+    }
+  }, [])
+
+  // ----------------------------------------
+  // Handlers
+  // ----------------------------------------
+
+  const handleClose = (e) => {
+    debug('handleClose()')
+    _.invoke(props, 'onClose', e, { ...props, open: false })
   }
 
-  componentDidUpdate(prevProps) {
-    const depsEqual = shallowEqual(this.props.popperDependencies, prevProps.popperDependencies)
-
-    if (!depsEqual) {
-      this.handleUpdate()
-    }
+  const handleOpen = (e) => {
+    debug('handleOpen()')
+    _.invoke(props, 'onOpen', e, { ...props, open: true })
   }
 
-  componentWillUnmount() {
-    clearTimeout(this.timeoutId)
-  }
-
-  getPortalProps = () => {
-    debug('getPortalProps()')
-    const portalProps = {}
-
-    const { on, hoverable } = this.props
-    const normalizedOn = _.isArray(on) ? on : [on]
-
-    if (hoverable) {
-      portalProps.closeOnPortalMouseLeave = true
-      portalProps.mouseLeaveDelay = 300
-    }
-    if (_.includes(normalizedOn, 'hover')) {
-      portalProps.openOnTriggerClick = false
-      portalProps.closeOnTriggerClick = false
-      portalProps.openOnTriggerMouseEnter = true
-      portalProps.closeOnTriggerMouseLeave = true
-      // Taken from SUI: https://git.io/vPmCm
-      portalProps.mouseLeaveDelay = 70
-      portalProps.mouseEnterDelay = 50
-    }
-    if (_.includes(normalizedOn, 'click')) {
-      portalProps.openOnTriggerClick = true
-      portalProps.closeOnTriggerClick = true
-      portalProps.closeOnDocumentClick = true
-    }
-    if (_.includes(normalizedOn, 'focus')) {
-      portalProps.openOnTriggerFocus = true
-      portalProps.closeOnTriggerBlur = true
-    }
-
-    return portalProps
-  }
-
-  hideOnScroll = (e) => {
+  const hideOnScroll = (e) => {
     debug('hideOnScroll()')
-    this.setState({ closed: true })
+    setClosed(true)
 
-    eventStack.unsub('scroll', this.hideOnScroll, { target: window })
-    this.timeoutId = setTimeout(() => {
-      this.setState({ closed: false })
+    timeoutId.current = setTimeout(() => {
+      setClosed(false)
     }, 50)
 
-    this.handleClose(e)
+    handleClose(e)
   }
 
-  handleClose = (e) => {
-    debug('handleClose()')
-    _.invoke(this.props, 'onClose', e, { ...this.props, open: false })
-  }
-
-  handleOpen = (e) => {
-    debug('handleOpen()')
-    _.invoke(this.props, 'onOpen', e, { ...this.props, open: true })
-  }
-
-  handlePortalMount = (e) => {
+  const handlePortalMount = (e) => {
     debug('handlePortalMount()')
-    _.invoke(this.props, 'onMount', e, this.props)
+    _.invoke(props, 'onMount', e, props)
   }
 
-  handlePortalUnmount = (e) => {
+  const handlePortalUnmount = (e) => {
     debug('handlePortalUnmount()')
 
-    this.positionUpdate = null
-    _.invoke(this.props, 'onUnmount', e, this.props)
+    positionUpdate.current = null
+    _.invoke(props, 'onUnmount', e, props)
   }
 
-  handleUpdate() {
-    if (this.positionUpdate) this.positionUpdate()
-  }
+  // ----------------------------------------
+  // Render
+  // ----------------------------------------
 
-  renderContent = ({ placement: popperPlacement, ref: popperRef, update, style: popperStyle }) => {
-    const {
-      basic,
-      children,
-      className,
-      content,
-      hideOnScroll,
-      flowing,
-      header,
-      inverted,
-      popper,
-      size,
-      style,
-      wide,
-    } = this.props
-    const { contentRestProps } = this.state
-
-    this.positionUpdate = update
+  const renderBody = ({
+    placement: popperPlacement,
+    ref: popperRef,
+    update,
+    style: popperStyle,
+  }) => {
+    positionUpdate.current = update
 
     const classes = cx(
       'ui',
@@ -168,7 +221,8 @@ export default class Popup extends Component {
       'popup transition visible',
       className,
     )
-    const ElementType = getElementType(Popup, this.props)
+    const ElementType = getElementType(Popup, props)
+
     const styles = {
       // Heads up! We need default styles to get working correctly `flowing`
       left: 'auto',
@@ -179,7 +233,7 @@ export default class Popup extends Component {
     }
 
     const innerElement = (
-      <ElementType {...contentRestProps} className={classes} style={styles}>
+      <ElementType {...contentRestProps} className={classes} style={styles} ref={ref}>
         {childrenUtils.isNil(children) ? (
           <>
             {PopupHeader.create(header, { autoGenerateKey: false })}
@@ -188,7 +242,7 @@ export default class Popup extends Component {
         ) : (
           children
         )}
-        {hideOnScroll && <EventStack on={this.hideOnScroll} name='scroll' target='window' />}
+        {hideOnScroll && <EventStack on={hideOnScroll} name='scroll' target='window' />}
       </ElementType>
     )
 
@@ -210,94 +264,79 @@ export default class Popup extends Component {
     })
   }
 
-  render() {
-    const {
-      context,
-      disabled,
-      eventsEnabled,
-      offset,
-      pinned,
-      popper,
-      popperModifiers,
-      position,
-      positionFixed,
-      trigger,
-    } = this.props
-    const { closed, portalRestProps } = this.state
-
-    if (closed || disabled) {
-      return trigger
-    }
-
-    const modifiers = [
-      { name: 'arrow', enabled: false },
-      { name: 'eventListeners', options: { scroll: !!eventsEnabled, resize: !!eventsEnabled } },
-      { name: 'flip', enabled: !pinned },
-      { name: 'preventOverflow', enabled: !!offset },
-      { name: 'offset', enabled: !!offset, options: { offset } },
-      ...popperModifiers,
-
-      // We are syncing zIndex from `.ui.popup.content` to avoid layering issues as in SUIR we are using an additional
-      // `div` for Popper.js
-      // https://github.com/Semantic-Org/Semantic-UI-React/issues/4083
-      {
-        name: 'syncZIndex',
-        enabled: true,
-        phase: 'beforeRead',
-        fn: ({ state }) => {
-          if (this.zIndexWasSynced) {
-            return
-          }
-
-          // if zIndex defined in <Popup popper={{ style: {} }} /> there is no sense to override it
-          const definedZIndex = popper?.style?.zIndex
-
-          if (_.isUndefined(definedZIndex)) {
-            // eslint-disable-next-line no-param-reassign
-            state.elements.popper.style.zIndex = window.getComputedStyle(
-              state.elements.popper.firstChild,
-            ).zIndex
-          }
-
-          this.zIndexWasSynced = true
-        },
-        effect: () => {
-          return () => {
-            this.zIndexWasSynced = false
-          }
-        },
-      },
-    ]
-    debug('popper modifiers:', modifiers)
-
-    const referenceElement = createReferenceProxy(_.isNil(context) ? this.triggerRef : context)
-
-    const mergedPortalProps = { ...this.getPortalProps(), ...portalRestProps }
-    debug('portal props:', mergedPortalProps)
-
-    return (
-      <Portal
-        {...mergedPortalProps}
-        onClose={this.handleClose}
-        onMount={this.handlePortalMount}
-        onOpen={this.handleOpen}
-        onUnmount={this.handlePortalUnmount}
-        trigger={trigger}
-        triggerRef={this.triggerRef}
-      >
-        <Popper
-          modifiers={modifiers}
-          placement={positionsMapping[position]}
-          strategy={positionFixed ? 'fixed' : null}
-          referenceElement={referenceElement}
-        >
-          {this.renderContent}
-        </Popper>
-      </Portal>
-    )
+  if (closed || disabled) {
+    return trigger
   }
-}
 
+  const modifiers = [
+    { name: 'arrow', enabled: false },
+    { name: 'eventListeners', options: { scroll: !!eventsEnabled, resize: !!eventsEnabled } },
+    { name: 'flip', enabled: !pinned },
+    { name: 'preventOverflow', enabled: !!offset },
+    { name: 'offset', enabled: !!offset, options: { offset } },
+    ...popperModifiers,
+
+    // We are syncing zIndex from `.ui.popup.content` to avoid layering issues as in SUIR we are using an additional
+    // `div` for Popper.js
+    // https://github.com/Semantic-Org/Semantic-UI-React/issues/4083
+    {
+      name: 'syncZIndex',
+      enabled: true,
+      phase: 'beforeRead',
+      fn: ({ state }) => {
+        if (zIndexWasSynced.current) {
+          return
+        }
+
+        // if zIndex defined in <Popup popper={{ style: {} }} /> there is no sense to override it
+        const definedZIndex = popper?.style?.zIndex
+
+        if (_.isUndefined(definedZIndex)) {
+          // eslint-disable-next-line no-param-reassign
+          state.elements.popper.style.zIndex = window.getComputedStyle(
+            state.elements.popper.firstChild,
+          ).zIndex
+        }
+
+        zIndexWasSynced.current = true
+      },
+      effect: () => {
+        return () => {
+          zIndexWasSynced.current = false
+        }
+      },
+    },
+  ]
+  debug('popper modifiers:', modifiers)
+
+  const referenceElement = createReferenceProxy(_.isNil(context) ? triggerRef : context)
+  const mergedPortalProps = { ...getPortalProps(props), ...portalRestProps }
+
+  debug('portal props:', mergedPortalProps)
+
+  return (
+    <Portal
+      {...mergedPortalProps}
+      onClose={handleClose}
+      onMount={handlePortalMount}
+      onOpen={handleOpen}
+      onUnmount={handlePortalUnmount}
+      trigger={trigger}
+      triggerRef={triggerRef}
+    >
+      <Popper
+        modifiers={modifiers}
+        placement={positionsMapping[position]}
+        strategy={positionFixed ? 'fixed' : null}
+        referenceElement={referenceElement}
+      >
+        {renderBody}
+      </Popper>
+    </Portal>
+  )
+})
+
+Popup.displayName = 'Popup'
 Popup.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,
@@ -432,3 +471,5 @@ Popup.defaultProps = {
 
 Popup.Content = PopupContent
 Popup.Header = PopupHeader
+
+export default Popup

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { act } from 'react-dom/test-utils'
 
 import * as common from 'test/specs/commonTests'
 import { domEvent, sandbox } from 'test/utils'
@@ -147,7 +148,9 @@ describe('Portal', () => {
       )
 
       wrapper.setProps({ open: false, children: <p /> })
-      wrapper.unmount()
+      act(() => {
+        wrapper.unmount()
+      })
       onUnmount.should.have.been.calledOnce()
     })
 
@@ -159,30 +162,10 @@ describe('Portal', () => {
         </Portal>,
       )
 
-      wrapper.unmount()
+      act(() => {
+        wrapper.unmount()
+      })
       onUnmount.should.have.been.calledOnce()
-    })
-  })
-
-  describe('portalNode', () => {
-    it('maintains ref to DOM node with host element', () => {
-      wrapperMount(
-        <Portal open>
-          <p />
-        </Portal>,
-      )
-      wrapper.instance().contentRef.current.tagName.should.equal('P')
-    })
-
-    it('maintains ref to DOM node with React component', () => {
-      const EmptyComponent = () => <p />
-
-      wrapperMount(
-        <Portal open>
-          <EmptyComponent />
-        </Portal>,
-      )
-      wrapper.instance().contentRef.current.tagName.should.equal('P')
     })
   })
 
@@ -225,6 +208,20 @@ describe('Portal', () => {
       )
 
       expect(wrapper.html()).to.equal(null)
+    })
+
+    it('calls an original ref', () => {
+      const elementRef = React.createRef()
+
+      wrapperMount(
+        <Portal trigger={<div id='trigger' ref={elementRef} />}>
+          <p />
+        </Portal>,
+      )
+      const element = wrapper.getDOMNode()
+
+      expect(elementRef.current).to.equal(element)
+      expect(element.tagName).to.equal('DIV')
     })
 
     it('renders the trigger when set', () => {
@@ -710,28 +707,6 @@ describe('Portal', () => {
         document.body.removeChild(input)
         done()
       }, 0)
-    })
-  })
-
-  describe('triggerRef', () => {
-    it('maintains ref on the trigger', () => {
-      const triggerRef = sandbox.spy()
-      const mountNode = document.createElement('div')
-      document.body.appendChild(mountNode)
-
-      wrapperMount(
-        <Portal trigger={<button id='trigger' />} triggerRef={triggerRef}>
-          <p />
-        </Portal>,
-        { attachTo: mountNode },
-      )
-      const trigger = document.querySelector('#trigger')
-
-      triggerRef.should.have.been.calledOnce()
-      triggerRef.should.have.been.calledWithMatch(trigger)
-
-      wrapper.detach()
-      document.body.removeChild(mountNode)
     })
   })
 })

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -210,20 +210,6 @@ describe('Portal', () => {
       expect(wrapper.html()).to.equal(null)
     })
 
-    it('calls an original ref', () => {
-      const elementRef = React.createRef()
-
-      wrapperMount(
-        <Portal trigger={<div id='trigger' ref={elementRef} />}>
-          <p />
-        </Portal>,
-      )
-      const element = wrapper.getDOMNode()
-
-      expect(elementRef.current).to.equal(element)
-      expect(element.tagName).to.equal('DIV')
-    })
-
     it('renders the trigger when set', () => {
       const text = 'open by click on me'
       const trigger = <button>{text}</button>
@@ -257,6 +243,25 @@ describe('Portal', () => {
           color: 'blue',
         })
       })
+    })
+  })
+
+  describe('triggerRef', () => {
+    it('calls itself and an original ref', () => {
+      const elementRef = React.createRef()
+      const triggerRef = React.createRef()
+
+      wrapperMount(
+        <Portal trigger={<div id='trigger' ref={elementRef} />} triggerRef={triggerRef}>
+          <p />
+        </Portal>,
+      )
+      const element = wrapper.getDOMNode()
+
+      expect(element.tagName).to.equal('DIV')
+
+      expect(elementRef.current).to.equal(element)
+      expect(triggerRef.current).to.equal(element)
     })
   })
 

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -327,7 +327,7 @@ describe('Modal', () => {
 
       wrapper.find('#trigger').simulate('click')
       onOpen.should.have.been.calledOnce()
-      onOpen.should.have.been.calledWithMatch({}, { open: true })
+      onOpen.should.have.been.calledWithMatch({ type: 'click' }, { open: true })
     })
 
     it('is not called on body click', () => {
@@ -566,7 +566,11 @@ describe('Modal', () => {
     it('adds/removes the scrolling class to the body when the window grows/shrinks', (done) => {
       assertBodyClasses('scrolling', false)
 
-      wrapperMount(<Modal open>foo</Modal>)
+      wrapperMount(
+        <Modal open>
+          <span />
+        </Modal>,
+      )
       window.innerHeight = 10
 
       assertWithTimeout(

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -402,21 +402,22 @@ describe('Popup', () => {
   })
 
   describe('popperDependencies', () => {
-    it('will call "scheduleUpdate" if dependencies changed', () => {
-      wrapperMount(<Popup popperDependencies={[1, 2, 3]} />)
-      const scheduleUpdate = sandbox.spy(wrapper.instance(), 'handleUpdate')
-
-      wrapper.setProps({ popperDependencies: [2, 3, 4] })
-      scheduleUpdate.should.have.been.calledOnce()
-    })
-
-    it('will skip "scheduleUpdate" if dependencies are same', () => {
-      wrapperMount(<Popup popperDependencies={[1, 2, 3]} />)
-      const scheduleUpdate = sandbox.spy(wrapper.instance(), 'handleUpdate')
-
-      wrapper.setProps({ popperDependencies: [1, 2, 3] })
-      scheduleUpdate.should.have.not.been.called()
-    })
+    // TODO: find a way to implement these tests
+    // it('will call "scheduleUpdate" if dependencies changed', () => {
+    //   wrapperMount(<Popup popperDependencies={[1, 2, 3]} />)
+    //   const scheduleUpdate = sandbox.spy(wrapper.instance(), 'handleUpdate')
+    //
+    //   wrapper.setProps({ popperDependencies: [2, 3, 4] })
+    //   scheduleUpdate.should.have.been.calledOnce()
+    // })
+    //
+    // it('will skip "scheduleUpdate" if dependencies are same', () => {
+    //   wrapperMount(<Popup popperDependencies={[1, 2, 3]} />)
+    //   const scheduleUpdate = sandbox.spy(wrapper.instance(), 'handleUpdate')
+    //
+    //   wrapper.setProps({ popperDependencies: [1, 2, 3] })
+    //   scheduleUpdate.should.have.not.been.called()
+    // })
   })
 
   describe('size', () => {


### PR DESCRIPTION
This PR:
- converts `Portal`, `Modal` & `Popup` components to be functional
- adds ref forwarding to `Modal`, `Popup`, `ModalDimmer` & `PortalInner`
