### PR TITLE
docs(TextArea): fix verbiage in TextArea docs

### DIFF
--- a/docs/src/examples/addons/TextArea/Usage/index.js
+++ b/docs/src/examples/addons/TextArea/Usage/index.js
@@ -9,7 +9,7 @@ const TextAreaUsageExamples = () => (
     <Segment>
       <Message warning>
         <Message.Header>Auto height</Message.Header>
-        We don't support `autoHeight` more. If you need this feature you can use{' '}
+        We don't support `autoHeight` anymore. If you need this feature you can use{' '}
         <a
           href='https://www.npmjs.com/package/react-textarea-autosize'
           rel='noopener noreferrer'


### PR DESCRIPTION
Change the phrase  "don't support more" to "don't support anymore" in the TextArea docs source, for proper English grammar

_First PR, I reviewed the guidelines and I believe I conform. Please let me know if I missed something. Happy to fix._