### PR TITLE
Menu Item Keyboard Accessibility

### DIFF
--- a/src/collections/Menu/MenuItem.d.ts
+++ b/src/collections/Menu/MenuItem.d.ts
@@ -63,7 +63,7 @@ export interface StrictMenuItemProps {
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
    * @param {object} data - All props.
    */
-  onKeyPress?: (event: React.MouseEvent<HTMLAnchorElement>, data: MenuItemProps) => void
+  onKeyDown?: (event: React.MouseEvent<HTMLAnchorElement>, data: MenuItemProps) => void
 
   /** A menu item can take left or right position. */
   position?: 'left' | 'right'

--- a/src/collections/Menu/MenuItem.d.ts
+++ b/src/collections/Menu/MenuItem.d.ts
@@ -63,7 +63,7 @@ export interface StrictMenuItemProps {
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
    * @param {object} data - All props.
    */
-  onKeyDown?: (event: React.MouseEvent<HTMLAnchorElement>, data: MenuItemProps) => void
+  onKeyPress?: (event: React.MouseEvent<HTMLAnchorElement>, data: MenuItemProps) => void
 
   /** A menu item can take left or right position. */
   position?: 'left' | 'right'

--- a/src/collections/Menu/MenuItem.d.ts
+++ b/src/collections/Menu/MenuItem.d.ts
@@ -56,6 +56,15 @@ export interface StrictMenuItemProps {
    */
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>, data: MenuItemProps) => void
 
+  /**
+   * Called on key press, specifically on 'enter'. When passed, the component will render as an `a`
+   * tag by default instead of a `div`.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
+   */
+  onKeyPress?: (event: React.MouseEvent<HTMLAnchorElement>, data: MenuItemProps) => void
+
   /** A menu item can take left or right position. */
   position?: 'left' | 'right'
 }

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -26,13 +26,16 @@ export default class MenuItem extends Component {
   }
 
   handleKeyPress = (e) => {
-    _.invoke(this.props, 'onKeyPress', e, this.props)
-    if (e.charCode === 13 || e.charCode === 32) {
-      // Prevent the default action to stop scrolling when space is pressed
-      e.preventDefault()
+    const { disabled } = this.props
+    if (!disabled) {
+      _.invoke(this.props, 'onKeyPress', e, this.props)
 
-      const { disabled } = this.props
-      if (!disabled) _.invoke(this.props, 'onClick', e, this.props)
+      if (e.charCode === 13 || e.charCode === 32) {
+        // Prevent the default action to stop scrolling when space is pressed
+        e.preventDefault()
+
+        _.invoke(this.props, 'onClick', e, this.props)
+      }
     }
   }
 

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -27,11 +27,9 @@ export default class MenuItem extends Component {
 
   handleKeyDown = (e) => {
     _.invoke(this.props, 'onKeyDown', e, this.props)
-    if (e.charCode === 13 || e.charCode === 32) {
-      // Prevent the default action to stop scrolling when space is pressed
-      e.preventDefault()
-
+    if (e.charCode === 13) {
       const { disabled } = this.props
+
       if (!disabled) _.invoke(this.props, 'onClick', e, this.props)
     }
   }

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -27,15 +27,16 @@ export default class MenuItem extends Component {
 
   handleKeyPress = (e) => {
     const { disabled } = this.props
-    if (!disabled) {
-      _.invoke(this.props, 'onKeyPress', e, this.props)
 
-      if (e.charCode === 13 || e.charCode === 32) {
-        // Prevent the default action to stop scrolling when space is pressed
-        e.preventDefault()
+    if (disabled) return
 
-        _.invoke(this.props, 'onClick', e, this.props)
-      }
+    _.invoke(this.props, 'onKeyPress', e, this.props)
+
+    if (e.charCode === 13 || e.charCode === 32) {
+      // Prevent the default action to stop scrolling when space is pressed
+      e.preventDefault()
+
+      _.invoke(this.props, 'onClick', e, this.props)
     }
   }
 

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -61,14 +61,14 @@ export default class MenuItem extends Component {
 
     if (!childrenUtils.isNil(children)) {
       return (
-        <ElementType {...rest} className={classes} onClick={this.handleClick}>
+        <ElementType {...rest} className={classes} onClick={this.handleClick} tabIndex={0}>
           {children}
         </ElementType>
       )
     }
 
     return (
-      <ElementType {...rest} className={classes} onClick={this.handleClick}>
+      <ElementType {...rest} className={classes} onClick={this.handleClick} tabIndex={0}>
         {Icon.create(icon, { autoGenerateKey: false })}
         {childrenUtils.isNil(content) ? _.startCase(name) : content}
       </ElementType>

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -77,7 +77,7 @@ export default class MenuItem extends Component {
           {...rest}
           className={classes}
           onClick={this.handleClick}
-          onKeyPress={this.handleKeyDown}
+          onKeyPress={this.handleKeyPress}
           tabIndex={disabled ? -1 : 0}
         >
           {children}

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -25,10 +25,13 @@ export default class MenuItem extends Component {
     if (!disabled) _.invoke(this.props, 'onClick', e, this.props)
   }
 
-  handleKeyPress = (e) => {
-    if (e.charCode === 13) {
-      const { disabled } = this.props
+  handleKeyDown = (e) => {
+    _.invoke(this.props, 'onKeyDown', e, this.props)
+    if (e.charCode === 13 || e.charCode === 32) {
+      // Prevent the default action to stop scrolling when space is pressed
+      e.preventDefault()
 
+      const { disabled } = this.props
       if (!disabled) _.invoke(this.props, 'onClick', e, this.props)
     }
   }
@@ -47,7 +50,7 @@ export default class MenuItem extends Component {
       link,
       name,
       onClick,
-      onKeyPress,
+      onKeyDown,
       position,
     } = this.props
 
@@ -64,7 +67,7 @@ export default class MenuItem extends Component {
       className,
     )
     const ElementType = getElementType(MenuItem, this.props, () => {
-      if (onClick || onKeyPress) return 'a'
+      if (onClick || onKeyDown) return 'a'
     })
     const rest = getUnhandledProps(MenuItem, this.props)
 
@@ -74,8 +77,8 @@ export default class MenuItem extends Component {
           {...rest}
           className={classes}
           onClick={this.handleClick}
-          onKeyPress={this.handleKeyPress}
-          tabIndex={0}
+          onKeyDown={this.handleKeyDown}
+          tabIndex={disabled ? -1 : 0}
         >
           {children}
         </ElementType>
@@ -87,8 +90,8 @@ export default class MenuItem extends Component {
         {...rest}
         className={classes}
         onClick={this.handleClick}
-        onKeyPress={this.handleKeyPress}
-        tabIndex={0}
+        onKeyDown={this.handleKeyDown}
+        tabIndex={disabled ? -1 : 0}
       >
         {Icon.create(icon, { autoGenerateKey: false })}
         {childrenUtils.isNil(content) ? _.startCase(name) : content}
@@ -146,7 +149,14 @@ MenuItem.propTypes = {
    */
   onClick: PropTypes.func,
 
-  onKeyPress: PropTypes.func,
+  /**
+   * Called on key press specifically on 'enter'. When passed, the component will render as an `a`
+   * tag by default instead of a `div`.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props.
+   */
+  onKeyDown: PropTypes.func,
 
   /** A menu item can take left or right position. */
   position: PropTypes.oneOf(['left', 'right']),

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -25,11 +25,13 @@ export default class MenuItem extends Component {
     if (!disabled) _.invoke(this.props, 'onClick', e, this.props)
   }
 
-  handleKeyDown = (e) => {
-    _.invoke(this.props, 'onKeyDown', e, this.props)
-    if (e.charCode === 13) {
-      const { disabled } = this.props
+  handleKeyPress = (e) => {
+    _.invoke(this.props, 'onKeyPress', e, this.props)
+    if (e.charCode === 13 || e.charCode === 32) {
+      // Prevent the default action to stop scrolling when space is pressed
+      e.preventDefault()
 
+      const { disabled } = this.props
       if (!disabled) _.invoke(this.props, 'onClick', e, this.props)
     }
   }
@@ -48,7 +50,7 @@ export default class MenuItem extends Component {
       link,
       name,
       onClick,
-      onKeyDown,
+      onKeyPress,
       position,
     } = this.props
 
@@ -65,7 +67,7 @@ export default class MenuItem extends Component {
       className,
     )
     const ElementType = getElementType(MenuItem, this.props, () => {
-      if (onClick || onKeyDown) return 'a'
+      if (onClick || onKeyPress) return 'a'
     })
     const rest = getUnhandledProps(MenuItem, this.props)
 
@@ -75,7 +77,7 @@ export default class MenuItem extends Component {
           {...rest}
           className={classes}
           onClick={this.handleClick}
-          onKeyDown={this.handleKeyDown}
+          onKeyPress={this.handleKeyDown}
           tabIndex={disabled ? -1 : 0}
         >
           {children}
@@ -88,7 +90,7 @@ export default class MenuItem extends Component {
         {...rest}
         className={classes}
         onClick={this.handleClick}
-        onKeyDown={this.handleKeyDown}
+        onKeyPress={this.handleKeyPress}
         tabIndex={disabled ? -1 : 0}
       >
         {Icon.create(icon, { autoGenerateKey: false })}
@@ -154,7 +156,7 @@ MenuItem.propTypes = {
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
    * @param {object} data - All props.
    */
-  onKeyDown: PropTypes.func,
+  onKeyPress: PropTypes.func,
 
   /** A menu item can take left or right position. */
   position: PropTypes.oneOf(['left', 'right']),

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -25,6 +25,14 @@ export default class MenuItem extends Component {
     if (!disabled) _.invoke(this.props, 'onClick', e, this.props)
   }
 
+  handleKeyPress = (e) => {
+    if (e.charCode === 13) {
+      const { disabled } = this.props
+
+      if (!disabled) _.invoke(this.props, 'onClick', e, this.props)
+    }
+  }
+
   render() {
     const {
       active,
@@ -39,6 +47,7 @@ export default class MenuItem extends Component {
       link,
       name,
       onClick,
+      onKeyPress,
       position,
     } = this.props
 
@@ -55,20 +64,32 @@ export default class MenuItem extends Component {
       className,
     )
     const ElementType = getElementType(MenuItem, this.props, () => {
-      if (onClick) return 'a'
+      if (onClick || onKeyPress) return 'a'
     })
     const rest = getUnhandledProps(MenuItem, this.props)
 
     if (!childrenUtils.isNil(children)) {
       return (
-        <ElementType {...rest} className={classes} onClick={this.handleClick} tabIndex={0}>
+        <ElementType
+          {...rest}
+          className={classes}
+          onClick={this.handleClick}
+          onKeyPress={this.handleKeyPress}
+          tabIndex={0}
+        >
           {children}
         </ElementType>
       )
     }
 
     return (
-      <ElementType {...rest} className={classes} onClick={this.handleClick} tabIndex={0}>
+      <ElementType
+        {...rest}
+        className={classes}
+        onClick={this.handleClick}
+        onKeyPress={this.handleKeyPress}
+        tabIndex={0}
+      >
         {Icon.create(icon, { autoGenerateKey: false })}
         {childrenUtils.isNil(content) ? _.startCase(name) : content}
       </ElementType>
@@ -124,6 +145,8 @@ MenuItem.propTypes = {
    * @param {object} data - All props.
    */
   onClick: PropTypes.func,
+
+  onKeyPress: PropTypes.func,
 
   /** A menu item can take left or right position. */
   position: PropTypes.oneOf(['left', 'right']),

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -69,6 +69,19 @@ describe('MenuItem', () => {
     })
   })
 
+  describe('onKeyDown', () => {
+    it('is called with (e, data) when clicked', () => {
+      const onKeyDown = sandbox.spy()
+      const event = { keyCode: 13 }
+      const props = { tabIndex: 0 }
+
+      shallow(<MenuItem onKeyDown={onKeyDown} {...props} />).simulate('keydown', event)
+
+      onKeyDown.should.have.been.calledOnce()
+      onKeyDown.should.have.been.calledWithMatch(event, props)
+    })
+  })
+
   describe('tabIndex', () => {
     it('defaults to 0', () => {
       shallow(<MenuItem />).should.have.prop('tabIndex', 0)

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -72,7 +72,7 @@ describe('MenuItem', () => {
   describe('onKeyPress', () => {
     it('is called with (e, data) on Enter keyPress', () => {
       const onKeyPress = sandbox.spy()
-      const event = { keyCode: 13 }
+      const event = { charCode: 13, preventDefault: sandbox.spy() }
       const props = { tabIndex: 0 }
 
       shallow(<MenuItem onKeyPress={onKeyPress} {...props} />).simulate('keypress', event)
@@ -83,7 +83,7 @@ describe('MenuItem', () => {
 
     it('is called with (e, data) on Space keyPress', () => {
       const onKeyPress = sandbox.spy()
-      const event = { keyCode: 32, preventDefault: sandbox.spy() }
+      const event = { charCode: 32, preventDefault: sandbox.spy() }
       const props = { tabIndex: 0 }
 
       shallow(<MenuItem onKeyPress={onKeyPress} {...props} />).simulate('keypress', event)
@@ -92,19 +92,42 @@ describe('MenuItem', () => {
       onKeyPress.should.have.been.calledWithMatch(event, props)
     })
 
+    it('does not call onClick when non space/enter key is pressed', () => {
+      const onClick = sandbox.spy()
+      const event = { charCode: 14, preventDefault: sandbox.spy() }
+
+      shallow(<MenuItem onClick={onClick} />).simulate('keypress', event)
+
+      onClick.should.not.have.been.called()
+      event.preventDefault.should.not.have.been.called()
+    })
+
     it('is not called when disabled', () => {
       const onKeyPress = sandbox.spy()
       const onClick = sandbox.spy()
-      const event = { keyCode: 13 }
+      const event = { charCode: 13 }
       const props = { tabIndex: -1 }
 
       shallow(<MenuItem disabled onClick={onClick} onKeyPress={onKeyPress} {...props} />).simulate(
         'keypress',
         event,
       )
+      shallow(<MenuItem disabled onClick={onClick} onKeyPress={onKeyPress} {...props} />).simulate(
+        'click',
+      )
 
       onClick.should.have.callCount(0)
       onKeyPress.should.have.callCount(0)
+    })
+
+    it('prevent default is called', () => {
+      const onKeyPress = sandbox.spy()
+      const event = { charCode: 32, preventDefault: sandbox.spy() }
+      const props = { tabIndex: 0 }
+
+      shallow(<MenuItem onKeyPress={onKeyPress} {...props} />).simulate('keypress', event)
+
+      event.preventDefault.should.have.been.calledOnce()
     })
   })
 

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -70,7 +70,7 @@ describe('MenuItem', () => {
   })
 
   describe('onKeyPress', () => {
-    it('is called with (e, data) when clicked', () => {
+    it('is called with (e, data) on Enter keyPress', () => {
       const onKeyPress = sandbox.spy()
       const event = { keyCode: 13 }
       const props = { tabIndex: 0 }
@@ -79,6 +79,32 @@ describe('MenuItem', () => {
 
       onKeyPress.should.have.been.calledOnce()
       onKeyPress.should.have.been.calledWithMatch(event, props)
+    })
+
+    it('is called with (e, data) on Space keyPress', () => {
+      const onKeyPress = sandbox.spy()
+      const event = { keyCode: 32, preventDefault: sandbox.spy() }
+      const props = { tabIndex: 0 }
+
+      shallow(<MenuItem onKeyPress={onKeyPress} {...props} />).simulate('keypress', event)
+
+      onKeyPress.should.have.been.calledOnce()
+      onKeyPress.should.have.been.calledWithMatch(event, props)
+    })
+
+    it('is not called when disabled', () => {
+      const onKeyPress = sandbox.spy()
+      const onClick = sandbox.spy()
+      const event = { keyCode: 13 }
+      const props = { tabIndex: -1 }
+
+      shallow(<MenuItem disabled onClick={onClick} onKeyPress={onKeyPress} {...props} />).simulate(
+        'keypress',
+        event,
+      )
+
+      onClick.should.have.callCount(0)
+      onKeyPress.should.have.callCount(0)
     })
   })
 

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -69,16 +69,16 @@ describe('MenuItem', () => {
     })
   })
 
-  describe('onKeyDown', () => {
+  describe('onKeyPress', () => {
     it('is called with (e, data) when clicked', () => {
-      const onKeyDown = sandbox.spy()
+      const onKeyPress = sandbox.spy()
       const event = { keyCode: 13 }
       const props = { tabIndex: 0 }
 
-      shallow(<MenuItem onKeyDown={onKeyDown} {...props} />).simulate('keydown', event)
+      shallow(<MenuItem onKeyPress={onKeyPress} {...props} />).simulate('keydown', event)
 
-      onKeyDown.should.have.been.calledOnce()
-      onKeyDown.should.have.been.calledWithMatch(event, props)
+      onKeyPress.should.have.been.calledOnce()
+      onKeyPress.should.have.been.calledWithMatch(event, props)
     })
   })
 

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -68,4 +68,18 @@ describe('MenuItem', () => {
       shallow(<MenuItem onClick={() => null} />).should.have.tagName('a')
     })
   })
+
+  describe('tabIndex', () => {
+    it('defaults to 0', () => {
+      shallow(<MenuItem />).should.have.prop('tabIndex', 0)
+    })
+
+    it('defaults to 0 as <a>', () => {
+      shallow(<MenuItem as='a' />).should.have.prop('tabIndex', 0)
+    })
+
+    it('defaults to -1 when disabled', () => {
+      shallow(<MenuItem disabled />).should.have.prop('tabIndex', -1)
+    })
+  })
 })

--- a/test/specs/collections/Menu/MenuItem-test.js
+++ b/test/specs/collections/Menu/MenuItem-test.js
@@ -75,7 +75,7 @@ describe('MenuItem', () => {
       const event = { keyCode: 13 }
       const props = { tabIndex: 0 }
 
-      shallow(<MenuItem onKeyPress={onKeyPress} {...props} />).simulate('keydown', event)
+      shallow(<MenuItem onKeyPress={onKeyPress} {...props} />).simulate('keypress', event)
 
       onKeyPress.should.have.been.calledOnce()
       onKeyPress.should.have.been.calledWithMatch(event, props)


### PR DESCRIPTION
### Menu Item Accessibility
_Any feedback will be appreciated 💗_

Relates to Issue #4384

1. Added tabIndex on MenuItem component for accessibility
2. Added onKeyPress to handle on `Enter` & `Space` selection for accessibility
3. Added additional test coverage for MenuItem-test.js

Testing:
Can test on Tab element
Can test disabled functionality on Menu element

Limitations:
_Another issue should be created if there isn't one already for:_
* Dropdown children Menu Items are not keyboard accessible
<img width="366" alt="Screen Shot 2022-10-31 at 2 10 21 PM" src="https://user-images.githubusercontent.com/31292683/199111298-17644691-e898-4c36-a579-e2f22e6f7f39.png">
