### PR TITLE
fix(Search): moved calling on .close() after invoking the results to …

### DIFF
--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -129,7 +129,7 @@ export default class Search extends Component {
     debug(result)
 
     _.invoke(this.props, 'onResultSelect', e, { ...this.props, result })
-    this.close();
+    this.close()
   }
 
   handleSelectionChange = (e) => {

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -129,6 +129,7 @@ export default class Search extends Component {
     debug(result)
 
     _.invoke(this.props, 'onResultSelect', e, { ...this.props, result })
+    this.close();
   }
 
   handleSelectionChange = (e) => {
@@ -176,7 +177,6 @@ export default class Search extends Component {
     // notify the onResultSelect prop that the user is trying to change value
     this.setValue(result.title)
     this.handleResultSelect(e, result)
-    this.close()
   }
 
   closeOnDocumentClick = (e) => {
@@ -224,7 +224,6 @@ export default class Search extends Component {
     // notify the onResultSelect prop that the user is trying to change value
     this.setValue(result.title)
     this.handleResultSelect(e, result)
-    this.close()
   }
 
   handleItemMouseDown = (e) => {


### PR DESCRIPTION
fixes #3389 

Other components closes before invoking. The Search component doesn't do this.

Both handleItemClick and selectItemOnEnter invoke before closing, which can lead to issues when close() is called after the Search component has been unmounted by the parent component (Warning: Can't perform a React state update on an unmounted component).

[In this issue](https://github.com/Semantic-Org/Semantic-UI-React/issues/3389) there also an demo in codesandbox illustrating what happens.

I found it most easy to move the .close() inside handleResultSelect, since its used by both handleItemClick and selectItemOnEnter.