### PR TITLE
docs: change links from google.com to example.com

### DIFF
--- a/docs/src/examples/collections/Menu/Content/MenuExampleLinkItem.js
+++ b/docs/src/examples/collections/Menu/Content/MenuExampleLinkItem.js
@@ -11,8 +11,8 @@ export default class MenuExampleLinkItem extends Component {
     return (
       <div>
         <Menu vertical>
-          <Menu.Item href='//google.com' target='_blank'>
-            Visit Google
+          <Menu.Item href='//example.com' target='_blank'>
+            Visit another website
           </Menu.Item>
           <Menu.Item link>Link via prop</Menu.Item>
           <Menu.Item onClick={this.handleClick}>Javascript Link</Menu.Item>

--- a/docs/src/examples/elements/Image/Types/ImageExampleLink.js
+++ b/docs/src/examples/elements/Image/Types/ImageExampleLink.js
@@ -6,7 +6,7 @@ const ImageExampleLink = () => (
     src='/images/wireframe/image-text.png'
     as='a'
     size='medium'
-    href='http://google.com'
+    href='http://example.com'
     target='_blank'
   />
 )

--- a/docs/src/examples/elements/Step/Content/StepExampleLinkHref.js
+++ b/docs/src/examples/elements/Step/Content/StepExampleLinkHref.js
@@ -3,14 +3,14 @@ import { Icon, Step } from 'semantic-ui-react'
 
 const StepExampleLinkHref = () => (
   <Step.Group>
-    <Step active href='http://google.com'>
+    <Step active href='http://example.com'>
       <Icon name='truck' />
       <Step.Content>
         <Step.Title>Shipping</Step.Title>
         <Step.Description>Choose your shipping options</Step.Description>
       </Step.Content>
     </Step>
-    <Step href='http://google.com'>
+    <Step href='http://example.com'>
       <Icon name='credit card' />
       <Step.Content>
         <Step.Title>Billing</Step.Title>

--- a/test/specs/collections/Breadcrumb/Breadcrumb-test.js
+++ b/test/specs/collections/Breadcrumb/Breadcrumb-test.js
@@ -19,7 +19,7 @@ describe('Breadcrumb', () => {
 
   const sections = [
     { key: 'home', content: 'Home', link: true },
-    { key: 't-shirt', content: 'T-Shirt', href: 'google.com' },
+    { key: 't-shirt', content: 'T-Shirt', href: 'example.com' },
   ]
 
   it('renders children with `sections` prop', () => {

--- a/test/specs/collections/Breadcrumb/BreadcrumbSection-test.js
+++ b/test/specs/collections/Breadcrumb/BreadcrumbSection-test.js
@@ -26,10 +26,10 @@ describe('BreadcrumbSection', () => {
     })
 
     it('should have attr `href` when has prop', () => {
-      const section = shallow(<BreadcrumbSection href='http://google.com' />)
+      const section = shallow(<BreadcrumbSection href='http://example.com' />)
 
       section.should.have.tagName('a')
-      section.should.have.attr('href').and.equal('http://google.com')
+      section.should.have.attr('href').and.equal('http://example.com')
     })
   })
 

--- a/test/specs/elements/Image/Image-test.js
+++ b/test/specs/elements/Image/Image-test.js
@@ -49,7 +49,7 @@ describe('Image', () => {
 
   describe('href', () => {
     it('renders an a tag', () => {
-      shallow(<Image href='http://google.com' />)
+      shallow(<Image href='http://example.com' />)
         .type()
         .should.equal('a')
     })

--- a/test/specs/modules/Embed/Embed-test.js
+++ b/test/specs/modules/Embed/Embed-test.js
@@ -165,7 +165,7 @@ describe('Embed', () => {
 
   describe('url', () => {
     it('passes url to iframe', () => {
-      const url = 'https://google.com'
+      const url = 'https://example.com'
 
       shallow(<Embed active url={url} />)
         .find('iframe')


### PR DESCRIPTION
There are sample links in documentation/code to present how link can be created. Currently they link to `google.com`. I suggest to change those to `example.com`. Domain was created by IANA with exactly this usage in mind - showing sample links in documentation.