### PR TITLE
fix(types): Update SemanticShorthandCollection to support Typescript 4.8

### DIFF
--- a/src/generic.d.ts
+++ b/src/generic.d.ts
@@ -70,7 +70,7 @@ export type ShorthandRenderFunction<C extends React.ElementType, P> = (
   props: P,
 ) => React.ReactNode
 
-export type SemanticShorthandCollection<TProps> = SemanticShorthandItem<TProps>[]
+export type SemanticShorthandCollection<TProps extends Record<string, any>> = SemanticShorthandItem<TProps>[]
 export type SemanticShorthandContent = React.ReactNode
 export type SemanticShorthandItem<TProps extends Record<string, any>> =
   | React.ReactNode


### PR DESCRIPTION
`typescript@4.8.4` build error

```
73 export type SemanticShorthandCollection<TProps> = SemanticShorthandItem<TProps>[]
                                               ~~~~~~
    This type parameter might need an `extends Record<string, any>` constraint.
```


For completeness, here is the breaking change in question
https://devblogs.microsoft.com/typescript/announcing-typescript-4-8-beta/#breaking-changes


