### PR TITLE
chore(Select,FormSelect,FormDropdown): use React.forwardRef()

### DIFF
--- a/src/addons/Select/Select.js
+++ b/src/addons/Select/Select.js
@@ -8,10 +8,11 @@ import Dropdown from '../../modules/Dropdown'
  * @see Dropdown
  * @see Form
  */
-function Select(props) {
-  return <Dropdown {...props} selection />
-}
+const Select = React.forwardRef(function (props, ref) {
+  return <Dropdown {...props} selection ref={ref} />
+})
 
+Select.displayName = 'Select'
 Select.propTypes = {
   /** Array of Dropdown.Item props e.g. `{ text: '', value: '' }` */
   options: PropTypes.arrayOf(PropTypes.shape(Dropdown.Item.propTypes)).isRequired,

--- a/src/collections/Form/FormDropdown.js
+++ b/src/collections/Form/FormDropdown.js
@@ -10,14 +10,15 @@ import FormField from './FormField'
  * @see Dropdown
  * @see Form
  */
-function FormDropdown(props) {
+const FormDropdown = React.forwardRef(function (props, ref) {
   const { control } = props
   const rest = getUnhandledProps(FormDropdown, props)
   const ElementType = getElementType(FormDropdown, props)
 
-  return <ElementType {...rest} control={control} />
-}
+  return <ElementType {...rest} control={control} ref={ref} />
+})
 
+FormDropdown.displayName = 'FormDropdown'
 FormDropdown.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/collections/Form/FormSelect.js
+++ b/src/collections/Form/FormSelect.js
@@ -11,14 +11,15 @@ import FormField from './FormField'
  * @see Form
  * @see Select
  */
-function FormSelect(props) {
+const FormSelect = React.forwardRef(function (props, ref) {
   const { control, options } = props
   const rest = getUnhandledProps(FormSelect, props)
   const ElementType = getElementType(FormSelect, props)
 
-  return <ElementType {...rest} control={control} options={options} />
-}
+  return <ElementType {...rest} control={control} options={options} ref={ref} />
+})
 
+FormSelect.displayName = 'FormSelect'
 FormSelect.propTypes = {
   /** An element type to render as (string or function). */
   as: PropTypes.elementType,

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -15,6 +15,7 @@ import {
   getUnhandledProps,
   makeDebugger,
   objectDiff,
+  setRef,
   useKeyOnly,
   useKeyOrValueAndKey,
 } from '../../lib'
@@ -72,6 +73,11 @@ class DropdownInner extends Component {
   searchRef = createRef()
   sizerRef = createRef()
   ref = createRef()
+
+  handleRef = (el) => {
+    this.ref.current = el
+    setRef(this.props.innerRef, el)
+  }
 
   getInitialAutoControlledState() {
     return { focus: false, searchQuery: '' }
@@ -1097,7 +1103,7 @@ class DropdownInner extends Component {
         onFocus={this.handleFocus}
         onChange={this.handleChange}
         tabIndex={this.computeTabIndex()}
-        ref={this.ref}
+        ref={this.handleRef}
       >
         {this.renderLabels()}
         {this.renderSearchInput()}

--- a/test/specs/addons/Select/Select-test.js
+++ b/test/specs/addons/Select/Select-test.js
@@ -11,7 +11,7 @@ const requiredProps = {
 describe('Select', () => {
   common.isConformant(Select, { requiredProps })
   common.hasSubcomponents(Select, [Dropdown.Divider, Dropdown.Header, Dropdown.Item, Dropdown.Menu])
-  common.forwardsRef(Select)
+  common.forwardsRef(Select, { requiredProps })
 
   it('renders a selection Dropdown', () => {
     shallow(<Select {...requiredProps} />)

--- a/test/specs/addons/Select/Select-test.js
+++ b/test/specs/addons/Select/Select-test.js
@@ -11,6 +11,7 @@ const requiredProps = {
 describe('Select', () => {
   common.isConformant(Select, { requiredProps })
   common.hasSubcomponents(Select, [Dropdown.Divider, Dropdown.Header, Dropdown.Item, Dropdown.Menu])
+  common.forwardsRef(Select)
 
   it('renders a selection Dropdown', () => {
     shallow(<Select {...requiredProps} />)

--- a/test/specs/collections/Form/FormDropdown-test.js
+++ b/test/specs/collections/Form/FormDropdown-test.js
@@ -7,6 +7,7 @@ import * as common from 'test/specs/commonTests'
 describe('FormDropdown', () => {
   common.isConformant(FormDropdown, { ignoredTypingsProps: ['error'] })
   common.labelImplementsHtmlForProp(FormDropdown)
+  common.forwardsRef(FormDropdown)
 
   it('renders a FormField with a Dropdown control', () => {
     shallow(<FormDropdown />)

--- a/test/specs/collections/Form/FormSelect-test.js
+++ b/test/specs/collections/Form/FormSelect-test.js
@@ -11,6 +11,7 @@ const requiredProps = {
 describe('FormSelect', () => {
   common.isConformant(FormSelect, { requiredProps, ignoredTypingsProps: ['error'] })
   common.labelImplementsHtmlForProp(FormSelect, { requiredProps })
+  common.forwardsRef(FormSelect)
 
   it('renders a FormField with a Select control', () => {
     shallow(<FormSelect {...requiredProps} />)

--- a/test/specs/collections/Form/FormSelect-test.js
+++ b/test/specs/collections/Form/FormSelect-test.js
@@ -11,7 +11,7 @@ const requiredProps = {
 describe('FormSelect', () => {
   common.isConformant(FormSelect, { requiredProps, ignoredTypingsProps: ['error'] })
   common.labelImplementsHtmlForProp(FormSelect, { requiredProps })
-  common.forwardsRef(FormSelect)
+  common.forwardsRef(FormSelect, { requiredProps })
 
   it('renders a FormField with a Select control', () => {
     shallow(<FormSelect {...requiredProps} />)

--- a/test/specs/modules/Dropdown/Dropdown-test.js
+++ b/test/specs/modules/Dropdown/Dropdown-test.js
@@ -100,6 +100,7 @@ describe('Dropdown', () => {
   })
 
   common.isConformant(Dropdown)
+  common.forwardsRef(Dropdown)
   common.hasUIClassName(Dropdown)
   common.hasSubcomponents(Dropdown, [
     DropdownDivider,


### PR DESCRIPTION
For some reason `common.forwardsRef` fails on num of spy calls