### PR TITLE
fix(Dropdown): Keep open dropdown focused on mousedown

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -404,10 +404,15 @@ export default class Dropdown extends Component {
 
   handleMouseDown = (e) => {
     debug('handleMouseDown()')
+    const { open } = this.state
 
     this.isMouseDown = true
     _.invoke(this.props, 'onMouseDown', e, this.props)
     document.addEventListener('mouseup', this.handleDocumentMouseUp)
+
+    if (open) {
+      _.invoke(this.ref.current, 'focus')
+    }
   }
 
   handleDocumentMouseUp = () => {


### PR DESCRIPTION
Ensure that dropdown focus is not taken over by `mousedown` propagation.
Otherwise, this could cause the dropdown from remaining open after onClick
option.

Closes #4036