### PR TITLE
fix(core): add `enterKeyHint` to list of `htmlInputAttrs`

### DIFF
--- a/src/lib/htmlPropsUtils.js
+++ b/src/lib/htmlPropsUtils.js
@@ -14,6 +14,7 @@ export const htmlInputAttrs = [
   'autoFocus',
   'checked',
   'disabled',
+  'enterKeyHint',
   'form',
   'id',
   'inputMode',


### PR DESCRIPTION
This PR adds the missing `enterKeyHint` attribute which allows the customisability of the enter key on virtual keyboards.

In my usage, this fixes an issue on Android where the enter button character doesn't reflect the action it performs.

Closes #4371