### PR TITLE
fix(Progress): clamp bar width and improve propTypes check for progress prop

### DIFF
--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -161,7 +161,12 @@ Progress.propTypes = {
   precision: PropTypes.number,
 
   /** A progress bar can contain a text value indicating current progress. */
-  progress: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['percent', 'ratio', 'value'])]),
+  progress: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.oneOf(['percent']),
+    customPropTypes.every([PropTypes.oneOf(['value']), customPropTypes.demand(['value'])]),
+    customPropTypes.every([PropTypes.oneOf(['ratio']), customPropTypes.demand(['value', 'total'])]),
+  ]),
 
   /** A progress bar can vary in size. */
   size: PropTypes.oneOf(_.without(SUI.SIZES, 'mini', 'huge', 'massive')),

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -23,6 +23,7 @@ class Progress extends Component {
 
     if (!_.isUndefined(percent)) return percent
     if (!_.isUndefined(total) && !_.isUndefined(value)) return (value / total) * 100
+    if (!_.isUndefined(value)) return value
   }
 
   computeValueText = (percent) => {
@@ -34,13 +35,9 @@ class Progress extends Component {
   }
 
   getPercent = () => {
-    const { precision, progress, total, value } = this.props
+    const { precision } = this.props
     const percent = _.clamp(this.calculatePercent(), 0, 100)
 
-    if (!_.isUndefined(total) && !_.isUndefined(value) && progress === 'value') {
-      return (value / total) * 100
-    }
-    if (progress === 'value') return value
     if (_.isUndefined(precision)) return percent
     return _.round(percent, precision)
   }

--- a/test/specs/modules/Progress/Progress-test.js
+++ b/test/specs/modules/Progress/Progress-test.js
@@ -85,6 +85,15 @@ describe('Progress', () => {
         .find('.bar')
         .should.have.style('width', '50%')
     })
+    it('cannot have its width set >100%, when progress="value"', () => {
+      shallow(<Progress progress='value' value={10} total={5} />)
+        .find('.bar')
+        .should.have.style('width', '100%')
+
+      shallow(<Progress progress='value' value={200} />)
+        .find('.bar')
+        .should.have.style('width', '100%')
+    })
   })
 
   describe('data-percent', () => {


### PR DESCRIPTION
Fix some inconsistencies in `Progress` bar width and invalid prop combos.

1. bar width: `progress='value'` and `value > total`
e.g. `<Progress progress='value' value={51} total={50} />` 
 
**Expected Result**: progress bar with text `51` and width clamped to 100% to match behavior with any other value for `progress`
 
**Actual Result**: progress bar with text `51` and width 102%

1. bar width: `value` without `total`
e.g. `<Progress value={50} />`
 
**Expected Result**: progress bar with width 50% to match behavior with `progress='value'`
 
**Actual Result**: progress bar with min width

1. bad prop combo: `progress='ratio` without `value` or `total`
e.g. `<Progress progress="ratio" />`
 
**Expected Result**: `propTypes` error
 
**Actual Result**: no `propTypes` error, progress bar with text `undefined/undefined`

1. bad prop combo: `progress='value'` without `value`
e.g. `<Progress progress="value" />`
 
**Expected Result**: `propTypes` error
 
**Actual Result**: no `propTypes` error

### Version
2.1.1

### Testcase
https://codesandbox.io/s/progress-problem-with-progress-value-odipb?file=/index.js