### PR TITLE
fix(typings): update types to support `ref`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,12 +52,7 @@ export {
   StrictBreadcrumbSectionProps,
 } from './dist/commonjs/collections/Breadcrumb/BreadcrumbSection'
 
-export {
-  default as Form,
-  FormComponent,
-  FormProps,
-  StrictFormProps,
-} from './dist/commonjs/collections/Form'
+export { default as Form, FormProps, StrictFormProps } from './dist/commonjs/collections/Form'
 export {
   default as FormButton,
   FormButtonProps,

--- a/src/addons/Confirm/Confirm.d.ts
+++ b/src/addons/Confirm/Confirm.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandItem } from '../../generic'
 import { ButtonProps } from '../../elements/Button'
 import { StrictModalProps } from '../../modules/Modal'
 import { ModalContentProps } from '../../modules/Modal/ModalContent'
@@ -42,10 +42,10 @@ export interface StrictConfirmProps extends StrictModalProps {
   /** Whether or not the modal is visible. */
   open?: boolean
 
-  /** A confirm can vary in size. */
+  /** A Confirm can vary in size. */
   size?: 'mini' | 'tiny' | 'small' | 'large' | 'fullscreen'
 }
 
-declare const Confirm: React.ComponentClass<ConfirmProps>
+declare const Confirm: ForwardRefComponent<ConfirmProps, HTMLDivElement>
 
 export default Confirm

--- a/src/addons/Pagination/Pagination.d.ts
+++ b/src/addons/Pagination/Pagination.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandItem } from '../../generic'
 import PaginationItem, { PaginationItemProps } from './PaginationItem'
 
 export interface PaginationProps extends StrictPaginationProps {
@@ -56,8 +56,8 @@ export interface StrictPaginationProps {
   totalPages: number | string
 }
 
-declare class Pagination extends React.Component<PaginationProps> {
-  static Item: typeof PaginationItem
+declare const Pagination: ForwardRefComponent<PaginationProps, HTMLDivElement> & {
+  Item: typeof PaginationItem
 }
 
 export default Pagination

--- a/src/addons/Pagination/PaginationItem.d.ts
+++ b/src/addons/Pagination/PaginationItem.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface PaginationItemProps extends StrictPaginationItemProps {
   [key: string]: any
@@ -31,6 +32,6 @@ export interface StrictPaginationItemProps {
   type?: 'ellipsisItem' | 'firstItem' | 'prevItem' | 'pageItem' | 'nextItem' | 'lastItem'
 }
 
-declare class PaginationItem extends React.Component<PaginationItemProps> {}
+declare const PaginationItem: ForwardRefComponent<PaginationItemProps, HTMLDivElement>
 
 export default PaginationItem

--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -97,8 +97,8 @@ export interface StrictPortalProps {
   triggerRef?: React.Ref<any>
 }
 
-declare class Portal extends React.Component<PortalProps> {
-  static Inner: typeof PortalInner
+declare const Portal: React.FC<PortalProps> & {
+  Inner: typeof PortalInner
 }
 
 export default Portal

--- a/src/addons/Portal/PortalInner.d.ts
+++ b/src/addons/Portal/PortalInner.d.ts
@@ -28,6 +28,6 @@ export interface StrictPortalInnerProps {
   onUnmount?: (nothing: null, data: PortalInnerProps) => void
 }
 
-declare class PortalInner extends React.Component<PortalInnerProps> {}
+declare const PortalInner: React.FC<PortalInnerProps>
 
 export default PortalInner

--- a/src/addons/Radio/Radio.d.ts
+++ b/src/addons/Radio/Radio.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 import { StrictCheckboxProps } from '../../modules/Checkbox'
 
 export interface RadioProps extends StrictRadioProps {
@@ -16,6 +16,6 @@ export interface StrictRadioProps extends StrictCheckboxProps {
   type?: 'checkbox' | 'radio'
 }
 
-declare const Radio: React.FC<RadioProps>
+declare const Radio: ForwardRefComponent<RadioProps, HTMLInputElement>
 
 export default Radio

--- a/src/addons/Select/Select.d.ts
+++ b/src/addons/Select/Select.d.ts
@@ -1,10 +1,9 @@
-import * as React from 'react'
-
 import { StrictDropdownProps } from '../../modules/Dropdown'
 import DropdownDivider from '../../modules/Dropdown/DropdownDivider'
 import DropdownHeader from '../../modules/Dropdown/DropdownHeader'
 import DropdownItem, { DropdownItemProps } from '../../modules/Dropdown/DropdownItem'
 import DropdownMenu from '../../modules/Dropdown/DropdownMenu'
+import { ForwardRefComponent } from '../../generic'
 
 export interface SelectProps extends StrictSelectProps {
   [key: string]: any
@@ -15,13 +14,11 @@ export interface StrictSelectProps extends StrictDropdownProps {
   options: DropdownItemProps[]
 }
 
-interface SelectComponent extends React.FC<SelectProps> {
+declare const Select: ForwardRefComponent<SelectProps, HTMLDivElement> & {
   Divider: typeof DropdownDivider
   Header: typeof DropdownHeader
   Item: typeof DropdownItem
   Menu: typeof DropdownMenu
 }
-
-declare const Select: SelectComponent
 
 export default Select

--- a/src/addons/TextArea/TextArea.d.ts
+++ b/src/addons/TextArea/TextArea.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface TextAreaProps extends StrictTextAreaProps {
   [key: string]: any
@@ -31,8 +32,6 @@ export interface StrictTextAreaProps {
   value?: number | string
 }
 
-declare class TextArea extends React.Component<TextAreaProps> {
-  focus: () => void
-}
+declare const TextArea: ForwardRefComponent<TextAreaProps, HTMLTextAreaElement>
 
 export default TextArea

--- a/src/collections/Breadcrumb/Breadcrumb.d.ts
+++ b/src/collections/Breadcrumb/Breadcrumb.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticShorthandCollection,
   SemanticShorthandContent,
   SemanticShorthandItem,
@@ -38,11 +39,9 @@ export interface StrictBreadcrumbProps {
   size?: 'mini' | 'tiny' | 'small' | 'large' | 'big' | 'huge' | 'massive'
 }
 
-interface BreadcrumbComponent extends React.ComponentClass<BreadcrumbProps> {
+declare const Breadcrumb: ForwardRefComponent<BreadcrumbProps, HTMLDivElement> & {
   Divider: typeof BreadcrumbDivider
   Section: typeof BreadcrumbSection
 }
-
-declare const Breadcrumb: BreadcrumbComponent
 
 export default Breadcrumb

--- a/src/collections/Breadcrumb/BreadcrumbDivider.d.ts
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface BreadcrumbDividerProps extends StrictBreadcrumbDividerProps {
@@ -24,6 +24,6 @@ export interface StrictBreadcrumbDividerProps {
   icon?: SemanticShorthandItem<IconProps>
 }
 
-declare const BreadcrumbDivider: React.FC<BreadcrumbDividerProps>
+declare const BreadcrumbDivider: ForwardRefComponent<BreadcrumbDividerProps, HTMLDivElement>
 
 export default BreadcrumbDivider

--- a/src/collections/Breadcrumb/BreadcrumbSection.d.ts
+++ b/src/collections/Breadcrumb/BreadcrumbSection.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface BreadcrumbSectionProps extends StrictBreadcrumbSectionProps {
   [key: string]: any
@@ -37,6 +37,6 @@ export interface StrictBreadcrumbSectionProps {
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>, data: BreadcrumbSectionProps) => void
 }
 
-declare const BreadcrumbSection: React.ComponentClass<BreadcrumbSectionProps>
+declare const BreadcrumbSection: ForwardRefComponent<BreadcrumbSectionProps, HTMLDivElement>
 
 export default BreadcrumbSection

--- a/src/collections/Form/Form.d.ts
+++ b/src/collections/Form/Form.d.ts
@@ -9,6 +9,7 @@ import FormInput from './FormInput'
 import FormRadio from './FormRadio'
 import FormSelect from './FormSelect'
 import FormTextArea from './FormTextArea'
+import { ForwardRefComponent } from '../../generic'
 
 export interface FormProps extends StrictFormProps {
   [key: string]: any
@@ -58,7 +59,7 @@ export interface StrictFormProps {
   widths?: 'equal'
 }
 
-export interface FormComponent extends React.FC<FormProps> {
+declare const Form: ForwardRefComponent<FormProps, HTMLFormElement> & {
   Field: typeof FormField
   Button: typeof FormButton
   Checkbox: typeof FormCheckbox
@@ -69,7 +70,5 @@ export interface FormComponent extends React.FC<FormProps> {
   Select: typeof FormSelect
   TextArea: typeof FormTextArea
 }
-
-declare const Form: FormComponent
 
 export default Form

--- a/src/collections/Form/FormButton.d.ts
+++ b/src/collections/Form/FormButton.d.ts
@@ -1,6 +1,4 @@
-import * as React from 'react'
-
-import { SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandItem } from '../../generic'
 import { StrictButtonProps } from '../../elements/Button'
 import { LabelProps } from '../../elements/Label'
 import { StrictFormFieldProps } from './FormField'
@@ -22,6 +20,6 @@ export interface StrictFormButtonProps
   label?: SemanticShorthandItem<LabelProps>
 }
 
-declare const FormButton: React.FC<FormButtonProps>
+declare const FormButton: ForwardRefComponent<FormButtonProps, HTMLButtonElement>
 
 export default FormButton

--- a/src/collections/Form/FormCheckbox.d.ts
+++ b/src/collections/Form/FormCheckbox.d.ts
@@ -1,6 +1,5 @@
-import * as React from 'react'
-
 import { StrictCheckboxProps } from '../../modules/Checkbox'
+import { ForwardRefComponent } from '../../generic'
 import { StrictFormFieldProps } from './FormField'
 
 export interface FormCheckboxProps extends StrictFormCheckboxProps {
@@ -18,6 +17,6 @@ export interface StrictFormCheckboxProps extends StrictFormFieldProps, StrictChe
   type?: 'checkbox' | 'radio'
 }
 
-declare const FormCheckbox: React.FC<FormCheckboxProps>
+declare const FormCheckbox: ForwardRefComponent<FormCheckboxProps, HTMLInputElement>
 
 export default FormCheckbox

--- a/src/collections/Form/FormDropdown.d.ts
+++ b/src/collections/Form/FormDropdown.d.ts
@@ -1,6 +1,5 @@
-import * as React from 'react'
-
 import { StrictDropdownProps } from '../../modules/Dropdown'
+import { ForwardRefComponent } from '../../generic'
 import { StrictFormFieldProps } from './FormField'
 
 export interface FormDropdownProps extends StrictFormDropdownProps {
@@ -18,6 +17,6 @@ export interface StrictFormDropdownProps extends StrictFormFieldProps, StrictDro
   error?: any
 }
 
-declare const FormDropdown: React.FC<FormDropdownProps>
+declare const FormDropdown: ForwardRefComponent<FormDropdownProps, HTMLDivElement>
 
 export default FormDropdown

--- a/src/collections/Form/FormField.d.ts
+++ b/src/collections/Form/FormField.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   HtmlLabelProps,
   SemanticShorthandContent,
   SemanticShorthandItem,
@@ -57,6 +58,6 @@ export interface StrictFormFieldProps {
   width?: SemanticWIDTHS
 }
 
-declare const FormField: React.FC<FormFieldProps>
+declare const FormField: ForwardRefComponent<FormFieldProps, HTMLElement>
 
 export default FormField

--- a/src/collections/Form/FormGroup.d.ts
+++ b/src/collections/Form/FormGroup.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticWIDTHS } from '../../generic'
+import { ForwardRefComponent, SemanticWIDTHS } from '../../generic'
 
 export interface FormGroupProps extends StrictFormGroupProps {
   [key: string]: any
@@ -34,6 +34,6 @@ export interface StrictFormGroupProps {
   widths?: SemanticWIDTHS | 'equal'
 }
 
-declare const FormGroup: React.FC<FormGroupProps>
+declare const FormGroup: ForwardRefComponent<FormGroupProps, HTMLInputElement>
 
 export default FormGroup

--- a/src/collections/Form/FormInput.d.ts
+++ b/src/collections/Form/FormInput.d.ts
@@ -1,6 +1,4 @@
-import * as React from 'react'
-
-import { SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandItem } from '../../generic'
 import { LabelProps } from '../../elements/Label'
 import { StrictInputProps } from '../../elements/Input'
 import { StrictFormFieldProps } from './FormField'
@@ -25,6 +23,6 @@ export interface StrictFormInputProps
   label?: SemanticShorthandItem<LabelProps>
 }
 
-declare const FormInput: React.FC<FormInputProps>
+declare const FormInput: ForwardRefComponent<FormInputProps, HTMLInputElement>
 
 export default FormInput

--- a/src/collections/Form/FormRadio.d.ts
+++ b/src/collections/Form/FormRadio.d.ts
@@ -1,6 +1,5 @@
-import * as React from 'react'
-
 import { StrictRadioProps } from '../../addons/Radio'
+import { ForwardRefComponent } from '../../generic'
 import { StrictFormFieldProps } from './FormField'
 
 export interface FormRadioProps extends StrictFormRadioProps {
@@ -18,6 +17,6 @@ export interface StrictFormRadioProps extends StrictFormFieldProps, StrictRadioP
   type?: 'checkbox' | 'radio'
 }
 
-declare const FormRadio: React.FC<FormRadioProps>
+declare const FormRadio: ForwardRefComponent<FormRadioProps, HTMLInputElement>
 
 export default FormRadio

--- a/src/collections/Form/FormSelect.d.ts
+++ b/src/collections/Form/FormSelect.d.ts
@@ -1,10 +1,7 @@
-import * as React from 'react'
-
 import { StrictSelectProps } from '../../addons/Select'
 import { DropdownItemProps } from '../../modules/Dropdown/DropdownItem'
 import { StrictFormFieldProps } from './FormField'
-import { SemanticShorthandItem } from '../../generic'
-import { LabelProps } from '../../elements/Label'
+import { ForwardRefComponent } from '../../generic'
 
 export interface FormSelectProps extends StrictFormSelectProps {
   [key: string]: any
@@ -24,6 +21,6 @@ export interface StrictFormSelectProps extends StrictFormFieldProps, StrictSelec
   options: DropdownItemProps[]
 }
 
-declare const FormSelect: React.FC<FormSelectProps>
+declare const FormSelect: ForwardRefComponent<FormSelectProps, HTMLDivElement>
 
 export default FormSelect

--- a/src/collections/Form/FormTextArea.d.ts
+++ b/src/collections/Form/FormTextArea.d.ts
@@ -1,6 +1,5 @@
-import * as React from 'react'
-
 import { StrictTextAreaProps } from '../../addons/TextArea'
+import { ForwardRefComponent } from '../../generic'
 import { StrictFormFieldProps } from './FormField'
 
 export interface FormTextAreaProps extends StrictFormTextAreaProps {
@@ -15,6 +14,6 @@ export interface StrictFormTextAreaProps extends StrictFormFieldProps, StrictTex
   control?: any
 }
 
-declare const FormTextArea: React.FC<FormTextAreaProps>
+declare const FormTextArea: ForwardRefComponent<FormTextAreaProps, HTMLTextAreaElement>
 
 export default FormTextArea

--- a/src/collections/Form/index.d.ts
+++ b/src/collections/Form/index.d.ts
@@ -1,1 +1,1 @@
-export { default, FormComponent, FormProps, StrictFormProps } from './Form'
+export { default, FormProps, StrictFormProps } from './Form'

--- a/src/collections/Grid/Grid.d.ts
+++ b/src/collections/Grid/Grid.d.ts
@@ -1,6 +1,11 @@
 import * as React from 'react'
 
-import { SemanticTEXTALIGNMENTS, SemanticVERTICALALIGNMENTS, SemanticWIDTHS } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticTEXTALIGNMENTS,
+  SemanticVERTICALALIGNMENTS,
+  SemanticWIDTHS,
+} from '../../generic'
 import GridColumn from './GridColumn'
 import GridRow from './GridRow'
 
@@ -70,11 +75,9 @@ export interface StrictGridProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-interface GridComponent extends React.FC<GridProps> {
+declare const Grid: ForwardRefComponent<GridProps, HTMLDivElement> & {
   Column: typeof GridColumn
   Row: typeof GridRow
 }
-
-declare const Grid: GridComponent
 
 export default Grid

--- a/src/collections/Grid/GridColumn.d.ts
+++ b/src/collections/Grid/GridColumn.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import {
+  ForwardRefComponent,
   SemanticCOLORS,
   SemanticFLOATS,
   SemanticTEXTALIGNMENTS,
@@ -67,6 +68,6 @@ export interface StrictGridColumnProps {
   width?: SemanticWIDTHS
 }
 
-declare const GridColumn: React.FC<GridColumnProps>
+declare const GridColumn: ForwardRefComponent<GridColumnProps, HTMLDivElement>
 
 export default GridColumn

--- a/src/collections/Grid/GridRow.d.ts
+++ b/src/collections/Grid/GridRow.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticCOLORS,
   SemanticTEXTALIGNMENTS,
   SemanticVERTICALALIGNMENTS,
@@ -51,6 +52,6 @@ export interface StrictGridRowProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-declare const GridRow: React.FC<GridRowProps>
+declare const GridRow: ForwardRefComponent<GridRowProps, HTMLDivElement>
 
 export default GridRow

--- a/src/collections/Menu/Menu.d.ts
+++ b/src/collections/Menu/Menu.d.ts
@@ -1,6 +1,11 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticShorthandCollection, SemanticWIDTHS } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticCOLORS,
+  SemanticShorthandCollection,
+  SemanticWIDTHS,
+} from '../../generic'
 import MenuHeader from './MenuHeader'
 import MenuItem, { MenuItemProps } from './MenuItem'
 import MenuMenu from './MenuMenu'
@@ -91,12 +96,10 @@ export interface StrictMenuProps {
   widths?: SemanticWIDTHS
 }
 
-interface MenuComponent extends React.ComponentClass<MenuProps> {
+declare const Menu: ForwardRefComponent<MenuProps, HTMLDivElement> & {
   Header: typeof MenuHeader
   Item: typeof MenuItem
   Menu: typeof MenuMenu
 }
-
-declare const Menu: MenuComponent
 
 export default Menu

--- a/src/collections/Menu/MenuHeader.d.ts
+++ b/src/collections/Menu/MenuHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface MenuHeaderProps extends StrictMenuHeaderProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictMenuHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const MenuHeader: React.ComponentClass<MenuHeaderProps>
+declare const MenuHeader: ForwardRefComponent<MenuHeaderProps, HTMLDivElement>
 
 export default MenuHeader

--- a/src/collections/Menu/MenuItem.d.ts
+++ b/src/collections/Menu/MenuItem.d.ts
@@ -1,6 +1,11 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticCOLORS,
+  SemanticShorthandContent,
+  SemanticShorthandItem,
+} from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface MenuItemProps extends StrictMenuItemProps {
@@ -60,6 +65,6 @@ export interface StrictMenuItemProps {
   position?: 'left' | 'right'
 }
 
-declare const MenuItem: React.ComponentClass<MenuItemProps>
+declare const MenuItem: ForwardRefComponent<MenuItemProps, HTMLDivElement>
 
 export default MenuItem

--- a/src/collections/Menu/MenuMenu.d.ts
+++ b/src/collections/Menu/MenuMenu.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface MenuMenuProps extends StrictMenuMenuProps {
   [key: string]: any
@@ -22,6 +22,6 @@ export interface StrictMenuMenuProps {
   position?: 'left' | 'right'
 }
 
-declare const MenuMenu: React.FC<MenuMenuProps>
+declare const MenuMenu: ForwardRefComponent<MenuMenuProps, HTMLDivElement>
 
 export default MenuMenu

--- a/src/collections/Message/Message.d.ts
+++ b/src/collections/Message/Message.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticCOLORS,
   SemanticShorthandCollection,
   SemanticShorthandContent,
@@ -88,13 +89,11 @@ export interface StrictMessageProps {
   warning?: boolean
 }
 
-interface MessageComponent extends React.ComponentClass<MessageProps> {
+declare const Message: ForwardRefComponent<MessageProps, HTMLDivElement> & {
   Content: typeof MessageContent
   Header: typeof MessageHeader
   List: typeof MessageList
   Item: typeof MessageItem
 }
-
-declare const Message: MessageComponent
 
 export default Message

--- a/src/collections/Message/MessageContent.d.ts
+++ b/src/collections/Message/MessageContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface MessageContentProps extends StrictMessageContentProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictMessageContentProps {
   content?: SemanticShorthandContent
 }
 
-declare const MessageContent: React.FC<MessageContentProps>
+declare const MessageContent: ForwardRefComponent<MessageContentProps, HTMLDivElement>
 
 export default MessageContent

--- a/src/collections/Message/MessageHeader.d.ts
+++ b/src/collections/Message/MessageHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface MessageHeaderProps extends StrictMessageHeaderProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictMessageHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const MessageHeader: React.FC<MessageHeaderProps>
+declare const MessageHeader: ForwardRefComponent<MessageHeaderProps, HTMLDivElement>
 
 export default MessageHeader

--- a/src/collections/Message/MessageItem.d.ts
+++ b/src/collections/Message/MessageItem.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface MessageItemProps extends StrictMessageItemProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictMessageItemProps {
   content?: SemanticShorthandContent
 }
 
-declare const MessageItem: React.FC<MessageItemProps>
+declare const MessageItem: ForwardRefComponent<MessageItemProps, HTMLLIElement>
 
 export default MessageItem

--- a/src/collections/Message/MessageList.d.ts
+++ b/src/collections/Message/MessageList.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandCollection } from '../../generic'
 import { MessageItemProps } from './MessageItem'
 
 export interface MessageListProps extends StrictMessageListProps {
@@ -21,6 +21,6 @@ export interface StrictMessageListProps {
   items?: SemanticShorthandCollection<MessageItemProps>
 }
 
-declare const MessageList: React.FC<MessageListProps>
+declare const MessageList: ForwardRefComponent<MessageListProps, HTMLUListElement>
 
 export default MessageList

--- a/src/collections/Table/Table.d.ts
+++ b/src/collections/Table/Table.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticCOLORS,
   SemanticShorthandCollection,
   SemanticShorthandItem,
@@ -115,7 +116,7 @@ export interface StrictTableProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-interface TableComponent extends React.FC<TableProps> {
+declare const Table: ForwardRefComponent<TableProps, HTMLTableElement> & {
   Body: typeof TableBody
   Cell: typeof TableCell
   Footer: typeof TableFooter
@@ -123,7 +124,5 @@ interface TableComponent extends React.FC<TableProps> {
   HeaderCell: typeof TableHeaderCell
   Row: typeof TableRow
 }
-
-declare const Table: TableComponent
 
 export default Table

--- a/src/collections/Table/TableBody.d.ts
+++ b/src/collections/Table/TableBody.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface TableBodyProps extends StrictTableBodyProps {
   [key: string]: any
@@ -15,6 +16,6 @@ export interface StrictTableBodyProps {
   className?: string
 }
 
-declare const TableBody: React.FC<TableBodyProps>
+declare const TableBody: ForwardRefComponent<TableBodyProps, HTMLTableSectionElement>
 
 export default TableBody

--- a/src/collections/Table/TableCell.d.ts
+++ b/src/collections/Table/TableCell.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticShorthandContent,
   SemanticShorthandItem,
   SemanticVERTICALALIGNMENTS,
@@ -65,6 +66,6 @@ export interface StrictTableCellProps {
   width?: SemanticWIDTHS
 }
 
-declare const TableCell: React.FC<TableCellProps>
+declare const TableCell: ForwardRefComponent<TableCellProps, HTMLTableCellElement>
 
 export default TableCell

--- a/src/collections/Table/TableFooter.d.ts
+++ b/src/collections/Table/TableFooter.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 import { StrictTableHeaderProps } from './TableHeader'
 
 export interface TableFooterProps extends StrictTableFooterProps {
@@ -10,6 +10,6 @@ export interface StrictTableFooterProps extends StrictTableHeaderProps {
   as?: any
 }
 
-declare const TableFooter: React.FC<TableFooterProps>
+declare const TableFooter: ForwardRefComponent<TableFooterProps, HTMLTableSectionElement>
 
 export default TableFooter

--- a/src/collections/Table/TableHeader.d.ts
+++ b/src/collections/Table/TableHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface TableHeaderProps extends StrictTableHeaderProps {
   [key: string]: any
@@ -22,6 +22,6 @@ export interface StrictTableHeaderProps {
   fullWidth?: boolean
 }
 
-declare const TableHeader: React.FC<TableHeaderProps>
+declare const TableHeader: ForwardRefComponent<TableHeaderProps, HTMLTableSectionElement>
 
 export default TableHeader

--- a/src/collections/Table/TableHeaderCell.d.ts
+++ b/src/collections/Table/TableHeaderCell.d.ts
@@ -1,5 +1,5 @@
-import * as React from 'react'
 import { StrictTableCellProps } from './TableCell'
+import { ForwardRefComponent } from '../../generic'
 
 export interface TableHeaderCellProps extends StrictTableHeaderCellProps {
   [key: string]: any
@@ -16,6 +16,6 @@ export interface StrictTableHeaderCellProps extends StrictTableCellProps {
   sorted?: 'ascending' | 'descending'
 }
 
-declare const TableHeaderCell: React.FC<TableHeaderCellProps>
+declare const TableHeaderCell: ForwardRefComponent<TableHeaderCellProps, HTMLTableCellElement>
 
 export default TableHeaderCell

--- a/src/collections/Table/TableRow.d.ts
+++ b/src/collections/Table/TableRow.d.ts
@@ -1,6 +1,10 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection, SemanticVERTICALALIGNMENTS } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticShorthandCollection,
+  SemanticVERTICALALIGNMENTS,
+} from '../../generic'
 import { TableCellProps } from './TableCell'
 
 export interface TableRowProps extends StrictTableRowProps {
@@ -48,6 +52,6 @@ export interface StrictTableRowProps {
   warning?: boolean
 }
 
-declare const TableRow: React.FC<TableRowProps>
+declare const TableRow: ForwardRefComponent<TableRowProps, HTMLTableCellElement>
 
 export default TableRow

--- a/src/elements/Button/Button.d.ts
+++ b/src/elements/Button/Button.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticCOLORS,
   SemanticFLOATS,
   SemanticShorthandContent,
@@ -118,12 +119,10 @@ export interface StrictButtonProps {
   type?: 'submit' | 'reset' | 'button'
 }
 
-declare class Button extends React.Component<ButtonProps> {
-  static Content: typeof ButtonContent
-  static Group: typeof ButtonGroup
-  static Or: typeof ButtonOr
-
-  focus: (options?: FocusOptions) => void
+declare const Button: ForwardRefComponent<ButtonProps, HTMLButtonElement> & {
+  Content: typeof ButtonContent
+  Group: typeof ButtonGroup
+  Or: typeof ButtonOr
 }
 
 export default Button

--- a/src/elements/Button/ButtonContent.d.ts
+++ b/src/elements/Button/ButtonContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ButtonContentProps extends StrictButtonContentProps {
   [key: string]: any
@@ -25,6 +25,6 @@ export interface StrictButtonContentProps {
   visible?: boolean
 }
 
-declare const ButtonContent: React.FC<ButtonContentProps>
+declare const ButtonContent: ForwardRefComponent<ButtonContentProps, HTMLDivElement>
 
 export default ButtonContent

--- a/src/elements/Button/ButtonGroup.d.ts
+++ b/src/elements/Button/ButtonGroup.d.ts
@@ -7,6 +7,7 @@ import {
   SemanticShorthandCollection,
   SemanticSIZES,
   SemanticWIDTHS,
+  ForwardRefComponent,
 } from '../../generic'
 import { ButtonProps } from './Button'
 
@@ -82,6 +83,6 @@ export interface StrictButtonGroupProps {
   widths?: SemanticWIDTHS
 }
 
-declare const ButtonGroup: React.FC<ButtonGroupProps>
+declare const ButtonGroup: ForwardRefComponent<ButtonGroupProps, HTMLDivElement>
 
 export default ButtonGroup

--- a/src/elements/Button/ButtonOr.d.ts
+++ b/src/elements/Button/ButtonOr.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface ButtonOrProps extends StrictButtonOrProps {
   [key: string]: any
@@ -15,6 +15,6 @@ export interface StrictButtonOrProps {
   text?: number | string
 }
 
-declare const ButtonOr: React.FC<ButtonOrProps>
+declare const ButtonOr: ForwardRefComponent<ButtonOrProps, HTMLDivElement>
 
 export default ButtonOr

--- a/src/elements/Container/Container.d.ts
+++ b/src/elements/Container/Container.d.ts
@@ -1,5 +1,9 @@
 import * as React from 'react'
-import { SemanticShorthandContent, SemanticTEXTALIGNMENTS } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticShorthandContent,
+  SemanticTEXTALIGNMENTS,
+} from '../../generic'
 
 export interface ContainerProps extends StrictContainerProps {
   [key: string]: any
@@ -28,6 +32,6 @@ export interface StrictContainerProps {
   textAlign?: SemanticTEXTALIGNMENTS
 }
 
-declare const Container: React.FC<ContainerProps>
+declare const Container: ForwardRefComponent<ContainerProps, HTMLDivElement>
 
 export default Container

--- a/src/elements/Divider/Divider.d.ts
+++ b/src/elements/Divider/Divider.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface DividerProps extends StrictDividerProps {
   [key: string]: any
@@ -40,6 +40,6 @@ export interface StrictDividerProps {
   vertical?: boolean
 }
 
-declare const Divider: React.FC<DividerProps>
+declare const Divider: ForwardRefComponent<DividerProps, HTMLDivElement>
 
 export default Divider

--- a/src/elements/Flag/Flag.d.ts
+++ b/src/elements/Flag/Flag.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export type FlagNameValues =
   | 'ad'
@@ -511,6 +512,6 @@ export interface StrictFlagProps {
   name: FlagNameValues
 }
 
-declare class Flag extends React.PureComponent<FlagProps> {}
+declare const Flag: ForwardRefComponent<FlagProps, HTMLElement>
 
 export default Flag

--- a/src/elements/Header/Header.d.ts
+++ b/src/elements/Header/Header.d.ts
@@ -1,8 +1,13 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticFLOATS, SemanticTEXTALIGNMENTS } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticCOLORS,
+  SemanticFLOATS,
+  SemanticTEXTALIGNMENTS,
+} from '../../generic'
 import HeaderContent from './HeaderContent'
-import HeaderSubHeader from './HeaderSubheader'
+import HeaderSubheader from './HeaderSubheader'
 
 export interface HeaderProps extends StrictHeaderProps {
   [key: string]: any
@@ -61,11 +66,9 @@ export interface StrictHeaderProps {
   textAlign?: SemanticTEXTALIGNMENTS
 }
 
-interface HeaderComponent extends React.FC<HeaderProps> {
+declare const Header: ForwardRefComponent<HeaderProps, HTMLDivElement> & {
   Content: typeof HeaderContent
-  Subheader: typeof HeaderSubHeader
+  Subheader: typeof HeaderSubheader
 }
-
-declare const Header: HeaderComponent
 
 export default Header

--- a/src/elements/Header/HeaderContent.d.ts
+++ b/src/elements/Header/HeaderContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface HeaderContentProps extends StrictHeaderContentProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictHeaderContentProps {
   content?: SemanticShorthandContent
 }
 
-declare const HeaderContent: React.FC<HeaderContentProps>
+declare const HeaderContent: ForwardRefComponent<HeaderContentProps, HTMLDivElement>
 
 export default HeaderContent

--- a/src/elements/Header/HeaderSubheader.d.ts
+++ b/src/elements/Header/HeaderSubheader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface HeaderSubheaderProps extends StrictHeaderSubheaderProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictHeaderSubheaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const HeaderSubHeader: React.FC<HeaderSubheaderProps>
+declare const HeaderSubheader: ForwardRefComponent<HeaderSubheaderProps, HTMLDivElement>
 
-export default HeaderSubHeader
+export default HeaderSubheader

--- a/src/elements/Icon/Icon.d.ts
+++ b/src/elements/Icon/Icon.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticICONS } from '../../generic'
+import { ForwardRefComponent, SemanticCOLORS, SemanticICONS } from '../../generic'
 import IconGroup from './IconGroup'
 
 export type IconSizeProp = 'mini' | 'tiny' | 'small' | 'large' | 'big' | 'huge' | 'massive'
@@ -63,8 +63,8 @@ export interface StrictIconProps {
   'aria-label'?: string
 }
 
-declare class Icon extends React.PureComponent<IconProps> {
-  static Group: typeof IconGroup
+declare const Icon: ForwardRefComponent<IconProps, HTMLElement> & {
+  Group: typeof IconGroup
 }
 
 export default Icon

--- a/src/elements/Icon/IconGroup.d.ts
+++ b/src/elements/Icon/IconGroup.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 import { IconSizeProp } from './Icon'
 
 export interface IconGroupProps extends StrictIconGroupProps {
@@ -24,6 +24,6 @@ export interface StrictIconGroupProps {
   size?: IconSizeProp
 }
 
-declare const IconGroup: React.FC<IconGroupProps>
+declare const IconGroup: ForwardRefComponent<IconGroupProps, HTMLElement>
 
 export default IconGroup

--- a/src/elements/Image/Image.d.ts
+++ b/src/elements/Image/Image.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticFLOATS,
   SemanticShorthandContent,
   SemanticShorthandItem,
@@ -84,10 +85,8 @@ export interface StrictImageProps {
   wrapped?: boolean
 }
 
-interface ImageComponent extends React.FC<ImageProps> {
+declare const Image: ForwardRefComponent<ImageProps, HTMLImageElement> & {
   Group: typeof ImageGroup
 }
-
-declare const Image: ImageComponent
 
 export default Image

--- a/src/elements/Image/ImageGroup.d.ts
+++ b/src/elements/Image/ImageGroup.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticSIZES, SemanticShorthandContent } from '../../generic'
+import { SemanticSIZES, SemanticShorthandContent, ForwardRefComponent } from '../../generic'
 
 export interface ImageGroupProps extends StrictImageGroupProps {
   [key: string]: any
@@ -22,6 +22,6 @@ export interface StrictImageGroupProps {
   size?: SemanticSIZES
 }
 
-declare const ImageGroup: React.FC<ImageGroupProps>
+declare const ImageGroup: ForwardRefComponent<ImageGroupProps, HTMLDivElement>
 
 export default ImageGroup

--- a/src/elements/Input/Input.d.ts
+++ b/src/elements/Input/Input.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { HtmlInputrops, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, HtmlInputrops, SemanticShorthandItem } from '../../generic'
 import { LabelProps } from '../Label'
 
 export interface InputProps extends StrictInputProps {
@@ -81,9 +81,6 @@ export interface InputOnChangeData extends InputProps {
   value: string
 }
 
-declare class Input extends React.Component<InputProps> {
-  focus: (options?: FocusOptions) => void
-  select: () => void
-}
+declare const Input: ForwardRefComponent<InputProps, HTMLInputElement>
 
 export default Input

--- a/src/elements/Label/Label.d.ts
+++ b/src/elements/Label/Label.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticCOLORS,
   SemanticShorthandContent,
   SemanticShorthandItem,
@@ -98,11 +99,9 @@ export interface StrictLabelProps {
   tag?: boolean
 }
 
-interface LabelComponent extends React.ComponentClass<LabelProps> {
+declare const Label: ForwardRefComponent<LabelProps, HTMLDivElement> & {
   Detail: typeof LabelDetail
   Group: typeof LabelGroup
 }
-
-declare const Label: LabelComponent
 
 export default Label

--- a/src/elements/Label/LabelDetail.d.ts
+++ b/src/elements/Label/LabelDetail.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface LabelDetailProps extends StrictLabelDetailProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictLabelDetailProps {
   content?: SemanticShorthandContent
 }
 
-declare const LabelDetail: React.FC<LabelDetailProps>
+declare const LabelDetail: ForwardRefComponent<LabelDetailProps, HTMLDivElement>
 
 export default LabelDetail

--- a/src/elements/Label/LabelGroup.d.ts
+++ b/src/elements/Label/LabelGroup.d.ts
@@ -1,5 +1,10 @@
 import * as React from 'react'
-import { SemanticCOLORS, SemanticShorthandContent, SemanticSIZES } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticCOLORS,
+  SemanticShorthandContent,
+  SemanticSIZES,
+} from '../../generic'
 
 export interface LabelGroupProps extends StrictLabelGroupProps {
   [key: string]: any
@@ -31,6 +36,6 @@ export interface StrictLabelGroupProps {
   tag?: boolean
 }
 
-declare const LabelGroup: React.FC<LabelGroupProps>
+declare const LabelGroup: ForwardRefComponent<LabelGroupProps, HTMLDivElement>
 
 export default LabelGroup

--- a/src/elements/List/List.d.ts
+++ b/src/elements/List/List.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticFLOATS,
   SemanticShorthandCollection,
   SemanticShorthandContent,
@@ -82,7 +83,7 @@ export interface StrictListProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-interface ListComponent extends React.FC<ListProps> {
+declare const List: ForwardRefComponent<ListProps, HTMLDivElement> & {
   Content: typeof ListContent
   Description: typeof ListDescription
   Header: typeof ListHeader
@@ -90,7 +91,5 @@ interface ListComponent extends React.FC<ListProps> {
   Item: typeof ListItem
   List: typeof ListList
 }
-
-declare const List: ListComponent
 
 export default List

--- a/src/elements/List/ListContent.d.ts
+++ b/src/elements/List/ListContent.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticFLOATS,
   SemanticShorthandContent,
   SemanticShorthandItem,
@@ -39,6 +40,6 @@ export interface StrictListContentProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-declare const ListContent: React.FC<ListContentProps>
+declare const ListContent: ForwardRefComponent<ListContentProps, HTMLDivElement>
 
 export default ListContent

--- a/src/elements/List/ListDescription.d.ts
+++ b/src/elements/List/ListDescription.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ListDescriptionProps extends StrictListDescriptionProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictListDescriptionProps {
   content?: SemanticShorthandContent
 }
 
-declare const ListDescription: React.FC<ListDescriptionProps>
+declare const ListDescription: ForwardRefComponent<ListDescriptionProps, HTMLDivElement>
 
 export default ListDescription

--- a/src/elements/List/ListHeader.d.ts
+++ b/src/elements/List/ListHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ListHeaderProps extends StrictListHeaderProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictListHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const ListHeader: React.FC<ListHeaderProps>
+declare const ListHeader: ForwardRefComponent<ListHeaderProps, HTMLDivElement>
 
 export default ListHeader

--- a/src/elements/List/ListIcon.d.ts
+++ b/src/elements/List/ListIcon.d.ts
@@ -1,6 +1,4 @@
-import * as React from 'react'
-
-import { SemanticVERTICALALIGNMENTS } from '../../generic'
+import { ForwardRefComponent, SemanticVERTICALALIGNMENTS } from '../../generic'
 import { StrictIconProps } from '../Icon'
 
 export interface ListIconProps extends StrictListIconProps {
@@ -15,6 +13,6 @@ export interface StrictListIconProps extends StrictIconProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-declare const ListIcon: React.FC<ListIconProps>
+declare const ListIcon: ForwardRefComponent<ListIconProps, HTMLElement>
 
 export default ListIcon

--- a/src/elements/List/ListItem.d.ts
+++ b/src/elements/List/ListItem.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandItem } from '../../generic'
 import { ImageProps } from '../Image'
 import { ListContentProps } from './ListContent'
 import { ListDescriptionProps } from './ListDescription'
@@ -54,6 +54,6 @@ export interface StrictListItemProps {
   value?: string
 }
 
-declare const ListItem: React.FC<ListItemProps>
+declare const ListItem: ForwardRefComponent<ListItemProps, HTMLDivElement>
 
 export default ListItem

--- a/src/elements/List/ListList.d.ts
+++ b/src/elements/List/ListList.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ListListProps extends StrictListListProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictListListProps {
   content?: SemanticShorthandContent
 }
 
-declare const ListList: React.FC<ListListProps>
+declare const ListList: ForwardRefComponent<ListListProps, HTMLDivElement>
 
 export default ListList

--- a/src/elements/Loader/Loader.d.ts
+++ b/src/elements/Loader/Loader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent, SemanticSIZES } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticSIZES } from '../../generic'
 
 export interface LoaderProps extends StrictLoaderProps {
   [key: string]: any
@@ -37,6 +37,6 @@ export interface StrictLoaderProps {
   size?: SemanticSIZES
 }
 
-declare const Loader: React.FC<LoaderProps>
+declare const Loader: ForwardRefComponent<LoaderProps, HTMLDivElement>
 
 export default Loader

--- a/src/elements/Placeholder/Placeholder.d.ts
+++ b/src/elements/Placeholder/Placeholder.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 import PlaceholderHeader from './PlaceholderHeader'
 import PlaceholderImage from './PlaceholderImage'
@@ -30,13 +30,11 @@ export interface StrictPlaceholderProps {
   inverted?: boolean
 }
 
-interface PlaceholderComponent extends React.FC<PlaceholderProps> {
+declare const Placeholder: ForwardRefComponent<PlaceholderProps, HTMLDivElement> & {
   Header: typeof PlaceholderHeader
   Line: typeof PlaceholderLine
   Image: typeof PlaceholderImage
   Paragraph: typeof PlaceholderParagraph
 }
-
-declare const Placeholder: PlaceholderComponent
 
 export default Placeholder

--- a/src/elements/Placeholder/PlaceholderHeader.d.ts
+++ b/src/elements/Placeholder/PlaceholderHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface PlaceholderHeaderProps extends StrictPlaceholderHeaderProps {
   [key: string]: any
@@ -22,8 +22,6 @@ export interface StrictPlaceholderHeaderProps {
   image?: boolean
 }
 
-interface PlaceholderHeaderComponent extends React.FC<PlaceholderHeaderProps> {}
-
-declare const PlaceholderHeader: PlaceholderHeaderComponent
+declare const PlaceholderHeader: ForwardRefComponent<PlaceholderHeaderProps, HTMLDivElement>
 
 export default PlaceholderHeader

--- a/src/elements/Placeholder/PlaceholderImage.d.ts
+++ b/src/elements/Placeholder/PlaceholderImage.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface PlaceholderImageProps extends StrictPlaceholderImageProps {
   [key: string]: any
@@ -18,8 +19,6 @@ export interface StrictPlaceholderImageProps {
   rectangular?: boolean
 }
 
-interface PlaceholderImageComponent extends React.FC<PlaceholderImageProps> {}
-
-declare const PlaceholderImage: PlaceholderImageComponent
+declare const PlaceholderImage: ForwardRefComponent<PlaceholderImageProps, HTMLDivElement>
 
 export default PlaceholderImage

--- a/src/elements/Placeholder/PlaceholderLine.d.ts
+++ b/src/elements/Placeholder/PlaceholderLine.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface PlaceholderLineProps extends StrictPlaceholderLineProps {
   [key: string]: any
@@ -15,8 +16,6 @@ export interface StrictPlaceholderLineProps {
   length?: 'full' | 'very long' | 'long' | 'medium' | 'short' | 'very short'
 }
 
-interface PlaceholderLineComponent extends React.FC<PlaceholderLineProps> {}
-
-declare const PlaceholderLine: PlaceholderLineComponent
+declare const PlaceholderLine: ForwardRefComponent<PlaceholderLineProps, HTMLDivElement>
 
 export default PlaceholderLine

--- a/src/elements/Placeholder/PlaceholderParagraph.d.ts
+++ b/src/elements/Placeholder/PlaceholderParagraph.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface PlaceholderParagraphProps extends StrictPlaceholderParagraphProps {
   [key: string]: any
@@ -19,8 +19,6 @@ export interface StrictPlaceholderParagraphProps {
   content?: SemanticShorthandContent
 }
 
-interface PlaceholderParagraphComponent extends React.FC<PlaceholderParagraphProps> {}
-
-declare const PlaceholderParagraph: PlaceholderParagraphComponent
+declare const PlaceholderParagraph: ForwardRefComponent<PlaceholderParagraphProps, HTMLDivElement>
 
 export default PlaceholderParagraph

--- a/src/elements/Rail/Rail.d.ts
+++ b/src/elements/Rail/Rail.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticFLOATS, SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticFLOATS, SemanticShorthandContent } from '../../generic'
 
 export interface RailProps extends StrictRailProps {
   [key: string]: any
@@ -37,6 +37,6 @@ export interface StrictRailProps {
   size?: 'mini' | 'tiny' | 'small' | 'large' | 'big' | 'huge' | 'massive'
 }
 
-declare const Rail: React.FC<RailProps>
+declare const Rail: ForwardRefComponent<RailProps, HTMLDivElement>
 
 export default Rail

--- a/src/elements/Reveal/Reveal.d.ts
+++ b/src/elements/Reveal/Reveal.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 import RevealContent from './RevealContent'
 
 export interface RevealProps extends StrictRevealProps {
@@ -41,10 +41,6 @@ export interface StrictRevealProps {
   instant?: boolean
 }
 
-interface RevealComponent extends React.FC<RevealProps> {
-  Content: typeof RevealContent
-}
-
-declare const Reveal: RevealComponent
+declare const Reveal: ForwardRefComponent<RevealProps, HTMLDivElement>
 
 export default Reveal

--- a/src/elements/Reveal/RevealContent.d.ts
+++ b/src/elements/Reveal/RevealContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface RevealContentProps extends StrictRevealContentProps {
   [key: string]: any
@@ -25,6 +25,6 @@ export interface StrictRevealContentProps {
   visible?: boolean
 }
 
-declare const RevealContent: React.FC<RevealContentProps>
+declare const RevealContent: ForwardRefComponent<RevealContentProps, HTMLDivElement>
 
 export default RevealContent

--- a/src/elements/Segment/Segment.d.ts
+++ b/src/elements/Segment/Segment.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticCOLORS,
   SemanticFLOATS,
   SemanticShorthandContent,
@@ -89,11 +90,9 @@ export interface StrictSegmentProps {
   vertical?: boolean
 }
 
-interface SegmentComponent extends React.FC<SegmentProps> {
+declare const Segment: ForwardRefComponent<SegmentProps, HTMLDivElement> & {
   Group: typeof SegmentGroup
   Inline: typeof SegmentInline
 }
-
-declare const Segment: SegmentComponent
 
 export default Segment

--- a/src/elements/Segment/SegmentGroup.d.ts
+++ b/src/elements/Segment/SegmentGroup.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 import { SegmentSizeProp } from './Segment'
 
 export interface SegmentGroupProps extends StrictSegmentGroupProps {
@@ -39,6 +39,6 @@ export interface StrictSegmentGroupProps {
   stacked?: boolean
 }
 
-declare const SegmentGroup: React.FC<SegmentGroupProps>
+declare const SegmentGroup: ForwardRefComponent<SegmentGroupProps, HTMLDivElement>
 
 export default SegmentGroup

--- a/src/elements/Segment/SegmentInline.d.ts
+++ b/src/elements/Segment/SegmentInline.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface SegmentInlineProps extends StrictSegmentInlineProps {
   [key: string]: any
@@ -19,8 +19,6 @@ export interface StrictSegmentInlineProps {
   content?: SemanticShorthandContent
 }
 
-interface SegmentInlineComponent extends React.FC<SegmentInlineProps> {}
-
-declare const SegmentInline: SegmentInlineComponent
+declare const SegmentInline: ForwardRefComponent<SegmentInlineProps, HTMLDivElement>
 
 export default SegmentInline

--- a/src/elements/Step/Step.d.ts
+++ b/src/elements/Step/Step.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../Icon'
 import StepContent from './StepContent'
 import StepDescription, { StepDescriptionProps } from './StepDescription'
@@ -61,13 +61,11 @@ export interface StrictStepProps {
   title?: SemanticShorthandItem<StepTitleProps>
 }
 
-interface StepComponent extends React.ComponentClass<StepProps> {
+declare const Step: ForwardRefComponent<StepProps, HTMLDivElement> & {
   Content: typeof StepContent
   Description: typeof StepDescription
   Group: typeof StepGroup
   Title: typeof StepTitle
 }
-
-declare const Step: StepComponent
 
 export default Step

--- a/src/elements/Step/StepContent.d.ts
+++ b/src/elements/Step/StepContent.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem, SemanticShorthandContent } from '../../generic'
+import { SemanticShorthandItem, SemanticShorthandContent, ForwardRefComponent } from '../../generic'
 import { StepDescriptionProps } from './StepDescription'
 import { StepTitleProps } from './StepTitle'
 
@@ -28,6 +28,6 @@ export interface StrictStepContentProps {
   title?: SemanticShorthandItem<StepTitleProps>
 }
 
-declare const StepContent: React.FC<StepContentProps>
+declare const StepContent: ForwardRefComponent<StepContentProps, HTMLDivElement>
 
 export default StepContent

--- a/src/elements/Step/StepDescription.d.ts
+++ b/src/elements/Step/StepDescription.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface StepDescriptionProps extends StrictStepDescriptionProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictStepDescriptionProps {
   content?: SemanticShorthandContent
 }
 
-declare const StepDescription: React.FC<StepDescriptionProps>
+declare const StepDescription: ForwardRefComponent<StepDescriptionProps, HTMLDivElement>
 
 export default StepDescription

--- a/src/elements/Step/StepGroup.d.ts
+++ b/src/elements/Step/StepGroup.d.ts
@@ -1,6 +1,10 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection, SemanticShorthandContent } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticShorthandCollection,
+  SemanticShorthandContent,
+} from '../../generic'
 import { StepProps } from './Step'
 
 export interface StepGroupProps extends StrictStepGroupProps {
@@ -72,6 +76,6 @@ export interface StrictStepGroupProps {
     | 'eight'
 }
 
-declare const StepGroup: React.FC<StepGroupProps>
+declare const StepGroup: ForwardRefComponent<StepGroupProps, HTMLDivElement>
 
 export default StepGroup

--- a/src/elements/Step/StepTitle.d.ts
+++ b/src/elements/Step/StepTitle.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface StepTitleProps extends StrictStepTitleProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictStepTitleProps {
   content?: SemanticShorthandContent
 }
 
-declare const StepTitle: React.FC<StepTitleProps>
+declare const StepTitle: ForwardRefComponent<StepTitleProps, HTMLDivElement>
 
 export default StepTitle

--- a/src/generic.d.ts
+++ b/src/generic.d.ts
@@ -1,6 +1,12 @@
 import * as React from 'react'
 
 // ======================================================
+// Utility types
+// ======================================================
+
+export type ForwardRefComponent<P, T> = React.ForwardRefExoticComponent<P & React.RefAttributes<T>>
+
+// ======================================================
 // Alignments
 // ======================================================
 
@@ -70,7 +76,9 @@ export type ShorthandRenderFunction<C extends React.ElementType, P> = (
   props: P,
 ) => React.ReactNode
 
-export type SemanticShorthandCollection<TProps extends Record<string, any>> = SemanticShorthandItem<TProps>[]
+export type SemanticShorthandCollection<TProps extends Record<string, any>> = SemanticShorthandItem<
+  TProps
+>[]
 export type SemanticShorthandContent = React.ReactNode
 export type SemanticShorthandItem<TProps extends Record<string, any>> =
   | React.ReactNode

--- a/src/modules/Accordion/Accordion.d.ts
+++ b/src/modules/Accordion/Accordion.d.ts
@@ -4,6 +4,7 @@ import AccordionAccordion, { StrictAccordionAccordionProps } from './AccordionAc
 import AccordionContent from './AccordionContent'
 import AccordionPanel from './AccordionPanel'
 import AccordionTitle from './AccordionTitle'
+import { ForwardRefComponent } from '../../generic'
 
 export interface AccordionProps extends StrictAccordionProps {
   [key: string]: any
@@ -23,13 +24,11 @@ export interface StrictAccordionProps extends StrictAccordionAccordionProps {
   styled?: boolean
 }
 
-interface AccordionComponent extends React.ComponentClass<AccordionProps> {
+declare const Accordion: ForwardRefComponent<AccordionProps, HTMLDivElement> & {
   Accordion: typeof AccordionAccordion
   Content: typeof AccordionContent
   Panel: typeof AccordionPanel
   Title: typeof AccordionTitle
 }
-
-declare const Accordion: AccordionComponent
 
 export default Accordion

--- a/src/modules/Accordion/AccordionAccordion.d.ts
+++ b/src/modules/Accordion/AccordionAccordion.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandCollection } from '../../generic'
 import { AccordionPanelProps } from './AccordionPanel'
 import { AccordionTitleProps } from './AccordionTitle'
 
@@ -39,6 +39,6 @@ export interface StrictAccordionAccordionProps {
   panels?: SemanticShorthandCollection<AccordionPanelProps>
 }
 
-declare const AccordionAccordion: React.ComponentClass<AccordionAccordionProps>
+declare const AccordionAccordion: ForwardRefComponent<AccordionAccordionProps, HTMLDivElement>
 
 export default AccordionAccordion

--- a/src/modules/Accordion/AccordionContent.d.ts
+++ b/src/modules/Accordion/AccordionContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface AccordionContentProps extends StrictAccordionContentProps {
   [key: string]: any
@@ -22,6 +22,6 @@ export interface StrictAccordionContentProps {
   content?: SemanticShorthandContent
 }
 
-declare const AccordionContent: React.FC<AccordionContentProps>
+declare const AccordionContent: ForwardRefComponent<AccordionContentProps, HTMLDivElement>
 
 export default AccordionContent

--- a/src/modules/Accordion/AccordionPanel.d.ts
+++ b/src/modules/Accordion/AccordionPanel.d.ts
@@ -30,6 +30,6 @@ export interface StrictAccordionPanelProps {
   title?: SemanticShorthandItem<AccordionTitleProps>
 }
 
-declare class AccordionPanel extends React.Component<AccordionPanelProps> {}
+declare const AccordionPanel: React.ComponentClass<AccordionPanelProps>
 
 export default AccordionPanel

--- a/src/modules/Accordion/AccordionTitle.d.ts
+++ b/src/modules/Accordion/AccordionTitle.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { IconProps } from '../../elements/Icon'
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 
 export interface AccordionTitleProps extends StrictAccordionTitleProps {
   [key: string]: any
@@ -38,6 +38,6 @@ export interface StrictAccordionTitleProps {
   onClick?: (event: React.MouseEvent<HTMLDivElement>, data: AccordionTitleProps) => void
 }
 
-declare const AccordionTitle: React.ComponentClass<AccordionTitleProps>
+declare const AccordionTitle: ForwardRefComponent<AccordionTitleProps, HTMLDivElement>
 
 export default AccordionTitle

--- a/src/modules/Checkbox/Checkbox.d.ts
+++ b/src/modules/Checkbox/Checkbox.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { HtmlLabelProps, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, HtmlLabelProps, SemanticShorthandItem } from '../../generic'
 
 export interface CheckboxProps extends StrictCheckboxProps {
   [key: string]: any
@@ -93,6 +93,6 @@ export interface StrictCheckboxProps {
   value?: number | string
 }
 
-declare const Checkbox: React.ComponentClass<CheckboxProps>
+declare const Checkbox: ForwardRefComponent<CheckboxProps, HTMLDivElement>
 
 export default Checkbox

--- a/src/modules/Dimmer/Dimmer.d.ts
+++ b/src/modules/Dimmer/Dimmer.d.ts
@@ -1,5 +1,4 @@
-import * as React from 'react'
-
+import { ForwardRefComponent } from '../../generic'
 import DimmerDimmable from './DimmerDimmable'
 import DimmerInner from './DimmerInner'
 
@@ -15,11 +14,9 @@ export interface StrictDimmerProps {
   page?: boolean
 }
 
-interface DimmerComponent extends React.ComponentClass<DimmerProps> {
+declare const Dimmer: ForwardRefComponent<DimmerProps, HTMLDivElement> & {
   Dimmable: typeof DimmerDimmable
   Inner: typeof DimmerInner
 }
-
-declare const Dimmer: DimmerComponent
 
 export default Dimmer

--- a/src/modules/Dimmer/DimmerDimmable.d.ts
+++ b/src/modules/Dimmer/DimmerDimmable.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface DimmerDimmableProps extends StrictDimmerDimmableProps {
   [key: string]: any
@@ -25,6 +25,6 @@ export interface StrictDimmerDimmableProps {
   dimmed?: boolean
 }
 
-declare const DimmerDimmable: React.ComponentClass<DimmerDimmableProps>
+declare const DimmerDimmable: ForwardRefComponent<DimmerDimmableProps, HTMLDivElement>
 
 export default DimmerDimmable

--- a/src/modules/Dimmer/DimmerInner.d.ts
+++ b/src/modules/Dimmer/DimmerInner.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface DimmerInnerProps extends StrictDimmerInnerProps {
   [key: string]: any
@@ -53,6 +53,6 @@ export interface StrictDimmerInnerProps {
   verticalAlign?: 'bottom' | 'top'
 }
 
-declare class DimmerInner extends React.Component<DimmerInnerProps> {}
+declare const DimmerInner: ForwardRefComponent<DimmerInnerProps, HTMLDivElement>
 
 export default DimmerInner

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -6,6 +6,7 @@ import DropdownHeader from './DropdownHeader'
 import DropdownItem, { DropdownItemProps } from './DropdownItem'
 import DropdownMenu from './DropdownMenu'
 import DropdownSearchInput from './DropdownSearchInput'
+import { ForwardRefComponent } from '../../generic'
 
 export interface DropdownProps extends StrictDropdownProps {
   [key: string]: any
@@ -298,14 +299,12 @@ export interface DropdownOnSearchChangeData extends DropdownProps {
   searchQuery: string
 }
 
-interface DropdownComponent extends React.ComponentClass<DropdownProps> {
+declare const Dropdown: ForwardRefComponent<DropdownProps, HTMLDivElement> & {
   Divider: typeof DropdownDivider
   Header: typeof DropdownHeader
   Item: typeof DropdownItem
   Menu: typeof DropdownMenu
   SearchInput: typeof DropdownSearchInput
 }
-
-declare const Dropdown: DropdownComponent
 
 export default Dropdown

--- a/src/modules/Dropdown/DropdownDivider.d.ts
+++ b/src/modules/Dropdown/DropdownDivider.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface DropdownDividerProps extends StrictDropdownDividerProps {
   [key: string]: any
@@ -12,6 +12,6 @@ export interface StrictDropdownDividerProps {
   className?: string
 }
 
-declare const DropdownDivider: React.ComponentClass<DropdownDividerProps>
+declare const DropdownDivider: ForwardRefComponent<DropdownDividerProps, HTMLDivElement>
 
 export default DropdownDivider

--- a/src/modules/Dropdown/DropdownHeader.d.ts
+++ b/src/modules/Dropdown/DropdownHeader.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface DropdownHeaderProps extends StrictDropdownHeaderProps {
@@ -24,6 +24,6 @@ export interface StrictDropdownHeaderProps {
   icon?: SemanticShorthandItem<IconProps>
 }
 
-declare const DropdownHeader: React.ComponentClass<DropdownHeaderProps>
+declare const DropdownHeader: ForwardRefComponent<DropdownHeaderProps, HTMLDivElement>
 
 export default DropdownHeader

--- a/src/modules/Dropdown/DropdownItem.d.ts
+++ b/src/modules/Dropdown/DropdownItem.d.ts
@@ -1,6 +1,11 @@
 import * as React from 'react'
 
-import { HtmlSpanProps, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import {
+  ForwardRefComponent,
+  HtmlSpanProps,
+  SemanticShorthandContent,
+  SemanticShorthandItem,
+} from '../../generic'
 import { FlagProps } from '../../elements/Flag'
 import { IconProps } from '../../elements/Icon'
 import { ImageProps } from '../../elements/Image'
@@ -65,6 +70,6 @@ export interface StrictDropdownItemProps {
   value?: boolean | number | string
 }
 
-declare const DropdownItem: React.ComponentClass<DropdownItemProps>
+declare const DropdownItem: ForwardRefComponent<DropdownItemProps, HTMLDivElement>
 
 export default DropdownItem

--- a/src/modules/Dropdown/DropdownMenu.d.ts
+++ b/src/modules/Dropdown/DropdownMenu.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface DropdownMenuProps extends StrictDropdownMenuProps {
   [key: string]: any
@@ -28,6 +28,6 @@ export interface StrictDropdownMenuProps {
   scrolling?: boolean
 }
 
-declare const DropdownMenu: React.FC<DropdownMenuProps>
+declare const DropdownMenu: ForwardRefComponent<DropdownMenuProps, HTMLDivElement>
 
 export default DropdownMenu

--- a/src/modules/Dropdown/DropdownSearchInput.d.ts
+++ b/src/modules/Dropdown/DropdownSearchInput.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface DropdownSearchInputProps extends StrictDropdownSearchInputProps {
   [key: string]: any
@@ -24,6 +24,6 @@ export interface StrictDropdownSearchInputProps {
   value?: number | string
 }
 
-declare const DropdownSearchInput: React.ComponentClass<DropdownSearchInputProps>
+declare const DropdownSearchInput: ForwardRefComponent<DropdownSearchInputProps, HTMLInputElement>
 
 export default DropdownSearchInput

--- a/src/modules/Dropdown/DropdownText.d.ts
+++ b/src/modules/Dropdown/DropdownText.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface DropdownTextProps extends StrictDropdownTextProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictDropdownTextProps {
   content?: SemanticShorthandContent
 }
 
-declare const DropdownText: React.FunctionComponent<DropdownTextProps>
+declare const DropdownText: ForwardRefComponent<DropdownTextProps, HTMLDivElement>
 
 export default DropdownText

--- a/src/modules/Embed/Embed.d.ts
+++ b/src/modules/Embed/Embed.d.ts
@@ -1,6 +1,11 @@
 import * as React from 'react'
 
-import { HtmlIframeProps, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import {
+  ForwardRefComponent,
+  HtmlIframeProps,
+  SemanticShorthandContent,
+  SemanticShorthandItem,
+} from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface EmbedProps extends StrictEmbedProps {
@@ -68,6 +73,6 @@ export interface StrictEmbedProps {
   url?: string
 }
 
-declare const Embed: React.ComponentClass<EmbedProps>
+declare const Embed: ForwardRefComponent<EmbedProps, HTMLDivElement>
 
 export default Embed

--- a/src/modules/Modal/Modal.d.ts
+++ b/src/modules/Modal/Modal.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandItem } from '../../generic'
 import { StrictPortalProps } from '../../addons/Portal'
 import ModalActions, { ModalActionsProps } from './ModalActions'
 import ModalContent, { ModalContentProps } from './ModalContent'
@@ -111,14 +111,12 @@ export interface StrictModalProps extends StrictPortalProps {
   trigger?: React.ReactNode
 }
 
-interface ModalComponent extends React.ComponentClass<ModalProps> {
+declare const Modal: ForwardRefComponent<ModalProps, HTMLDivElement> & {
   Actions: typeof ModalActions
   Content: typeof ModalContent
   Description: typeof ModalDescription
   Dimmer: typeof ModalDimmer
   Header: typeof ModalHeader
 }
-
-declare const Modal: ModalComponent
 
 export default Modal

--- a/src/modules/Modal/ModalActions.d.ts
+++ b/src/modules/Modal/ModalActions.d.ts
@@ -1,7 +1,11 @@
 import * as React from 'react'
 
 import { ButtonProps } from '../../elements/Button'
-import { SemanticShorthandCollection, SemanticShorthandContent } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticShorthandCollection,
+  SemanticShorthandContent,
+} from '../../generic'
 
 export interface ModalActionsProps extends StrictModalActionsProps {
   [key: string]: any
@@ -32,6 +36,6 @@ export interface StrictModalActionsProps {
   onActionClick?: (event: React.MouseEvent<HTMLAnchorElement>, data: ButtonProps) => void
 }
 
-declare const ModalActions: React.ComponentClass<ModalActionsProps>
+declare const ModalActions: ForwardRefComponent<ModalActionsProps, HTMLDivElement>
 
 export default ModalActions

--- a/src/modules/Modal/ModalContent.d.ts
+++ b/src/modules/Modal/ModalContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ModalContentProps extends StrictModalContentProps {
   [key: string]: any
@@ -25,6 +25,6 @@ export interface StrictModalContentProps {
   scrolling?: boolean
 }
 
-declare const ModalContent: React.FC<ModalContentProps>
+declare const ModalContent: ForwardRefComponent<ModalContentProps, HTMLDivElement>
 
 export default ModalContent

--- a/src/modules/Modal/ModalDescription.d.ts
+++ b/src/modules/Modal/ModalDescription.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ModalDescriptionProps extends StrictModalDescriptionProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictModalDescriptionProps {
   content?: SemanticShorthandContent
 }
 
-declare const ModalDescription: React.FC<ModalDescriptionProps>
+declare const ModalDescription: ForwardRefComponent<ModalDescriptionProps, HTMLDivElement>
 
 export default ModalDescription

--- a/src/modules/Modal/ModalDimmer.d.ts
+++ b/src/modules/Modal/ModalDimmer.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ModalDimmerProps extends StrictModalDimmerProps {
   [key: string]: any
@@ -34,6 +34,6 @@ export interface StrictModalDimmerProps {
   scrolling?: boolean
 }
 
-declare const ModalDimmer: React.FC<ModalDimmerProps>
+declare const ModalDimmer: ForwardRefComponent<ModalDimmerProps, HTMLDivElement>
 
 export default ModalDimmer

--- a/src/modules/Modal/ModalHeader.d.ts
+++ b/src/modules/Modal/ModalHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ModalHeaderProps extends StrictModalHeaderProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictModalHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const ModalHeader: React.FC<ModalHeaderProps>
+declare const ModalHeader: ForwardRefComponent<ModalHeaderProps, HTMLDivElement>
 
 export default ModalHeader

--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -141,11 +141,9 @@ export interface StrictPopupProps extends StrictPortalProps {
   wide?: boolean | 'very'
 }
 
-interface PopupComponent extends React.ComponentClass<PopupProps> {
+declare const Popup: React.FC<PopupProps> & {
   Content: typeof PopupContent
   Header: typeof PopupHeader
 }
-
-declare const Popup: PopupComponent
 
 export default Popup

--- a/src/modules/Popup/PopupContent.d.ts
+++ b/src/modules/Popup/PopupContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface PopupContentProps extends StrictPopupContentProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictPopupContentProps {
   content?: SemanticShorthandContent
 }
 
-declare const PopupContent: React.FC<PopupContentProps>
+declare const PopupContent: ForwardRefComponent<PopupContentProps, HTMLDivElement>
 
 export default PopupContent

--- a/src/modules/Popup/PopupHeader.d.ts
+++ b/src/modules/Popup/PopupHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface PopupHeaderProps extends StrictPopupHeaderProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictPopupHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const PopupHeader: React.FC<PopupHeaderProps>
+declare const PopupHeader: ForwardRefComponent<PopupHeaderProps, HTMLDivElement>
 
 export default PopupHeader

--- a/src/modules/Progress/Progress.d.ts
+++ b/src/modules/Progress/Progress.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import {
+  ForwardRefComponent,
   HtmlLabelProps,
   SemanticCOLORS,
   SemanticShorthandContent,
@@ -75,6 +76,6 @@ export interface StrictProgressProps {
   warning?: boolean
 }
 
-declare const Progress: React.ComponentClass<ProgressProps>
+declare const Progress: ForwardRefComponent<ProgressProps, HTMLDivElement>
 
 export default Progress

--- a/src/modules/Rating/Rating.d.ts
+++ b/src/modules/Rating/Rating.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import RatingIcon from './RatingIcon'
+import { ForwardRefComponent } from '../../generic'
 
 export interface RatingProps extends StrictRatingProps {
   [key: string]: any
@@ -46,10 +47,8 @@ export interface StrictRatingProps {
   size?: 'mini' | 'tiny' | 'small' | 'large' | 'huge' | 'massive'
 }
 
-interface RatingComponent extends React.ComponentClass<RatingProps> {
+declare const Rating: ForwardRefComponent<RatingProps, HTMLDivElement> & {
   Icon: typeof RatingIcon
 }
-
-declare const Rating: RatingComponent
 
 export default Rating

--- a/src/modules/Rating/RatingIcon.d.ts
+++ b/src/modules/Rating/RatingIcon.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface RatingIconProps extends StrictRatingIconProps {
   [key: string]: any
@@ -45,6 +46,6 @@ export interface StrictRatingIconProps {
   selected?: boolean
 }
 
-declare const RatingIcon: React.ComponentClass<RatingIconProps>
+declare const RatingIcon: ForwardRefComponent<RatingIconProps, HTMLElement>
 
 export default RatingIcon

--- a/src/modules/Search/Search.d.ts
+++ b/src/modules/Search/Search.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandItem } from '../../generic'
 import { InputProps } from '../../elements/Input'
 import SearchCategory, { SearchCategoryProps } from './SearchCategory'
 import SearchResult, { SearchResultProps } from './SearchResult'
@@ -65,7 +65,9 @@ export interface StrictSearchProps {
    * @param {object} props - The SearchCategoryLayout props object.
    * @returns {*} - Renderable SearchCategory layout.
    */
-  categoryLayoutRenderer?: (props: Pick<SearchCategoryLayoutProps, 'categoryContent' | 'resultsContent'>) => React.ReactElement<any>
+  categoryLayoutRenderer?: (
+    props: Pick<SearchCategoryLayoutProps, 'categoryContent' | 'resultsContent'>,
+  ) => React.ReactElement<any>
 
   /**
    * Renders the SearchCategory contents.
@@ -168,12 +170,10 @@ export interface SearchResultData extends SearchProps {
   result: any
 }
 
-interface SearchComponent extends React.ComponentClass<SearchProps> {
+declare const Search: ForwardRefComponent<SearchProps, HTMLDivElement> & {
   Category: typeof SearchCategory
   Result: typeof SearchResult
   Results: typeof SearchResults
 }
-
-declare const Search: SearchComponent
 
 export default Search

--- a/src/modules/Search/SearchCategory.d.ts
+++ b/src/modules/Search/SearchCategory.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 import { SearchCategoryLayoutProps } from './SearchCategoryLayout'
 import SearchResult from './SearchResult'
 
@@ -49,6 +49,6 @@ export interface StrictSearchCategoryProps {
   results?: typeof SearchResult[]
 }
 
-declare const SearchCategory: React.FC<SearchCategoryProps>
+declare const SearchCategory: ForwardRefComponent<SearchCategoryProps, HTMLDivElement>
 
 export default SearchCategory

--- a/src/modules/Search/SearchResult.d.ts
+++ b/src/modules/Search/SearchResult.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface SearchResultProps extends StrictSearchResultProps {
   [key: string]: any
@@ -50,6 +50,6 @@ export interface StrictSearchResultProps {
   title: string
 }
 
-declare const SearchResult: React.ComponentClass<SearchResultProps>
+declare const SearchResult: ForwardRefComponent<SearchResultProps, HTMLDivElement>
 
 export default SearchResult

--- a/src/modules/Search/SearchResults.d.ts
+++ b/src/modules/Search/SearchResults.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface SearchResultsProps extends StrictSearchResultsProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictSearchResultsProps {
   content?: SemanticShorthandContent
 }
 
-declare const SearchResults: React.FC<SearchResultsProps>
+declare const SearchResults: ForwardRefComponent<SearchResultsProps, HTMLDivElement>
 
 export default SearchResults

--- a/src/modules/Sidebar/Sidebar.d.ts
+++ b/src/modules/Sidebar/Sidebar.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 import SidebarPushable from './SidebarPushable'
 import SidebarPusher from './SidebarPusher'
@@ -69,11 +69,9 @@ export interface StrictSidebarProps {
   width?: 'very thin' | 'thin' | 'wide' | 'very wide'
 }
 
-interface SidebarComponent extends React.ComponentClass<SidebarProps> {
+declare const Sidebar: ForwardRefComponent<SidebarProps, HTMLDivElement> & {
   Pushable: typeof SidebarPushable
   Pusher: typeof SidebarPusher
 }
-
-declare const Sidebar: SidebarComponent
 
 export default Sidebar

--- a/src/modules/Sidebar/SidebarPushable.d.ts
+++ b/src/modules/Sidebar/SidebarPushable.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface SidebarPushableProps extends StrictSidebarPushableProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictSidebarPushableProps {
   content?: SemanticShorthandContent
 }
 
-declare const SidebarPushable: React.FC<SidebarPushableProps>
+declare const SidebarPushable: ForwardRefComponent<SidebarPushableProps, HTMLDivElement>
 
 export default SidebarPushable

--- a/src/modules/Sidebar/SidebarPusher.d.ts
+++ b/src/modules/Sidebar/SidebarPusher.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface SidebarPusherProps extends StrictSidebarPusherProps {
   [key: string]: any
@@ -22,6 +22,6 @@ export interface StrictSidebarPusherProps {
   dimmed?: boolean
 }
 
-declare const SidebarPusher: React.FC<SidebarPusherProps>
+declare const SidebarPusher: ForwardRefComponent<SidebarPusherProps, HTMLDivElement>
 
 export default SidebarPusher

--- a/src/modules/Sticky/Sticky.d.ts
+++ b/src/modules/Sticky/Sticky.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface StickyProps extends StrictStickyProps {
   [key: string]: any
@@ -68,6 +69,6 @@ export interface StrictStickyProps {
   styleElement?: React.CSSProperties
 }
 
-declare const Sticky: React.ComponentClass<StickyProps>
+declare const Sticky: ForwardRefComponent<StickyProps, HTMLDivElement>
 
 export default Sticky

--- a/src/modules/Tab/Tab.d.ts
+++ b/src/modules/Tab/Tab.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandItem } from '../../generic'
 import TabPane, { TabPaneProps } from './TabPane'
 
 export interface TabProps extends StrictTabProps {
@@ -58,10 +58,6 @@ export interface StrictTabProps {
   renderActiveOnly?: boolean
 }
 
-interface TabComponent extends React.ComponentClass<TabProps> {
-  Pane: typeof TabPane
-}
-
-declare const Tab: TabComponent
+declare const Tab: ForwardRefComponent<TabProps, HTMLDivElement>
 
 export default Tab

--- a/src/modules/Tab/TabPane.d.ts
+++ b/src/modules/Tab/TabPane.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface TabPaneProps extends StrictTabPaneProps {
   [key: string]: any
@@ -25,6 +25,6 @@ export interface StrictTabPaneProps {
   loading?: boolean
 }
 
-declare const TabPane: React.FC<TabPaneProps>
+declare const TabPane: ForwardRefComponent<TabPaneProps, HTMLDivElement>
 
 export default TabPane

--- a/src/modules/Transition/Transition.d.ts
+++ b/src/modules/Transition/Transition.d.ts
@@ -81,12 +81,6 @@ export interface TransitionPropDuration {
 
 interface TransitionComponent extends React.ComponentClass<TransitionProps> {
   Group: typeof TransitionGroup
-
-  ENTERED: 'ENTERED'
-  ENTERING: 'ENTERING'
-  EXITED: 'EXITED'
-  EXITING: 'EXITING'
-  UNMOUNTED: 'UNMOUNTED'
 }
 
 declare const Transition: TransitionComponent

--- a/src/modules/Transition/TransitionGroup.d.ts
+++ b/src/modules/Transition/TransitionGroup.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticTRANSITIONS } from '../../generic'
+import { ForwardRefComponent, SemanticTRANSITIONS } from '../../generic'
 import { TransitionPropDuration } from './Transition'
 
 export interface TransitionGroupProps extends StrictTransitionGroupProps {
@@ -24,8 +24,6 @@ export interface StrictTransitionGroupProps {
   duration?: number | string | TransitionPropDuration
 }
 
-interface TransitionGroupComponent extends React.ComponentClass<TransitionGroupProps> {}
-
-declare const TransitionGroup: TransitionGroupComponent
+declare const TransitionGroup: ForwardRefComponent<TransitionGroupProps, HTMLDivElement>
 
 export default TransitionGroup

--- a/src/views/Advertisement/Advertisement.d.ts
+++ b/src/views/Advertisement/Advertisement.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface AdvertisementProps extends StrictAdvertisementProps {
   [key: string]: any
@@ -51,6 +51,6 @@ export interface StrictAdvertisementProps {
     | 'small square'
 }
 
-declare const Advertisement: React.FC<AdvertisementProps>
+declare const Advertisement: ForwardRefComponent<AdvertisementProps, HTMLDivElement>
 
 export default Advertisement

--- a/src/views/Card/Card.d.ts
+++ b/src/views/Card/Card.d.ts
@@ -1,6 +1,11 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticCOLORS,
+  SemanticShorthandContent,
+  SemanticShorthandItem,
+} from '../../generic'
 import { ImageProps } from '../../elements/Image'
 import CardContent from './CardContent'
 import CardDescription, { CardDescriptionProps } from './CardDescription'
@@ -68,14 +73,12 @@ export interface StrictCardProps {
   raised?: boolean
 }
 
-interface CardComponent extends React.ComponentClass<CardProps> {
+declare const Card: ForwardRefComponent<CardProps, HTMLDivElement> & {
   Content: typeof CardContent
   Description: typeof CardDescription
   Group: typeof CardGroup
   Header: typeof CardHeader
   Meta: typeof CardMeta
 }
-
-declare const Card: CardComponent
 
 export default Card

--- a/src/views/Card/CardContent.d.ts
+++ b/src/views/Card/CardContent.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { CardDescriptionProps } from './CardDescription'
 import { CardHeaderProps } from './CardHeader'
 import { CardMetaProps } from './CardMeta'
@@ -38,6 +38,6 @@ export interface StrictCardContentProps {
   textAlign?: 'center' | 'left' | 'right'
 }
 
-declare const CardContent: React.FC<CardContentProps>
+declare const CardContent: ForwardRefComponent<CardContentProps, HTMLDivElement>
 
 export default CardContent

--- a/src/views/Card/CardDescription.d.ts
+++ b/src/views/Card/CardDescription.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface CardDescriptionProps extends StrictCardDescriptionProps {
   [key: string]: any
@@ -22,6 +22,6 @@ export interface StrictCardDescriptionProps {
   textAlign?: 'center' | 'left' | 'right'
 }
 
-declare const CardDescription: React.FC<CardDescriptionProps>
+declare const CardDescription: ForwardRefComponent<CardDescriptionProps, HTMLDivElement>
 
 export default CardDescription

--- a/src/views/Card/CardGroup.d.ts
+++ b/src/views/Card/CardGroup.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticShorthandCollection,
   SemanticShorthandContent,
   SemanticWIDTHS,
@@ -43,6 +44,6 @@ export interface StrictCardGroupProps {
   textAlign?: 'center' | 'left' | 'right'
 }
 
-declare const CardGroup: React.FC<CardGroupProps>
+declare const CardGroup: ForwardRefComponent<CardGroupProps, HTMLDivElement>
 
 export default CardGroup

--- a/src/views/Card/CardHeader.d.ts
+++ b/src/views/Card/CardHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface CardHeaderProps extends StrictCardHeaderProps {
   [key: string]: any
@@ -22,6 +22,6 @@ export interface StrictCardHeaderProps {
   textAlign?: 'center' | 'left' | 'right'
 }
 
-declare const CardHeader: React.FC<CardHeaderProps>
+declare const CardHeader: ForwardRefComponent<CardHeaderProps, HTMLDivElement>
 
 export default CardHeader

--- a/src/views/Card/CardMeta.d.ts
+++ b/src/views/Card/CardMeta.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface CardMetaProps extends StrictCardMetaProps {
   [key: string]: any
@@ -22,6 +22,6 @@ export interface StrictCardMetaProps {
   textAlign?: 'center' | 'left' | 'right'
 }
 
-declare const CardMeta: React.FC<CardMetaProps>
+declare const CardMeta: ForwardRefComponent<CardMetaProps, HTMLDivElement>
 
 export default CardMeta

--- a/src/views/Comment/Comment.d.ts
+++ b/src/views/Comment/Comment.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 import CommentAction from './CommentAction'
 import CommentActions from './CommentActions'
 import CommentAuthor from './CommentAuthor'
@@ -31,7 +31,7 @@ export interface StrictCommentProps {
   content?: SemanticShorthandContent
 }
 
-interface CommentComponent extends React.FC<CommentProps> {
+declare const Comment: ForwardRefComponent<CommentProps, HTMLDivElement> & {
   Action: typeof CommentAction
   Actions: typeof CommentActions
   Author: typeof CommentAuthor
@@ -41,7 +41,5 @@ interface CommentComponent extends React.FC<CommentProps> {
   Metadata: typeof CommentMetadata
   Text: typeof CommentText
 }
-
-declare const Comment: CommentComponent
 
 export default Comment

--- a/src/views/Comment/CommentAction.d.ts
+++ b/src/views/Comment/CommentAction.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface CommentActionProps extends StrictCommentActionProps {
   [key: string]: any
@@ -22,6 +22,6 @@ export interface StrictCommentActionProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentAction: React.ComponentClass<CommentActionProps>
+declare const CommentAction: ForwardRefComponent<CommentActionProps, HTMLDivElement>
 
 export default CommentAction

--- a/src/views/Comment/CommentActions.d.ts
+++ b/src/views/Comment/CommentActions.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface CommentActionsProps extends StrictCommentActionsProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictCommentActionsProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentActions: React.FC<CommentActionsProps>
+declare const CommentActions: ForwardRefComponent<CommentActionsProps, HTMLDivElement>
 
 export default CommentActions

--- a/src/views/Comment/CommentAuthor.d.ts
+++ b/src/views/Comment/CommentAuthor.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface CommentAuthorProps extends StrictCommentAuthorProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictCommentAuthorProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentAuthor: React.FC<CommentAuthorProps>
+declare const CommentAuthor: ForwardRefComponent<CommentAuthorProps, HTMLDivElement>
 
 export default CommentAuthor

--- a/src/views/Comment/CommentAvatar.d.ts
+++ b/src/views/Comment/CommentAvatar.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { ForwardRefComponent } from '../../generic'
 
 export interface CommentAvatarProps extends StrictCommentAvatarProps {
   [key: string]: any
@@ -15,6 +15,6 @@ export interface StrictCommentAvatarProps {
   src?: string
 }
 
-declare const CommentAvatar: React.FC<CommentAvatarProps>
+declare const CommentAvatar: ForwardRefComponent<CommentAvatarProps, HTMLDivElement>
 
 export default CommentAvatar

--- a/src/views/Comment/CommentContent.d.ts
+++ b/src/views/Comment/CommentContent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface CommentContentProps extends StrictCommentContentProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictCommentContentProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentContent: React.FC<CommentContentProps>
+declare const CommentContent: ForwardRefComponent<CommentContentProps, HTMLDivElement>
 
 export default CommentContent

--- a/src/views/Comment/CommentGroup.d.ts
+++ b/src/views/Comment/CommentGroup.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface CommentGroupProps extends StrictCommentGroupProps {
   [key: string]: any
@@ -31,6 +31,6 @@ export interface StrictCommentGroupProps {
   threaded?: boolean
 }
 
-declare const CommentGroup: React.FC<CommentGroupProps>
+declare const CommentGroup: ForwardRefComponent<CommentGroupProps, HTMLDivElement>
 
 export default CommentGroup

--- a/src/views/Comment/CommentMetadata.d.ts
+++ b/src/views/Comment/CommentMetadata.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface CommentMetadataProps extends StrictCommentMetadataProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictCommentMetadataProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentMetadata: React.FC<CommentMetadataProps>
+declare const CommentMetadata: ForwardRefComponent<CommentMetadataProps, HTMLDivElement>
 
 export default CommentMetadata

--- a/src/views/Comment/CommentText.d.ts
+++ b/src/views/Comment/CommentText.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface CommentTextProps extends StrictCommentTextProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictCommentTextProps {
   content?: SemanticShorthandContent
 }
 
-declare const CommentText: React.FC<CommentTextProps>
+declare const CommentText: ForwardRefComponent<CommentTextProps, HTMLDivElement>
 
 export default CommentText

--- a/src/views/Feed/Feed.d.ts
+++ b/src/views/Feed/Feed.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandCollection } from '../../generic'
 import FeedContent from './FeedContent'
 import FeedDate from './FeedDate'
 import FeedEvent, { FeedEventProps } from './FeedEvent'
@@ -32,7 +32,7 @@ export interface StrictFeedProps {
   size?: 'small' | 'large'
 }
 
-interface FeedComponent extends React.FC<FeedProps> {
+declare const Feed: ForwardRefComponent<FeedProps, HTMLDivElement> & {
   Content: typeof FeedContent
   Date: typeof FeedDate
   Event: typeof FeedEvent
@@ -43,7 +43,5 @@ interface FeedComponent extends React.FC<FeedProps> {
   Summary: typeof FeedSummary
   User: typeof FeedUser
 }
-
-declare const Feed: FeedComponent
 
 export default Feed

--- a/src/views/Feed/FeedContent.d.ts
+++ b/src/views/Feed/FeedContent.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { FeedDateProps } from './FeedDate'
 import { FeedExtraProps } from './FeedExtra'
 import { FeedMetaProps } from './FeedMeta'
@@ -39,6 +39,6 @@ export interface StrictFeedContentProps {
   summary?: SemanticShorthandItem<FeedSummaryProps>
 }
 
-declare const FeedContent: React.FC<FeedContentProps>
+declare const FeedContent: ForwardRefComponent<FeedContentProps, HTMLDivElement>
 
 export default FeedContent

--- a/src/views/Feed/FeedDate.d.ts
+++ b/src/views/Feed/FeedDate.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface FeedDateProps extends StrictFeedDateProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictFeedDateProps {
   content?: SemanticShorthandContent
 }
 
-declare const FeedDate: React.FC<FeedDateProps>
+declare const FeedDate: ForwardRefComponent<FeedDateProps, HTMLDivElement>
 
 export default FeedDate

--- a/src/views/Feed/FeedEvent.d.ts
+++ b/src/views/Feed/FeedEvent.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandItem } from '../../generic'
 import { FeedContentProps } from './FeedContent'
 import { FeedDateProps } from './FeedDate'
 import { FeedLabelProps } from './FeedLabel'
@@ -47,6 +47,6 @@ export interface StrictFeedEventProps {
   summary?: SemanticShorthandItem<FeedSummaryProps>
 }
 
-declare const FeedEvent: React.FC<FeedEventProps>
+declare const FeedEvent: ForwardRefComponent<FeedEventProps, HTMLDivElement>
 
 export default FeedEvent

--- a/src/views/Feed/FeedExtra.d.ts
+++ b/src/views/Feed/FeedExtra.d.ts
@@ -3,6 +3,7 @@ import {
   HtmlImageProps,
   SemanticShorthandContent,
   SemanticShorthandCollection,
+  ForwardRefComponent,
 } from '../../generic'
 
 export interface FeedExtraProps extends StrictFeedExtraProps {
@@ -29,6 +30,6 @@ export interface StrictFeedExtraProps {
   text?: boolean
 }
 
-declare const FeedExtra: React.FC<FeedExtraProps>
+declare const FeedExtra: ForwardRefComponent<FeedExtraProps, HTMLDivElement>
 
 export default FeedExtra

--- a/src/views/Feed/FeedLabel.d.ts
+++ b/src/views/Feed/FeedLabel.d.ts
@@ -1,6 +1,11 @@
 import * as React from 'react'
 
-import { HtmlImageProps, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import {
+  ForwardRefComponent,
+  HtmlImageProps,
+  SemanticShorthandContent,
+  SemanticShorthandItem,
+} from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface FeedLabelProps extends StrictFeedLabelProps {
@@ -27,6 +32,6 @@ export interface StrictFeedLabelProps {
   image?: SemanticShorthandItem<HtmlImageProps>
 }
 
-declare const FeedLabel: React.FC<FeedLabelProps>
+declare const FeedLabel: ForwardRefComponent<FeedLabelProps, HTMLDivElement>
 
 export default FeedLabel

--- a/src/views/Feed/FeedLike.d.ts
+++ b/src/views/Feed/FeedLike.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { IconProps } from '../../elements/Icon'
 
 export interface FeedLikeProps extends StrictFeedLikeProps {
@@ -24,6 +24,6 @@ export interface StrictFeedLikeProps {
   icon?: SemanticShorthandItem<IconProps>
 }
 
-declare const FeedLike: React.FC<FeedLikeProps>
+declare const FeedLike: ForwardRefComponent<FeedLikeProps, HTMLDivElement>
 
 export default FeedLike

--- a/src/views/Feed/FeedMeta.d.ts
+++ b/src/views/Feed/FeedMeta.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { FeedLikeProps } from './FeedLike'
 
 export interface FeedMetaProps extends StrictFeedMetaProps {
@@ -24,6 +24,6 @@ export interface StrictFeedMetaProps {
   like?: SemanticShorthandItem<FeedLikeProps>
 }
 
-declare const FeedMeta: React.FC<FeedMetaProps>
+declare const FeedMeta: ForwardRefComponent<FeedMetaProps, HTMLDivElement>
 
 export default FeedMeta

--- a/src/views/Feed/FeedSummary.d.ts
+++ b/src/views/Feed/FeedSummary.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import { FeedDateProps } from './FeedDate'
 import { FeedUserProps } from './FeedUser'
 
@@ -28,6 +28,6 @@ export interface StrictFeedSummaryProps {
   user?: SemanticShorthandItem<FeedUserProps>
 }
 
-declare const FeedSummary: React.FC<FeedSummaryProps>
+declare const FeedSummary: ForwardRefComponent<FeedSummaryProps, HTMLDivElement>
 
 export default FeedSummary

--- a/src/views/Feed/FeedUser.d.ts
+++ b/src/views/Feed/FeedUser.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface FeedUserProps extends StrictFeedUserProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictFeedUserProps {
   content?: SemanticShorthandContent
 }
 
-declare const FeedUser: React.FC<FeedUserProps>
+declare const FeedUser: ForwardRefComponent<FeedUserProps, HTMLAnchorElement>
 
 export default FeedUser

--- a/src/views/Item/Item.d.ts
+++ b/src/views/Item/Item.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent, SemanticShorthandItem } from '../../generic'
 import ItemContent from './ItemContent'
 import ItemDescription, { ItemDescriptionProps } from './ItemDescription'
 import ItemExtra, { ItemExtraProps } from './ItemExtra'
@@ -42,7 +42,7 @@ export interface StrictItemProps {
   meta?: SemanticShorthandItem<ItemMetaProps>
 }
 
-interface ItemComponent extends React.FC<ItemProps> {
+declare const Item: ForwardRefComponent<ItemProps, HTMLDivElement> & {
   Content: typeof ItemContent
   Description: typeof ItemDescription
   Extra: typeof ItemExtra
@@ -51,7 +51,5 @@ interface ItemComponent extends React.FC<ItemProps> {
   Image: typeof ItemImage
   Meta: typeof ItemMeta
 }
-
-declare const Item: ItemComponent
 
 export default Item

--- a/src/views/Item/ItemContent.d.ts
+++ b/src/views/Item/ItemContent.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticShorthandContent,
   SemanticShorthandItem,
   SemanticVERTICALALIGNMENTS,
@@ -43,6 +44,6 @@ export interface StrictItemContentProps {
   verticalAlign?: SemanticVERTICALALIGNMENTS
 }
 
-declare const ItemContent: React.ComponentClass<ItemContentProps>
+declare const ItemContent: ForwardRefComponent<ItemContentProps, HTMLDivElement>
 
 export default ItemContent

--- a/src/views/Item/ItemDescription.d.ts
+++ b/src/views/Item/ItemDescription.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ItemDescriptionProps extends StrictItemDescriptionProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictItemDescriptionProps {
   content?: SemanticShorthandContent
 }
 
-declare const ItemDescription: React.FC<ItemDescriptionProps>
+declare const ItemDescription: ForwardRefComponent<ItemDescriptionProps, HTMLDivElement>
 
 export default ItemDescription

--- a/src/views/Item/ItemExtra.d.ts
+++ b/src/views/Item/ItemExtra.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ItemExtraProps extends StrictItemExtraProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictItemExtraProps {
   content?: SemanticShorthandContent
 }
 
-declare const ItemExtra: React.FC<ItemExtraProps>
+declare const ItemExtra: ForwardRefComponent<ItemExtraProps, HTMLDivElement>
 
 export default ItemExtra

--- a/src/views/Item/ItemGroup.d.ts
+++ b/src/views/Item/ItemGroup.d.ts
@@ -1,6 +1,10 @@
 import * as React from 'react'
 
-import { SemanticShorthandCollection, SemanticShorthandContent } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticShorthandCollection,
+  SemanticShorthandContent,
+} from '../../generic'
 import { ItemProps } from './Item'
 
 export interface ItemGroupProps extends StrictItemGroupProps {
@@ -36,6 +40,6 @@ export interface StrictItemGroupProps {
   unstackable?: boolean
 }
 
-declare const ItemGroup: React.FC<ItemGroupProps>
+declare const ItemGroup: ForwardRefComponent<ItemGroupProps, HTMLDivElement>
 
 export default ItemGroup

--- a/src/views/Item/ItemHeader.d.ts
+++ b/src/views/Item/ItemHeader.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ItemHeaderProps extends StrictItemHeaderProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictItemHeaderProps {
   content?: SemanticShorthandContent
 }
 
-declare const ItemHeader: React.FC<ItemHeaderProps>
+declare const ItemHeader: ForwardRefComponent<ItemHeaderProps, HTMLDivElement>
 
 export default ItemHeader

--- a/src/views/Item/ItemImage.d.ts
+++ b/src/views/Item/ItemImage.d.ts
@@ -1,7 +1,5 @@
-import * as React from 'react'
-
 import { ImageProps, StrictImageProps } from '../../elements/Image'
-import { SemanticSIZES } from '../../generic'
+import { ForwardRefComponent, SemanticSIZES } from '../../generic'
 
 export interface ItemImageProps extends ImageProps {
   [key: string]: any
@@ -15,6 +13,6 @@ export interface StrictItemImageProps extends StrictImageProps {
   size?: SemanticSIZES
 }
 
-declare const ItemImage: React.FC<ItemImageProps>
+declare const ItemImage: ForwardRefComponent<ItemImageProps, HTMLImageElement>
 
 export default ItemImage

--- a/src/views/Item/ItemMeta.d.ts
+++ b/src/views/Item/ItemMeta.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface ItemMetaProps extends StrictItemMetaProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictItemMetaProps {
   content?: SemanticShorthandContent
 }
 
-declare const ItemMeta: React.FC<ItemMetaProps>
+declare const ItemMeta: ForwardRefComponent<ItemMetaProps, HTMLDivElement>
 
 export default ItemMeta

--- a/src/views/Statistic/Statistic.d.ts
+++ b/src/views/Statistic/Statistic.d.ts
@@ -1,6 +1,11 @@
 import * as React from 'react'
 
-import { SemanticCOLORS, SemanticFLOATS, SemanticShorthandContent } from '../../generic'
+import {
+  ForwardRefComponent,
+  SemanticCOLORS,
+  SemanticFLOATS,
+  SemanticShorthandContent,
+} from '../../generic'
 import StatisticGroup from './StatisticGroup'
 import StatisticLabel from './StatisticLabel'
 import StatisticValue from './StatisticValue'
@@ -49,12 +54,10 @@ export interface StrictStatisticProps {
   value?: SemanticShorthandContent
 }
 
-interface StatisticComponent extends React.FC<StatisticProps> {
+declare const Statistic: ForwardRefComponent<StatisticProps, HTMLDivElement> & {
   Group: typeof StatisticGroup
   Label: typeof StatisticLabel
   Value: typeof StatisticValue
 }
-
-declare const Statistic: StatisticComponent
 
 export default Statistic

--- a/src/views/Statistic/StatisticGroup.d.ts
+++ b/src/views/Statistic/StatisticGroup.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  ForwardRefComponent,
   SemanticCOLORS,
   SemanticShorthandCollection,
   SemanticShorthandContent,
@@ -44,6 +45,6 @@ export interface StrictStatisticGroupProps {
   widths?: SemanticWIDTHS
 }
 
-declare const StatisticGroup: React.FC<StatisticGroupProps>
+declare const StatisticGroup: ForwardRefComponent<StatisticGroupProps, HTMLDivElement>
 
 export default StatisticGroup

--- a/src/views/Statistic/StatisticLabel.d.ts
+++ b/src/views/Statistic/StatisticLabel.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface StatisticLabelProps extends StrictStatisticLabelProps {
   [key: string]: any
@@ -19,6 +19,6 @@ export interface StrictStatisticLabelProps {
   content?: SemanticShorthandContent
 }
 
-declare const StatisticLabel: React.FC<StatisticLabelProps>
+declare const StatisticLabel: ForwardRefComponent<StatisticLabelProps, HTMLDivElement>
 
 export default StatisticLabel

--- a/src/views/Statistic/StatisticValue.d.ts
+++ b/src/views/Statistic/StatisticValue.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SemanticShorthandContent } from '../../generic'
+import { ForwardRefComponent, SemanticShorthandContent } from '../../generic'
 
 export interface StatisticValueProps extends StrictStatisticValueProps {
   [key: string]: any
@@ -22,6 +22,6 @@ export interface StrictStatisticValueProps {
   text?: boolean
 }
 
-declare const StatisticValue: React.FC<StatisticValueProps>
+declare const StatisticValue: ForwardRefComponent<StatisticValueProps, HTMLDivElement>
 
 export default StatisticValue

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -38,7 +38,7 @@ describe('Portal', () => {
   })
 
   common.hasSubcomponents(Portal, [PortalInner])
-  common.hasValidTypings(Portal)
+  common.hasValidTypings(Portal, { forwardsRef: false })
 
   it('propTypes.children should be required', () => {
     Portal.propTypes.children.should.equal(PropTypes.node.isRequired)

--- a/test/specs/addons/Portal/PortalInner-test.js
+++ b/test/specs/addons/Portal/PortalInner-test.js
@@ -10,6 +10,7 @@ describe('PortalInner', () => {
   common.isConformant(PortalInner, {
     rendersChildren: false,
     requiredProps: { children: <p /> },
+    forwardsRef: false,
   })
 
   describe('children', () => {

--- a/test/specs/addons/TransitionablePortal/TransitionablePortal-test.js
+++ b/test/specs/addons/TransitionablePortal/TransitionablePortal-test.js
@@ -13,6 +13,7 @@ describe('TransitionablePortal', () => {
   common.isConformant(TransitionablePortal, {
     rendersPortal: true,
     requiredProps,
+    forwardsRef: false,
   })
 
   describe('children', () => {

--- a/test/specs/commonTests/isConformant.js
+++ b/test/specs/commonTests/isConformant.js
@@ -26,6 +26,7 @@ import hasValidTypings from './hasValidTypings'
  * @param {boolean} [options.rendersFragmentByDefault=false] Does this component renders React.Fragment by default?
  * @param {boolean} [options.rendersPortal=false] Does this component render a Portal powered component?
  * @param {Object} [options.requiredProps={}] Props required to render Component without errors or warnings.
+ * @param {Object} [options.forwardsRef=true] Indicates if component forwards refs.
  */
 export default function isConformant(Component, options = {}) {
   const {
@@ -394,5 +395,5 @@ export default function isConformant(Component, options = {}) {
   // ----------------------------------------
   // Test typings
   // ----------------------------------------
-  hasValidTypings(Component, info, options)
+  hasValidTypings(Component, options)
 }

--- a/test/specs/commonTests/tsHelpers.js
+++ b/test/specs/commonTests/tsHelpers.js
@@ -7,6 +7,7 @@ const isInterface = ({ kind }) => kind === SyntaxKind.InterfaceDeclaration
 const isExportModifier = ({ kind }) => kind === SyntaxKind.ExportKeyword
 const isPropertySignature = ({ kind }) => kind === SyntaxKind.PropertySignature
 const isTypeReference = ({ kind }) => kind === SyntaxKind.TypeReference
+const isIntersectionType = ({ kind }) => kind === SyntaxKind.IntersectionType
 const isShorthandProperty = (node) => {
   if (!isPropertySignature(node) || !isTypeReference(node.type)) return false
   return _.includes(
@@ -15,6 +16,7 @@ const isShorthandProperty = (node) => {
   )
 }
 const isStringKeyword = ({ kind }) => kind === SyntaxKind.StringKeyword
+const isVariableDeclaration = ({ kind }) => kind === SyntaxKind.VariableDeclaration
 
 const getProps = (members) => {
   const props = _.filter(members, isPropertySignature)
@@ -60,6 +62,28 @@ export const getInterfaces = (nodes) => {
     props: getProps(members),
     shorthands: getShorthands(members),
   }))
+}
+
+export const getComponentType = (nodes, componentName) => {
+  return nodes.find((node) => isVariableDeclaration(node) && node.name.text === componentName)
+}
+
+export const isForwardRefComponent = (componentType) => {
+  if (isIntersectionType(componentType.type)) {
+    if (Array.isArray(componentType.type.types)) {
+      if (componentType.type.types.length === 2) {
+        const [type] = componentType.type.types
+
+        return type.typeName.text === 'ForwardRefComponent'
+      }
+    }
+  }
+
+  if (isTypeReference(componentType.type)) {
+    return componentType.type.typeName.text === 'ForwardRefComponent'
+  }
+
+  return false
 }
 
 export const hasAnySignature = (nodes) => {

--- a/test/specs/modules/Accordion/AccordionPanel-test.js
+++ b/test/specs/modules/Accordion/AccordionPanel-test.js
@@ -7,7 +7,7 @@ import * as common from 'test/specs/commonTests'
 import { sandbox } from 'test/utils'
 
 describe('AccordionPanel', () => {
-  common.isConformant(AccordionPanel, { rendersChildren: false })
+  common.isConformant(AccordionPanel, { rendersChildren: false, forwardsRef: false })
 
   common.implementsShorthandProp(AccordionPanel, {
     assertExactMatch: false,

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -38,7 +38,7 @@ describe('Popup', () => {
     if (wrapper && wrapper.unmount) wrapper.unmount()
   })
 
-  common.isConformant(Popup, { rendersChildren: false, rendersPortal: true })
+  common.isConformant(Popup, { rendersChildren: false, rendersPortal: true, forwardsRef: false })
   common.hasSubcomponents(Popup, [PopupHeader, PopupContent])
 
   // Heads up!

--- a/test/specs/modules/Search/SearchCategoryLayout-test.js
+++ b/test/specs/modules/Search/SearchCategoryLayout-test.js
@@ -9,5 +9,9 @@ const requiredProps = {
 }
 
 describe('SearchCategoryLayout', () => {
-  common.isConformant(SearchCategoryLayout, { requiredProps, rendersChildren: false })
+  common.isConformant(SearchCategoryLayout, {
+    requiredProps,
+    forwardsRef: false,
+    rendersChildren: false,
+  })
 })

--- a/test/specs/modules/Transition/Transition-test.js
+++ b/test/specs/modules/Transition/Transition-test.js
@@ -19,7 +19,7 @@ const wrapperShallow = (...args) => (wrapper = shallow(...args))
 
 describe('Transition', () => {
   common.hasSubcomponents(Transition, [TransitionGroup])
-  common.hasValidTypings(Transition)
+  common.hasValidTypings(Transition, { forwardsRef: false })
 
   beforeEach(() => {
     wrapper = undefined

--- a/test/typings.tsx
+++ b/test/typings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Button, Dropdown } from '../index'
+import { Button, Dropdown, Icon } from '../index'
 
 export const BasicAssert = () => (
   <>
@@ -8,6 +8,18 @@ export const BasicAssert = () => (
     <Button>Foo</Button>
   </>
 )
+
+export const RefAssert = () => {
+  const buttonRef = React.useRef<HTMLButtonElement>(null)
+  const iconRef = React.useRef<HTMLElement>(null)
+
+  return (
+    <>
+      <Button ref={buttonRef} />
+      <Icon name='history' ref={iconRef} />
+    </>
+  )
+}
 
 export const ShorthandItemElementAssert = () => (
   <Dropdown additionLabel={<i style={{ color: 'red' }}>Custom Language: </i>} />


### PR DESCRIPTION
Fixes #4432.

- Adds `ForwardRefComponent` type
- Adds conformance tests to ensure that a type for a component exists and it had proper type
- Updates all components' types