### PR TITLE
docs(Visibility|Ref): deprecate components

### DIFF
--- a/docs/src/examples/addons/Ref/index.js
+++ b/docs/src/examples/addons/Ref/index.js
@@ -1,26 +1,36 @@
 import React from 'react'
-import { Message } from 'semantic-ui-react'
+import { Message, Icon } from 'semantic-ui-react'
 
 import Types from './Types'
 
 const RefExamples = () => (
   <>
-    <Message info>
-      <p>
-        Currently, it's recommended to use <code>Ref</code> component to get
-        refs to HTML elements from Semantic UI React components as not all
-        components support native ref forwarding via{' '}
-        <code>React.forwardRef()</code>.
-      </p>
-      <p>
-        As it uses deprecated <code>ReactDOM.findDOMNode()</code> you may
-        receive warnings in React's StrictMode. We are working on it in{' '}
-        <a href='https://github.com/Semantic-Org/Semantic-UI-React/issues/3819'>
-          Semantic-Org/Semantic-UI-React#3819
-        </a>
-        .
-      </p>
+    <Message icon warning>
+      <Icon name='warning sign' />
+
+      <Message.Content>
+        <Message.Header>Deprecation notice</Message.Header>
+        <p>
+          <code>Ref</code> component is deprecated and will be removed in the
+          next major release. Please follow our{' '}
+          <a href='https://github.com/Semantic-Org/Semantic-UI-React/pull/4324'>
+            upgrade guide
+          </a>{' '}
+          to avoid breaks during upgrade to v3.
+        </p>
+        <p>
+          It's still recommended to use <code>Ref</code> component with v2 to
+          get refs to HTML elements from Semantic UI React components, but as it
+          uses deprecated <code>ReactDOM.findDOMNode()</code> you may receive
+          warnings in React's StrictMode. We are working on it in{' '}
+          <a href='https://github.com/Semantic-Org/Semantic-UI-React/issues/3819'>
+            Semantic-Org/Semantic-UI-React#3819
+          </a>
+          .
+        </p>
+      </Message.Content>
     </Message>
+
     <Types />
   </>
 )

--- a/docs/src/examples/behaviors/Visibility/index.js
+++ b/docs/src/examples/behaviors/Visibility/index.js
@@ -1,13 +1,30 @@
 import React from 'react'
+import { Message, Icon } from 'semantic-ui-react'
 
 import Types from './Types'
 import Settings from './Settings'
 
 const VisibilityExamples = () => (
-  <div>
+  <>
+    <Message icon warning>
+      <Icon name='warning sign' />
+
+      <Message.Content>
+        <Message.Header>Deprecation notice</Message.Header>
+        <p>
+          <code>Visibility</code> component is deprecated and will be removed in
+          the next major release. Please follow our{' '}
+          <a href='https://github.com/Semantic-Org/Semantic-UI-React/pull/4324'>
+            upgrade guide
+          </a>{' '}
+          to avoid breaks during upgrade to v3.
+        </p>
+      </Message.Content>
+    </Message>
+
     <Types />
     <Settings />
-  </div>
+  </>
 )
 
 export default VisibilityExamples

--- a/src/behaviors/Visibility/Visibility.js
+++ b/src/behaviors/Visibility/Visibility.js
@@ -13,6 +13,8 @@ import {
 
 /**
  * Visibility provides a set of callbacks for when a content appears in the viewport.
+ *
+ * @deprecated This component is deprecated and will be removed in next major release.
  */
 export default class Visibility extends Component {
   calculations = {

--- a/static.routes.js
+++ b/static.routes.js
@@ -107,7 +107,7 @@ export default async () => {
           exampleSources,
           sidebarSections,
           displayName: 'Ref',
-          deprecated: false,
+          deprecated: true,
           seeTags: [],
         }
       },


### PR DESCRIPTION
### ⚠️ Deprecation notice

This PR marks `Visibility` and `Ref` components as deprecated. We will remove them in the next major release, i.e. `3.0.0`.

# `<Ref />`

Internally this component uses [`ReactDOM.findDOMNode()`](https://reactjs.org/docs/react-dom.html#finddomnode) that [has been deprecated in StrictMode](https://reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage) (#3819). [It's not supported in Concurrent mode](https://reactjs.org/docs/concurrent-mode-adoption.html#feature-comparison), too ( ´･･)ﾉ(._.`) This means that usage of `.findDOMNode()` will be problem with upcoming React 18.

## Migration

Semantic UI React v3 will support native ref forwarding via `React.forwardRef()`, but to prevent breaks during upgrade we suggest to import it from a dedicated package:

```diff
-import { Ref } from "semantic-ui-react";
+import Ref from "@semantic-ui-react/component-ref";
```

# `<Visibility />`

The main reason for deprecation and upcoming removal is performance that is far away from native APIs, even in our docs we use [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) (#3985).

### Migration

We suggest to use [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) directly or via React wrappers, for example: [react-intersection-observer](https://www.npmjs.com/package/react-intersection-observer). As it's not a straightforward replacement that may cause issues with adoption we moved out `Visibility` component to a separate package (`@semantic-ui-react/component-visibility`). This means that you can use it already with v2 or upcoming v3:

```diff
-import { Visibility } from "semantic-ui-react";
+import Visibility from "@semantic-ui-react/component-visibility";
```
