### PR TITLE
fix(Modal|Portal): fix an error with unsafe setState()

### DIFF
--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -196,8 +196,8 @@ class Portal extends Component {
   close = (e) => {
     debug('close()')
 
-    _.invoke(this.props, 'onClose', e, { ...this.props, open: false })
     this.setState({ open: false })
+    _.invoke(this.props, 'onClose', e, { ...this.props, open: false })
   }
 
   closeWithTimeout = (e, delay) => {

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -59,8 +59,8 @@ class Modal extends Component {
   handleClose = (e) => {
     debug('close()')
 
-    _.invoke(this.props, 'onClose', e, { ...this.props, open: false })
     this.setState({ open: false })
+    _.invoke(this.props, 'onClose', e, { ...this.props, open: false })
   }
 
   handleDocumentMouseDown = (e) => {
@@ -80,8 +80,8 @@ class Modal extends Component {
     )
       return
 
-    _.invoke(this.props, 'onClose', e, { ...this.props, open: false })
     this.setState({ open: false })
+    _.invoke(this.props, 'onClose', e, { ...this.props, open: false })
   }
 
   handleIconOverrides = (predefinedProps) => ({

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -421,6 +421,25 @@ describe('Modal', () => {
       domEvent.click(document.body)
       onClose.should.not.have.been.called()
     })
+
+    it('handles unmount without errors', () => {
+      function ControlledExample() {
+        const [open, setState] = React.useState(true)
+
+        return (
+          <>
+            {open && <Modal open onClose={() => setState(false)} />}
+            <button id='close-button' />
+          </>
+        )
+      }
+
+      wrapperMount(<ControlledExample />)
+      assertBodyContains('.ui.modal')
+
+      domEvent.keyDown(document, { key: 'Escape' })
+      assertBodyContains('.ui.modal', false)
+    })
   })
 
   describe('closeOnEscape', () => {


### PR DESCRIPTION
Fixes #4200.

---

This PR fixes a reported issue in #4200. It happens when a component gets unmounted before `.setState()` call.
Test that covers this scenario is also added.