### PR TITLE
Bug: Put contentRef in state to let EventStack track changes

### DIFF
--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -171,7 +171,7 @@ describe('Portal', () => {
           <p />
         </Portal>,
       )
-      wrapper.instance().contentRef.current.tagName.should.equal('P')
+      wrapper.instance().state.contentRef.tagName.should.equal('P')
     })
 
     it('maintains ref to DOM node with React component', () => {
@@ -182,7 +182,7 @@ describe('Portal', () => {
           <EmptyComponent />
         </Portal>,
       )
-      wrapper.instance().contentRef.current.tagName.should.equal('P')
+      wrapper.instance().state.contentRef.tagName.should.equal('P')
     })
   })
 


### PR DESCRIPTION
contentRef is passed to EventStack to subscribe for mouse events. 
Passing a `contentRef` created using `React.createRef()` does not allow EventStack to keep track of contentRef changes (since only `contentRef.current` changes).
Ultimately when PortalInner unmount `contentRef.current` is set to undefined and EventStack `unsubscribe` handlers with `undefined` as a target instead of unsubscribing with real content. This leads to the event-stack Map keeping a reference to the real content thus leaking all dom tree related to the contentRef node.

Putting contentRef in the state and passing the element directly to EventStack allow for EventStack to detect change in its props and execute the componentDidUpdate routine which unsubscribe from the previous element on unmount.