### PR TITLE
docs(Checkbox): minor rework to use hooks, better show controlled mode

### DIFF
--- a/docs/src/examples/modules/Checkbox/Types/CheckboxExampleRadioGroup.js
+++ b/docs/src/examples/modules/Checkbox/Types/CheckboxExampleRadioGroup.js
@@ -1,37 +1,37 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Form, Checkbox } from 'semantic-ui-react'
 
-export default class CheckboxExampleRadioGroup extends Component {
-  state = {}
-  handleChange = (e, { value }) => this.setState({ value })
+function CheckboxExampleRadioGroup() {
+  const [value, setValue] = React.useState('this')
+  const handleChange = (e, data) => setValue({ value: data.value })
 
-  render() {
-    return (
-      <Form>
-        <Form.Field>
-          Selected value: <b>{this.state.value}</b>
-        </Form.Field>
-        <Form.Field>
-          <Checkbox
-            radio
-            label='Choose this'
-            name='checkboxRadioGroup'
-            value='this'
-            checked={this.state.value === 'this'}
-            onChange={this.handleChange}
-          />
-        </Form.Field>
-        <Form.Field>
-          <Checkbox
-            radio
-            label='Or that'
-            name='checkboxRadioGroup'
-            value='that'
-            checked={this.state.value === 'that'}
-            onChange={this.handleChange}
-          />
-        </Form.Field>
-      </Form>
-    )
-  }
+  return (
+    <Form>
+      <Form.Field>
+        Selected value: <b>{value}</b>
+      </Form.Field>
+      <Form.Field>
+        <Checkbox
+          radio
+          label='Choose this'
+          name='checkboxRadioGroup'
+          value='this'
+          checked={value === 'this'}
+          onChange={handleChange}
+        />
+      </Form.Field>
+      <Form.Field>
+        <Checkbox
+          radio
+          label='Or that'
+          name='checkboxRadioGroup'
+          value='that'
+          checked={value === 'that'}
+          onChange={handleChange}
+        />
+      </Form.Field>
+    </Form>
+  )
 }
+
+export default CheckboxExampleRadioGroup

--- a/docs/src/examples/modules/Checkbox/Types/CheckboxExampleRadioGroup.js
+++ b/docs/src/examples/modules/Checkbox/Types/CheckboxExampleRadioGroup.js
@@ -3,7 +3,6 @@ import { Form, Checkbox } from 'semantic-ui-react'
 
 function CheckboxExampleRadioGroup() {
   const [value, setValue] = React.useState('this')
-  const handleChange = (e, data) => setValue({ value: data.value })
 
   return (
     <Form>
@@ -17,7 +16,7 @@ function CheckboxExampleRadioGroup() {
           name='checkboxRadioGroup'
           value='this'
           checked={value === 'this'}
-          onChange={handleChange}
+          onChange={(e, data) => setValue(data.value)}
         />
       </Form.Field>
       <Form.Field>
@@ -27,7 +26,7 @@ function CheckboxExampleRadioGroup() {
           name='checkboxRadioGroup'
           value='that'
           checked={value === 'that'}
-          onChange={handleChange}
+          onChange={(e, data) => setValue(data.value)}
         />
       </Form.Field>
     </Form>

--- a/docs/src/examples/modules/Checkbox/Usage/CheckboxExampleRemoteControl.js
+++ b/docs/src/examples/modules/Checkbox/Usage/CheckboxExampleRemoteControl.js
@@ -1,20 +1,21 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Button, Checkbox } from 'semantic-ui-react'
 
-export default class CheckboxExampleRemoteControl extends Component {
-  state = { checked: false }
-  toggle = () => this.setState((prevState) => ({ checked: !prevState.checked }))
+function CheckboxExampleRemoteControl() {
+  const [checked, setChecked] = React.useState(false)
 
-  render() {
-    return (
-      <div>
-        <Button onClick={this.toggle}>Toggle it</Button>
-        <Checkbox
-          label='Check this box'
-          onChange={this.toggle}
-          checked={this.state.checked}
-        />
-      </div>
-    )
-  }
+  return (
+    <div>
+      <Button onClick={() => setChecked((prevChecked) => !prevChecked)}>
+        Toggle it
+      </Button>
+      <Checkbox
+        label='Check this box'
+        onChange={(e, data) => setChecked(data.checked)}
+        checked={checked}
+      />
+    </div>
+  )
 }
+
+export default CheckboxExampleRemoteControl


### PR DESCRIPTION
This PR updates `CheckboxExampleRemoteControl` & `CheckboxExampleRadioGroup` examples to use functional components & hooks. `CheckboxExampleRemoteControl` shows better work with controlled mode.