### PR TITLE
fix(Popup): fix positioning in scrollable container

### DIFF
--- a/src/modules/Popup/lib/createReferenceProxy.js
+++ b/src/modules/Popup/lib/createReferenceProxy.js
@@ -21,6 +21,10 @@ class ReferenceProxy {
   get parentNode() {
     return this.ref.current ? this.ref.current.parentNode : undefined
   }
+
+  get contextElement() {
+    return this.ref.current;
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/Semantic-Org/Semantic-UI-React/issues/4444

This PR addresses a regression for the `Popup` component where a `Popup` inside a non-document scrollable container would not update its position on scroll.

**Context:**
`Popper.JS` attempts to find scroll ancestors based on the reference element here: https://github.com/floating-ui/floating-ui/blob/92195083958c9496988ed4526b82b75b7256b5a4/src/createPopper.js#L80-L83.

The problem is that the [reference element provided via `Popup`](https://github.com/Semantic-Org/Semantic-UI-React/blob/ba4b72031d202388768779e4f908b9cc7b0271d0/src/modules/Popup/Popup.js#L321) fails the `isElement()` check and the fallback, a `contextElement` property does not exist.

This PR updates `ReferenceProxy` to add the `contextElement` property.

Original fix: https://github.com/Semantic-Org/Semantic-UI-React/pull/3607