### PR TITLE
chore: refactor tests for shorthands to use mount()

### DIFF
--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -530,14 +530,13 @@ Flag.propTypes = {
   name: customPropTypes.suggest(names),
 }
 
-Flag.defaultProps = {
-  as: 'i',
-}
-
 // Heads up!
 // .create() factories should be defined on exported component to be visible as static properties
 const MemoFlag = React.memo(Flag)
 
 MemoFlag.create = createShorthandFactory(MemoFlag, (value) => ({ name: value }))
+MemoFlag.defaultProps = {
+  as: 'i',
+}
 
 export default MemoFlag

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -148,15 +148,15 @@ Icon.propTypes = {
   'aria-label': PropTypes.string,
 }
 
-Icon.defaultProps = {
-  as: 'i',
-}
-
 // Heads up!
 // .create() factories should be defined on exported component to be visible as static properties
 const MemoIcon = React.memo(Icon)
 
 MemoIcon.Group = IconGroup
 MemoIcon.create = createShorthandFactory(MemoIcon, (value) => ({ name: value }))
+
+MemoIcon.defaultProps = {
+  as: 'i',
+}
 
 export default MemoIcon

--- a/test/specs/addons/Confirm/Confirm-test.js
+++ b/test/specs/addons/Confirm/Confirm-test.js
@@ -34,6 +34,7 @@ describe('Confirm', () => {
     ShorthandComponent: Modal.Header,
     rendersPortal: true,
     mapValueToProps: (content) => ({ content }),
+    requiredProps: { open: true },
   })
   common.implementsShorthandProp(Confirm, {
     autoGenerateKey: false,
@@ -41,6 +42,7 @@ describe('Confirm', () => {
     ShorthandComponent: Modal.Content,
     rendersPortal: true,
     mapValueToProps: (content) => ({ content }),
+    requiredProps: { open: true },
   })
 
   describe('children', () => {

--- a/test/specs/commonTests/implementsCommonProps.js
+++ b/test/specs/commonTests/implementsCommonProps.js
@@ -110,6 +110,7 @@ export const implementsHTMLLabelProp = (Component, options = {}) => {
  */
 export const implementsIconProp = (Component, options = {}) => {
   implementsShorthandProp(Component, {
+    assertExactMatch: false,
     propKey: 'icon',
     ShorthandComponent: Icon,
     mapValueToProps: (val) => ({ name: val }),

--- a/test/specs/commonTests/implementsShorthandProp.js
+++ b/test/specs/commonTests/implementsShorthandProp.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
-import React, { createElement } from 'react'
+import React from 'react'
+import ReactIs from 'react-is'
 
 import { createShorthand } from 'src/lib'
 import { consoleUtil, getComponentName } from 'test/utils'
@@ -41,13 +42,18 @@ export default (Component, options = {}) => {
     parentIsFragment = false,
     rendersPortal = false,
     propKey,
-    ShorthandComponent,
     shorthandDefaultProps = {},
     shorthandOverrideProps = {},
+    rendersPortal = false,
     requiredProps = {},
   } = options
   const { assertRequired } = helpers('implementsShorthandProp', Component)
-  const assertMethod = assertExactMatch ? 'contain' : 'containMatchingElement'
+
+  const assertMethod = assertExactMatch ? 'equals' : 'matchesElement'
+  const ShorthandComponent =
+    options.ShorthandComponent.$$typeof === ReactIs.Memo
+      ? options.ShorthandComponent.type
+      : options.ShorthandComponent
 
   describe(`${propKey} shorthand prop (common)`, () => {
     assertRequired(Component, 'a `Component`')
@@ -62,23 +68,25 @@ export default (Component, options = {}) => {
         overrideProps: shorthandOverrideProps,
         autoGenerateKey,
       })
-      const element = createElement(Component, { ...requiredProps, [propKey]: value })
-      const wrapper = shallow(element)
+      const wrapper = mount(React.createElement(Component, { ...requiredProps, [propKey]: value }))
 
-      wrapper.should[assertMethod](expectedShorthandElement)
+      const result = wrapper.find(ShorthandComponent)
+
+      expect(result[assertMethod](expectedShorthandElement)).to.equal(true)
 
       // Enzyme's .key() method is not consistent with React for elements with
       // no key (`undefined` vs `null`), so use the underlying element instead
       // Will fail if more than one element of this type is found
       if (autoGenerateKey) {
-        const shorthandElement = wrapper.find(ShorthandComponent).getElement()
-        expect(shorthandElement.key).to.equal(expectedShorthandElement.key, "key doesn't match")
+        expect(result.getElement().key).to.equal(expectedShorthandElement.key, "key doesn't match")
       }
     }
 
     if (alwaysPresent || (Component.defaultProps && Component.defaultProps[propKey])) {
       it(`has default ${name} when not defined`, () => {
-        shallow(<Component {...requiredProps} />).should.have.descendants(ShorthandComponent)
+        const wrapper = mount(React.createElement(Component, requiredProps))
+
+        wrapper.should.have.descendants(ShorthandComponent)
       })
     } else {
       if (!parentIsFragment && !rendersPortal) {
@@ -86,15 +94,18 @@ export default (Component, options = {}) => {
       }
 
       it(`has no ${name} when not defined`, () => {
-        shallow(<Component {...requiredProps} />).should.not.have.descendants(ShorthandComponent)
+        const wrapper = mount(React.createElement(Component, requiredProps))
+
+        wrapper.should.not.have.descendants(ShorthandComponent)
       })
     }
 
     if (!alwaysPresent) {
       it(`has no ${name} when null`, () => {
-        shallow(
-          createElement(Component, { ...requiredProps, [propKey]: null }),
-        ).should.not.have.descendants(ShorthandComponent)
+        const element = React.createElement(Component, { ...requiredProps, [propKey]: null })
+        const wrapper = mount(element)
+
+        wrapper.should.not.have.descendants(ShorthandComponent)
       })
     }
 

--- a/test/specs/commonTests/implementsShorthandProp.js
+++ b/test/specs/commonTests/implementsShorthandProp.js
@@ -58,6 +58,12 @@ export default (Component, options = {}) => {
       : options.ShorthandComponent
 
   describe(`${propKey} shorthand prop (common)`, () => {
+    let wrapper
+
+    afterEach(() => {
+      if (wrapper && wrapper.unmount) wrapper.unmount()
+    })
+
     assertRequired(Component, 'a `Component`')
     assertRequired(_.isPlainObject(options), 'an `options` object')
     assertRequired(propKey, 'a `propKey`')
@@ -70,7 +76,7 @@ export default (Component, options = {}) => {
         overrideProps: shorthandOverrideProps,
         autoGenerateKey,
       })
-      const wrapper = mount(React.createElement(Component, { ...requiredProps, [propKey]: value }))
+      wrapper = mount(React.createElement(Component, { ...requiredProps, [propKey]: value }))
 
       const result = wrapper.find(ShorthandComponent)
 
@@ -86,7 +92,7 @@ export default (Component, options = {}) => {
 
     if (alwaysPresent || (Component.defaultProps && Component.defaultProps[propKey])) {
       it(`has default ${name} when not defined`, () => {
-        const wrapper = mount(React.createElement(Component, requiredProps))
+        wrapper = mount(React.createElement(Component, requiredProps))
 
         wrapper.should.have.descendants(ShorthandComponent)
       })
@@ -96,7 +102,7 @@ export default (Component, options = {}) => {
       }
 
       it(`has no ${name} when not defined`, () => {
-        const wrapper = mount(React.createElement(Component, requiredProps))
+        wrapper = mount(React.createElement(Component, requiredProps))
 
         wrapper.should.not.have.descendants(ShorthandComponent)
       })
@@ -105,7 +111,7 @@ export default (Component, options = {}) => {
     if (!alwaysPresent) {
       it(`has no ${name} when null`, () => {
         const element = React.createElement(Component, { ...requiredProps, [propKey]: null })
-        const wrapper = mount(element)
+        wrapper = mount(element)
 
         wrapper.should.not.have.descendants(ShorthandComponent)
       })

--- a/test/specs/commonTests/implementsShorthandProp.js
+++ b/test/specs/commonTests/implementsShorthandProp.js
@@ -44,12 +44,14 @@ export default (Component, options = {}) => {
     propKey,
     shorthandDefaultProps = {},
     shorthandOverrideProps = {},
-    rendersPortal = false,
     requiredProps = {},
   } = options
   const { assertRequired } = helpers('implementsShorthandProp', Component)
 
   const assertMethod = assertExactMatch ? 'equals' : 'matchesElement'
+  // Heads up!
+  // Enzyme does handle properly React.memo() in find and always returns inner component
+  // That's why we should unwrap it, otherwise "wrapper.find(Component)" is not equal to "Component" 💥
   const ShorthandComponent =
     options.ShorthandComponent.$$typeof === ReactIs.Memo
       ? options.ShorthandComponent.type

--- a/test/specs/modules/Dropdown/DropdownItem-test.js
+++ b/test/specs/modules/Dropdown/DropdownItem-test.js
@@ -22,6 +22,7 @@ describe('DropdownItem', () => {
   common.implementsImageProp(DropdownItem, { autoGenerateKey: false })
 
   common.implementsShorthandProp(DropdownItem, {
+    assertExactMatch: false,
     autoGenerateKey: false,
     propKey: 'flag',
     ShorthandComponent: Flag,


### PR DESCRIPTION
This PR refactors tests for shorthands use `mount()` from Enzyme.

This is mainly a requirement for #4338. _And extracted from there to better understand coverage issues happened in that PR._