### PR TITLE
fix: make typings compatible with @types/react@18

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,8 +197,7 @@
     "react-router": "^5.0.0",
     "react-router-dom": "^5.0.0",
     "react-test-renderer": "^17.0.0",
-    "react-universal-component": "^3.0.3",
-    "@types/react": "18.0.5"
+    "react-universal-component": "^3.0.3"
   },
   "changelog": {
     "repo": "Semantic-Org/Semantic-UI-React",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@percy/cli": "^1.0.0-beta.73",
     "@percy/cypress": "^3.1.1",
     "@size-limit/file": "^4.5.5",
-    "@types/react": "^16.9.43",
+    "@types/react": "18.0.5",
     "@typescript-eslint/eslint-plugin": "^3.7.1",
     "@typescript-eslint/parser": "^3.7.1",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.1.1",
@@ -197,7 +197,8 @@
     "react-router": "^5.0.0",
     "react-router-dom": "^5.0.0",
     "react-test-renderer": "^17.0.0",
-    "react-universal-component": "^3.0.3"
+    "react-universal-component": "^3.0.3",
+    "@types/react": "18.0.5"
   },
   "changelog": {
     "repo": "Semantic-Org/Semantic-UI-React",

--- a/src/addons/Radio/Radio.d.ts
+++ b/src/addons/Radio/Radio.d.ts
@@ -16,6 +16,6 @@ export interface StrictRadioProps extends StrictCheckboxProps {
   type?: 'checkbox' | 'radio'
 }
 
-declare const Radio: React.StatelessComponent<RadioProps>
+declare const Radio: React.FC<RadioProps>
 
 export default Radio

--- a/src/addons/Select/Select.d.ts
+++ b/src/addons/Select/Select.d.ts
@@ -15,7 +15,7 @@ export interface StrictSelectProps extends StrictDropdownProps {
   options: DropdownItemProps[]
 }
 
-interface SelectComponent extends React.StatelessComponent<SelectProps> {
+interface SelectComponent extends React.FC<SelectProps> {
   Divider: typeof DropdownDivider
   Header: typeof DropdownHeader
   Item: typeof DropdownItem

--- a/src/collections/Breadcrumb/BreadcrumbDivider.d.ts
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.d.ts
@@ -24,6 +24,6 @@ export interface StrictBreadcrumbDividerProps {
   icon?: SemanticShorthandItem<IconProps>
 }
 
-declare const BreadcrumbDivider: React.StatelessComponent<BreadcrumbDividerProps>
+declare const BreadcrumbDivider: React.FC<BreadcrumbDividerProps>
 
 export default BreadcrumbDivider

--- a/src/collections/Form/Form.d.ts
+++ b/src/collections/Form/Form.d.ts
@@ -58,7 +58,7 @@ export interface StrictFormProps {
   widths?: 'equal'
 }
 
-export interface FormComponent extends React.StatelessComponent<FormProps> {
+export interface FormComponent extends React.FC<FormProps> {
   Field: typeof FormField
   Button: typeof FormButton
   Checkbox: typeof FormCheckbox

--- a/src/collections/Form/FormButton.d.ts
+++ b/src/collections/Form/FormButton.d.ts
@@ -10,7 +10,7 @@ export interface FormButtonProps extends StrictFormButtonProps {
 }
 
 export interface StrictFormButtonProps
-  extends StrictFormFieldProps,
+  extends Omit<StrictFormFieldProps, 'label'>,
     Omit<StrictButtonProps, 'type'> {
   /** An element type to render as (string or function). */
   as?: any
@@ -22,6 +22,6 @@ export interface StrictFormButtonProps
   label?: SemanticShorthandItem<LabelProps>
 }
 
-declare const FormButton: React.StatelessComponent<FormButtonProps>
+declare const FormButton: React.FC<FormButtonProps>
 
 export default FormButton

--- a/src/collections/Form/FormCheckbox.d.ts
+++ b/src/collections/Form/FormCheckbox.d.ts
@@ -18,6 +18,6 @@ export interface StrictFormCheckboxProps extends StrictFormFieldProps, StrictChe
   type?: 'checkbox' | 'radio'
 }
 
-declare const FormCheckbox: React.StatelessComponent<FormCheckboxProps>
+declare const FormCheckbox: React.FC<FormCheckboxProps>
 
 export default FormCheckbox

--- a/src/collections/Form/FormDropdown.d.ts
+++ b/src/collections/Form/FormDropdown.d.ts
@@ -18,6 +18,6 @@ export interface StrictFormDropdownProps extends StrictFormFieldProps, StrictDro
   error?: any
 }
 
-declare const FormDropdown: React.StatelessComponent<FormDropdownProps>
+declare const FormDropdown: React.FC<FormDropdownProps>
 
 export default FormDropdown

--- a/src/collections/Form/FormField.d.ts
+++ b/src/collections/Form/FormField.d.ts
@@ -57,6 +57,6 @@ export interface StrictFormFieldProps {
   width?: SemanticWIDTHS
 }
 
-declare const FormField: React.StatelessComponent<FormFieldProps>
+declare const FormField: React.FC<FormFieldProps>
 
 export default FormField

--- a/src/collections/Form/FormGroup.d.ts
+++ b/src/collections/Form/FormGroup.d.ts
@@ -28,6 +28,6 @@ export interface StrictFormGroupProps {
   widths?: SemanticWIDTHS | 'equal'
 }
 
-declare const FormGroup: React.StatelessComponent<FormGroupProps>
+declare const FormGroup: React.FC<FormGroupProps>
 
 export default FormGroup

--- a/src/collections/Form/FormInput.d.ts
+++ b/src/collections/Form/FormInput.d.ts
@@ -9,7 +9,9 @@ export interface FormInputProps extends StrictFormInputProps {
   [key: string]: any
 }
 
-export interface StrictFormInputProps extends StrictFormFieldProps, StrictInputProps {
+export interface StrictFormInputProps
+  extends Omit<StrictFormFieldProps, 'label'>,
+    StrictInputProps {
   /** An element type to render as (string or function). */
   as?: any
 
@@ -23,6 +25,6 @@ export interface StrictFormInputProps extends StrictFormFieldProps, StrictInputP
   label?: SemanticShorthandItem<LabelProps>
 }
 
-declare const FormInput: React.StatelessComponent<FormInputProps>
+declare const FormInput: React.FC<FormInputProps>
 
 export default FormInput

--- a/src/collections/Form/FormRadio.d.ts
+++ b/src/collections/Form/FormRadio.d.ts
@@ -18,6 +18,6 @@ export interface StrictFormRadioProps extends StrictFormFieldProps, StrictRadioP
   type?: 'checkbox' | 'radio'
 }
 
-declare const FormRadio: React.StatelessComponent<FormRadioProps>
+declare const FormRadio: React.FC<FormRadioProps>
 
 export default FormRadio

--- a/src/collections/Form/FormSelect.d.ts
+++ b/src/collections/Form/FormSelect.d.ts
@@ -24,6 +24,6 @@ export interface StrictFormSelectProps extends StrictFormFieldProps, StrictSelec
   options: DropdownItemProps[]
 }
 
-declare const FormSelect: React.StatelessComponent<FormSelectProps>
+declare const FormSelect: React.FC<FormSelectProps>
 
 export default FormSelect

--- a/src/collections/Form/FormTextArea.d.ts
+++ b/src/collections/Form/FormTextArea.d.ts
@@ -15,6 +15,6 @@ export interface StrictFormTextAreaProps extends StrictFormFieldProps, StrictTex
   control?: any
 }
 
-declare const FormTextArea: React.StatelessComponent<FormTextAreaProps>
+declare const FormTextArea: React.FC<FormTextAreaProps>
 
 export default FormTextArea

--- a/src/collections/Grid/Grid.d.ts
+++ b/src/collections/Grid/Grid.d.ts
@@ -70,7 +70,7 @@ export interface StrictGridProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-interface GridComponent extends React.StatelessComponent<GridProps> {
+interface GridComponent extends React.FC<GridProps> {
   Column: typeof GridColumn
   Row: typeof GridRow
 }

--- a/src/collections/Grid/GridColumn.d.ts
+++ b/src/collections/Grid/GridColumn.d.ts
@@ -67,6 +67,6 @@ export interface StrictGridColumnProps {
   width?: SemanticWIDTHS
 }
 
-declare const GridColumn: React.StatelessComponent<GridColumnProps>
+declare const GridColumn: React.FC<GridColumnProps>
 
 export default GridColumn

--- a/src/collections/Grid/GridRow.d.ts
+++ b/src/collections/Grid/GridRow.d.ts
@@ -51,6 +51,6 @@ export interface StrictGridRowProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-declare const GridRow: React.StatelessComponent<GridRowProps>
+declare const GridRow: React.FC<GridRowProps>
 
 export default GridRow

--- a/src/collections/Menu/MenuMenu.d.ts
+++ b/src/collections/Menu/MenuMenu.d.ts
@@ -22,6 +22,6 @@ export interface StrictMenuMenuProps {
   position?: 'left' | 'right'
 }
 
-declare const MenuMenu: React.StatelessComponent<MenuMenuProps>
+declare const MenuMenu: React.FC<MenuMenuProps>
 
 export default MenuMenu

--- a/src/collections/Message/MessageContent.d.ts
+++ b/src/collections/Message/MessageContent.d.ts
@@ -19,6 +19,6 @@ export interface StrictMessageContentProps {
   content?: SemanticShorthandContent
 }
 
-declare const MessageContent: React.StatelessComponent<MessageContentProps>
+declare const MessageContent: React.FC<MessageContentProps>
 
 export default MessageContent

--- a/src/collections/Message/MessageHeader.d.ts
+++ b/src/collections/Message/MessageHeader.d.ts
@@ -19,6 +19,6 @@ export interface StrictMessageHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const MessageHeader: React.StatelessComponent<MessageHeaderProps>
+declare const MessageHeader: React.FC<MessageHeaderProps>
 
 export default MessageHeader

--- a/src/collections/Message/MessageItem.d.ts
+++ b/src/collections/Message/MessageItem.d.ts
@@ -19,6 +19,6 @@ export interface StrictMessageItemProps {
   content?: SemanticShorthandContent
 }
 
-declare const MessageItem: React.StatelessComponent<MessageItemProps>
+declare const MessageItem: React.FC<MessageItemProps>
 
 export default MessageItem

--- a/src/collections/Message/MessageList.d.ts
+++ b/src/collections/Message/MessageList.d.ts
@@ -21,6 +21,6 @@ export interface StrictMessageListProps {
   items?: SemanticShorthandCollection<MessageItemProps>
 }
 
-declare const MessageList: React.StatelessComponent<MessageListProps>
+declare const MessageList: React.FC<MessageListProps>
 
 export default MessageList

--- a/src/collections/Table/Table.d.ts
+++ b/src/collections/Table/Table.d.ts
@@ -115,7 +115,7 @@ export interface StrictTableProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-interface TableComponent extends React.StatelessComponent<TableProps> {
+interface TableComponent extends React.FC<TableProps> {
   Body: typeof TableBody
   Cell: typeof TableCell
   Footer: typeof TableFooter

--- a/src/collections/Table/TableBody.d.ts
+++ b/src/collections/Table/TableBody.d.ts
@@ -15,6 +15,6 @@ export interface StrictTableBodyProps {
   className?: string
 }
 
-declare const TableBody: React.StatelessComponent<TableBodyProps>
+declare const TableBody: React.FC<TableBodyProps>
 
 export default TableBody

--- a/src/collections/Table/TableCell.d.ts
+++ b/src/collections/Table/TableCell.d.ts
@@ -65,6 +65,6 @@ export interface StrictTableCellProps {
   width?: SemanticWIDTHS
 }
 
-declare const TableCell: React.StatelessComponent<TableCellProps>
+declare const TableCell: React.FC<TableCellProps>
 
 export default TableCell

--- a/src/collections/Table/TableFooter.d.ts
+++ b/src/collections/Table/TableFooter.d.ts
@@ -10,6 +10,6 @@ export interface StrictTableFooterProps extends StrictTableHeaderProps {
   as?: any
 }
 
-declare const TableFooter: React.StatelessComponent<TableFooterProps>
+declare const TableFooter: React.FC<TableFooterProps>
 
 export default TableFooter

--- a/src/collections/Table/TableHeader.d.ts
+++ b/src/collections/Table/TableHeader.d.ts
@@ -22,6 +22,6 @@ export interface StrictTableHeaderProps {
   fullWidth?: boolean
 }
 
-declare const TableHeader: React.StatelessComponent<TableHeaderProps>
+declare const TableHeader: React.FC<TableHeaderProps>
 
 export default TableHeader

--- a/src/collections/Table/TableHeaderCell.d.ts
+++ b/src/collections/Table/TableHeaderCell.d.ts
@@ -16,6 +16,6 @@ export interface StrictTableHeaderCellProps extends StrictTableCellProps {
   sorted?: 'ascending' | 'descending'
 }
 
-declare const TableHeaderCell: React.StatelessComponent<TableHeaderCellProps>
+declare const TableHeaderCell: React.FC<TableHeaderCellProps>
 
 export default TableHeaderCell

--- a/src/collections/Table/TableRow.d.ts
+++ b/src/collections/Table/TableRow.d.ts
@@ -48,6 +48,6 @@ export interface StrictTableRowProps {
   warning?: boolean
 }
 
-declare const TableRow: React.StatelessComponent<TableRowProps>
+declare const TableRow: React.FC<TableRowProps>
 
 export default TableRow

--- a/src/elements/Button/ButtonContent.d.ts
+++ b/src/elements/Button/ButtonContent.d.ts
@@ -25,6 +25,6 @@ export interface StrictButtonContentProps {
   visible?: boolean
 }
 
-declare const ButtonContent: React.StatelessComponent<ButtonContentProps>
+declare const ButtonContent: React.FC<ButtonContentProps>
 
 export default ButtonContent

--- a/src/elements/Button/ButtonGroup.d.ts
+++ b/src/elements/Button/ButtonGroup.d.ts
@@ -82,6 +82,6 @@ export interface StrictButtonGroupProps {
   widths?: SemanticWIDTHS
 }
 
-declare const ButtonGroup: React.StatelessComponent<ButtonGroupProps>
+declare const ButtonGroup: React.FC<ButtonGroupProps>
 
 export default ButtonGroup

--- a/src/elements/Button/ButtonOr.d.ts
+++ b/src/elements/Button/ButtonOr.d.ts
@@ -15,6 +15,6 @@ export interface StrictButtonOrProps {
   text?: number | string
 }
 
-declare const ButtonOr: React.StatelessComponent<ButtonOrProps>
+declare const ButtonOr: React.FC<ButtonOrProps>
 
 export default ButtonOr

--- a/src/elements/Container/Container.d.ts
+++ b/src/elements/Container/Container.d.ts
@@ -28,6 +28,6 @@ export interface StrictContainerProps {
   textAlign?: SemanticTEXTALIGNMENTS
 }
 
-declare const Container: React.StatelessComponent<ContainerProps>
+declare const Container: React.FC<ContainerProps>
 
 export default Container

--- a/src/elements/Divider/Divider.d.ts
+++ b/src/elements/Divider/Divider.d.ts
@@ -40,6 +40,6 @@ export interface StrictDividerProps {
   vertical?: boolean
 }
 
-declare const Divider: React.StatelessComponent<DividerProps>
+declare const Divider: React.FC<DividerProps>
 
 export default Divider

--- a/src/elements/Header/Header.d.ts
+++ b/src/elements/Header/Header.d.ts
@@ -61,7 +61,7 @@ export interface StrictHeaderProps {
   textAlign?: SemanticTEXTALIGNMENTS
 }
 
-interface HeaderComponent extends React.StatelessComponent<HeaderProps> {
+interface HeaderComponent extends React.FC<HeaderProps> {
   Content: typeof HeaderContent
   Subheader: typeof HeaderSubHeader
 }

--- a/src/elements/Header/HeaderContent.d.ts
+++ b/src/elements/Header/HeaderContent.d.ts
@@ -19,6 +19,6 @@ export interface StrictHeaderContentProps {
   content?: SemanticShorthandContent
 }
 
-declare const HeaderContent: React.StatelessComponent<HeaderContentProps>
+declare const HeaderContent: React.FC<HeaderContentProps>
 
 export default HeaderContent

--- a/src/elements/Header/HeaderSubheader.d.ts
+++ b/src/elements/Header/HeaderSubheader.d.ts
@@ -19,6 +19,6 @@ export interface StrictHeaderSubheaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const HeaderSubHeader: React.StatelessComponent<HeaderSubheaderProps>
+declare const HeaderSubHeader: React.FC<HeaderSubheaderProps>
 
 export default HeaderSubHeader

--- a/src/elements/Icon/IconGroup.d.ts
+++ b/src/elements/Icon/IconGroup.d.ts
@@ -24,6 +24,6 @@ export interface StrictIconGroupProps {
   size?: IconSizeProp
 }
 
-declare const IconGroup: React.StatelessComponent<IconGroupProps>
+declare const IconGroup: React.FC<IconGroupProps>
 
 export default IconGroup

--- a/src/elements/Image/Image.d.ts
+++ b/src/elements/Image/Image.d.ts
@@ -84,7 +84,7 @@ export interface StrictImageProps {
   wrapped?: boolean
 }
 
-interface ImageComponent extends React.StatelessComponent<ImageProps> {
+interface ImageComponent extends React.FC<ImageProps> {
   Group: typeof ImageGroup
 }
 

--- a/src/elements/Image/ImageGroup.d.ts
+++ b/src/elements/Image/ImageGroup.d.ts
@@ -22,6 +22,6 @@ export interface StrictImageGroupProps {
   size?: SemanticSIZES
 }
 
-declare const ImageGroup: React.StatelessComponent<ImageGroupProps>
+declare const ImageGroup: React.FC<ImageGroupProps>
 
 export default ImageGroup

--- a/src/elements/Label/LabelDetail.d.ts
+++ b/src/elements/Label/LabelDetail.d.ts
@@ -19,6 +19,6 @@ export interface StrictLabelDetailProps {
   content?: SemanticShorthandContent
 }
 
-declare const LabelDetail: React.StatelessComponent<LabelDetailProps>
+declare const LabelDetail: React.FC<LabelDetailProps>
 
 export default LabelDetail

--- a/src/elements/Label/LabelGroup.d.ts
+++ b/src/elements/Label/LabelGroup.d.ts
@@ -31,6 +31,6 @@ export interface StrictLabelGroupProps {
   tag?: boolean
 }
 
-declare const LabelGroup: React.StatelessComponent<LabelGroupProps>
+declare const LabelGroup: React.FC<LabelGroupProps>
 
 export default LabelGroup

--- a/src/elements/List/List.d.ts
+++ b/src/elements/List/List.d.ts
@@ -82,7 +82,7 @@ export interface StrictListProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-interface ListComponent extends React.StatelessComponent<ListProps> {
+interface ListComponent extends React.FC<ListProps> {
   Content: typeof ListContent
   Description: typeof ListDescription
   Header: typeof ListHeader

--- a/src/elements/List/ListContent.d.ts
+++ b/src/elements/List/ListContent.d.ts
@@ -39,6 +39,6 @@ export interface StrictListContentProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-declare const ListContent: React.StatelessComponent<ListContentProps>
+declare const ListContent: React.FC<ListContentProps>
 
 export default ListContent

--- a/src/elements/List/ListDescription.d.ts
+++ b/src/elements/List/ListDescription.d.ts
@@ -19,6 +19,6 @@ export interface StrictListDescriptionProps {
   content?: SemanticShorthandContent
 }
 
-declare const ListDescription: React.StatelessComponent<ListDescriptionProps>
+declare const ListDescription: React.FC<ListDescriptionProps>
 
 export default ListDescription

--- a/src/elements/List/ListHeader.d.ts
+++ b/src/elements/List/ListHeader.d.ts
@@ -19,6 +19,6 @@ export interface StrictListHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const ListHeader: React.StatelessComponent<ListHeaderProps>
+declare const ListHeader: React.FC<ListHeaderProps>
 
 export default ListHeader

--- a/src/elements/List/ListIcon.d.ts
+++ b/src/elements/List/ListIcon.d.ts
@@ -15,6 +15,6 @@ export interface StrictListIconProps extends StrictIconProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-declare const ListIcon: React.StatelessComponent<ListIconProps>
+declare const ListIcon: React.FC<ListIconProps>
 
 export default ListIcon

--- a/src/elements/List/ListItem.d.ts
+++ b/src/elements/List/ListItem.d.ts
@@ -54,6 +54,6 @@ export interface StrictListItemProps {
   value?: string
 }
 
-declare const ListItem: React.StatelessComponent<ListItemProps>
+declare const ListItem: React.FC<ListItemProps>
 
 export default ListItem

--- a/src/elements/List/ListList.d.ts
+++ b/src/elements/List/ListList.d.ts
@@ -19,6 +19,6 @@ export interface StrictListListProps {
   content?: SemanticShorthandContent
 }
 
-declare const ListList: React.StatelessComponent<ListListProps>
+declare const ListList: React.FC<ListListProps>
 
 export default ListList

--- a/src/elements/Loader/Loader.d.ts
+++ b/src/elements/Loader/Loader.d.ts
@@ -37,6 +37,6 @@ export interface StrictLoaderProps {
   size?: SemanticSIZES
 }
 
-declare const Loader: React.StatelessComponent<LoaderProps>
+declare const Loader: React.FC<LoaderProps>
 
 export default Loader

--- a/src/elements/Placeholder/Placeholder.d.ts
+++ b/src/elements/Placeholder/Placeholder.d.ts
@@ -30,7 +30,7 @@ export interface StrictPlaceholderProps {
   inverted?: boolean
 }
 
-interface PlaceholderComponent extends React.StatelessComponent<PlaceholderProps> {
+interface PlaceholderComponent extends React.FC<PlaceholderProps> {
   Header: typeof PlaceholderHeader
   Line: typeof PlaceholderLine
   Image: typeof PlaceholderImage

--- a/src/elements/Placeholder/PlaceholderHeader.d.ts
+++ b/src/elements/Placeholder/PlaceholderHeader.d.ts
@@ -22,7 +22,7 @@ export interface StrictPlaceholderHeaderProps {
   image?: boolean
 }
 
-interface PlaceholderHeaderComponent extends React.StatelessComponent<PlaceholderHeaderProps> {}
+interface PlaceholderHeaderComponent extends React.FC<PlaceholderHeaderProps> {}
 
 declare const PlaceholderHeader: PlaceholderHeaderComponent
 

--- a/src/elements/Placeholder/PlaceholderImage.d.ts
+++ b/src/elements/Placeholder/PlaceholderImage.d.ts
@@ -18,7 +18,7 @@ export interface StrictPlaceholderImageProps {
   rectangular?: boolean
 }
 
-interface PlaceholderImageComponent extends React.StatelessComponent<PlaceholderImageProps> {}
+interface PlaceholderImageComponent extends React.FC<PlaceholderImageProps> {}
 
 declare const PlaceholderImage: PlaceholderImageComponent
 

--- a/src/elements/Placeholder/PlaceholderLine.d.ts
+++ b/src/elements/Placeholder/PlaceholderLine.d.ts
@@ -15,7 +15,7 @@ export interface StrictPlaceholderLineProps {
   length?: 'full' | 'very long' | 'long' | 'medium' | 'short' | 'very short'
 }
 
-interface PlaceholderLineComponent extends React.StatelessComponent<PlaceholderLineProps> {}
+interface PlaceholderLineComponent extends React.FC<PlaceholderLineProps> {}
 
 declare const PlaceholderLine: PlaceholderLineComponent
 

--- a/src/elements/Placeholder/PlaceholderParagraph.d.ts
+++ b/src/elements/Placeholder/PlaceholderParagraph.d.ts
@@ -19,8 +19,7 @@ export interface StrictPlaceholderParagraphProps {
   content?: SemanticShorthandContent
 }
 
-interface PlaceholderParagraphComponent
-  extends React.StatelessComponent<PlaceholderParagraphProps> {}
+interface PlaceholderParagraphComponent extends React.FC<PlaceholderParagraphProps> {}
 
 declare const PlaceholderParagraph: PlaceholderParagraphComponent
 

--- a/src/elements/Rail/Rail.d.ts
+++ b/src/elements/Rail/Rail.d.ts
@@ -37,6 +37,6 @@ export interface StrictRailProps {
   size?: 'mini' | 'tiny' | 'small' | 'large' | 'big' | 'huge' | 'massive'
 }
 
-declare const Rail: React.StatelessComponent<RailProps>
+declare const Rail: React.FC<RailProps>
 
 export default Rail

--- a/src/elements/Reveal/Reveal.d.ts
+++ b/src/elements/Reveal/Reveal.d.ts
@@ -41,7 +41,7 @@ export interface StrictRevealProps {
   instant?: boolean
 }
 
-interface RevealComponent extends React.StatelessComponent<RevealProps> {
+interface RevealComponent extends React.FC<RevealProps> {
   Content: typeof RevealContent
 }
 

--- a/src/elements/Reveal/RevealContent.d.ts
+++ b/src/elements/Reveal/RevealContent.d.ts
@@ -25,6 +25,6 @@ export interface StrictRevealContentProps {
   visible?: boolean
 }
 
-declare const RevealContent: React.StatelessComponent<RevealContentProps>
+declare const RevealContent: React.FC<RevealContentProps>
 
 export default RevealContent

--- a/src/elements/Segment/Segment.d.ts
+++ b/src/elements/Segment/Segment.d.ts
@@ -89,7 +89,7 @@ export interface StrictSegmentProps {
   vertical?: boolean
 }
 
-interface SegmentComponent extends React.StatelessComponent<SegmentProps> {
+interface SegmentComponent extends React.FC<SegmentProps> {
   Group: typeof SegmentGroup
   Inline: typeof SegmentInline
 }

--- a/src/elements/Segment/SegmentGroup.d.ts
+++ b/src/elements/Segment/SegmentGroup.d.ts
@@ -39,6 +39,6 @@ export interface StrictSegmentGroupProps {
   stacked?: boolean
 }
 
-declare const SegmentGroup: React.StatelessComponent<SegmentGroupProps>
+declare const SegmentGroup: React.FC<SegmentGroupProps>
 
 export default SegmentGroup

--- a/src/elements/Segment/SegmentInline.d.ts
+++ b/src/elements/Segment/SegmentInline.d.ts
@@ -19,7 +19,7 @@ export interface StrictSegmentInlineProps {
   content?: SemanticShorthandContent
 }
 
-interface SegmentInlineComponent extends React.StatelessComponent<SegmentInlineProps> {}
+interface SegmentInlineComponent extends React.FC<SegmentInlineProps> {}
 
 declare const SegmentInline: SegmentInlineComponent
 

--- a/src/elements/Step/StepContent.d.ts
+++ b/src/elements/Step/StepContent.d.ts
@@ -28,6 +28,6 @@ export interface StrictStepContentProps {
   title?: SemanticShorthandItem<StepTitleProps>
 }
 
-declare const StepContent: React.StatelessComponent<StepContentProps>
+declare const StepContent: React.FC<StepContentProps>
 
 export default StepContent

--- a/src/elements/Step/StepDescription.d.ts
+++ b/src/elements/Step/StepDescription.d.ts
@@ -19,6 +19,6 @@ export interface StrictStepDescriptionProps {
   content?: SemanticShorthandContent
 }
 
-declare const StepDescription: React.StatelessComponent<StepDescriptionProps>
+declare const StepDescription: React.FC<StepDescriptionProps>
 
 export default StepDescription

--- a/src/elements/Step/StepGroup.d.ts
+++ b/src/elements/Step/StepGroup.d.ts
@@ -72,6 +72,6 @@ export interface StrictStepGroupProps {
     | 'eight'
 }
 
-declare const StepGroup: React.StatelessComponent<StepGroupProps>
+declare const StepGroup: React.FC<StepGroupProps>
 
 export default StepGroup

--- a/src/elements/Step/StepTitle.d.ts
+++ b/src/elements/Step/StepTitle.d.ts
@@ -19,6 +19,6 @@ export interface StrictStepTitleProps {
   content?: SemanticShorthandContent
 }
 
-declare const StepTitle: React.StatelessComponent<StepTitleProps>
+declare const StepTitle: React.FC<StepTitleProps>
 
 export default StepTitle

--- a/src/modules/Accordion/AccordionContent.d.ts
+++ b/src/modules/Accordion/AccordionContent.d.ts
@@ -22,6 +22,6 @@ export interface StrictAccordionContentProps {
   content?: SemanticShorthandContent
 }
 
-declare const AccordionContent: React.StatelessComponent<AccordionContentProps>
+declare const AccordionContent: React.FC<AccordionContentProps>
 
 export default AccordionContent

--- a/src/modules/Dropdown/DropdownMenu.d.ts
+++ b/src/modules/Dropdown/DropdownMenu.d.ts
@@ -28,6 +28,6 @@ export interface StrictDropdownMenuProps {
   scrolling?: boolean
 }
 
-declare const DropdownMenu: React.StatelessComponent<DropdownMenuProps>
+declare const DropdownMenu: React.FC<DropdownMenuProps>
 
 export default DropdownMenu

--- a/src/modules/Modal/ModalContent.d.ts
+++ b/src/modules/Modal/ModalContent.d.ts
@@ -25,6 +25,6 @@ export interface StrictModalContentProps {
   scrolling?: boolean
 }
 
-declare const ModalContent: React.StatelessComponent<ModalContentProps>
+declare const ModalContent: React.FC<ModalContentProps>
 
 export default ModalContent

--- a/src/modules/Modal/ModalDescription.d.ts
+++ b/src/modules/Modal/ModalDescription.d.ts
@@ -19,6 +19,6 @@ export interface StrictModalDescriptionProps {
   content?: SemanticShorthandContent
 }
 
-declare const ModalDescription: React.StatelessComponent<ModalDescriptionProps>
+declare const ModalDescription: React.FC<ModalDescriptionProps>
 
 export default ModalDescription

--- a/src/modules/Modal/ModalDimmer.d.ts
+++ b/src/modules/Modal/ModalDimmer.d.ts
@@ -34,6 +34,6 @@ export interface StrictModalDimmerProps {
   scrolling?: boolean
 }
 
-declare const ModalDimmer: React.StatelessComponent<ModalDimmerProps>
+declare const ModalDimmer: React.FC<ModalDimmerProps>
 
 export default ModalDimmer

--- a/src/modules/Modal/ModalHeader.d.ts
+++ b/src/modules/Modal/ModalHeader.d.ts
@@ -19,6 +19,6 @@ export interface StrictModalHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const ModalHeader: React.StatelessComponent<ModalHeaderProps>
+declare const ModalHeader: React.FC<ModalHeaderProps>
 
 export default ModalHeader

--- a/src/modules/Popup/PopupContent.d.ts
+++ b/src/modules/Popup/PopupContent.d.ts
@@ -19,6 +19,6 @@ export interface StrictPopupContentProps {
   content?: SemanticShorthandContent
 }
 
-declare const PopupContent: React.StatelessComponent<PopupContentProps>
+declare const PopupContent: React.FC<PopupContentProps>
 
 export default PopupContent

--- a/src/modules/Popup/PopupHeader.d.ts
+++ b/src/modules/Popup/PopupHeader.d.ts
@@ -19,6 +19,6 @@ export interface StrictPopupHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const PopupHeader: React.StatelessComponent<PopupHeaderProps>
+declare const PopupHeader: React.FC<PopupHeaderProps>
 
 export default PopupHeader

--- a/src/modules/Search/SearchCategory.d.ts
+++ b/src/modules/Search/SearchCategory.d.ts
@@ -33,7 +33,9 @@ export interface StrictSearchCategoryProps {
    * @param {object} props - The SearchCategoryLayout props object.
    * @returns {*} - Renderable SearchCategory layout.
    */
-  layoutRenderer?: (props: Pick<SearchCategoryLayoutProps, 'categoryContent' | 'resultsContent'>) => React.ReactElement<any>
+  layoutRenderer?: (
+    props: Pick<SearchCategoryLayoutProps, 'categoryContent' | 'resultsContent'>,
+  ) => React.ReactElement<any>
 
   /**
    * Renders the category contents.
@@ -47,6 +49,6 @@ export interface StrictSearchCategoryProps {
   results?: typeof SearchResult[]
 }
 
-declare const SearchCategory: React.StatelessComponent<SearchCategoryProps>
+declare const SearchCategory: React.FC<SearchCategoryProps>
 
 export default SearchCategory

--- a/src/modules/Search/SearchCategoryLayout.d.ts
+++ b/src/modules/Search/SearchCategoryLayout.d.ts
@@ -15,6 +15,6 @@ export interface StrictSearchCategoryLayoutProps {
   resultsContent: React.ReactElement<any>
 }
 
-declare const SearchCategoryLayout: React.StatelessComponent<SearchCategoryLayoutProps>
+declare const SearchCategoryLayout: React.FC<SearchCategoryLayoutProps>
 
 export default SearchCategoryLayout

--- a/src/modules/Search/SearchResults.d.ts
+++ b/src/modules/Search/SearchResults.d.ts
@@ -19,6 +19,6 @@ export interface StrictSearchResultsProps {
   content?: SemanticShorthandContent
 }
 
-declare const SearchResults: React.StatelessComponent<SearchResultsProps>
+declare const SearchResults: React.FC<SearchResultsProps>
 
 export default SearchResults

--- a/src/modules/Sidebar/SidebarPushable.d.ts
+++ b/src/modules/Sidebar/SidebarPushable.d.ts
@@ -19,6 +19,6 @@ export interface StrictSidebarPushableProps {
   content?: SemanticShorthandContent
 }
 
-declare const SidebarPushable: React.StatelessComponent<SidebarPushableProps>
+declare const SidebarPushable: React.FC<SidebarPushableProps>
 
 export default SidebarPushable

--- a/src/modules/Sidebar/SidebarPusher.d.ts
+++ b/src/modules/Sidebar/SidebarPusher.d.ts
@@ -22,6 +22,6 @@ export interface StrictSidebarPusherProps {
   dimmed?: boolean
 }
 
-declare const SidebarPusher: React.StatelessComponent<SidebarPusherProps>
+declare const SidebarPusher: React.FC<SidebarPusherProps>
 
 export default SidebarPusher

--- a/src/modules/Tab/TabPane.d.ts
+++ b/src/modules/Tab/TabPane.d.ts
@@ -25,6 +25,6 @@ export interface StrictTabPaneProps {
   loading?: boolean
 }
 
-declare const TabPane: React.StatelessComponent<TabPaneProps>
+declare const TabPane: React.FC<TabPaneProps>
 
 export default TabPane

--- a/src/views/Advertisement/Advertisement.d.ts
+++ b/src/views/Advertisement/Advertisement.d.ts
@@ -51,6 +51,6 @@ export interface StrictAdvertisementProps {
     | 'small square'
 }
 
-declare const Advertisement: React.StatelessComponent<AdvertisementProps>
+declare const Advertisement: React.FC<AdvertisementProps>
 
 export default Advertisement

--- a/src/views/Card/CardContent.d.ts
+++ b/src/views/Card/CardContent.d.ts
@@ -38,6 +38,6 @@ export interface StrictCardContentProps {
   textAlign?: 'center' | 'left' | 'right'
 }
 
-declare const CardContent: React.StatelessComponent<CardContentProps>
+declare const CardContent: React.FC<CardContentProps>
 
 export default CardContent

--- a/src/views/Card/CardDescription.d.ts
+++ b/src/views/Card/CardDescription.d.ts
@@ -22,6 +22,6 @@ export interface StrictCardDescriptionProps {
   textAlign?: 'center' | 'left' | 'right'
 }
 
-declare const CardDescription: React.StatelessComponent<CardDescriptionProps>
+declare const CardDescription: React.FC<CardDescriptionProps>
 
 export default CardDescription

--- a/src/views/Card/CardGroup.d.ts
+++ b/src/views/Card/CardGroup.d.ts
@@ -43,6 +43,6 @@ export interface StrictCardGroupProps {
   textAlign?: 'center' | 'left' | 'right'
 }
 
-declare const CardGroup: React.StatelessComponent<CardGroupProps>
+declare const CardGroup: React.FC<CardGroupProps>
 
 export default CardGroup

--- a/src/views/Card/CardHeader.d.ts
+++ b/src/views/Card/CardHeader.d.ts
@@ -22,6 +22,6 @@ export interface StrictCardHeaderProps {
   textAlign?: 'center' | 'left' | 'right'
 }
 
-declare const CardHeader: React.StatelessComponent<CardHeaderProps>
+declare const CardHeader: React.FC<CardHeaderProps>
 
 export default CardHeader

--- a/src/views/Card/CardMeta.d.ts
+++ b/src/views/Card/CardMeta.d.ts
@@ -22,6 +22,6 @@ export interface StrictCardMetaProps {
   textAlign?: 'center' | 'left' | 'right'
 }
 
-declare const CardMeta: React.StatelessComponent<CardMetaProps>
+declare const CardMeta: React.FC<CardMetaProps>
 
 export default CardMeta

--- a/src/views/Comment/Comment.d.ts
+++ b/src/views/Comment/Comment.d.ts
@@ -31,7 +31,7 @@ export interface StrictCommentProps {
   content?: SemanticShorthandContent
 }
 
-interface CommentComponent extends React.StatelessComponent<CommentProps> {
+interface CommentComponent extends React.FC<CommentProps> {
   Action: typeof CommentAction
   Actions: typeof CommentActions
   Author: typeof CommentAuthor

--- a/src/views/Comment/CommentActions.d.ts
+++ b/src/views/Comment/CommentActions.d.ts
@@ -19,6 +19,6 @@ export interface StrictCommentActionsProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentActions: React.StatelessComponent<CommentActionsProps>
+declare const CommentActions: React.FC<CommentActionsProps>
 
 export default CommentActions

--- a/src/views/Comment/CommentAuthor.d.ts
+++ b/src/views/Comment/CommentAuthor.d.ts
@@ -19,6 +19,6 @@ export interface StrictCommentAuthorProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentAuthor: React.StatelessComponent<CommentAuthorProps>
+declare const CommentAuthor: React.FC<CommentAuthorProps>
 
 export default CommentAuthor

--- a/src/views/Comment/CommentAvatar.d.ts
+++ b/src/views/Comment/CommentAvatar.d.ts
@@ -15,6 +15,6 @@ export interface StrictCommentAvatarProps {
   src?: string
 }
 
-declare const CommentAvatar: React.StatelessComponent<CommentAvatarProps>
+declare const CommentAvatar: React.FC<CommentAvatarProps>
 
 export default CommentAvatar

--- a/src/views/Comment/CommentContent.d.ts
+++ b/src/views/Comment/CommentContent.d.ts
@@ -19,6 +19,6 @@ export interface StrictCommentContentProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentContent: React.StatelessComponent<CommentContentProps>
+declare const CommentContent: React.FC<CommentContentProps>
 
 export default CommentContent

--- a/src/views/Comment/CommentGroup.d.ts
+++ b/src/views/Comment/CommentGroup.d.ts
@@ -31,6 +31,6 @@ export interface StrictCommentGroupProps {
   threaded?: boolean
 }
 
-declare const CommentGroup: React.StatelessComponent<CommentGroupProps>
+declare const CommentGroup: React.FC<CommentGroupProps>
 
 export default CommentGroup

--- a/src/views/Comment/CommentMetadata.d.ts
+++ b/src/views/Comment/CommentMetadata.d.ts
@@ -19,6 +19,6 @@ export interface StrictCommentMetadataProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentMetadata: React.StatelessComponent<CommentMetadataProps>
+declare const CommentMetadata: React.FC<CommentMetadataProps>
 
 export default CommentMetadata

--- a/src/views/Comment/CommentText.d.ts
+++ b/src/views/Comment/CommentText.d.ts
@@ -19,6 +19,6 @@ export interface StrictCommentTextProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentText: React.StatelessComponent<CommentTextProps>
+declare const CommentText: React.FC<CommentTextProps>
 
 export default CommentText

--- a/src/views/Feed/Feed.d.ts
+++ b/src/views/Feed/Feed.d.ts
@@ -32,7 +32,7 @@ export interface StrictFeedProps {
   size?: 'small' | 'large'
 }
 
-interface FeedComponent extends React.StatelessComponent<FeedProps> {
+interface FeedComponent extends React.FC<FeedProps> {
   Content: typeof FeedContent
   Date: typeof FeedDate
   Event: typeof FeedEvent

--- a/src/views/Feed/FeedContent.d.ts
+++ b/src/views/Feed/FeedContent.d.ts
@@ -39,6 +39,6 @@ export interface StrictFeedContentProps {
   summary?: SemanticShorthandItem<FeedSummaryProps>
 }
 
-declare const FeedContent: React.StatelessComponent<FeedContentProps>
+declare const FeedContent: React.FC<FeedContentProps>
 
 export default FeedContent

--- a/src/views/Feed/FeedDate.d.ts
+++ b/src/views/Feed/FeedDate.d.ts
@@ -19,6 +19,6 @@ export interface StrictFeedDateProps {
   content?: SemanticShorthandContent
 }
 
-declare const FeedDate: React.StatelessComponent<FeedDateProps>
+declare const FeedDate: React.FC<FeedDateProps>
 
 export default FeedDate

--- a/src/views/Feed/FeedEvent.d.ts
+++ b/src/views/Feed/FeedEvent.d.ts
@@ -47,6 +47,6 @@ export interface StrictFeedEventProps {
   summary?: SemanticShorthandItem<FeedSummaryProps>
 }
 
-declare const FeedEvent: React.StatelessComponent<FeedEventProps>
+declare const FeedEvent: React.FC<FeedEventProps>
 
 export default FeedEvent

--- a/src/views/Feed/FeedExtra.d.ts
+++ b/src/views/Feed/FeedExtra.d.ts
@@ -29,6 +29,6 @@ export interface StrictFeedExtraProps {
   text?: boolean
 }
 
-declare const FeedExtra: React.StatelessComponent<FeedExtraProps>
+declare const FeedExtra: React.FC<FeedExtraProps>
 
 export default FeedExtra

--- a/src/views/Feed/FeedLabel.d.ts
+++ b/src/views/Feed/FeedLabel.d.ts
@@ -27,6 +27,6 @@ export interface StrictFeedLabelProps {
   image?: SemanticShorthandItem<HtmlImageProps>
 }
 
-declare const FeedLabel: React.StatelessComponent<FeedLabelProps>
+declare const FeedLabel: React.FC<FeedLabelProps>
 
 export default FeedLabel

--- a/src/views/Feed/FeedLike.d.ts
+++ b/src/views/Feed/FeedLike.d.ts
@@ -24,6 +24,6 @@ export interface StrictFeedLikeProps {
   icon?: SemanticShorthandItem<IconProps>
 }
 
-declare const FeedLike: React.StatelessComponent<FeedLikeProps>
+declare const FeedLike: React.FC<FeedLikeProps>
 
 export default FeedLike

--- a/src/views/Feed/FeedMeta.d.ts
+++ b/src/views/Feed/FeedMeta.d.ts
@@ -24,6 +24,6 @@ export interface StrictFeedMetaProps {
   like?: SemanticShorthandItem<FeedLikeProps>
 }
 
-declare const FeedMeta: React.StatelessComponent<FeedMetaProps>
+declare const FeedMeta: React.FC<FeedMetaProps>
 
 export default FeedMeta

--- a/src/views/Feed/FeedSummary.d.ts
+++ b/src/views/Feed/FeedSummary.d.ts
@@ -28,6 +28,6 @@ export interface StrictFeedSummaryProps {
   user?: SemanticShorthandItem<FeedUserProps>
 }
 
-declare const FeedSummary: React.StatelessComponent<FeedSummaryProps>
+declare const FeedSummary: React.FC<FeedSummaryProps>
 
 export default FeedSummary

--- a/src/views/Feed/FeedUser.d.ts
+++ b/src/views/Feed/FeedUser.d.ts
@@ -19,6 +19,6 @@ export interface StrictFeedUserProps {
   content?: SemanticShorthandContent
 }
 
-declare const FeedUser: React.StatelessComponent<FeedUserProps>
+declare const FeedUser: React.FC<FeedUserProps>
 
 export default FeedUser

--- a/src/views/Item/Item.d.ts
+++ b/src/views/Item/Item.d.ts
@@ -42,7 +42,7 @@ export interface StrictItemProps {
   meta?: SemanticShorthandItem<ItemMetaProps>
 }
 
-interface ItemComponent extends React.StatelessComponent<ItemProps> {
+interface ItemComponent extends React.FC<ItemProps> {
   Content: typeof ItemContent
   Description: typeof ItemDescription
   Extra: typeof ItemExtra

--- a/src/views/Item/ItemDescription.d.ts
+++ b/src/views/Item/ItemDescription.d.ts
@@ -19,6 +19,6 @@ export interface StrictItemDescriptionProps {
   content?: SemanticShorthandContent
 }
 
-declare const ItemDescription: React.StatelessComponent<ItemDescriptionProps>
+declare const ItemDescription: React.FC<ItemDescriptionProps>
 
 export default ItemDescription

--- a/src/views/Item/ItemExtra.d.ts
+++ b/src/views/Item/ItemExtra.d.ts
@@ -19,6 +19,6 @@ export interface StrictItemExtraProps {
   content?: SemanticShorthandContent
 }
 
-declare const ItemExtra: React.StatelessComponent<ItemExtraProps>
+declare const ItemExtra: React.FC<ItemExtraProps>
 
 export default ItemExtra

--- a/src/views/Item/ItemGroup.d.ts
+++ b/src/views/Item/ItemGroup.d.ts
@@ -36,6 +36,6 @@ export interface StrictItemGroupProps {
   unstackable?: boolean
 }
 
-declare const ItemGroup: React.StatelessComponent<ItemGroupProps>
+declare const ItemGroup: React.FC<ItemGroupProps>
 
 export default ItemGroup

--- a/src/views/Item/ItemHeader.d.ts
+++ b/src/views/Item/ItemHeader.d.ts
@@ -19,6 +19,6 @@ export interface StrictItemHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const ItemHeader: React.StatelessComponent<ItemHeaderProps>
+declare const ItemHeader: React.FC<ItemHeaderProps>
 
 export default ItemHeader

--- a/src/views/Item/ItemImage.d.ts
+++ b/src/views/Item/ItemImage.d.ts
@@ -5,6 +5,6 @@ export interface ItemImageProps extends ImageProps {}
 
 export interface StrictItemImageProps extends StrictImageProps {}
 
-declare const ItemImage: React.StatelessComponent<ItemImageProps>
+declare const ItemImage: React.FC<ItemImageProps>
 
 export default ItemImage

--- a/src/views/Item/ItemMeta.d.ts
+++ b/src/views/Item/ItemMeta.d.ts
@@ -19,6 +19,6 @@ export interface StrictItemMetaProps {
   content?: SemanticShorthandContent
 }
 
-declare const ItemMeta: React.StatelessComponent<ItemMetaProps>
+declare const ItemMeta: React.FC<ItemMetaProps>
 
 export default ItemMeta

--- a/src/views/Statistic/Statistic.d.ts
+++ b/src/views/Statistic/Statistic.d.ts
@@ -49,7 +49,7 @@ export interface StrictStatisticProps {
   value?: SemanticShorthandContent
 }
 
-interface StatisticComponent extends React.StatelessComponent<StatisticProps> {
+interface StatisticComponent extends React.FC<StatisticProps> {
   Group: typeof StatisticGroup
   Label: typeof StatisticLabel
   Value: typeof StatisticValue

--- a/src/views/Statistic/StatisticGroup.d.ts
+++ b/src/views/Statistic/StatisticGroup.d.ts
@@ -44,6 +44,6 @@ export interface StrictStatisticGroupProps {
   widths?: SemanticWIDTHS
 }
 
-declare const StatisticGroup: React.StatelessComponent<StatisticGroupProps>
+declare const StatisticGroup: React.FC<StatisticGroupProps>
 
 export default StatisticGroup

--- a/src/views/Statistic/StatisticLabel.d.ts
+++ b/src/views/Statistic/StatisticLabel.d.ts
@@ -19,6 +19,6 @@ export interface StrictStatisticLabelProps {
   content?: SemanticShorthandContent
 }
 
-declare const StatisticLabel: React.StatelessComponent<StatisticLabelProps>
+declare const StatisticLabel: React.FC<StatisticLabelProps>
 
 export default StatisticLabel

--- a/src/views/Statistic/StatisticValue.d.ts
+++ b/src/views/Statistic/StatisticValue.d.ts
@@ -22,6 +22,6 @@ export interface StrictStatisticValueProps {
   text?: boolean
 }
 
-declare const StatisticValue: React.StatelessComponent<StatisticValueProps>
+declare const StatisticValue: React.FC<StatisticValueProps>
 
 export default StatisticValue

--- a/test/typings.tsx
+++ b/test/typings.tsx
@@ -5,6 +5,7 @@ export const BasicAssert = () => (
   <>
     <Button />
     <Button content='Foo' />
+    <Button>Foo</Button>
   </>
 )
 

--- a/test/typings.tsx
+++ b/test/typings.tsx
@@ -32,7 +32,7 @@ export const ShorthandItemFuncAssert = () => (
         ),
       }}
     />
-    <Button label={{ children: <div className='bar' /> }} />
+    <Button label={{ children: () => <div className='bar' /> }} />
   </>
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,10 +1493,19 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.0.5", "@types/react@^16.0.18":
+"@types/react@*", "@types/react@18.0.5":
   version "18.0.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.5.tgz#1a4d4b705ae6af5aed369dec22800b20f89f5301"
   integrity sha512-UPxNGInDCIKlfqBrm8LDXYWNfLHwIdisWcsH5GpMyGjhEDLFgTtlRBaoWuCua9HcyuE0rMkmAeZ3FXV1pYLIYQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16.0.18":
+  version "16.14.25"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.25.tgz#d003f712c7563fdef5a87327f1892825af375608"
+  integrity sha512-cXRVHd7vBT5v1is72mmvmsg9stZrbJO04DJqFeh3Yj2tVKO6vmxg5BI+ybI6Ls7ROXRG3aFbZj9x0WA3ZAoDQw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,13 +1493,19 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.0.18", "@types/react@^16.9.43":
-  version "16.9.43"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.43.tgz#c287f23f6189666ee3bebc2eb8d0f84bcb6cdb6b"
-  integrity sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==
+"@types/react@*", "@types/react@18.0.5", "@types/react@^16.0.18":
+  version "18.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.5.tgz#1a4d4b705ae6af5aed369dec22800b20f89f5301"
+  integrity sha512-UPxNGInDCIKlfqBrm8LDXYWNfLHwIdisWcsH5GpMyGjhEDLFgTtlRBaoWuCua9HcyuE0rMkmAeZ3FXV1pYLIYQ==
   dependencies:
     "@types/prop-types" "*"
-    csstype "^2.2.0"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/sinonjs__fake-timers@^6.0.1":
   version "6.0.2"
@@ -4908,9 +4914,10 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-csstype@^2.2.0:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.5.tgz#4125484a3d42189a863943f23b9e4b80fedfa106"
+csstype@^3.0.2:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
+  integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
fixes #4352

## what changed
react typing package is updated to the latest version (18.0.5) (also added to package.resolutions because of react-helm)
Most of the work in typings was React.StatelessComponent to React.FC replacement
