### PR TITLE
chore(FormField): use React.forwardRef()

### DIFF
--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -27,7 +27,7 @@ import Radio from '../../addons/Radio'
  * @see Radio
  * @see Select
  */
-function FormField(props) {
+const FormField = React.forwardRef(function (props, ref) {
   const {
     children,
     className,
@@ -77,14 +77,14 @@ function FormField(props) {
   if (_.isNil(control)) {
     if (_.isNil(label)) {
       return (
-        <ElementType {...rest} className={classes} id={id}>
+        <ElementType {...rest} className={classes} id={id} ref={ref}>
           {childrenUtils.isNil(children) ? content : children}
         </ElementType>
       )
     }
 
     return (
-      <ElementType {...rest} className={classes} id={id}>
+      <ElementType {...rest} className={classes} id={id} ref={ref}>
         {errorLabelBefore}
         {createHTMLLabel(label, { autoGenerateKey: false })}
         {errorLabelAfter}
@@ -109,7 +109,7 @@ function FormField(props) {
       <ElementType className={classes}>
         <label>
           {errorLabelBefore}
-          {createElement(control, { ...ariaAttrs, ...controlProps })} {label}
+          {createElement(control, { ...ariaAttrs, ...controlProps, ref })} {label}
           {errorLabelAfter}
         </label>
       </ElementType>
@@ -121,7 +121,7 @@ function FormField(props) {
     return (
       <ElementType className={classes}>
         {errorLabelBefore}
-        {createElement(control, { ...ariaAttrs, ...controlProps, label })}
+        {createElement(control, { ...ariaAttrs, ...controlProps, label, ref })}
         {errorLabelAfter}
       </ElementType>
     )
@@ -138,11 +138,13 @@ function FormField(props) {
         autoGenerateKey: false,
       })}
       {errorLabelBefore}
-      {createElement(control, { ...ariaAttrs, ...controlProps })}
+      {createElement(control, { ...ariaAttrs, ...controlProps, ref })}
       {errorLabelAfter}
     </ElementType>
   )
-}
+})
+
+FormField.displayName = 'FormField'
 
 FormField.propTypes = {
   /** An element type to render as (string or function). */

--- a/src/collections/Form/FormField.js
+++ b/src/collections/Form/FormField.js
@@ -101,7 +101,7 @@ const FormField = React.forwardRef(function (props, ref) {
     'aria-describedby': ariaDescribedBy,
     'aria-invalid': error ? true : undefined,
   }
-  const controlProps = { ...rest, content, children, disabled, required, type, id }
+  const controlProps = { ...rest, content, children, disabled, required, type, id, ref }
 
   // wrap HTML checkboxes/radios in the label
   if (control === 'input' && (type === 'checkbox' || type === 'radio')) {
@@ -109,7 +109,7 @@ const FormField = React.forwardRef(function (props, ref) {
       <ElementType className={classes}>
         <label>
           {errorLabelBefore}
-          {createElement(control, { ...ariaAttrs, ...controlProps, ref })} {label}
+          {createElement(control, { ...ariaAttrs, ...controlProps })} {label}
           {errorLabelAfter}
         </label>
       </ElementType>
@@ -121,7 +121,7 @@ const FormField = React.forwardRef(function (props, ref) {
     return (
       <ElementType className={classes}>
         {errorLabelBefore}
-        {createElement(control, { ...ariaAttrs, ...controlProps, label, ref })}
+        {createElement(control, { ...ariaAttrs, ...controlProps, label })}
         {errorLabelAfter}
       </ElementType>
     )
@@ -138,7 +138,7 @@ const FormField = React.forwardRef(function (props, ref) {
         autoGenerateKey: false,
       })}
       {errorLabelBefore}
-      {createElement(control, { ...ariaAttrs, ...controlProps, ref })}
+      {createElement(control, { ...ariaAttrs, ...controlProps })}
       {errorLabelAfter}
     </ElementType>
   )

--- a/test/specs/collections/Form/FormField-test.js
+++ b/test/specs/collections/Form/FormField-test.js
@@ -13,6 +13,41 @@ describe('FormField', () => {
   common.isConformant(FormField)
   common.rendersChildren(FormField)
 
+  // No Control
+  common.forwardsRef(FormField)
+  common.forwardsRef(FormField, {
+    tagName: 'div',
+    requiredProps: {
+      children: <input />,
+    },
+  })
+
+  // HTML Checkbox/Radio Control
+  common.forwardsRef(FormField, {
+    tagName: 'input',
+    requiredProps: { control: 'input', type: 'radio' },
+  })
+  common.forwardsRef(FormField, {
+    tagName: 'input',
+    requiredProps: { control: 'input', type: 'checkbox' },
+  })
+
+  // Checkbox/Radio Control
+  common.forwardsRef(FormField, {
+    tagName: 'input',
+    requiredProps: { control: Checkbox },
+  })
+  common.forwardsRef(FormField, {
+    tagName: 'input',
+    requiredProps: { control: Radio },
+  })
+
+  // Other Control
+  common.forwardsRef(FormField, {
+    tagName: 'input',
+    requiredProps: { control: 'input' },
+  })
+
   common.implementsHTMLLabelProp(FormField, { autoGenerateKey: false })
   common.implementsWidthProp(FormField, SUI.WIDTHS, {
     canEqual: false,
@@ -245,26 +280,5 @@ describe('FormField', () => {
         .find('input')
         .should.have.prop('aria-invalid', true)
     })
-  })
-
-  common.forwardsRef(FormField)
-  common.forwardsRef(FormField, {
-    tagName: 'input',
-    requiredProps: { control: 'input' },
-  })
-  common.forwardsRef(FormField, {
-    tagName: 'input',
-    requiredProps: { control: 'input', type: 'radio' },
-  })
-  common.forwardsRef(FormField, {
-    tagName: 'input',
-    requiredProps: { control: 'input', type: 'checkbox' },
-  })
-
-  common.forwardsRef(FormField, {
-    tagName: 'div',
-    requiredProps: {
-      children: <input />,
-    },
   })
 })

--- a/test/specs/collections/Form/FormField-test.js
+++ b/test/specs/collections/Form/FormField-test.js
@@ -246,4 +246,8 @@ describe('FormField', () => {
         .should.have.prop('aria-invalid', true)
     })
   })
+
+  describe.only('forwards ref', () => {
+    common.forwardsRef(FormField)
+  })
 })

--- a/test/specs/collections/Form/FormField-test.js
+++ b/test/specs/collections/Form/FormField-test.js
@@ -247,26 +247,24 @@ describe('FormField', () => {
     })
   })
 
-  describe.only('forwards ref', () => {
-    common.forwardsRef(FormField)
-    common.forwardsRef(FormField, {
-      tagName: 'input',
-      requiredProps: { control: 'input' },
-    })
-    common.forwardsRef(FormField, {
-      tagName: 'input',
-      requiredProps: { control: 'input', type: 'radio' },
-    })
-    common.forwardsRef(FormField, {
-      tagName: 'input',
-      requiredProps: { control: 'input', type: 'checkbox' },
-    })
+  common.forwardsRef(FormField)
+  common.forwardsRef(FormField, {
+    tagName: 'input',
+    requiredProps: { control: 'input' },
+  })
+  common.forwardsRef(FormField, {
+    tagName: 'input',
+    requiredProps: { control: 'input', type: 'radio' },
+  })
+  common.forwardsRef(FormField, {
+    tagName: 'input',
+    requiredProps: { control: 'input', type: 'checkbox' },
+  })
 
-    common.forwardsRef(FormField, {
-      tagName: 'div',
-      requiredProps: {
-        children: <input />,
-      },
-    })
+  common.forwardsRef(FormField, {
+    tagName: 'div',
+    requiredProps: {
+      children: <input />,
+    },
   })
 })

--- a/test/specs/collections/Form/FormField-test.js
+++ b/test/specs/collections/Form/FormField-test.js
@@ -249,5 +249,24 @@ describe('FormField', () => {
 
   describe.only('forwards ref', () => {
     common.forwardsRef(FormField)
+    common.forwardsRef(FormField, {
+      tagName: 'input',
+      requiredProps: { control: 'input' },
+    })
+    common.forwardsRef(FormField, {
+      tagName: 'input',
+      requiredProps: { control: 'input', type: 'radio' },
+    })
+    common.forwardsRef(FormField, {
+      tagName: 'input',
+      requiredProps: { control: 'input', type: 'checkbox' },
+    })
+
+    common.forwardsRef(FormField, {
+      tagName: 'div',
+      requiredProps: {
+        children: <input />,
+      },
+    })
   })
 })


### PR DESCRIPTION
Similarly to #4234, adds native ref forwarding to FormField.

I'm not sure if the added tests are sufficient, but I can adjust them as needed.

~I'm working on a create-react-app yarn-linked test project to verify all my assumptions about this code~

EDIT: They were verified.

@layershifter let me know if this is more trouble than it's worth.
