### PR TITLE
fix(Search): type definition for layout renderer

### DIFF
--- a/src/modules/Search/Search.d.ts
+++ b/src/modules/Search/Search.d.ts
@@ -5,6 +5,7 @@ import { InputProps } from '../../elements/Input'
 import SearchCategory, { SearchCategoryProps } from './SearchCategory'
 import SearchResult, { SearchResultProps } from './SearchResult'
 import SearchResults from './SearchResults'
+import { SearchCategoryLayoutProps } from './SearchCategoryLayout'
 
 export interface SearchProps extends StrictSearchProps {
   [key: string]: any
@@ -61,11 +62,10 @@ export interface StrictSearchProps {
   /**
    * Renders the SearchCategory layout.
    *
-   * @param {object} categoryContent - The Renderable SearchCategory contents.
-   * @param {object} resultsContent - The Renderable SearchResult contents.
+   * @param {object} props - The SearchCategoryLayout props object.
    * @returns {*} - Renderable SearchCategory layout.
    */
-  categoryLayoutRenderer?: (props: SearchCategoryProps) => React.ReactElement<any>
+  categoryLayoutRenderer?: (props: SearchCategoryLayoutProps) => React.ReactElement<any>
 
   /**
    * Renders the SearchCategory contents.

--- a/src/modules/Search/Search.d.ts
+++ b/src/modules/Search/Search.d.ts
@@ -65,7 +65,7 @@ export interface StrictSearchProps {
    * @param {object} props - The SearchCategoryLayout props object.
    * @returns {*} - Renderable SearchCategory layout.
    */
-  categoryLayoutRenderer?: (props: SearchCategoryLayoutProps) => React.ReactElement<any>
+  categoryLayoutRenderer?: (props: Pick<SearchCategoryLayoutProps, 'categoryContent' | 'resultsContent'>) => React.ReactElement<any>
 
   /**
    * Renders the SearchCategory contents.

--- a/src/modules/Search/SearchCategory.d.ts
+++ b/src/modules/Search/SearchCategory.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { SemanticShorthandContent } from '../../generic'
+import { SearchCategoryLayoutProps } from './SearchCategoryLayout'
 import SearchResult from './SearchResult'
 
 export interface SearchCategoryProps extends StrictSearchCategoryProps {
@@ -29,14 +30,10 @@ export interface StrictSearchCategoryProps {
   /**
    * Renders the SearchCategory layout.
    *
-   * @param {object} categoryContent - The Renderable SearchCategory contents.
-   * @param {object} resultsContent - The Renderable SearchResult contents.
+   * @param {object} props - The SearchCategoryLayout props object.
    * @returns {*} - Renderable SearchCategory layout.
    */
-  layoutRenderer?: (
-    categoryContent: React.ReactElement<any>,
-    resultsContent: React.ReactElement<any>,
-  ) => React.ReactElement<any>
+  layoutRenderer?: (props: SearchCategoryLayoutProps) => React.ReactElement<any>
 
   /**
    * Renders the category contents.

--- a/src/modules/Search/SearchCategory.d.ts
+++ b/src/modules/Search/SearchCategory.d.ts
@@ -33,7 +33,7 @@ export interface StrictSearchCategoryProps {
    * @param {object} props - The SearchCategoryLayout props object.
    * @returns {*} - Renderable SearchCategory layout.
    */
-  layoutRenderer?: (props: SearchCategoryLayoutProps) => React.ReactElement<any>
+  layoutRenderer?: (props: Pick<SearchCategoryLayoutProps, 'categoryContent' | 'resultsContent'>) => React.ReactElement<any>
 
   /**
    * Renders the category contents.


### PR DESCRIPTION
Fixes #4308 

- Corrected Types.
- `SearchCategoryLayoutProps` is defined and should be used.