### PR TITLE
chore: refactor tests for classnames to use mount()

### DIFF
--- a/test/specs/addons/Confirm/Confirm-test.js
+++ b/test/specs/addons/Confirm/Confirm-test.js
@@ -32,12 +32,14 @@ describe('Confirm', () => {
     autoGenerateKey: false,
     propKey: 'header',
     ShorthandComponent: Modal.Header,
+    rendersPortal: true,
     mapValueToProps: (content) => ({ content }),
   })
   common.implementsShorthandProp(Confirm, {
     autoGenerateKey: false,
     propKey: 'content',
     ShorthandComponent: Modal.Content,
+    rendersPortal: true,
     mapValueToProps: (content) => ({ content }),
   })
 

--- a/test/specs/commonTests/implementsClassNameProps.js
+++ b/test/specs/commonTests/implementsClassNameProps.js
@@ -55,12 +55,11 @@ export const propKeyOnlyToClassName = (Component, propKey, options = {}) => {
 
       const element = React.createElement(Component, { ...requiredProps, [propKey]: true })
       const wrapper = mount(element)
+      const elementClassName = wrapper.childAt(0).getDOMNode().className
 
       // ".should.have.className" with "mount" renderer does not handle properly cases when "className" contains
-      // multiple classes. That's why ".split()" is required.
-      className.split(' ').forEach((classNamePart) => {
-        wrapper.childAt(0).should.have.className(classNamePart)
-      })
+      // multiple classes.
+      expect(elementClassName).include(className)
     })
 
     it('does not add prop value to className', () => {
@@ -100,15 +99,13 @@ export const propKeyOrValueAndKeyToClassName = (Component, propKey, propValues, 
     })
 
     it('adds only the name to className when true', () => {
-      shallow(React.createElement(Component, { ...requiredProps, [propKey]: true }), {
-        autoNesting: true,
-      }).should.have.className(className)
+      const wrapper = mount(React.createElement(Component, { ...requiredProps, [propKey]: true }))
+
+      wrapper.should.have.className(className)
     })
 
     it('adds no className when false', () => {
-      const wrapper = shallow(
-        React.createElement(Component, { ...requiredProps, [propKey]: false }),
-      )
+      const wrapper = mount(React.createElement(Component, { ...requiredProps, [propKey]: false }))
 
       wrapper.should.not.have.className(className)
       wrapper.should.not.have.className('true')

--- a/test/specs/commonTests/implementsShorthandProp.js
+++ b/test/specs/commonTests/implementsShorthandProp.js
@@ -28,6 +28,7 @@ const shorthandComponentName = (ShorthandComponent) => {
  * @param {function} options.mapValueToProps A function that maps a primitive value to the Component props.
  * @param {Boolean} [options.parentIsFragment=false] A flag that shows the type of the Component to test.
  * @param {Object} [options.requiredProps={}] Props required to render the component.
+ * @param {boolean} [options.rendersPortal=false] Does this component render a Portal powered component?
  * @param {Object} [options.shorthandDefaultProps] Default props for the shorthand component.
  * @param {Object} [options.shorthandOverrideProps] Override props for the shorthand component.
  */
@@ -38,6 +39,7 @@ export default (Component, options = {}) => {
     autoGenerateKey = true,
     mapValueToProps,
     parentIsFragment = false,
+    rendersPortal = false,
     propKey,
     ShorthandComponent,
     shorthandDefaultProps = {},
@@ -79,7 +81,7 @@ export default (Component, options = {}) => {
         shallow(<Component {...requiredProps} />).should.have.descendants(ShorthandComponent)
       })
     } else {
-      if (!parentIsFragment) {
+      if (!parentIsFragment && !rendersPortal) {
         noDefaultClassNameFromProp(Component, propKey, [], options)
       }
 


### PR DESCRIPTION
This PR refactors tests for classes use `mount()` from Enzyme.

This is mainly a requirement for #4338. And extracted from there to better understand coverage issues happened in that PR.