### PR TITLE
chore(TransitionGroup): use React.forwardRef()

### DIFF
--- a/src/modules/Transition/Transition.js
+++ b/src/modules/Transition/Transition.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import { cloneElement, Component } from 'react'
+import * as React from 'react'
 
 import { makeDebugger, normalizeTransitionDuration, SUI, useKeyOnly } from '../../lib'
 import TransitionGroup from './TransitionGroup'
@@ -29,15 +29,7 @@ const TRANSITION_STYLE_TYPE = {
 /**
  * A transition is an animation usually used to move content in or out of view.
  */
-export default class Transition extends Component {
-  /** @deprecated Static properties will be removed in v2. */
-  static INITIAL = TRANSITION_STATUS_INITIAL
-  static ENTERED = TRANSITION_STATUS_ENTERED
-  static ENTERING = TRANSITION_STATUS_ENTERING
-  static EXITED = TRANSITION_STATUS_EXITED
-  static EXITING = TRANSITION_STATUS_EXITING
-  static UNMOUNTED = TRANSITION_STATUS_UNMOUNTED
-
+export default class Transition extends React.Component {
   static Group = TransitionGroup
 
   state = {
@@ -171,7 +163,7 @@ export default class Transition extends Component {
       return null
     }
 
-    return cloneElement(children, {
+    return React.cloneElement(children, {
       className: this.computeClasses(),
       style: this.computeStyle(),
       ...(process.env.NODE_ENV !== 'production' && {

--- a/test/specs/modules/Transition/TransitionGroup-test.js
+++ b/test/specs/modules/Transition/TransitionGroup-test.js
@@ -7,13 +7,13 @@ import * as common from 'test/specs/commonTests'
 let wrapper
 
 const wrapperMount = (...args) => (wrapper = mount(...args))
-const wrapperShallow = (...args) => (wrapper = shallow(...args))
 
 describe('TransitionGroup', () => {
   common.isConformant(TransitionGroup, {
     rendersFragmentByDefault: true,
     rendersChildren: false,
   })
+  common.forwardsRef(TransitionGroup, { requiredProps: { as: 'div' } })
 
   beforeEach(() => {
     wrapper = undefined
@@ -25,50 +25,50 @@ describe('TransitionGroup', () => {
 
   describe('children', () => {
     it('wraps all children to Transition', () => {
-      shallow(
+      wrapperMount(
         <TransitionGroup>
           <div />
           <div />
           <div />
         </TransitionGroup>,
       )
-        .children()
-        .everyWhere((item) => item.type().should.equal(Transition))
+
+      wrapper.children().everyWhere((item) => item.type().should.equal(Transition))
     })
 
     it('passes props to children', () => {
-      shallow(
+      wrapperMount(
         <TransitionGroup animation='scale' directional duration={1500}>
           <div />
           <div />
           <div />
         </TransitionGroup>,
       )
-        .children()
-        .everyWhere((item) => {
-          item.should.have.prop('animation', 'scale')
-          item.should.have.prop('directional', true)
-          item.should.have.prop('duration', 1500)
-          item.type().should.equal(Transition)
-        })
+
+      wrapper.children().everyWhere((item) => {
+        item.should.have.prop('animation', 'scale')
+        item.should.have.prop('directional', true)
+        item.should.have.prop('duration', 1500)
+        item.type().should.equal(Transition)
+      })
     })
 
     it('wraps new child to Transition and sets transitionOnMount to true', () => {
-      wrapperShallow(
+      wrapperMount(
         <TransitionGroup>
           <div key='first' />
         </TransitionGroup>,
       )
       wrapper.setProps({ children: [<div key='first' />, <div key='second' />] })
 
-      const child = wrapper.childAt(1)
-      child.key().should.equal('.$second')
-      child.type().should.equal(Transition)
-      child.should.have.prop('transitionOnMount', true)
+      const secondChild = wrapper.childAt(1)
+      secondChild.key().should.equal('.$second')
+      secondChild.type().should.equal(Transition)
+      secondChild.should.have.prop('transitionOnMount', true)
     })
 
     it('skips invalid children', () => {
-      wrapperShallow(
+      wrapperMount(
         <TransitionGroup>
           <div key='first' />
         </TransitionGroup>,
@@ -81,7 +81,7 @@ describe('TransitionGroup', () => {
     })
 
     it('sets visible to false when child was removed', () => {
-      wrapperShallow(
+      wrapperMount(
         <TransitionGroup>
           <div key='first' />
           <div key='second' />


### PR DESCRIPTION
Similarly to #4234, adds native ref forwarding to `TransitionGroup`.

### BREAKING CHANGE

This PR also remove static properties on `Transition` component:

```diff
-  static INITIAL = TRANSITION_STATUS_INITIAL
-  static ENTERED = TRANSITION_STATUS_ENTERED
-  static ENTERING = TRANSITION_STATUS_ENTERING
-  static EXITED = TRANSITION_STATUS_EXITED
-  static EXITING = TRANSITION_STATUS_EXITING
-  static UNMOUNTED = TRANSITION_STATUS_UNMOUNTED
```

This properties should not be used in public APIs, but it's still a breaking change.