### PR TITLE
fix(Search): remove "placeholder" from "defaultProps"

### DIFF
--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -678,7 +678,6 @@ Search.defaultProps = {
   minCharacters: 1,
   noResultsMessage: 'No results found.',
   showNoResults: true,
-  placeholder: '',
 }
 
 Search.autoControlledProps = ['open', 'value']


### PR DESCRIPTION
Fixes a small regression introduced in #4282.
Per https://github.com/Semantic-Org/Semantic-UI-React/pull/4282#issuecomment-1020789792, there is no sense to have `placeholder` in `defaultProps`.