### PR TITLE
chore(Dimmer|Grid|Sidebar): use React.forwardRef()

### DIFF
--- a/src/collections/Grid/Grid.js
+++ b/src/collections/Grid/Grid.js
@@ -20,7 +20,7 @@ import GridRow from './GridRow'
 /**
  * A grid is used to harmonize negative space in a layout.
  */
-function Grid(props) {
+const Grid = React.forwardRef(function (props, ref) {
   const {
     celled,
     centered,
@@ -63,15 +63,16 @@ function Grid(props) {
   const ElementType = getElementType(Grid, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {children}
     </ElementType>
   )
-}
+})
 
 Grid.Column = GridColumn
 Grid.Row = GridRow
 
+Grid.displayName = 'Grid'
 Grid.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/collections/Grid/GridColumn.js
+++ b/src/collections/Grid/GridColumn.js
@@ -19,7 +19,7 @@ import {
 /**
  * A column sub-component for Grid.
  */
-function GridColumn(props) {
+const GridColumn = React.forwardRef(function (props, ref) {
   const {
     children,
     className,
@@ -57,12 +57,13 @@ function GridColumn(props) {
   const ElementType = getElementType(GridColumn, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {children}
     </ElementType>
   )
-}
+})
 
+GridColumn.displayName = 'GridColumn'
 GridColumn.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/collections/Grid/GridRow.js
+++ b/src/collections/Grid/GridRow.js
@@ -17,7 +17,7 @@ import {
 /**
  * A row sub-component for Grid.
  */
-function GridRow(props) {
+const GridRow = React.forwardRef(function (props, ref) {
   const {
     centered,
     children,
@@ -49,12 +49,13 @@ function GridRow(props) {
   const ElementType = getElementType(GridRow, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {children}
     </ElementType>
   )
-}
+})
 
+GridRow.displayName = 'GridRow'
 GridRow.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/modules/Dimmer/Dimmer.js
+++ b/src/modules/Dimmer/Dimmer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React from 'react'
 
 import { createShorthandFactory, getUnhandledProps, isBrowser } from '../../lib'
 import Portal from '../../addons/Portal'
@@ -9,46 +9,49 @@ import DimmerInner from './DimmerInner'
 /**
  * A dimmer hides distractions to focus attention on particular content.
  */
-export default class Dimmer extends Component {
-  handlePortalMount = () => {
-    if (!isBrowser()) return
+const Dimmer = React.forwardRef(function (props, ref) {
+  const { active, page } = props
+  const rest = getUnhandledProps(Dimmer, props)
 
-    // Heads up, IE doesn't support second argument in add()
-    document.body.classList.add('dimmed')
-    document.body.classList.add('dimmable')
-  }
+  if (page) {
+    const handlePortalMount = () => {
+      if (!isBrowser()) {
+        return
+      }
 
-  handlePortalUnmount = () => {
-    if (!isBrowser()) return
-
-    // Heads up, IE doesn't support second argument in add()
-    document.body.classList.remove('dimmed')
-    document.body.classList.remove('dimmable')
-  }
-
-  render() {
-    const { active, page } = this.props
-    const rest = getUnhandledProps(Dimmer, this.props)
-
-    if (page) {
-      return (
-        <Portal
-          closeOnEscape={false}
-          closeOnDocumentClick={false}
-          onMount={this.handlePortalMount}
-          onUnmount={this.handlePortalUnmount}
-          open={active}
-          openOnTriggerClick={false}
-        >
-          <DimmerInner {...rest} active={active} page={page} />
-        </Portal>
-      )
+      // Heads up, IE doesn't support second argument in add()
+      document.body.classList.add('dimmed')
+      document.body.classList.add('dimmable')
     }
 
-    return <DimmerInner {...rest} active={active} page={page} />
-  }
-}
+    const handlePortalUnmount = () => {
+      if (!isBrowser()) {
+        return
+      }
 
+      // Heads up, IE doesn't support second argument in add()
+      document.body.classList.remove('dimmed')
+      document.body.classList.remove('dimmable')
+    }
+
+    return (
+      <Portal
+        closeOnEscape={false}
+        closeOnDocumentClick={false}
+        onMount={handlePortalMount}
+        onUnmount={handlePortalUnmount}
+        open={active}
+        openOnTriggerClick={false}
+      >
+        <DimmerInner {...rest} active={active} page={page} ref={ref} />
+      </Portal>
+    )
+  }
+
+  return <DimmerInner {...rest} active={active} page={page} ref={ref} />
+})
+
+Dimmer.displayName = 'Dimmer'
 Dimmer.propTypes = {
   /** An active dimmer will dim its parent container. */
   active: PropTypes.bool,
@@ -61,3 +64,5 @@ Dimmer.Dimmable = DimmerDimmable
 Dimmer.Inner = DimmerInner
 
 Dimmer.create = createShorthandFactory(Dimmer, (value) => ({ content: value }))
+
+export default Dimmer

--- a/src/modules/Dimmer/DimmerDimmable.js
+++ b/src/modules/Dimmer/DimmerDimmable.js
@@ -13,7 +13,7 @@ import {
 /**
  * A dimmable sub-component for Dimmer.
  */
-function DimmerDimmable(props) {
+const DimmerDimmable = React.forwardRef(function (props, ref) {
   const { blurring, className, children, content, dimmed } = props
 
   const classes = cx(
@@ -26,12 +26,13 @@ function DimmerDimmable(props) {
   const ElementType = getElementType(DimmerDimmable, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {childrenUtils.isNil(children) ? content : children}
     </ElementType>
   )
-}
+})
 
+DimmerDimmable.displayName = 'DimmerDimmable'
 DimmerDimmable.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/modules/Sidebar/SidebarPushable.js
+++ b/src/modules/Sidebar/SidebarPushable.js
@@ -7,19 +7,20 @@ import { childrenUtils, customPropTypes, getElementType, getUnhandledProps } fro
 /**
  * A pushable sub-component for Sidebar.
  */
-function SidebarPushable(props) {
+const SidebarPushable = React.forwardRef(function (props, ref) {
   const { className, children, content } = props
   const classes = cx('pushable', className)
   const rest = getUnhandledProps(SidebarPushable, props)
   const ElementType = getElementType(SidebarPushable, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {childrenUtils.isNil(children) ? content : children}
     </ElementType>
   )
-}
+})
 
+SidebarPushable.displayName = 'SidebarPushable'
 SidebarPushable.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/modules/Sidebar/SidebarPusher.js
+++ b/src/modules/Sidebar/SidebarPusher.js
@@ -13,7 +13,7 @@ import {
 /**
  * A pushable sub-component for Sidebar.
  */
-function SidebarPusher(props) {
+const SidebarPusher = React.forwardRef(function (props, ref) {
   const { className, dimmed, children, content } = props
 
   const classes = cx('pusher', useKeyOnly(dimmed, 'dimmed'), className)
@@ -21,12 +21,13 @@ function SidebarPusher(props) {
   const ElementType = getElementType(SidebarPusher, props)
 
   return (
-    <ElementType {...rest} className={classes}>
+    <ElementType {...rest} className={classes} ref={ref}>
       {childrenUtils.isNil(children) ? content : children}
     </ElementType>
   )
-}
+})
 
+SidebarPusher.displayName = 'SidebarPusher'
 SidebarPusher.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/test/specs/collections/Grid/Grid-test.js
+++ b/test/specs/collections/Grid/Grid-test.js
@@ -7,6 +7,7 @@ import { SUI } from 'src/lib'
 
 describe('Grid', () => {
   common.isConformant(Grid)
+  common.forwardsRef(Grid)
   common.hasSubcomponents(Grid, [GridRow, GridColumn])
   common.hasUIClassName(Grid)
   common.rendersChildren(Grid, {

--- a/test/specs/collections/Grid/GridColumn-test.js
+++ b/test/specs/collections/Grid/GridColumn-test.js
@@ -4,6 +4,7 @@ import * as common from 'test/specs/commonTests'
 
 describe('GridColumn', () => {
   common.isConformant(GridColumn)
+  common.forwardsRef(GridColumn)
   common.rendersChildren(GridColumn, {
     rendersContent: false,
   })

--- a/test/specs/collections/Grid/GridRow-test.js
+++ b/test/specs/collections/Grid/GridRow-test.js
@@ -4,6 +4,7 @@ import * as common from 'test/specs/commonTests'
 
 describe('GridRow', () => {
   common.isConformant(GridRow)
+  common.forwardsRef(GridRow)
   common.rendersChildren(GridRow, {
     rendersContent: false,
   })

--- a/test/specs/modules/Dimmer/Dimmer-test.js
+++ b/test/specs/modules/Dimmer/Dimmer-test.js
@@ -8,6 +8,7 @@ import * as common from 'test/specs/commonTests'
 
 describe('Dimmer', () => {
   common.isConformant(Dimmer)
+  common.forwardsRef(Dimmer)
   common.hasSubcomponents(Dimmer, [DimmerDimmable, DimmerInner])
 
   common.implementsCreateMethod(Dimmer)

--- a/test/specs/modules/Dimmer/DimmerDimmable-test.js
+++ b/test/specs/modules/Dimmer/DimmerDimmable-test.js
@@ -3,6 +3,7 @@ import * as common from 'test/specs/commonTests'
 
 describe('DimmerDimmable', () => {
   common.isConformant(DimmerDimmable)
+  common.forwardsRef(DimmerDimmable)
   common.rendersChildren(DimmerDimmable)
 
   common.propKeyOnlyToClassName(DimmerDimmable, 'blurring')

--- a/test/specs/modules/Dimmer/DimmerInner-test.js
+++ b/test/specs/modules/Dimmer/DimmerInner-test.js
@@ -7,6 +7,7 @@ import { sandbox } from 'test/utils'
 
 describe('DimmerInner', () => {
   common.isConformant(DimmerInner)
+  common.forwardsRef(DimmerInner)
   common.hasUIClassName(DimmerInner)
   common.rendersChildren(DimmerInner)
 
@@ -32,7 +33,7 @@ describe('DimmerInner', () => {
   describe('onClickOutside', () => {
     it('called when Dimmer has not children', () => {
       const onClickOutside = sandbox.spy()
-      const wrapper = shallow(<DimmerInner onClickOutside={onClickOutside} />)
+      const wrapper = mount(<DimmerInner onClickOutside={onClickOutside} />)
 
       wrapper.childAt(0).simulate('click')
       onClickOutside.should.have.been.calledOnce()
@@ -60,10 +61,11 @@ describe('DimmerInner', () => {
 
     it('called when click on Dimmer', () => {
       const onClickOutside = sandbox.spy()
-
-      mount(
+      const wrapper = mount(
         <DimmerInner onClickOutside={onClickOutside}>{faker.hacker.phrase()}</DimmerInner>,
-      ).simulate('click')
+      )
+
+      wrapper.simulate('click')
       onClickOutside.should.have.been.calledOnce()
     })
 

--- a/test/specs/modules/Sidebar/Sidebar-test.js
+++ b/test/specs/modules/Sidebar/Sidebar-test.js
@@ -2,10 +2,11 @@ import React from 'react'
 
 import Sidebar from 'src/modules/Sidebar/Sidebar'
 import * as common from 'test/specs/commonTests'
-import { domEvent, sandbox } from 'test/utils'
+import { assertWithTimeout, domEvent, sandbox } from 'test/utils'
 
 describe('Sidebar', () => {
   common.isConformant(Sidebar)
+  common.forwardsRef(Sidebar)
   common.hasUIClassName(Sidebar)
   common.rendersChildren(Sidebar)
 
@@ -23,12 +24,17 @@ describe('Sidebar', () => {
   common.propValueOnlyToClassName(Sidebar, 'width', ['very thin', 'thin', 'wide', 'very wide'])
 
   describe('componentWillUnmount', () => {
-    it('will call "clearTimeout"', () => {
+    it('will call "clearTimeout"', (done) => {
       const clear = sandbox.spy(window, 'clearTimeout')
       const wrapper = mount(<Sidebar />)
 
+      // start animation
       wrapper.setProps({ visible: true })
-      clear.should.have.been.calledOnce()
+      wrapper.unmount()
+
+      assertWithTimeout(() => {
+        clear.should.have.been.called()
+      }, done)
     })
   })
 

--- a/test/specs/modules/Sidebar/SidebarPushable-test.js
+++ b/test/specs/modules/Sidebar/SidebarPushable-test.js
@@ -3,5 +3,6 @@ import * as common from 'test/specs/commonTests'
 
 describe('SidebarPushable', () => {
   common.isConformant(SidebarPushable)
+  common.forwardsRef(SidebarPushable)
   common.rendersChildren(SidebarPushable)
 })

--- a/test/specs/modules/Sidebar/SidebarPusher-test.js
+++ b/test/specs/modules/Sidebar/SidebarPusher-test.js
@@ -3,6 +3,7 @@ import * as common from 'test/specs/commonTests'
 
 describe('SidebarPusher', () => {
   common.isConformant(SidebarPusher)
+  common.forwardsRef(SidebarPusher)
   common.rendersChildren(SidebarPusher)
 
   common.propKeyOnlyToClassName(SidebarPusher, 'dimmed')


### PR DESCRIPTION
Similarly to #4243, adds native ref forwarding to `Dimmer`, `Grid`, `Sidebar` and all subcomponents.