### PR TITLE
docs(MenuExampleStackable): Adding alt for logo

### DIFF
--- a/docs/src/examples/collections/Menu/Variations/MenuExampleStackable.js
+++ b/docs/src/examples/collections/Menu/Variations/MenuExampleStackable.js
@@ -12,7 +12,7 @@ export default class MenuExampleStackable extends Component {
     return (
       <Menu stackable>
         <Menu.Item>
-          <img src='/logo.png' />
+          <img alt="logo" src='/logo.png' />
         </Menu.Item>
 
         <Menu.Item


### PR DESCRIPTION
`img` elements must have an `alt prop`, either with meaningful text, or an empty string for decorative images =>  `jsx-a11y/alt-text`