### PR TITLE
fix(Button): pass focus options

### DIFF
--- a/src/elements/Button/Button.d.ts
+++ b/src/elements/Button/Button.d.ts
@@ -123,7 +123,7 @@ declare class Button extends React.Component<ButtonProps> {
   static Group: typeof ButtonGroup
   static Or: typeof ButtonOr
 
-  focus: () => void
+  focus: (options?: FocusOptions) => void
 }
 
 export default Button

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -51,7 +51,7 @@ class Button extends Component {
     if (ElementType === 'div') return 0
   }
 
-  focus = () => _.invoke(this.ref.current, 'focus')
+  focus = (options) => _.invoke(this.ref.current, 'focus', options)
 
   handleClick = (e) => {
     const { disabled } = this.props


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus the focus method can have an `options` parameter, which is useful, for example, to prevent scrolling. With this fix, `options` parameter is passed to the referenced DOM element.