### PR TITLE
fix(Input): pass focus options

### DIFF
--- a/src/elements/Input/Input.d.ts
+++ b/src/elements/Input/Input.d.ts
@@ -82,7 +82,7 @@ export interface InputOnChangeData extends InputProps {
 }
 
 declare class Input extends React.Component<InputProps> {
-  focus: () => void
+  focus: (options?: FocusOptions) => void
   select: () => void
 }
 

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -43,7 +43,7 @@ class Input extends Component {
     if (disabled) return -1
   }
 
-  focus = () => this.inputRef.current.focus()
+  focus = (options) => this.inputRef.current.focus(options)
 
   select = () => this.inputRef.current.select()
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus the focus method can have an `options` parameter, which is useful, for example, to prevent scrolling. With this fix, `options` parameter is passed to the referenced DOM element.