### PR TITLE
docs(Modal): fix minor confirm modal typo

### DIFF
--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -7,7 +7,7 @@ import Button from '../../elements/Button'
 import Modal from '../../modules/Modal'
 
 /**
- * A Confirm modal gives the user a choice to confirm or cancel an action/
+ * A Confirm modal gives the user a choice to confirm or cancel an action.
  * @see Modal
  */
 class Confirm extends Component {


### PR DESCRIPTION
Change a '/' to a '.' in docs for the confirm modal. Looks like this was a simple typo.

https://react.semantic-ui.com/addons/confirm/

Screenshot of current docs:
![image](https://user-images.githubusercontent.com/97761753/149830551-eed95836-f253-4b89-9590-f2ab2cacbc04.png)
