### PR TITLE
chore: add "use client" directive in components where it's needed

### DIFF
--- a/.babel-preset.js
+++ b/.babel-preset.js
@@ -33,6 +33,12 @@ const plugins = [
   // modules and avoid modules that prevent tree-shaking:
   // https://github.com/lodash/lodash/issues/4119
   'lodash',
+  [
+    'transform-next-use-client',
+    {
+      customClientImports: ['useAutoControlledValue', 'useEventCallback', 'useMergedRefs'],
+    },
+  ],
   // CJS modules are not tree-shakable in any bundler by default
   // https://github.com/formium/tsdx#using-lodash
   (isESBuild || isUMDBuild) && [

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "babel-plugin-filter-imports": "^4.0.0",
     "babel-plugin-istanbul": "^6.1.1",
     "babel-plugin-lodash": "^3.3.4",
+    "babel-plugin-transform-next-use-client": "^1.1.1",
     "babel-plugin-transform-react-handled-props": "^2.1.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-plugin-transform-rename-import": "^2.3.0",

--- a/src/addons/Confirm/Confirm.js
+++ b/src/addons/Confirm/Confirm.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { customPropTypes, getUnhandledProps } from '../../lib'
 import Button from '../../elements/Button'

--- a/src/addons/Pagination/Pagination.js
+++ b/src/addons/Pagination/Pagination.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   createPaginationItems,

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -2,7 +2,7 @@ import EventStack from '@semantic-ui-react/event-stack'
 import keyboardKey from 'keyboard-key'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   customPropTypes,
@@ -25,17 +25,17 @@ const debug = makeDebugger('portal')
 function Portal(props) {
   const {
     children,
-    closeOnDocumentClick,
-    closeOnEscape,
+    closeOnDocumentClick = true,
+    closeOnEscape = true,
     closeOnPortalMouseLeave,
     closeOnTriggerBlur,
     closeOnTriggerClick,
     closeOnTriggerMouseLeave,
-    eventPool,
+    eventPool = 'default',
     mountNode,
     mouseEnterDelay,
     mouseLeaveDelay,
-    openOnTriggerClick,
+    openOnTriggerClick = true,
     openOnTriggerFocus,
     openOnTriggerMouseEnter,
   } = props
@@ -376,13 +376,6 @@ Portal.propTypes = {
 
   /** Called with a ref to the trigger node. */
   triggerRef: customPropTypes.ref,
-}
-
-Portal.defaultProps = {
-  closeOnDocumentClick: true,
-  closeOnEscape: true,
-  eventPool: 'default',
-  openOnTriggerClick: true,
 }
 
 Portal.Inner = PortalInner

--- a/src/addons/Portal/PortalInner.js
+++ b/src/addons/Portal/PortalInner.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 import { createPortal } from 'react-dom'
 
 import { isBrowser, makeDebugger, useEventCallback } from '../../lib'

--- a/src/addons/Portal/usePortalElement.js
+++ b/src/addons/Portal/usePortalElement.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import ReactIs from 'react-is'
 
 import { useMergedRefs } from '../../lib'

--- a/src/addons/Portal/utils/useTrigger.js
+++ b/src/addons/Portal/utils/useTrigger.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { useMergedRefs } from '../../../lib'
 import validateTrigger from './validateTrigger'

--- a/src/addons/Portal/utils/validateTrigger.js
+++ b/src/addons/Portal/utils/validateTrigger.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import * as ReactIs from 'react-is'
 
 /**

--- a/src/addons/Radio/Radio.js
+++ b/src/addons/Radio/Radio.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { getUnhandledProps } from '../../lib'
 import Checkbox from '../../modules/Checkbox'

--- a/src/addons/Select/Select.js
+++ b/src/addons/Select/Select.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import Dropdown from '../../modules/Dropdown'
 

--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps, useMergedRefs } from '../../lib'
 

--- a/src/addons/TransitionablePortal/TransitionablePortal.js
+++ b/src/addons/TransitionablePortal/TransitionablePortal.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import Portal from '../Portal'
 import Transition from '../../modules/Transition'

--- a/src/collections/Breadcrumb/Breadcrumb.js
+++ b/src/collections/Breadcrumb/Breadcrumb.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getUnhandledProps, getComponentType, SUI } from '../../lib'
 import BreadcrumbDivider from './BreadcrumbDivider'

--- a/src/collections/Breadcrumb/BreadcrumbDivider.js
+++ b/src/collections/Breadcrumb/BreadcrumbDivider.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Breadcrumb/BreadcrumbSection.js
+++ b/src/collections/Breadcrumb/BreadcrumbSection.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Form/Form.js
+++ b/src/collections/Form/Form.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps, SUI, useKeyOnly, useWidthProp } from '../../lib'
 import FormButton from './FormButton'

--- a/src/collections/Form/FormButton.js
+++ b/src/collections/Form/FormButton.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 import Button from '../../elements/Button'

--- a/src/collections/Form/FormCheckbox.js
+++ b/src/collections/Form/FormCheckbox.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 import Checkbox from '../../modules/Checkbox'

--- a/src/collections/Form/FormDropdown.js
+++ b/src/collections/Form/FormDropdown.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 import Dropdown from '../../modules/Dropdown'

--- a/src/collections/Form/FormGroup.js
+++ b/src/collections/Form/FormGroup.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   customPropTypes,

--- a/src/collections/Form/FormInput.js
+++ b/src/collections/Form/FormInput.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 import Input from '../../elements/Input'

--- a/src/collections/Form/FormRadio.js
+++ b/src/collections/Form/FormRadio.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 import Radio from '../../addons/Radio'

--- a/src/collections/Form/FormSelect.js
+++ b/src/collections/Form/FormSelect.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 import Select from '../../addons/Select'

--- a/src/collections/Form/FormTextArea.js
+++ b/src/collections/Form/FormTextArea.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 import TextArea from '../../addons/TextArea'

--- a/src/collections/Grid/Grid.js
+++ b/src/collections/Grid/Grid.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   customPropTypes,

--- a/src/collections/Grid/GridColumn.js
+++ b/src/collections/Grid/GridColumn.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   customPropTypes,

--- a/src/collections/Grid/GridRow.js
+++ b/src/collections/Grid/GridRow.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   customPropTypes,

--- a/src/collections/Menu/Menu.js
+++ b/src/collections/Menu/Menu.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Menu/MenuHeader.js
+++ b/src/collections/Menu/MenuHeader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/collections/Menu/MenuItem.js
+++ b/src/collections/Menu/MenuItem.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Menu/MenuMenu.js
+++ b/src/collections/Menu/MenuMenu.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/collections/Message/Message.js
+++ b/src/collections/Message/Message.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Message/MessageContent.js
+++ b/src/collections/Message/MessageContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/collections/Message/MessageHeader.js
+++ b/src/collections/Message/MessageHeader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Message/MessageItem.js
+++ b/src/collections/Message/MessageItem.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Message/MessageList.js
+++ b/src/collections/Message/MessageList.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Table/Table.js
+++ b/src/collections/Table/Table.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Table/TableBody.js
+++ b/src/collections/Table/TableBody.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/collections/Table/TableCell.js
+++ b/src/collections/Table/TableCell.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Table/TableFooter.js
+++ b/src/collections/Table/TableFooter.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getUnhandledProps } from '../../lib'
 import TableHeader from './TableHeader'

--- a/src/collections/Table/TableHeader.js
+++ b/src/collections/Table/TableHeader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/collections/Table/TableHeaderCell.js
+++ b/src/collections/Table/TableHeaderCell.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getUnhandledProps, useValueAndKey } from '../../lib'
 import TableCell from './TableCell'

--- a/src/collections/Table/TableRow.js
+++ b/src/collections/Table/TableRow.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Button/Button.js
+++ b/src/elements/Button/Button.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Button/ButtonContent.js
+++ b/src/elements/Button/ButtonContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Button/ButtonGroup.js
+++ b/src/elements/Button/ButtonGroup.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Button/ButtonOr.js
+++ b/src/elements/Button/ButtonOr.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/elements/Container/Container.js
+++ b/src/elements/Container/Container.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Divider/Divider.js
+++ b/src/elements/Divider/Divider.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Flag/Flag.js
+++ b/src/elements/Flag/Flag.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   createShorthandFactory,

--- a/src/elements/Header/Header.js
+++ b/src/elements/Header/Header.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Header/HeaderContent.js
+++ b/src/elements/Header/HeaderContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/elements/Header/HeaderSubheader.js
+++ b/src/elements/Header/HeaderSubheader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Icon/Icon.js
+++ b/src/elements/Icon/Icon.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   createShorthandFactory,

--- a/src/elements/Icon/IconGroup.js
+++ b/src/elements/Icon/IconGroup.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps, SUI } from '../../lib'
 

--- a/src/elements/Image/Image.js
+++ b/src/elements/Image/Image.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Image/ImageGroup.js
+++ b/src/elements/Image/ImageGroup.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps, SUI } from '../../lib'
 

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Label/Label.js
+++ b/src/elements/Label/Label.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Label/LabelDetail.js
+++ b/src/elements/Label/LabelDetail.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Label/LabelGroup.js
+++ b/src/elements/Label/LabelGroup.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/List/List.js
+++ b/src/elements/List/List.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/List/ListContent.js
+++ b/src/elements/List/ListContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/List/ListDescription.js
+++ b/src/elements/List/ListDescription.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/List/ListHeader.js
+++ b/src/elements/List/ListHeader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/List/ListIcon.js
+++ b/src/elements/List/ListIcon.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { createShorthandFactory, getUnhandledProps, SUI, useVerticalAlignProp } from '../../lib'
 import Icon from '../Icon/Icon'

--- a/src/elements/List/ListList.js
+++ b/src/elements/List/ListList.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Loader/Loader.js
+++ b/src/elements/Loader/Loader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Placeholder/Placeholder.js
+++ b/src/elements/Placeholder/Placeholder.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Placeholder/PlaceholderHeader.js
+++ b/src/elements/Placeholder/PlaceholderHeader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Placeholder/PlaceholderImage.js
+++ b/src/elements/Placeholder/PlaceholderImage.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { customPropTypes, getComponentType, getUnhandledProps, useKeyOnly } from '../../lib'
 

--- a/src/elements/Placeholder/PlaceholderLine.js
+++ b/src/elements/Placeholder/PlaceholderLine.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/elements/Placeholder/PlaceholderParagraph.js
+++ b/src/elements/Placeholder/PlaceholderParagraph.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/elements/Rail/Rail.js
+++ b/src/elements/Rail/Rail.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Reveal/Reveal.js
+++ b/src/elements/Reveal/Reveal.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Reveal/RevealContent.js
+++ b/src/elements/Reveal/RevealContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Segment/Segment.js
+++ b/src/elements/Segment/Segment.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Segment/SegmentGroup.js
+++ b/src/elements/Segment/SegmentGroup.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Segment/SegmentInline.js
+++ b/src/elements/Segment/SegmentInline.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/elements/Step/Step.js
+++ b/src/elements/Step/Step.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Step/StepContent.js
+++ b/src/elements/Step/StepContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Step/StepDescription.js
+++ b/src/elements/Step/StepDescription.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Step/StepGroup.js
+++ b/src/elements/Step/StepGroup.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/elements/Step/StepTitle.js
+++ b/src/elements/Step/StepTitle.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/lib/ModernAutoControlledComponent.js
+++ b/src/lib/ModernAutoControlledComponent.js
@@ -24,7 +24,7 @@
  *    hoisted and exposed by the HOC.
  */
 import _ from 'lodash'
-import React from 'react'
+import * as React from 'react'
 
 const getDefaultPropName = (prop) => `default${prop[0].toUpperCase() + prop.slice(1)}`
 

--- a/src/lib/hooks/useClassNamesOnNode.js
+++ b/src/lib/hooks/useClassNamesOnNode.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import isRefObject from '../isRefObject'
 import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect'

--- a/src/lib/hooks/useIsomorphicLayoutEffect.js
+++ b/src/lib/hooks/useIsomorphicLayoutEffect.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import isBrowser from '../isBrowser'
 
 // useLayoutEffect() produces a warning with SSR rendering

--- a/src/modules/Accordion/Accordion.js
+++ b/src/modules/Accordion/Accordion.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getUnhandledProps, useKeyOnly } from '../../lib'
 import AccordionAccordion from './AccordionAccordion'

--- a/src/modules/Accordion/AccordionAccordion.js
+++ b/src/modules/Accordion/AccordionAccordion.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Accordion/AccordionContent.js
+++ b/src/modules/Accordion/AccordionContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Accordion/AccordionTitle.js
+++ b/src/modules/Accordion/AccordionTitle.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   createHTMLLabel,

--- a/src/modules/Dimmer/Dimmer.js
+++ b/src/modules/Dimmer/Dimmer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { createShorthandFactory, getUnhandledProps, isBrowser } from '../../lib'
 import Portal from '../../addons/Portal'

--- a/src/modules/Dimmer/DimmerDimmable.js
+++ b/src/modules/Dimmer/DimmerDimmable.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Dimmer/DimmerInner.js
+++ b/src/modules/Dimmer/DimmerInner.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Dropdown/DropdownDivider.js
+++ b/src/modules/Dropdown/DropdownDivider.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/modules/Dropdown/DropdownHeader.js
+++ b/src/modules/Dropdown/DropdownHeader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Dropdown/DropdownItem.js
+++ b/src/modules/Dropdown/DropdownItem.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Dropdown/DropdownMenu.js
+++ b/src/modules/Dropdown/DropdownMenu.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Dropdown/DropdownSearchInput.js
+++ b/src/modules/Dropdown/DropdownSearchInput.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { createShorthandFactory, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/modules/Dropdown/DropdownText.js
+++ b/src/modules/Dropdown/DropdownText.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Dropdown/utils/getMenuOptions.js
+++ b/src/modules/Dropdown/utils/getMenuOptions.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import React from 'react'
+import * as React from 'react'
 
 // There are times when we need to calculate the options based on a value
 // that hasn't yet been persisted to state.

--- a/src/modules/Embed/Embed.js
+++ b/src/modules/Embed/Embed.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 import shallowEqual from 'shallowequal'
 
 import {

--- a/src/modules/Modal/ModalActions.js
+++ b/src/modules/Modal/ModalActions.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Modal/ModalContent.js
+++ b/src/modules/Modal/ModalContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Modal/ModalDescription.js
+++ b/src/modules/Modal/ModalDescription.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/modules/Modal/ModalDimmer.js
+++ b/src/modules/Modal/ModalDimmer.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Modal/ModalHeader.js
+++ b/src/modules/Modal/ModalHeader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -2,7 +2,7 @@ import EventStack from '@semantic-ui-react/event-stack'
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 import { Popper } from 'react-popper'
 import shallowEqual from 'shallowequal'
 

--- a/src/modules/Popup/PopupContent.js
+++ b/src/modules/Popup/PopupContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Popup/PopupHeader.js
+++ b/src/modules/Popup/PopupHeader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Progress/Progress.js
+++ b/src/modules/Progress/Progress.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   getComponentType,

--- a/src/modules/Rating/RatingIcon.js
+++ b/src/modules/Rating/RatingIcon.js
@@ -2,7 +2,7 @@ import cx from 'clsx'
 import keyboardKey from 'keyboard-key'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { getComponentType, getUnhandledProps, useKeyOnly } from '../../lib'
 

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -2,7 +2,7 @@ import cx from 'clsx'
 import keyboardKey from 'keyboard-key'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 import shallowEqual from 'shallowequal'
 
 import {

--- a/src/modules/Search/SearchCategory.js
+++ b/src/modules/Search/SearchCategory.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Search/SearchCategoryLayout.js
+++ b/src/modules/Search/SearchCategoryLayout.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 function SearchCategoryLayout(props) {
   const { categoryContent, resultsContent } = props

--- a/src/modules/Search/SearchResult.js
+++ b/src/modules/Search/SearchResult.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   createHTMLImage,

--- a/src/modules/Search/SearchResults.js
+++ b/src/modules/Search/SearchResults.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -2,7 +2,7 @@ import { EventListener, documentRef } from '@fluentui/react-component-event-list
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Sidebar/SidebarPushable.js
+++ b/src/modules/Sidebar/SidebarPushable.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/modules/Sidebar/SidebarPusher.js
+++ b/src/modules/Sidebar/SidebarPusher.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Sticky/Sticky.js
+++ b/src/modules/Sticky/Sticky.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   customPropTypes,

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   customPropTypes,

--- a/src/modules/Tab/TabPane.js
+++ b/src/modules/Tab/TabPane.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/modules/Transition/TransitionGroup.js
+++ b/src/modules/Transition/TransitionGroup.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   getComponentType,

--- a/src/modules/Transition/utils/wrapChild.js
+++ b/src/modules/Transition/utils/wrapChild.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Transition from '../Transition'
 
 /**

--- a/src/views/Advertisement/Advertisement.js
+++ b/src/views/Advertisement/Advertisement.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Card/Card.js
+++ b/src/views/Card/Card.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Card/CardContent.js
+++ b/src/views/Card/CardContent.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Card/CardDescription.js
+++ b/src/views/Card/CardDescription.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Card/CardGroup.js
+++ b/src/views/Card/CardGroup.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Card/CardHeader.js
+++ b/src/views/Card/CardHeader.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Card/CardMeta.js
+++ b/src/views/Card/CardMeta.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Comment/Comment.js
+++ b/src/views/Comment/Comment.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Comment/CommentAction.js
+++ b/src/views/Comment/CommentAction.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Comment/CommentActions.js
+++ b/src/views/Comment/CommentActions.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/views/Comment/CommentAuthor.js
+++ b/src/views/Comment/CommentAuthor.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/views/Comment/CommentAvatar.js
+++ b/src/views/Comment/CommentAvatar.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   createHTMLImage,

--- a/src/views/Comment/CommentContent.js
+++ b/src/views/Comment/CommentContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/views/Comment/CommentGroup.js
+++ b/src/views/Comment/CommentGroup.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Comment/CommentMetadata.js
+++ b/src/views/Comment/CommentMetadata.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/views/Comment/CommentText.js
+++ b/src/views/Comment/CommentText.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/views/Feed/Feed.js
+++ b/src/views/Feed/Feed.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps, SUI } from '../../lib'
 import FeedContent from './FeedContent'

--- a/src/views/Feed/FeedContent.js
+++ b/src/views/Feed/FeedContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Feed/FeedDate.js
+++ b/src/views/Feed/FeedDate.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/views/Feed/FeedEvent.js
+++ b/src/views/Feed/FeedEvent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { createShorthand, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 import FeedContent from './FeedContent'

--- a/src/views/Feed/FeedExtra.js
+++ b/src/views/Feed/FeedExtra.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Feed/FeedLabel.js
+++ b/src/views/Feed/FeedLabel.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Feed/FeedLike.js
+++ b/src/views/Feed/FeedLike.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 import Icon from '../../elements/Icon'

--- a/src/views/Feed/FeedMeta.js
+++ b/src/views/Feed/FeedMeta.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Feed/FeedSummary.js
+++ b/src/views/Feed/FeedSummary.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Feed/FeedUser.js
+++ b/src/views/Feed/FeedUser.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 

--- a/src/views/Item/Item.js
+++ b/src/views/Item/Item.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import { childrenUtils, customPropTypes, getComponentType, getUnhandledProps } from '../../lib'
 import ItemContent from './ItemContent'

--- a/src/views/Item/ItemContent.js
+++ b/src/views/Item/ItemContent.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Item/ItemDescription.js
+++ b/src/views/Item/ItemDescription.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Item/ItemExtra.js
+++ b/src/views/Item/ItemExtra.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Item/ItemGroup.js
+++ b/src/views/Item/ItemGroup.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Item/ItemHeader.js
+++ b/src/views/Item/ItemHeader.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Item/ItemImage.js
+++ b/src/views/Item/ItemImage.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { createShorthandFactory, getUnhandledProps } from '../../lib'
 import Image from '../../elements/Image'

--- a/src/views/Item/ItemMeta.js
+++ b/src/views/Item/ItemMeta.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Statistic/Statistic.js
+++ b/src/views/Statistic/Statistic.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Statistic/StatisticGroup.js
+++ b/src/views/Statistic/StatisticGroup.js
@@ -1,7 +1,7 @@
 import cx from 'clsx'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Statistic/StatisticLabel.js
+++ b/src/views/Statistic/StatisticLabel.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/src/views/Statistic/StatisticValue.js
+++ b/src/views/Statistic/StatisticValue.js
@@ -1,6 +1,6 @@
 import cx from 'clsx'
 import PropTypes from 'prop-types'
-import React from 'react'
+import * as React from 'react'
 
 import {
   childrenUtils,

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -281,7 +281,19 @@ describe('Portal', () => {
 
   describe('openOnTriggerClick', () => {
     it('defaults to true', () => {
-      Portal.defaultProps.openOnTriggerClick.should.equal(true)
+      const onTriggerClick = sandbox.spy()
+      const trigger = <button onClick={onTriggerClick}>button</button>
+
+      wrapperMount(
+        <Portal trigger={trigger}>
+          <p />
+        </Portal>,
+      )
+      wrapper.should.not.have.descendants(PortalInner)
+
+      wrapper.find('button').simulate('click')
+      wrapper.should.have.descendants(PortalInner)
+      onTriggerClick.should.have.been.calledOnce()
     })
 
     it('does not open the portal on trigger click when false', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,6 +3449,11 @@ babel-plugin-transform-function-bind@^6.22.0:
     babel-plugin-syntax-function-bind "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-next-use-client@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-next-use-client/-/babel-plugin-transform-next-use-client-1.1.1.tgz#648f3b3de16a09b490f5d0bc34143516ef91a4df"
+  integrity sha512-qqyurXN5ZWP7kqmgzzXaEgF0fCi8d72tE+wCQwSCrjfN+LC0fI1+ejhNE+DtVECY1EvYkUoO0tcr9izwC9xexg==
+
 babel-plugin-transform-object-rest-spread@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"


### PR DESCRIPTION
This PR fixes #4433.

- Adds [babel-plugin-transform-next-use-client](https://github.com/kyletsang/babel-plugin-transform-next-use-client) to add "use client" directive on top of files that use hooks or APIs that are client only
- Changes `import React` to `import * as React` to be compatible with the plugin
- Removes `.defaultProps` from `Portal`, missed it in #4449

## ⚠️ Heads up

Next.js does not support `List.Item` syntax i.e. `ListItem` works `List.Item` does not 💥 There is an issue related to the problem (https://github.com/vercel/next.js/issues/44389), however with current implementation I don't believe that it's solvable on their side. I will create a follow-up PR to update examples to not reference that syntax.