### PR TITLE
Add mountNode prop to Popup module

### DIFF
--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -57,6 +57,9 @@ export interface StrictPopupProps extends StrictPortalProps {
   /** Invert the colors of the popup */
   inverted?: boolean
 
+  /** The node where the popup should mount. Defaults to document.body. */
+  mountNode?: any
+
   /**
    * Offset values in px unit to apply to rendered popup. The basic offset accepts an
    * array with two numbers in the form [skidding, distance]:

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -13,6 +13,7 @@ import {
   customPropTypes,
   getElementType,
   getUnhandledProps,
+  isBrowser,
   makeDebugger,
   SUI,
   useKeyOnly,
@@ -67,6 +68,9 @@ export default class Popup extends Component {
   componentWillUnmount() {
     clearTimeout(this.timeoutId)
   }
+
+  // Do not access document when server side rendering
+  getMountNode = () => (isBrowser() ? this.props.mountNode || document.body : null)
 
   getPortalProps = () => {
     debug('getPortalProps()')
@@ -231,6 +235,7 @@ export default class Popup extends Component {
       trigger,
     } = this.props
     const { closed, portalRestProps } = this.state
+    const mountNode = this.getMountNode()
 
     if (closed || disabled) {
       return trigger
@@ -285,6 +290,7 @@ export default class Popup extends Component {
     return (
       <Portal
         {...mergedPortalProps}
+        mountNode={mountNode}
         onClose={this.handleClose}
         onMount={this.handlePortalMount}
         onOpen={this.handleOpen}
@@ -348,6 +354,9 @@ Popup.propTypes = {
 
   /** Invert the colors of the Popup. */
   inverted: PropTypes.bool,
+
+  /** The node where the popup should mount. Defaults to document.body. */
+  mountNode: PropTypes.any,
 
   /**
    * Offset values in px unit to apply to rendered popup. The basic offset accepts an


### PR DESCRIPTION
If a React app with SUIR is running in a hidden IFRAME and rendering some or all of its virtual DOM to the parent frame or another frame, then the Popup component should not insert popup elements into the document.body of the React IFRAME, but instead should inject into the frame containing the Popup trigger, or even into some other container as may be more appropriate (due to size or layering concerns between multiple frames).

Adding a `mountNode` prop to Popup allows developers to specify the appropriate container for a displayed popup element in cases such as the above example.

This PR implements a `mountNode` prop for Popup, with code very similar to the same prop's implementation in Modal.