### PR TITLE
chore(Rating|Reveal): use React.forwardRef()

### DIFF
--- a/src/elements/Reveal/Reveal.js
+++ b/src/elements/Reveal/Reveal.js
@@ -14,7 +14,7 @@ import RevealContent from './RevealContent'
 /**
  * A reveal displays additional content in place of previous content when activated.
  */
-function Reveal(props) {
+const Reveal = React.forwardRef(function (props, ref) {
   const { active, animated, children, className, content, disabled, instant } = props
 
   const classes = cx(
@@ -30,12 +30,13 @@ function Reveal(props) {
   const ElementType = getElementType(Reveal, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {childrenUtils.isNil(children) ? content : children}
     </ElementType>
   )
-}
+})
 
+Reveal.displayName = 'Reveal'
 Reveal.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/elements/Reveal/RevealContent.js
+++ b/src/elements/Reveal/RevealContent.js
@@ -13,7 +13,7 @@ import {
 /**
  * A content sub-component for the Reveal.
  */
-function RevealContent(props) {
+const RevealContent = React.forwardRef(function (props, ref) {
   const { children, className, content, hidden, visible } = props
 
   const classes = cx(
@@ -27,12 +27,13 @@ function RevealContent(props) {
   const ElementType = getElementType(RevealContent, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {childrenUtils.isNil(children) ? content : children}
     </ElementType>
   )
-}
+})
 
+RevealContent.displayName = 'RevealContent'
 RevealContent.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -2,59 +2,60 @@ import cx from 'clsx'
 import keyboardKey from 'keyboard-key'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React from 'react'
 
 import { getElementType, getUnhandledProps, useKeyOnly } from '../../lib'
 
 /**
  * An internal icon sub-component for Rating component
  */
-export default class RatingIcon extends Component {
-  handleClick = (e) => {
-    _.invoke(this.props, 'onClick', e, this.props)
+const RatingIcon = React.forwardRef(function (props, ref) {
+  const { active, className, selected } = props
+
+  const classes = cx(
+    useKeyOnly(active, 'active'),
+    useKeyOnly(selected, 'selected'),
+    'icon',
+    className,
+  )
+  const rest = getUnhandledProps(RatingIcon, props)
+  const ElementType = getElementType(RatingIcon, props)
+
+  const handleClick = (e) => {
+    _.invoke(props, 'onClick', e, props)
   }
 
-  handleKeyUp = (e) => {
-    _.invoke(this.props, 'onKeyUp', e, this.props)
+  const handleKeyUp = (e) => {
+    _.invoke(props, 'onKeyUp', e, props)
 
     switch (keyboardKey.getCode(e)) {
       case keyboardKey.Enter:
       case keyboardKey.Spacebar:
         e.preventDefault()
-        _.invoke(this.props, 'onClick', e, this.props)
+        _.invoke(props, 'onClick', e, props)
         break
       default:
     }
   }
 
-  handleMouseEnter = (e) => {
-    _.invoke(this.props, 'onMouseEnter', e, this.props)
+  const handleMouseEnter = (e) => {
+    _.invoke(props, 'onMouseEnter', e, props)
   }
 
-  render() {
-    const { active, className, selected } = this.props
-    const classes = cx(
-      useKeyOnly(active, 'active'),
-      useKeyOnly(selected, 'selected'),
-      'icon',
-      className,
-    )
-    const rest = getUnhandledProps(RatingIcon, this.props)
-    const ElementType = getElementType(RatingIcon, this.props)
+  return (
+    <ElementType
+      role='radio'
+      {...rest}
+      className={classes}
+      onClick={handleClick}
+      onKeyUp={handleKeyUp}
+      onMouseEnter={handleMouseEnter}
+      ref={ref}
+    />
+  )
+})
 
-    return (
-      <ElementType
-        {...rest}
-        className={classes}
-        onClick={this.handleClick}
-        onKeyUp={this.handleKeyUp}
-        onMouseEnter={this.handleMouseEnter}
-        role='radio'
-      />
-    )
-  }
-}
-
+RatingIcon.displayName = 'RatingIcon'
 RatingIcon.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,
@@ -99,3 +100,5 @@ RatingIcon.propTypes = {
 RatingIcon.defaultProps = {
   as: 'i',
 }
+
+export default RatingIcon

--- a/test/specs/elements/Reveal/Reveal-test.js
+++ b/test/specs/elements/Reveal/Reveal-test.js
@@ -4,6 +4,7 @@ import * as common from 'test/specs/commonTests'
 
 describe('Reveal', () => {
   common.isConformant(Reveal)
+  common.forwardsRef(Reveal)
   common.hasSubcomponents(Reveal, [RevealContent])
   common.hasUIClassName(Reveal)
   common.rendersChildren(Reveal)

--- a/test/specs/elements/Reveal/RevealContent-test.js
+++ b/test/specs/elements/Reveal/RevealContent-test.js
@@ -3,6 +3,7 @@ import RevealContent from 'src/elements/Reveal/RevealContent'
 
 describe('RevealContent', () => {
   common.isConformant(RevealContent)
+  common.forwardsRef(RevealContent)
   common.rendersChildren(RevealContent)
 
   common.propKeyOnlyToClassName(RevealContent, 'hidden')

--- a/test/specs/modules/Rating/Rating-test.js
+++ b/test/specs/modules/Rating/Rating-test.js
@@ -8,6 +8,7 @@ import { sandbox } from 'test/utils'
 
 describe('Rating', () => {
   common.isConformant(Rating)
+  common.forwardsRef(Rating)
   common.hasUIClassName(Rating)
 
   common.propKeyOnlyToClassName(Rating, 'disabled')

--- a/test/specs/modules/Rating/RatingIcon-test.js
+++ b/test/specs/modules/Rating/RatingIcon-test.js
@@ -7,6 +7,7 @@ import { sandbox } from 'test/utils'
 
 describe('RatingIcon', () => {
   common.isConformant(RatingIcon)
+  common.forwardsRef(RatingIcon, { tagName: 'i' })
 
   common.propKeyOnlyToClassName(RatingIcon, 'active')
   common.propKeyOnlyToClassName(RatingIcon, 'selected')


### PR DESCRIPTION
Similarly to #4234, adds native ref forwarding to `Rating`, `Reveal` and all subcomponents.