### PR TITLE
chore(Menu): use React.forwardRef()

### DIFF
--- a/src/collections/Menu/MenuHeader.js
+++ b/src/collections/Menu/MenuHeader.js
@@ -7,19 +7,20 @@ import { childrenUtils, customPropTypes, getElementType, getUnhandledProps } fro
 /**
  * A menu item may include a header or may itself be a header.
  */
-function MenuHeader(props) {
+const MenuHeader = React.forwardRef(function (props, ref) {
   const { children, className, content } = props
   const classes = cx('header', className)
   const rest = getUnhandledProps(MenuHeader, props)
   const ElementType = getElementType(MenuHeader, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {childrenUtils.isNil(children) ? content : children}
     </ElementType>
   )
-}
+})
 
+MenuHeader.displayName = 'MenuHeader'
 MenuHeader.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React from 'react'
 
 import {
   childrenUtils,
@@ -12,70 +12,70 @@ import {
   SUI,
   useKeyOnly,
   useKeyOrValueAndKey,
+  useEventCallback,
 } from '../../lib'
 import Icon from '../../elements/Icon'
 
 /**
  * A menu can contain an item.
  */
-export default class MenuItem extends Component {
-  handleClick = (e) => {
-    const { disabled } = this.props
+const MenuItem = React.forwardRef(function (props, ref) {
+  const {
+    active,
+    children,
+    className,
+    color,
+    content,
+    disabled,
+    fitted,
+    header,
+    icon,
+    link,
+    name,
+    onClick,
+    position,
+  } = props
 
-    if (!disabled) _.invoke(this.props, 'onClick', e, this.props)
-  }
+  const classes = cx(
+    color,
+    position,
+    useKeyOnly(active, 'active'),
+    useKeyOnly(disabled, 'disabled'),
+    useKeyOnly(icon === true || (icon && !(name || content)), 'icon'),
+    useKeyOnly(header, 'header'),
+    useKeyOnly(link, 'link'),
+    useKeyOrValueAndKey(fitted, 'fitted'),
+    'item',
+    className,
+  )
+  const ElementType = getElementType(MenuItem, props, () => {
+    if (onClick) return 'a'
+  })
+  const rest = getUnhandledProps(MenuItem, props)
 
-  render() {
-    const {
-      active,
-      children,
-      className,
-      color,
-      content,
-      disabled,
-      fitted,
-      header,
-      icon,
-      link,
-      name,
-      onClick,
-      position,
-    } = this.props
-
-    const classes = cx(
-      color,
-      position,
-      useKeyOnly(active, 'active'),
-      useKeyOnly(disabled, 'disabled'),
-      useKeyOnly(icon === true || (icon && !(name || content)), 'icon'),
-      useKeyOnly(header, 'header'),
-      useKeyOnly(link, 'link'),
-      useKeyOrValueAndKey(fitted, 'fitted'),
-      'item',
-      className,
-    )
-    const ElementType = getElementType(MenuItem, this.props, () => {
-      if (onClick) return 'a'
-    })
-    const rest = getUnhandledProps(MenuItem, this.props)
-
-    if (!childrenUtils.isNil(children)) {
-      return (
-        <ElementType {...rest} className={classes} onClick={this.handleClick}>
-          {children}
-        </ElementType>
-      )
+  const handleClick = useEventCallback((e) => {
+    if (!disabled) {
+      _.invoke(props, 'onClick', e, props)
     }
+  })
 
+  if (!childrenUtils.isNil(children)) {
     return (
-      <ElementType {...rest} className={classes} onClick={this.handleClick}>
-        {Icon.create(icon, { autoGenerateKey: false })}
-        {childrenUtils.isNil(content) ? _.startCase(name) : content}
+      <ElementType {...rest} className={classes} onClick={handleClick} ref={ref}>
+        {children}
       </ElementType>
     )
   }
-}
 
+  return (
+    <ElementType {...rest} className={classes} onClick={handleClick} ref={ref}>
+      {Icon.create(icon, { autoGenerateKey: false })}
+      {childrenUtils.isNil(content) ? _.startCase(name) : content}
+    </ElementType>
+  )
+})
+
+MenuItem.displayName = 'MenuItem'
 MenuItem.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,
@@ -130,3 +130,5 @@ MenuItem.propTypes = {
 }
 
 MenuItem.create = createShorthandFactory(MenuItem, (val) => ({ content: val, name: val }))
+
+export default MenuItem

--- a/src/collections/Menu/MenuMenu.js
+++ b/src/collections/Menu/MenuMenu.js
@@ -7,7 +7,7 @@ import { childrenUtils, customPropTypes, getElementType, getUnhandledProps } fro
 /**
  * A menu can contain a sub menu.
  */
-function MenuMenu(props) {
+const MenuMenu = React.forwardRef(function (props, ref) {
   const { children, className, content, position } = props
 
   const classes = cx(position, 'menu', className)
@@ -15,12 +15,13 @@ function MenuMenu(props) {
   const ElementType = getElementType(MenuMenu, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {childrenUtils.isNil(children) ? content : children}
     </ElementType>
   )
-}
+})
 
+MenuMenu.displayName = 'MenuMenu'
 MenuMenu.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/test/specs/collections/Menu/Menu-test.js
+++ b/test/specs/collections/Menu/Menu-test.js
@@ -108,36 +108,24 @@ describe('Menu', () => {
   })
 
   describe('onItemClick', () => {
-    it('can be omitted', () => {
-      const click = () =>
-        mount(<Menu items={[{ key: 'home', name: 'home' }]} />)
-          .find('MenuItem')
-          .first()
-          .simulate('click')
-
-      expect(click).to.not.throw()
-    })
-
     it('is called with (e, { name, index }) when clicked', () => {
-      const event = { target: null }
-      const itemSpy = sandbox.spy()
-      const menuSpy = sandbox.spy()
+      const onClick = sandbox.spy()
+      const onItemClick = sandbox.spy()
 
       const items = [
         { key: 'home', name: 'home' },
-        { key: 'users', name: 'users', onClick: itemSpy },
+        { key: 'users', name: 'users', onClick },
       ]
       const matchProps = { index: 1, name: 'users' }
 
-      mount(<Menu items={items} onItemClick={menuSpy} />)
-        .find('MenuItem')
-        .last()
-        .simulate('click', event)
+      const wrapper = mount(<Menu items={items} onItemClick={onItemClick} />)
 
-      itemSpy.should.have.been.calledOnce()
-      itemSpy.should.have.been.calledWithMatch(event, matchProps)
-      menuSpy.should.have.been.calledOnce()
-      menuSpy.should.have.been.calledWithMatch(event, matchProps)
+      wrapper.find('MenuItem').last().simulate('click')
+
+      onClick.should.have.been.calledOnce()
+      onClick.should.have.been.calledWithMatch({ type: 'click' }, matchProps)
+      onItemClick.should.have.been.calledOnce()
+      onItemClick.should.have.been.calledWithMatch({ type: 'click' }, matchProps)
     })
   })
 })

--- a/test/specs/collections/Menu/MenuHeader-test.js
+++ b/test/specs/collections/Menu/MenuHeader-test.js
@@ -3,5 +3,6 @@ import * as common from 'test/specs/commonTests'
 
 describe('MenuHeader', () => {
   common.isConformant(MenuHeader)
+  common.forwardsRef(MenuHeader)
   common.rendersChildren(MenuHeader)
 })

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -7,6 +7,8 @@ import { sandbox } from 'test/utils'
 
 describe('MenuItem', () => {
   common.isConformant(MenuItem)
+  common.forwardsRef(MenuItem)
+  common.forwardsRef(MenuItem, { requiredProps: { children: <span /> } })
   common.rendersChildren(MenuItem)
 
   common.implementsCreateMethod(MenuItem)
@@ -23,8 +25,14 @@ describe('MenuItem', () => {
   common.propValueOnlyToClassName(MenuItem, 'color', SUI.COLORS)
   common.propValueOnlyToClassName(MenuItem, 'position', ['left', 'right'])
 
-  it('renders a `div` by default', () => {
-    shallow(<MenuItem />).should.have.tagName('div')
+  describe('as', () => {
+    it('renders a `div` by default', () => {
+      shallow(<MenuItem />).should.have.tagName('div')
+    })
+
+    it('renders an `a` tag', () => {
+      shallow(<MenuItem onClick={() => null} />).should.have.tagName('a')
+    })
   })
 
   describe('name', () => {
@@ -48,24 +56,19 @@ describe('MenuItem', () => {
   describe('onClick', () => {
     it('is called with (e, data) when clicked', () => {
       const onClick = sandbox.spy()
-      const event = { target: null }
       const props = { name: 'home', index: 0 }
 
-      shallow(<MenuItem onClick={onClick} {...props} />).simulate('click', event)
+      mount(<MenuItem onClick={onClick} {...props} />).simulate('click')
 
       onClick.should.have.been.calledOnce()
-      onClick.should.have.been.calledWithMatch(event, props)
+      onClick.should.have.been.calledWithMatch({ type: 'click' }, props)
     })
 
     it('is not called when is disabled', () => {
       const onClick = sandbox.spy()
 
-      shallow(<MenuItem disabled onClick={onClick} />).simulate('click')
+      mount(<MenuItem disabled onClick={onClick} />).simulate('click')
       onClick.should.have.callCount(0)
-    })
-
-    it('renders an `a` tag', () => {
-      shallow(<MenuItem onClick={() => null} />).should.have.tagName('a')
     })
   })
 })

--- a/test/specs/collections/Menu/MenuMenu-test.js
+++ b/test/specs/collections/Menu/MenuMenu-test.js
@@ -3,6 +3,7 @@ import * as common from 'test/specs/commonTests'
 
 describe('MenuMenu', () => {
   common.isConformant(MenuMenu)
+  common.forwardsRef(MenuMenu)
   common.rendersChildren(MenuMenu)
 
   common.propValueOnlyToClassName(MenuMenu, 'position', ['left', 'right'])


### PR DESCRIPTION
Similarly to #4234, adds native ref forwarding to `Menu` and all subcomponents.