### PR TITLE
Pass props and other data separately into all component callbacks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -426,7 +426,6 @@ export {
 export {
   default as Dropdown,
   DropdownProps,
-  DropdownOnSearchChangeData,
   StrictDropdownProps,
 } from './dist/commonjs/modules/Dropdown'
 export {

--- a/index.d.ts
+++ b/index.d.ts
@@ -254,12 +254,7 @@ export {
   StrictImageGroupProps,
 } from './dist/commonjs/elements/Image/ImageGroup'
 
-export {
-  default as Input,
-  InputProps,
-  InputOnChangeData,
-  StrictInputProps,
-} from './dist/commonjs/elements/Input'
+export { default as Input, InputProps, StrictInputProps } from './dist/commonjs/elements/Input'
 
 export { default as Label, LabelProps, StrictLabelProps } from './dist/commonjs/elements/Label'
 export {

--- a/index.d.ts
+++ b/index.d.ts
@@ -509,12 +509,7 @@ export {
   StrictRatingIconProps,
 } from './dist/commonjs/modules/Rating/RatingIcon'
 
-export {
-  default as Search,
-  SearchProps,
-  SearchResultData,
-  StrictSearchProps,
-} from './dist/commonjs/modules/Search'
+export { default as Search, SearchProps, StrictSearchProps } from './dist/commonjs/modules/Search'
 export {
   default as SearchCategory,
   SearchCategoryProps,

--- a/src/addons/Pagination/Pagination.d.ts
+++ b/src/addons/Pagination/Pagination.d.ts
@@ -45,9 +45,14 @@ export interface StrictPaginationProps {
    * Called on change of an active page.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
+   * @param {number} activePage - Index of the newly active page.
    */
-  onPageChange?: (event: React.MouseEvent<HTMLAnchorElement>, data: PaginationProps) => void
+  onPageChange?: (
+    event: React.MouseEvent<HTMLAnchorElement>,
+    props: PaginationProps,
+    activePage: number,
+  ) => void
 
   /** Number of always visible pages before and after the current one. */
   siblingRange?: number | string

--- a/src/addons/Pagination/Pagination.js
+++ b/src/addons/Pagination/Pagination.js
@@ -55,7 +55,7 @@ const Pagination = React.forwardRef(function (props, ref) {
     }
 
     setActivePage(nextActivePage)
-    _.invoke(props, 'onPageChange', e, { ...props, activePage: nextActivePage })
+    _.invoke(props, 'onPageChange', e, props, nextActivePage)
   }
 
   const handleItemOverrides = (active, type, value) => (predefinedProps) => ({

--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -50,33 +50,35 @@ export interface StrictPortalProps {
    * Called when a close event happens
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
+   * @param {boolean} open - Whether or not the portal is displayed.
    */
-  onClose?: (event: React.MouseEvent<HTMLElement>, data: PortalProps) => void
+  onClose?: (event: React.MouseEvent<HTMLElement>, props: PortalProps, open: boolean) => void
 
   /**
    * Called when the portal is mounted on the DOM
    *
    * @param {null}
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onMount?: (nothing: null, data: PortalProps) => void
+  onMount?: (nothing: null, props: PortalProps) => void
 
   /**
    * Called when an open event happens
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
+   * @param {boolean} open - Whether or not the portal is displayed.
    */
-  onOpen?: (event: React.MouseEvent<HTMLElement>, data: PortalProps) => void
+  onOpen?: (event: React.MouseEvent<HTMLElement>, props: PortalProps, open: boolean) => void
 
   /**
    * Called when the portal is unmounted from the DOM
    *
    * @param {null}
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onUnmount?: (nothing: null, data: PortalProps) => void
+  onUnmount?: (nothing: null, props: PortalProps) => void
 
   /** Controls whether or not the portal is displayed. */
   open?: boolean

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -61,7 +61,7 @@ function Portal(props) {
     debug('open()')
 
     setOpen(true)
-    _.invoke(props, 'onOpen', e, { ...props, open: true })
+    _.invoke(props, 'onOpen', e, props, true)
   }
 
   const openPortalWithTimeout = (e, delay) => {
@@ -77,7 +77,7 @@ function Portal(props) {
     debug('close()')
 
     setOpen(false)
-    _.invoke(props, 'onClose', e, { ...props, open: false })
+    _.invoke(props, 'onClose', e, props, false)
   }
 
   const closePortalWithTimeout = (e, delay) => {

--- a/src/addons/TextArea/TextArea.d.ts
+++ b/src/addons/TextArea/TextArea.d.ts
@@ -13,17 +13,27 @@ export interface StrictTextAreaProps {
    * Called on change.
    *
    * @param {SyntheticEvent} event - The React SyntheticEvent object
-   * @param {object} data - All props and the event value.
+   * @param {object} props - All props.
+   * @param {string} value - The value of the textarea.
    */
-  onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>, data: TextAreaProps) => void
+  onChange?: (
+    event: React.ChangeEvent<HTMLTextAreaElement>,
+    props: TextAreaProps,
+    value: string,
+  ) => void
 
   /**
    * Called on input.
    *
    * @param {SyntheticEvent} event - The React SyntheticEvent object
-   * @param {object} data - All props and the event value.
+   * @param {object} props - All props.
+   * @param {string} value - The value of the textarea.
    */
-  onInput?: (event: React.FormEvent<HTMLTextAreaElement>, data: TextAreaProps) => void
+  onInput?: (
+    event: React.FormEvent<HTMLTextAreaElement>,
+    props: TextAreaProps,
+    value: string,
+  ) => void
 
   /** Indicates row count for a TextArea. */
   rows?: number | string

--- a/src/addons/TextArea/TextArea.js
+++ b/src/addons/TextArea/TextArea.js
@@ -15,13 +15,13 @@ const TextArea = React.forwardRef(function (props, ref) {
   const handleChange = (e) => {
     const newValue = _.get(e, 'target.value')
 
-    _.invoke(props, 'onChange', e, { ...props, value: newValue })
+    _.invoke(props, 'onChange', e, props, newValue)
   }
 
   const handleInput = (e) => {
     const newValue = _.get(e, 'target.value')
 
-    _.invoke(props, 'onInput', e, { ...props, value: newValue })
+    _.invoke(props, 'onInput', e, props, newValue)
   }
 
   const rest = getUnhandledProps(TextArea, props)

--- a/src/addons/TransitionablePortal/TransitionablePortal.d.ts
+++ b/src/addons/TransitionablePortal/TransitionablePortal.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { TransitionEventData, TransitionProps } from '../../modules/Transition/Transition'
+import { TransitionProps, TRANSITION_STATUSES } from '../../modules/Transition/Transition'
 import { PortalProps } from '../Portal/Portal'
 
 export interface TransitionablePortalProps extends StrictTransitionablePortalProps {
@@ -15,33 +15,37 @@ export interface StrictTransitionablePortalProps {
    * Called when a close event happens.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and internal state.
+   * @param {object} props - All props.
+   * @param {object} state - Internal state.
    */
-  onClose?: (nothing: null, data: PortalProps & TransitionablePortalState) => void
+  onClose?: (nothing: null, props: PortalProps, state: TransitionablePortalState) => void
 
   /**
    * Callback on each transition that changes visibility to hidden.
    *
    * @param {null}
-   * @param {object} data - All props with status.
+   * @param {object} props - All props.
+   * @param {object} state - Internal state.
    */
-  onHide?: (nothing: null, data: TransitionEventData & TransitionablePortalState) => void
+  onHide?: (nothing: null, props: TransitionProps, state: TransitionablePortalState) => void
 
   /**
    * Called when an open event happens.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and internal state.
+   * @param {object} props - All props.
+   * @param {object} state - Internal state.
    */
-  onOpen?: (nothing: null, data: PortalProps & TransitionablePortalState) => void
+  onOpen?: (nothing: null, props: PortalProps, state: TransitionablePortalState) => void
 
   /**
    * Callback on animation start.
    *
    * @param {null}
-   * @param {object} data - All props with status.
+   * @param {object} props - All props.
+   * @param {object} state - Internal state.
    */
-  onStart?: (nothing: null, data: TransitionEventData & TransitionablePortalState) => void
+  onStart?: (nothing: null, props: TransitionProps, state: TransitionablePortalState) => void
 
   /** Controls whether or not the portal is displayed. */
   open?: boolean
@@ -51,6 +55,7 @@ export interface StrictTransitionablePortalProps {
 }
 
 export interface TransitionablePortalState {
+  transitionStatus: TRANSITION_STATUSES
   portalOpen: boolean
   transitionVisible: boolean
 }

--- a/src/addons/TransitionablePortal/TransitionablePortal.js
+++ b/src/addons/TransitionablePortal/TransitionablePortal.js
@@ -74,21 +74,28 @@ function TransitionablePortal(props) {
     setPortalOpen(true)
   }
 
-  const handleTransitionHide = (nothing, data) => {
+  const handleTransitionHide = (nothing, data, status) => {
     debug('handleTransitionHide()')
 
     setTransitionVisible(false)
-    _.invoke(props, 'onClose', null, { ...data, portalOpen: false, transitionVisible: false })
-    _.invoke(props, 'onHide', null, { ...data, portalOpen, transitionVisible: false })
+    _.invoke(props, 'onClose', null, data, {
+      transitionStatus: status,
+      portalOpen: false,
+      transitionVisible: false,
+    })
+    _.invoke(props, 'onHide', null, data, {
+      transitionStatus: status,
+      portalOpen,
+      transitionVisible: false,
+    })
   }
 
-  const handleTransitionStart = (nothing, data) => {
+  const handleTransitionStart = (nothing, data, status) => {
     debug('handleTransitionStart()')
-    const { status } = data
     const nextTransitionVisible = status === TRANSITION_STATUS_ENTERING
 
-    _.invoke(props, 'onStart', null, {
-      ...data,
+    _.invoke(props, 'onStart', null, data, {
+      transitionStatus: status,
       portalOpen,
       transitionVisible: nextTransitionVisible,
     })
@@ -99,8 +106,8 @@ function TransitionablePortal(props) {
     }
 
     setTransitionVisible(nextTransitionVisible)
-    _.invoke(props, 'onOpen', null, {
-      ...data,
+    _.invoke(props, 'onOpen', null, data, {
+      transitionStatus: status,
       transitionVisible: nextTransitionVisible,
       portalOpen: true,
     })

--- a/src/elements/Input/Input.d.ts
+++ b/src/elements/Input/Input.d.ts
@@ -60,9 +60,10 @@ export interface StrictInputProps {
    * Called on change.
    *
    * @param {ChangeEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and a proposed value.
+   * @param {object} props - All props.
+   * @param {string} value - The value of the input.
    */
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>, data: InputOnChangeData) => void
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>, props: InputProps, value: string) => void
 
   /** An Input can vary in size. */
   size?: 'mini' | 'small' | 'large' | 'big' | 'huge' | 'massive'
@@ -75,10 +76,6 @@ export interface StrictInputProps {
 
   /** The HTML input type. */
   type?: string
-}
-
-export interface InputOnChangeData extends InputProps {
-  value: string
 }
 
 declare const Input: ForwardRefComponent<InputProps, HTMLInputElement>

--- a/src/elements/Input/Input.js
+++ b/src/elements/Input/Input.js
@@ -72,7 +72,7 @@ const Input = React.forwardRef(function (props, ref) {
   const handleChange = (e) => {
     const newValue = _.get(e, 'target.value')
 
-    _.invoke(props, 'onChange', e, { ...props, value: newValue })
+    _.invoke(props, 'onChange', e, props, newValue)
   }
 
   const partitionProps = () => {

--- a/src/elements/Input/index.d.ts
+++ b/src/elements/Input/index.d.ts
@@ -1,1 +1,1 @@
-export { default, InputProps, StrictInputProps, InputOnChangeData } from './Input'
+export { default, InputProps, StrictInputProps } from './Input'

--- a/src/modules/Checkbox/Checkbox.d.ts
+++ b/src/modules/Checkbox/Checkbox.d.ts
@@ -43,33 +43,61 @@ export interface StrictCheckboxProps {
    * Called when the user attempts to change the checked state.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and proposed checked/indeterminate state.
+   * @param {object} props - All props.
+   * @param {boolean} checked - Current checked state.
+   * @param {boolean} indeterminate - Current indeterminate state.
    */
-  onChange?: (event: React.FormEvent<HTMLInputElement>, data: CheckboxProps) => void
+  onChange?: (
+    event: React.FormEvent<HTMLInputElement>,
+    props: CheckboxProps,
+    checked: boolean,
+    indeterminate: boolean,
+  ) => void
 
   /**
    * Called when the checkbox or label is clicked.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and current checked/indeterminate state.
+   * @param {object} props - All props.
+   * @param {boolean} checked - Current checked state.
+   * @param {boolean} indeterminate - Current indeterminate state.
    */
-  onClick?: (event: React.MouseEvent<HTMLInputElement>, data: CheckboxProps) => void
+  onClick?: (
+    event: React.MouseEvent<HTMLInputElement>,
+    props: CheckboxProps,
+    checked: boolean,
+    indeterminate: boolean,
+  ) => void
 
   /**
    * Called when the user presses down on the mouse.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and current checked/indeterminate state.
+   * @param {object} props - All props.
+   * @param {boolean} checked - Current checked state.
+   * @param {boolean} indeterminate - Current indeterminate state.
    */
-  onMouseDown?: (event: React.MouseEvent<HTMLInputElement>, data: CheckboxProps) => void
+  onMouseDown?: (
+    event: React.MouseEvent<HTMLInputElement>,
+    props: CheckboxProps,
+    checked: boolean,
+    indeterminate: boolean,
+  ) => void
 
   /**
    * Called when the user releases the mouse.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and current checked/indeterminate state.
+   * @param {object} props - All props.
+   * @param {boolean} checked - Current checked state.
+   * @param {boolean} indeterminate - Current indeterminate state.
    */
-  onMouseUp?: (event: React.MouseEvent<HTMLInputElement>, data: CheckboxProps) => void
+  onMouseUp?: (
+    event: React.MouseEvent<HTMLInputElement>,
+    props: CheckboxProps,
+    checked: boolean,
+    indeterminate: boolean,
+  ) => void
 
   /** Format as a radio element. This means it is an exclusive option. */
   radio?: boolean

--- a/src/modules/Checkbox/Checkbox.js
+++ b/src/modules/Checkbox/Checkbox.js
@@ -96,11 +96,7 @@ const Checkbox = React.forwardRef(function (props, ref) {
 
     debug('handleChange()', _.get(e, 'target.tagName'))
 
-    _.invoke(props, 'onChange', e, {
-      ...props,
-      checked: !checked,
-      indeterminate: false,
-    })
+    _.invoke(props, 'onChange', e, props, !checked, false)
     setChecked(!checked)
     setIndeterminate(false)
   }
@@ -117,11 +113,7 @@ const Checkbox = React.forwardRef(function (props, ref) {
 
     // https://github.com/Semantic-Org/Semantic-UI-React/pull/3351
     if (!isLabelClickAndForwardedToInput) {
-      _.invoke(props, 'onClick', e, {
-        ...props,
-        checked: !checked,
-        indeterminate: !!indeterminate,
-      })
+      _.invoke(props, 'onClick', e, props, !checked, !!indeterminate)
     }
 
     if (isClickFromMouse.current) {
@@ -147,11 +139,7 @@ const Checkbox = React.forwardRef(function (props, ref) {
   const handleMouseDown = (e) => {
     debug('handleMouseDown()')
 
-    _.invoke(props, 'onMouseDown', e, {
-      ...props,
-      checked: !!checked,
-      indeterminate: !!indeterminate,
-    })
+    _.invoke(props, 'onMouseDown', e, props, !!checked, !!indeterminate)
 
     if (!e.defaultPrevented) {
       _.invoke(inputRef.current, 'focus')
@@ -166,11 +154,7 @@ const Checkbox = React.forwardRef(function (props, ref) {
     debug('handleMouseUp()')
 
     isClickFromMouse.current = true
-    _.invoke(props, 'onMouseUp', e, {
-      ...props,
-      checked: !!checked,
-      indeterminate: !!indeterminate,
-    })
+    _.invoke(props, 'onMouseUp', e, props, !!checked, !!indeterminate)
   }
 
   // ----------------------------------------

--- a/src/modules/Dropdown/Dropdown.d.ts
+++ b/src/modules/Dropdown/Dropdown.d.ts
@@ -126,49 +126,57 @@ export interface StrictDropdownProps {
    * Called when a user adds a new item. Use this to update the options list.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and the new item's value.
+   * @param {object} props - All props.
    */
-  onAddItem?: (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => void
+  onAddItem?: (
+    event: React.SyntheticEvent<HTMLElement>,
+    props: DropdownProps,
+    value: boolean | number | string | (boolean | number | string)[],
+  ) => void
 
   /**
    * Called on blur.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onBlur?: (event: React.FocusEvent<HTMLElement>, data: DropdownProps) => void
+  onBlur?: (event: React.FocusEvent<HTMLElement>, props: DropdownProps) => void
 
   /**
    * Called when the user attempts to change the value.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and proposed value.
+   * @param {object} props - All props.
    */
-  onChange?: (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => void
+  onChange?: (
+    event: React.SyntheticEvent<HTMLElement>,
+    props: DropdownProps,
+    value: boolean | number | string | (boolean | number | string)[],
+  ) => void
 
   /**
    * Called on click.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onClick?: (event: React.MouseEvent<HTMLElement>, data: DropdownProps) => void
+  onClick?: (event: React.MouseEvent<HTMLElement>, props: DropdownProps) => void
 
   /**
    * Called when a close event happens.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onClose?: (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => void
+  onClose?: (event: React.SyntheticEvent<HTMLElement>, props: DropdownProps) => void
 
   /**
    * Called on focus.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onFocus?: (event: React.FocusEvent<HTMLElement>, data: DropdownProps) => void
+  onFocus?: (event: React.FocusEvent<HTMLElement>, props: DropdownProps) => void
 
   /**
    * Called when a multi-select label is clicked.
@@ -182,27 +190,29 @@ export interface StrictDropdownProps {
    * Called on mousedown.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onMouseDown?: (event: React.MouseEvent<HTMLElement>, data: DropdownProps) => void
+  onMouseDown?: (event: React.MouseEvent<HTMLElement>, props: DropdownProps) => void
 
   /**
    * Called when an open event happens.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onOpen?: (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => void
+  onOpen?: (event: React.SyntheticEvent<HTMLElement>, props: DropdownProps) => void
 
   /**
    * Called on search input change.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props, includes current value of searchQuery.
+   * @param {object} props - All props.
+   * @param {string} searchQuery - Current value of searchQuery.
    */
   onSearchChange?: (
     event: React.SyntheticEvent<HTMLElement>,
-    data: DropdownOnSearchChangeData,
+    data: DropdownProps,
+    searchQuery: string,
   ) => void
 
   /** Controls whether or not the dropdown menu is displayed. */
@@ -290,13 +300,6 @@ export interface StrictDropdownProps {
    * or go to the first when ArrowDown is pressed on the last( aka infinite selection )
    */
   wrapSelection?: boolean
-}
-
-/* TODO: replace with DropdownProps when #1829 will be fixed:
- * https://github.com/Semantic-Org/Semantic-UI-React/issues/1829
- */
-export interface DropdownOnSearchChangeData extends DropdownProps {
-  searchQuery: string
 }
 
 declare const Dropdown: ForwardRefComponent<DropdownProps, HTMLDivElement> & {

--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -231,7 +231,7 @@ class DropdownInner extends Component {
   // can't rely on props.value if we are controlled
   handleChange = (e, value) => {
     debug('handleChange()', value)
-    _.invoke(this.props, 'onChange', e, { ...this.props, value })
+    _.invoke(this.props, 'onChange', e, this.props, value)
   }
 
   closeOnChange = (e) => {
@@ -342,7 +342,7 @@ class DropdownInner extends Component {
       // Heads up! This event handler should be called after `onChange`
       // Notify the onAddItem prop if this is a new value
       if (item['data-additional']) {
-        _.invoke(this.props, 'onAddItem', e, { ...this.props, value: selectedValue })
+        _.invoke(this.props, 'onAddItem', e, this.props, selectedValue)
       }
     }
 
@@ -544,7 +544,7 @@ class DropdownInner extends Component {
     // Heads up! This event handler should be called after `onChange`
     // Notify the onAddItem prop if this is a new value
     if (isAdditionItem) {
-      _.invoke(this.props, 'onAddItem', e, { ...this.props, value })
+      _.invoke(this.props, 'onAddItem', e, this.props, value)
     }
   }
 
@@ -592,7 +592,7 @@ class DropdownInner extends Component {
     const { open } = this.state
     const newQuery = value
 
-    _.invoke(this.props, 'onSearchChange', e, { ...this.props, searchQuery: newQuery })
+    _.invoke(this.props, 'onSearchChange', e, this.props, newQuery)
     this.setState({ searchQuery: newQuery, selectedIndex: 0 })
 
     // open search dropdown on search query

--- a/src/modules/Dropdown/index.d.ts
+++ b/src/modules/Dropdown/index.d.ts
@@ -1,1 +1,1 @@
-export { default, DropdownProps, StrictDropdownProps, DropdownOnSearchChangeData } from './Dropdown'
+export { default, DropdownProps, StrictDropdownProps } from './Dropdown'

--- a/src/modules/Embed/Embed.d.ts
+++ b/src/modules/Embed/Embed.d.ts
@@ -59,9 +59,10 @@ export interface StrictEmbedProps {
    * Called on click.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and proposed value.
+   * @param {object} props - All props.
+   * @param {boolean} active - Whether the embed is active.
    */
-  onClick?: (event: React.MouseEvent<HTMLDivElement>, data: EmbedProps) => void
+  onClick?: (event: React.MouseEvent<HTMLDivElement>, props: EmbedProps, active: boolean) => void
 
   /** A placeholder image for embed. */
   placeholder?: string

--- a/src/modules/Embed/Embed.js
+++ b/src/modules/Embed/Embed.js
@@ -70,7 +70,7 @@ const Embed = React.forwardRef(function (props, ref) {
   }
 
   const handleClick = (e) => {
-    _.invoke(props, 'onClick', e, { ...props, active: true })
+    _.invoke(props, 'onClick', e, props, true)
     if (!active) {
       setActive(true)
     }

--- a/src/modules/Modal/Modal.d.ts
+++ b/src/modules/Modal/Modal.d.ts
@@ -62,41 +62,43 @@ export interface StrictModalProps extends StrictPortalProps {
    * Action onClick handler when using shorthand `actions`.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onActionClick?: (event: React.MouseEvent<HTMLElement>, data: ModalProps) => void
+  onActionClick?: (event: React.MouseEvent<HTMLElement>, props: ModalProps) => void
 
   /**
    * Called when a close event happens.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
+   * @param {boolean} open - Whether the modal is displayed.
    */
-  onClose?: (event: React.MouseEvent<HTMLElement>, data: ModalProps) => void
+  onClose?: (event: React.MouseEvent<HTMLElement>, props: ModalProps, open: boolean) => void
 
   /**
    * Called when the portal is mounted on the DOM.
    *
    * @param {null}
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onMount?: (nothing: null, data: ModalProps) => void
+  onMount?: (nothing: null, props: ModalProps) => void
 
   /**
    * Called when an open event happens.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
+   * @param {boolean} open - Whether the modal is displayed.
    */
-  onOpen?: (event: React.MouseEvent<HTMLElement>, data: ModalProps) => void
+  onOpen?: (event: React.MouseEvent<HTMLElement>, props: ModalProps, open: boolean) => void
 
   /**
    * Called when the portal is unmounted from the DOM.
    *
    * @param {null}
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onUnmount?: (nothing: null, data: ModalProps) => void
+  onUnmount?: (nothing: null, props: ModalProps) => void
 
   /** Controls whether or not the Modal is displayed. */
   open?: boolean

--- a/src/modules/Modal/Modal.js
+++ b/src/modules/Modal/Modal.js
@@ -108,7 +108,7 @@ const Modal = React.forwardRef(function (props, ref) {
     debug('close()')
 
     setOpen(false)
-    _.invoke(props, 'onClose', e, { ...props, open: false })
+    _.invoke(props, 'onClose', e, props, false)
   }
 
   const handleDocumentMouseDown = (e) => {
@@ -129,14 +129,14 @@ const Modal = React.forwardRef(function (props, ref) {
       return
 
     setOpen(false)
-    _.invoke(props, 'onClose', e, { ...props, open: false })
+    _.invoke(props, 'onClose', e, props, false)
   }
 
   const handleOpen = (e) => {
     debug('open()')
 
     setOpen(true)
-    _.invoke(props, 'onOpen', e, { ...props, open: true })
+    _.invoke(props, 'onOpen', e, props, true)
   }
 
   const handlePortalMount = (e) => {

--- a/src/modules/Popup/Popup.d.ts
+++ b/src/modules/Popup/Popup.d.ts
@@ -74,33 +74,35 @@ export interface StrictPopupProps extends StrictPortalProps {
    * Called when a close event happens.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
+   * @param {boolean} open - Whether the popup is displayed.
    */
-  onClose?: (event: React.MouseEvent<HTMLElement>, data: PopupProps) => void
+  onClose?: (event: React.MouseEvent<HTMLElement>, props: PopupProps, open: boolean) => void
 
   /**
    * Called when the portal is mounted on the DOM.
    *
    * @param {null}
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onMount?: (nothing: null, data: PopupProps) => void
+  onMount?: (nothing: null, props: PopupProps) => void
 
   /**
    * Called when an open event happens.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
+   * @param {boolean} open - Whether the popup is displayed
    */
-  onOpen?: (event: React.MouseEvent<HTMLElement>, data: PopupProps) => void
+  onOpen?: (event: React.MouseEvent<HTMLElement>, props: PopupProps, open: boolean) => void
 
   /**
    * Called when the portal is unmounted from the DOM.
    *
    * @param {null}
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onUnmount?: (nothing: null, data: PopupProps) => void
+  onUnmount?: (nothing: null, props: PopupProps) => void
 
   /** Disables automatic repositioning of the component, it will always be placed according to the position value. */
   pinned?: boolean

--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -171,12 +171,12 @@ const Popup = React.forwardRef(function (props, ref) {
 
   const handleClose = (e) => {
     debug('handleClose()')
-    _.invoke(props, 'onClose', e, { ...props, open: false })
+    _.invoke(props, 'onClose', e, props, false)
   }
 
   const handleOpen = (e) => {
     debug('handleOpen()')
-    _.invoke(props, 'onOpen', e, { ...props, open: true })
+    _.invoke(props, 'onOpen', e, props, true)
   }
 
   const hideOnScroll = (e) => {

--- a/src/modules/Rating/Rating.d.ts
+++ b/src/modules/Rating/Rating.d.ts
@@ -36,9 +36,10 @@ export interface StrictRatingProps {
    * Called after user selects a new rating.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props and proposed rating.
+   * @param {object} props - All props.
+   * @param {number} props - New rating.
    */
-  onRate?: (event: React.MouseEvent<HTMLDivElement>, data: RatingProps) => void
+  onRate?: (event: React.MouseEvent<HTMLDivElement>, props: RatingProps, rating: number) => void
 
   /** The current number of active icons. */
   rating?: number | string

--- a/src/modules/Rating/Rating.js
+++ b/src/modules/Rating/Rating.js
@@ -58,7 +58,7 @@ const Rating = React.forwardRef(function (props, ref) {
     setRating(newRating)
     setIsSelecting(false)
 
-    _.invoke(props, 'onRate', e, { ...props, rating: newRating })
+    _.invoke(props, 'onRate', e, props, newRating)
   }
 
   const handleIconMouseEnter = (e, { index }) => {

--- a/src/modules/Search/Search.d.ts
+++ b/src/modules/Search/Search.d.ts
@@ -93,49 +93,60 @@ export interface StrictSearchProps {
    * Called on blur.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onBlur?: (event: React.MouseEvent<HTMLElement>, data: SearchProps) => void
+  onBlur?: (event: React.MouseEvent<HTMLElement>, props: SearchProps) => void
 
   /**
    * Called on focus.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onFocus?: (event: React.MouseEvent<HTMLElement>, data: SearchProps) => void
+  onFocus?: (event: React.MouseEvent<HTMLElement>, props: SearchProps) => void
 
   /**
    * Called on mousedown.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onMouseDown?: (event: React.MouseEvent<HTMLElement>, data: SearchProps) => void
+  onMouseDown?: (event: React.MouseEvent<HTMLElement>, props: SearchProps) => void
 
   /**
    * Called when a result is selected.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
+   * @param {any} result - The search result.
    */
-  onResultSelect?: (event: React.MouseEvent<HTMLDivElement>, data: SearchResultData) => void
+  onResultSelect?: (
+    event: React.MouseEvent<HTMLDivElement>,
+    props: SearchProps,
+    result: any,
+  ) => void
 
   /**
    * Called on search input change.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props, includes current value of search input.
+   * @param {object} props - All props.
+   * @param {string} query - Current value of search input.
    */
-  onSearchChange?: (event: React.MouseEvent<HTMLElement>, data: SearchProps) => void
+  onSearchChange?: (event: React.MouseEvent<HTMLElement>, props: SearchProps, query: string) => void
 
   /**
    * Called when the active selection index is changed.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
+   * @param {any} result - The search result.
    */
-  onSelectionChange?: (event: React.MouseEvent<HTMLElement>, data: SearchResultData) => void
+  onSelectionChange?: (
+    event: React.MouseEvent<HTMLElement>,
+    props: SearchProps,
+    result: any,
+  ) => void
 
   // ------------------------------------
   // Style
@@ -164,10 +175,6 @@ export interface StrictSearchProps {
 
   /** A search can show placeholder text when empty. */
   placeholder?: string
-}
-
-export interface SearchResultData extends SearchProps {
-  result: any
 }
 
 declare const Search: ForwardRefComponent<SearchProps, HTMLDivElement> & {

--- a/src/modules/Search/Search.js
+++ b/src/modules/Search/Search.js
@@ -152,14 +152,14 @@ class SearchInner extends Component {
     debug('handleResultSelect()')
     debug(result)
 
-    _.invoke(this.props, 'onResultSelect', e, { ...this.props, result })
+    _.invoke(this.props, 'onResultSelect', e, this.props, result)
   }
 
   handleSelectionChange = (e) => {
     debug('handleSelectionChange()')
 
     const result = this.getSelectedResult()
-    _.invoke(this.props, 'onSelectionChange', e, { ...this.props, result })
+    _.invoke(this.props, 'onSelectionChange', e, this.props, result)
   }
 
   closeOnEscape = (e) => {
@@ -282,7 +282,7 @@ class SearchInner extends Component {
     const { open } = this.state
     const newQuery = e.target.value
 
-    _.invoke(this.props, 'onSearchChange', e, { ...this.props, value: newQuery })
+    _.invoke(this.props, 'onSearchChange', e, this.props, newQuery)
 
     // open search dropdown on search query
     if (newQuery.length < minCharacters) {

--- a/src/modules/Search/index.d.ts
+++ b/src/modules/Search/index.d.ts
@@ -1,1 +1,1 @@
-export { default, SearchProps, StrictSearchProps, SearchResultData } from './Search'
+export { default, SearchProps, StrictSearchProps } from './Search'

--- a/src/modules/Sidebar/Sidebar.d.ts
+++ b/src/modules/Sidebar/Sidebar.d.ts
@@ -31,33 +31,34 @@ export interface StrictSidebarProps {
    * Called before a sidebar begins to animate out.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - All props.
+   * @param {object} props - All props.
+   * @param {boolean} visible - Whether the sidebar is visible.
    */
-  onHide?: (event: React.MouseEvent<HTMLElement>, data: SidebarProps) => void
+  onHide?: (event: React.MouseEvent<HTMLElement>, props: SidebarProps, visible: boolean) => void
 
   /**
    * Called after a sidebar has finished animating out.
    *
    * @param {null}
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onHidden?: (event: React.MouseEvent<HTMLElement>, data: SidebarProps) => void
+  onHidden?: (event: React.MouseEvent<HTMLElement>, props: SidebarProps) => void
 
   /**
    * Called when a sidebar has finished animating in.
    *
    * @param {null}
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onShow?: (event: React.MouseEvent<HTMLElement>, data: SidebarProps) => void
+  onShow?: (event: React.MouseEvent<HTMLElement>, props: SidebarProps) => void
 
   /**
    * Called when a sidebar begins animating in.
    *
    * @param {null}
-   * @param {object} data - All props.
+   * @param {object} props - All props.
    */
-  onVisible?: (event: React.MouseEvent<HTMLElement>, data: SidebarProps) => void
+  onVisible?: (event: React.MouseEvent<HTMLElement>, props: SidebarProps) => void
 
   /** A sidebar can handle clicks on the passed element. */
   target?: Document | Window | HTMLElement | React.RefObject<HTMLElement>

--- a/src/modules/Sidebar/Sidebar.js
+++ b/src/modules/Sidebar/Sidebar.js
@@ -71,7 +71,7 @@ const Sidebar = React.forwardRef((props, ref) => {
     const callback = visible ? 'onShow' : 'onHidden'
 
     resetAnimationTick()
-    _.invoke(props, callback, null, props)
+    _.invoke(props, callback, null, props, visible)
   })
 
   const handleAnimationStart = useEventCallback(() => {
@@ -85,13 +85,13 @@ const Sidebar = React.forwardRef((props, ref) => {
       return
     }
 
-    _.invoke(props, callback, null, props)
+    _.invoke(props, callback, null, props, visible)
   })
 
   const handleDocumentClick = (e) => {
     if (!doesNodeContainClick(elementRef.current, e)) {
       skipNextCallback.current = true
-      _.invoke(props, 'onHide', e, { ...props, visible: false })
+      _.invoke(props, 'onHide', e, props, false)
     }
   }
 

--- a/src/modules/Tab/Tab.d.ts
+++ b/src/modules/Tab/Tab.d.ts
@@ -30,11 +30,15 @@ export interface StrictTabProps {
    * Called on tab change.
    *
    * @param {SyntheticEvent} event - React's original SyntheticEvent.
-   * @param {object} data - The proposed new Tab.Pane.
-   * @param {object} data.activeIndex - The new proposed activeIndex.
-   * @param {object} data.panes - Props of the new proposed active pane.
+   * @param {object} props - The proposed new Tab.Pane.
+   * @param {object} props.panes - Props of the new proposed active pane.
+   * @param {number} activeIndex - The current activeIndex.
    */
-  onTabChange?: (event: React.MouseEvent<HTMLDivElement>, data: TabProps) => void
+  onTabChange?: (
+    event: React.MouseEvent<HTMLDivElement>,
+    props: TabProps,
+    activeIndex: number,
+  ) => void
 
   /**
    * Array of objects describing each Menu.Item and Tab.Pane:

--- a/src/modules/Tab/Tab.js
+++ b/src/modules/Tab/Tab.js
@@ -34,7 +34,7 @@ const Tab = React.forwardRef(function (props, ref) {
   })
 
   const handleItemClick = (e, { index }) => {
-    _.invoke(props, 'onTabChange', e, { ...props, activeIndex: index })
+    _.invoke(props, 'onTabChange', e, props, index)
     setActiveIndex(index)
   }
 

--- a/src/modules/Transition/Transition.d.ts
+++ b/src/modules/Transition/Transition.d.ts
@@ -32,33 +32,37 @@ export interface StrictTransitionProps {
    * Callback on each transition that changes visibility to shown.
    *
    * @param {null}
-   * @param {object} data - All props with status.
+   * @param {object} props - All props.
+   * @param {TRANSITION_STATUSES} status - Transition status.
    */
-  onComplete?: (nothing: null, data: TransitionEventData) => void
+  onComplete?: (nothing: null, props: TransitionProps, status: TRANSITION_STATUSES) => void
 
   /**
    * Callback on each transition that changes visibility to hidden.
    *
    * @param {null}
-   * @param {object} data - All props with status.
+   * @param {object} props - All props.
+   * @param {TRANSITION_STATUSES} status - Transition status.
    */
-  onHide?: (nothing: null, data: TransitionEventData) => void
+  onHide?: (nothing: null, props: TransitionProps, status: TRANSITION_STATUSES) => void
 
   /**
    * Callback on each transition that changes visibility to shown.
    *
    * @param {null}
-   * @param {object} data - All props with status.
+   * @param {object} props - All props.
+   * @param {TRANSITION_STATUSES} status - Transition status.
    */
-  onShow?: (nothing: null, data: TransitionEventData) => void
+  onShow?: (nothing: null, props: TransitionProps, status: TRANSITION_STATUSES) => void
 
   /**
    * Callback on animation start.
    *
    * @param {null}
-   * @param {object} data - All props with status.
+   * @param {object} props - All props.
+   * @param {TRANSITION_STATUSES} status - Transition status.
    */
-  onStart?: (nothing: null, data: TransitionEventData) => void
+  onStart?: (nothing: null, props: TransitionProps, status: TRANSITION_STATUSES) => void
 
   /** React's key of the element. */
   reactKey?: string
@@ -68,10 +72,6 @@ export interface StrictTransitionProps {
 
   /** Unmount the component (remove it from the DOM) when it is not shown. */
   unmountOnHide?: boolean
-}
-
-export interface TransitionEventData extends TransitionProps {
-  status: TRANSITION_STATUSES
 }
 
 export interface TransitionPropDuration {

--- a/src/modules/Transition/Transition.js
+++ b/src/modules/Transition/Transition.js
@@ -97,14 +97,14 @@ export default class Transition extends React.Component {
     }
 
     if (!prevState.animating && this.state.animating) {
-      _.invoke(this.props, 'onStart', null, { ...this.props, status: this.state.status })
+      _.invoke(this.props, 'onStart', null, this.props, this.state.status)
     }
 
     if (prevState.animating && !this.state.animating) {
       const callback = this.state.status === TRANSITION_STATUS_ENTERED ? 'onShow' : 'onHide'
 
-      _.invoke(this.props, 'onComplete', null, { ...this.props, status: this.state.status })
-      _.invoke(this.props, callback, null, { ...this.props, status: this.state.status })
+      _.invoke(this.props, 'onComplete', null, this.props, this.state.status)
+      _.invoke(this.props, callback, null, this.props, this.state.status)
     }
   }
 

--- a/test/specs/addons/Pagination/Pagination-test.js
+++ b/test/specs/addons/Pagination/Pagination-test.js
@@ -24,7 +24,7 @@ describe('Pagination', () => {
   })
 
   describe('onPageChange', () => {
-    it('is called with (e, data) when clicked on a pagination item', () => {
+    it('is called when clicked a pagination item is clicked', () => {
       const onPageChange = sandbox.spy()
       const onPageItemClick = sandbox.spy()
 
@@ -40,7 +40,7 @@ describe('Pagination', () => {
       wrapper.find('PaginationItem').at(4).simulate('click')
 
       onPageChange.should.have.been.calledOnce()
-      onPageChange.should.have.been.calledWithMatch({ type: 'click' }, { activePage: 3 })
+      onPageChange.should.have.been.calledWithMatch({ type: 'click' }, {}, 3)
       onPageItemClick.should.have.been.calledOnce()
       onPageItemClick.should.have.been.calledWithMatch({ type: 'click' }, { value: 3 })
     })

--- a/test/specs/addons/Portal/Portal-test.js
+++ b/test/specs/addons/Portal/Portal-test.js
@@ -181,7 +181,7 @@ describe('Portal', () => {
 
       wrapper.find('#trigger').simulate('click')
       onOpen.should.have.been.calledOnce()
-      onOpen.should.have.been.calledWithMatch({}, { open: true })
+      onOpen.should.have.been.calledWithMatch({}, {}, true)
     })
   })
 
@@ -196,7 +196,7 @@ describe('Portal', () => {
 
       domEvent.click(document.body)
       onClose.should.have.been.called()
-      onClose.should.have.been.calledWithMatch({}, { open: false })
+      onClose.should.have.been.calledWithMatch({}, {}, false)
     })
   })
 

--- a/test/specs/addons/TextArea/TextArea-test.js
+++ b/test/specs/addons/TextArea/TextArea-test.js
@@ -50,7 +50,7 @@ describe('TextArea', () => {
   })
 
   describe('onChange', () => {
-    it('is called with (e, data) on change', () => {
+    it('is called with (e, props, value) on change', () => {
       const onChange = sandbox.spy()
       const e = { target: { value: 'name' } }
       const props = { 'data-foo': 'bar', onChange }
@@ -59,12 +59,12 @@ describe('TextArea', () => {
       wrapper.find('textarea').simulate('change', e)
 
       onChange.should.have.been.calledOnce()
-      onChange.should.have.been.calledWithMatch(e, { ...props, value: e.target.value })
+      onChange.should.have.been.calledWithMatch(e, props, e.target.value)
     })
   })
 
   describe('onInput', () => {
-    it('is called with (e, data) on input', () => {
+    it('is called with (e, props, value) on input', () => {
       const onInput = sandbox.spy()
       const e = { target: { value: 'name' } }
       const props = { 'data-foo': 'bar', onInput }
@@ -73,7 +73,7 @@ describe('TextArea', () => {
       wrapper.find('textarea').simulate('input', e)
 
       onInput.should.have.been.calledOnce()
-      onInput.should.have.been.calledWithMatch(e, { ...props, value: e.target.value })
+      onInput.should.have.been.calledWithMatch(e, props, e.target.value)
     })
   })
 

--- a/test/specs/addons/TransitionablePortal/TransitionablePortal-test.js
+++ b/test/specs/addons/TransitionablePortal/TransitionablePortal-test.js
@@ -25,7 +25,7 @@ describe('TransitionablePortal', () => {
   })
 
   describe('onClose', () => {
-    it('is called with (null, data) on a click outside', (done) => {
+    it('is called on a click outside', (done) => {
       const onClose = sandbox.spy()
       const wrapper = mount(
         <TransitionablePortal
@@ -41,7 +41,7 @@ describe('TransitionablePortal', () => {
 
       assertWithTimeout(() => {
         onClose.should.have.been.calledOnce()
-        onClose.should.have.been.calledWithMatch(null, { portalOpen: false })
+        onClose.should.have.been.calledWithMatch(null, {}, { portalOpen: false })
 
         wrapper.unmount()
       }, done)
@@ -60,7 +60,7 @@ describe('TransitionablePortal', () => {
   })
 
   describe('onHide', () => {
-    it('is called with (null, data) when exiting transition finished', (done) => {
+    it('is called when exiting transition finished', (done) => {
       const onHide = sandbox.spy()
       const wrapper = mount(
         <TransitionablePortal
@@ -75,11 +75,16 @@ describe('TransitionablePortal', () => {
       wrapper.setProps({ open: false })
       assertWithTimeout(() => {
         onHide.should.have.been.calledOnce()
-        onHide.should.have.been.calledWithMatch(null, {
-          ...quickTransition,
-          portalOpen: false,
-          transitionVisible: false,
-        })
+        onHide.should.have.been.calledWithMatch(
+          null,
+          {
+            ...quickTransition,
+          },
+          {
+            portalOpen: false,
+            transitionVisible: false,
+          },
+        )
 
         wrapper.unmount()
       }, done)
@@ -87,7 +92,7 @@ describe('TransitionablePortal', () => {
   })
 
   describe('onOpen', () => {
-    it('is called with (null, data) when opens', () => {
+    it('is called when opens', () => {
       const onOpen = sandbox.spy()
       const wrapper = mount(
         <TransitionablePortal {...requiredProps} onOpen={onOpen} trigger={<button />} />,
@@ -95,7 +100,7 @@ describe('TransitionablePortal', () => {
 
       wrapper.find('button').simulate('click')
       onOpen.should.have.been.calledOnce()
-      onOpen.should.have.been.calledWithMatch(null, { portalOpen: true })
+      onOpen.should.have.been.calledWithMatch(null, {}, { portalOpen: true })
     })
 
     it('renders contents', () => {

--- a/test/specs/elements/Input/Input-test.js
+++ b/test/specs/elements/Input/Input-test.js
@@ -170,7 +170,7 @@ describe('Input', () => {
   })
 
   describe('onChange', () => {
-    it('is called with (e, data) on change', () => {
+    it('is called on change', () => {
       const onChange = sandbox.spy()
       const e = { target: { value: 'name' } }
       const props = { 'data-foo': 'bar', onChange }
@@ -180,10 +180,10 @@ describe('Input', () => {
       wrapper.find('input').simulate('change', e)
 
       onChange.should.have.been.calledOnce()
-      onChange.should.have.been.calledWithMatch(e, { ...props, value: e.target.value })
+      onChange.should.have.been.calledWithMatch(e, props, e.target.value)
     })
 
-    it('is called with (e, data) on change when using children', () => {
+    it('is called on change when using children', () => {
       const onChange = sandbox.spy()
       const e = { target: { value: 'name' } }
       const props = { 'data-foo': 'bar', onChange }
@@ -197,7 +197,7 @@ describe('Input', () => {
       wrapper.find('input').simulate('change', e)
 
       onChange.should.have.been.calledOnce()
-      onChange.should.have.been.calledWithMatch(e, { ...props, value: e.target.value })
+      onChange.should.have.been.calledWithMatch(e, props, e.target.value)
     })
   })
 

--- a/test/specs/modules/Checkbox/Checkbox-test.js
+++ b/test/specs/modules/Checkbox/Checkbox-test.js
@@ -223,7 +223,7 @@ describe('Checkbox', () => {
   })
 
   describe('onChange', () => {
-    it('is called with (e, data) on mouse up', () => {
+    it('is called on mouse up', () => {
       const onChange = sandbox.spy()
       const props = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
 
@@ -233,17 +233,10 @@ describe('Checkbox', () => {
       wrapper.find('label').simulate('click')
 
       onChange.should.have.been.calledOnce()
-      onChange.should.have.been.calledWithMatch(
-        {},
-        {
-          ...props,
-          checked: true,
-          indeterminate: false,
-        },
-      )
+      onChange.should.have.been.calledWithMatch({}, props, true, false)
     })
 
-    it('is not called when on change when "id" is passed', () => {
+    it('is not called on change when "id" is passed', () => {
       const onChange = sandbox.spy()
       wrapperMount(<Checkbox id='foo' onChange={onChange} />)
 
@@ -264,22 +257,16 @@ describe('Checkbox', () => {
   })
 
   describe('onClick', () => {
-    it('is called with (event, data) on click', () => {
+    it('is called on click', () => {
       const onClick = sandbox.spy()
       const props = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
       mount(<Checkbox onClick={onClick} {...props} />).simulate('click')
 
       onClick.should.have.been.calledOnce()
-      onClick.should.have.been.calledWithMatch(
-        {},
-        {
-          ...props,
-          checked: true,
-        },
-      )
+      onClick.should.have.been.calledWithMatch({}, props, true, true)
     })
 
-    it('is not called when "id" is passed', () => {
+    it('is not called on click if "id" is passed', () => {
       const onClick = sandbox.spy()
       wrapperMount(<Checkbox id='foo' onClick={onClick} />)
 
@@ -290,13 +277,13 @@ describe('Checkbox', () => {
   })
 
   describe('onMouseDown', () => {
-    it('is called with (event, data) on mouse down', () => {
+    it('is called on mouse down without changing the checked status', () => {
       const onMousedDown = sandbox.spy()
       const props = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
       mount(<Checkbox onMouseDown={onMousedDown} {...props} />).simulate('mousedown')
 
       onMousedDown.should.have.been.calledOnce()
-      onMousedDown.should.have.been.calledWithMatch({}, props)
+      onMousedDown.should.have.been.calledWithMatch({}, props, false, true)
     })
 
     it('sets focus to container', () => {
@@ -307,7 +294,7 @@ describe('Checkbox', () => {
       document.activeElement.should.equal(input)
     })
 
-    it('will not set focus to container, if default is prevented', () => {
+    it('does not set focus to container, if default is prevented', () => {
       wrapperMount(<Checkbox onMouseDown={(e) => e.preventDefault()} />)
 
       domEvent.fire('.ui.checkbox input', 'mousedown')
@@ -316,20 +303,24 @@ describe('Checkbox', () => {
   })
 
   describe('onMouseUp', () => {
-    it('is called with (event, data) on mouse up', () => {
+    it('is called on mouse up without changing the checked status', () => {
       const onMouseUp = sandbox.spy()
       const props = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
       mount(<Checkbox onMouseUp={onMouseUp} {...props} />).simulate('mouseup')
 
       onMouseUp.should.have.been.calledOnce()
-      onMouseUp.should.have.been.calledWithMatch({}, props)
+      onMouseUp.should.have.been.calledWithMatch({}, props, false, true)
     })
 
-    it('is called with (event, data) on mouse up with right button', () => {
+    it('is called on mouse up with right button without changing the checked status', () => {
       const onMouseUp = sandbox.spy()
-      mount(<Checkbox id='foo' onMouseUp={onMouseUp} />).simulate('mouseup', { button: 2 })
+      const props = { name: 'foo', value: 'bar', checked: false, indeterminate: true }
+      mount(<Checkbox id='foo' onMouseUp={onMouseUp} {...props} />).simulate('mouseup', {
+        button: 2,
+      })
 
       onMouseUp.should.have.been.calledOnce()
+      onMouseUp.should.have.been.calledWithMatch({}, props, false, true)
     })
   })
 

--- a/test/specs/modules/Modal/Modal-test.js
+++ b/test/specs/modules/Modal/Modal-test.js
@@ -277,7 +277,7 @@ describe('Modal', () => {
 
       wrapper.find('#trigger').simulate('click')
       onOpen.should.have.been.calledOnce()
-      onOpen.should.have.been.calledWithMatch({ type: 'click' }, { open: true })
+      onOpen.should.have.been.calledWithMatch({ type: 'click' }, {}, true)
     })
 
     it('is not called on body click', () => {
@@ -296,7 +296,7 @@ describe('Modal', () => {
 
       domEvent.click('.ui.dimmer')
       onClose.should.have.been.calledOnce()
-      onClose.should.have.been.calledWithMatch({}, { open: false })
+      onClose.should.have.been.calledWithMatch({}, {}, false)
     })
 
     it('is called on click outside of the modal', () => {
@@ -305,6 +305,7 @@ describe('Modal', () => {
 
       domEvent.click(document.querySelector('.ui.modal').parentNode)
       onClose.should.have.been.calledOnce()
+      onClose.should.have.been.calledWithMatch({}, {}, false)
     })
 
     it('is not called on mousedown inside and mouseup outside of the modal', () => {
@@ -338,6 +339,7 @@ describe('Modal', () => {
 
       domEvent.keyDown(document, { key: 'Escape' })
       onClose.should.have.been.calledOnce()
+      onClose.should.have.been.calledWithMatch({}, {}, false)
     })
 
     it('is not called when the open prop changes to false', () => {

--- a/test/specs/modules/Popup/Popup-test.js
+++ b/test/specs/modules/Popup/Popup-test.js
@@ -150,7 +150,7 @@ describe('Popup', () => {
       assertInBody('.ui.popup.visible', false)
     })
 
-    it('is called with (e, props) when scroll', () => {
+    it('is called on scroll', () => {
       const onClose = sandbox.spy()
 
       wrapperMount(<Popup content='foo' hideOnScroll onClose={onClose} trigger={trigger} />)
@@ -159,7 +159,7 @@ describe('Popup', () => {
       domEvent.scroll(window)
 
       onClose.should.have.been.calledOnce()
-      onClose.should.have.been.calledWithMatch({}, { content: 'foo', onClose, trigger })
+      onClose.should.have.been.calledWithMatch({}, { content: 'foo', onClose, trigger }, false)
     })
 
     it('not hide on scroll from inside a popup', () => {
@@ -178,6 +178,7 @@ describe('Popup', () => {
 
       domEvent.scroll(window)
       onClose.should.have.been.calledOnce()
+      onClose.should.have.been.calledWithMatch({}, {}, false)
     })
   })
 
@@ -222,6 +223,7 @@ describe('Popup', () => {
 
       domEvent.click('body')
       onClose.should.have.been.calledOnce()
+      onClose.should.have.been.calledWithMatch({}, {}, false)
     })
 
     it('is called when pressing escape', () => {
@@ -230,6 +232,7 @@ describe('Popup', () => {
 
       domEvent.keyDown(document, { key: 'Escape' })
       onClose.should.have.been.calledOnce()
+      onClose.should.have.been.calledWithMatch({}, {}, false)
     })
 
     it('is not called when the open prop changes to false', () => {
@@ -252,7 +255,7 @@ describe('Popup', () => {
 
       wrapper.find('#trigger').simulate('click')
       onOpen.should.have.been.calledOnce()
-      onOpen.should.have.been.calledWithMatch({}, { open: true })
+      onOpen.should.have.been.calledWithMatch({}, {}, true)
     })
   })
 
@@ -267,7 +270,7 @@ describe('Popup', () => {
 
       domEvent.click(document.body)
       onClose.should.have.been.called()
-      onClose.should.have.been.calledWithMatch({}, { open: false })
+      onClose.should.have.been.calledWithMatch({}, {}, false)
     })
   })
 

--- a/test/specs/modules/Rating/Rating-test.js
+++ b/test/specs/modules/Rating/Rating-test.js
@@ -241,16 +241,16 @@ describe('Rating', () => {
 
   describe('onRate', () => {
     it('is called with (event, { rating, maxRating } on icon click', () => {
-      const spy = sandbox.spy()
+      const onRate = sandbox.spy()
       const event = { fake: 'event data' }
 
-      mount(<Rating maxRating={3} onRate={spy} />)
+      mount(<Rating maxRating={3} onRate={onRate} />)
         .find('RatingIcon')
         .last()
         .simulate('click', event)
 
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(event, { rating: 3, maxRating: 3 })
+      onRate.should.have.been.calledOnce()
+      onRate.should.have.been.calledWithMatch(event, { maxRating: 3 }, 3)
     })
   })
 

--- a/test/specs/modules/Search/Search-test.js
+++ b/test/specs/modules/Search/Search-test.js
@@ -485,7 +485,7 @@ describe('Search', () => {
   })
 
   describe('onBlur', () => {
-    it('is called with (event, data) on search input blur', () => {
+    it('is called on search input blur', () => {
       const onBlur = sandbox.spy()
       wrapperMount(<Search results={options} onBlur={onBlur} />).simulate('blur', nativeEvent)
 
@@ -504,7 +504,7 @@ describe('Search', () => {
   })
 
   describe('onFocus', () => {
-    it('is called with (event, data) on search input focus', () => {
+    it('is called on search input focus', () => {
       const onFocus = sandbox.spy()
       wrapperMount(<Search results={options} onFocus={onFocus} />).simulate('focus', nativeEvent)
 
@@ -514,15 +514,15 @@ describe('Search', () => {
   })
 
   describe('onResultSelect', () => {
-    let spy
+    let onResultSelect
     beforeEach(() => {
-      spy = sandbox.spy()
+      onResultSelect = sandbox.spy()
     })
 
-    it('is called with event and value on item click', () => {
+    it('is called on item click', () => {
       const randomIndex = _.random(options.length - 1)
       const randomResult = options[randomIndex]
-      wrapperMount(<Search results={options} minCharacters={0} onResultSelect={spy} />)
+      wrapperMount(<Search results={options} minCharacters={0} onResultSelect={onResultSelect} />)
 
       // open
       openSearchResults()
@@ -530,20 +530,25 @@ describe('Search', () => {
 
       wrapper.find('SearchResult').at(randomIndex).simulate('click', nativeEvent)
 
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(
+      onResultSelect.should.have.been.calledOnce()
+      onResultSelect.should.have.been.calledWithMatch(
         {},
         {
           minCharacters: 0,
-          result: randomResult,
           results: options,
         },
+        randomResult,
       )
     })
-    it('is called with event and value when pressing enter on a selected item', () => {
+    it('is called when pressing enter on a selected item', () => {
       const firstResult = options[0]
       wrapperMount(
-        <Search results={options} minCharacters={0} onResultSelect={spy} selectFirstResult />,
+        <Search
+          results={options}
+          minCharacters={0}
+          onResultSelect={onResultSelect}
+          selectFirstResult
+        />,
       )
 
       // open
@@ -552,18 +557,23 @@ describe('Search', () => {
 
       domEvent.keyDown(document, { key: 'Enter' })
 
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch({}, { result: firstResult })
+      onResultSelect.should.have.been.calledOnce()
+      onResultSelect.should.have.been.calledWithMatch({}, {}, firstResult)
     })
     it('is not called when updating the value prop', () => {
       const value = _.sample(options).title
       const next = _.sample(_.without(options, value)).title
 
       wrapperMount(
-        <Search results={options} minCharacters={0} value={value} onResultSelect={spy} />,
+        <Search
+          results={options}
+          minCharacters={0}
+          value={value}
+          onResultSelect={onResultSelect}
+        />,
       ).setProps({ value: next })
 
-      spy.should.not.have.been.called()
+      onResultSelect.should.not.have.been.called()
     })
     it('does not call onResultSelect on query change', () => {
       const onResultSelectSpy = sandbox.spy()
@@ -579,26 +589,26 @@ describe('Search', () => {
   })
 
   describe('onSearchChange', () => {
-    it('is called with (event, value) on search input change', () => {
-      const spy = sandbox.spy()
-      wrapperMount(<Search results={options} minCharacters={0} onSearchChange={spy} />)
+    it('is called on search input change', () => {
+      const onSearchChange = sandbox.spy()
+      wrapperMount(<Search results={options} minCharacters={0} onSearchChange={onSearchChange} />)
         .find('input.prompt')
         .simulate('change', { target: { value: 'a' }, stopPropagation: _.noop })
 
-      spy.should.have.been.calledOnce()
-      spy.should.have.been.calledWithMatch(
+      onSearchChange.should.have.been.calledOnce()
+      onSearchChange.should.have.been.calledWithMatch(
         { target: { value: 'a' } },
         {
           minCharacters: 0,
           results: options,
-          value: 'a',
         },
+        'a',
       )
     })
   })
 
-  describe('onSearchChange', () => {
-    it('is called with (event, data) when the active selection index is changed', () => {
+  describe('onSelectionChange', () => {
+    it('is called when the active selection index is changed', () => {
       const onSelectionChange = sandbox.spy()
 
       wrapperMount(
@@ -617,9 +627,9 @@ describe('Search', () => {
         {},
         {
           minCharacters: 0,
-          result: options[1],
           results: options,
         },
+        options[1],
       )
     })
   })

--- a/test/specs/modules/Sidebar/Sidebar-test.js
+++ b/test/specs/modules/Sidebar/Sidebar-test.js
@@ -48,7 +48,7 @@ describe('Sidebar', () => {
 
       wrapper.setProps({ visible: false })
       onHide.should.have.been.calledOnce()
-      onHide.should.have.been.calledWithMatch(null, { visible: false })
+      onHide.should.have.been.calledWithMatch(null, {}, false)
     })
 
     it('is called when a click on the document was done', () => {
@@ -58,7 +58,7 @@ describe('Sidebar', () => {
 
       domEvent.click(document)
       onHide.should.have.been.calledOnce()
-      onHide.should.have.been.calledWithMatch({}, { visible: false })
+      onHide.should.have.been.calledWithMatch({}, {}, false)
     })
 
     it('is called when a click on the document was done only once', () => {
@@ -68,6 +68,7 @@ describe('Sidebar', () => {
       domEvent.click(document)
       wrapper.setProps({ visible: false })
       onHide.should.have.been.calledOnce()
+      onHide.should.have.been.calledWithMatch({}, {}, false)
     })
 
     it('is not called when a click was done inside the component', () => {
@@ -101,7 +102,7 @@ describe('Sidebar', () => {
 
       setTimeout(() => {
         onHidden.should.have.been.calledOnce()
-        onHidden.should.have.been.calledWithMatch(null, { visible: false })
+        onHidden.should.have.been.calledWithMatch(null, {}, false)
 
         done()
       }, 0)
@@ -134,7 +135,7 @@ describe('Sidebar', () => {
 
       wrapper.setProps({ visible: true })
       onVisible.should.have.been.calledOnce()
-      onVisible.should.have.been.calledWithMatch(null, { visible: true })
+      onVisible.should.have.been.calledWithMatch(null, {}, true)
     })
   })
 

--- a/test/specs/modules/Tab/Tab-test.js
+++ b/test/specs/modules/Tab/Tab-test.js
@@ -154,11 +154,11 @@ describe('Tab', () => {
   })
 
   describe('onTabChange', () => {
-    it('is called with (e, { ...props, activeIndex }) a menu item is clicked', () => {
+    it('is called when a menu item is clicked', () => {
       const activeIndex = 1
-      const spy = sandbox.spy()
+      const onTabChange = sandbox.spy()
       const event = { fake: 'event' }
-      const props = { onTabChange: spy, panes }
+      const props = { onTabChange, panes }
 
       mount(<Tab {...props} />)
         .find('MenuItem')
@@ -167,30 +167,29 @@ describe('Tab', () => {
 
       // Since React will have generated a key the returned tab won't match
       // exactly so match on the props instead.
-      spy.should.have.been.calledOnce()
-      spy.firstCall.args[0].should.have.property('fake', 'event')
-      spy.firstCall.args[1].should.have.property('activeIndex', 1)
-      spy.firstCall.args[1].should.have.property('onTabChange', spy)
-      spy.firstCall.args[1].should.have.property('panes', panes)
+      onTabChange.should.have.been.calledOnce()
+      onTabChange.should.have.been.calledWithMatch(event, props, 1)
     })
     it('is called with the new proposed activeIndex, not the current', () => {
-      const spy = sandbox.spy()
+      const onTabChange = sandbox.spy()
 
-      const items = mount(<Tab activeIndex={-1} onTabChange={spy} panes={panes} />).find('MenuItem')
+      const items = mount(<Tab activeIndex={-1} onTabChange={onTabChange} panes={panes} />).find(
+        'MenuItem',
+      )
 
-      spy.should.have.callCount(0)
+      onTabChange.should.have.callCount(0)
 
       items.at(0).simulate('click')
-      spy.should.have.callCount(1)
-      spy.lastCall.args[1].should.have.property('activeIndex', 0)
+      onTabChange.should.have.callCount(1)
+      onTabChange.lastCall.args[2].should.equal(0)
 
       items.at(1).simulate('click')
-      spy.should.have.callCount(2)
-      spy.lastCall.args[1].should.have.property('activeIndex', 1)
+      onTabChange.should.have.callCount(2)
+      onTabChange.lastCall.args[2].should.equal(1)
 
       items.at(2).simulate('click')
-      spy.should.have.callCount(3)
-      spy.lastCall.args[1].should.have.property('activeIndex', 2)
+      onTabChange.should.have.callCount(3)
+      onTabChange.lastCall.args[2].should.equal(2)
     })
   })
 

--- a/test/specs/modules/Transition/Transition-test.js
+++ b/test/specs/modules/Transition/Transition-test.js
@@ -396,16 +396,19 @@ describe('Transition', () => {
   })
 
   describe('onComplete', () => {
-    it('is called with (null, props) when transition completed', (done) => {
+    it('is called when transition completes', (done) => {
       const onComplete = sandbox.spy()
       const handleComplete = (...args) => {
         onComplete(...args)
 
         onComplete.should.have.been.calledOnce()
-        onComplete.should.have.been.calledWithMatch(null, {
-          duration: 0,
-          status: TRANSITION_STATUS_ENTERED,
-        })
+        onComplete.should.have.been.calledWithMatch(
+          null,
+          {
+            duration: 0,
+          },
+          TRANSITION_STATUS_ENTERED,
+        )
 
         done()
       }
@@ -440,16 +443,19 @@ describe('Transition', () => {
   })
 
   describe('onHide', () => {
-    it('is called with (null, props) when hidden', (done) => {
+    it('is called when hidden', (done) => {
       const onHide = sandbox.spy()
       const handleHide = (...args) => {
         onHide(...args)
 
         onHide.should.have.been.calledOnce()
-        onHide.should.have.been.calledWithMatch(null, {
-          duration: 0,
-          status: TRANSITION_STATUS_EXITED,
-        })
+        onHide.should.have.been.calledWithMatch(
+          null,
+          {
+            duration: 0,
+          },
+          TRANSITION_STATUS_EXITED,
+        )
 
         done()
       }
@@ -509,16 +515,19 @@ describe('Transition', () => {
   })
 
   describe('onShow', () => {
-    it('is called with (null, props) when shown', (done) => {
+    it('is called when shown', (done) => {
       const onShow = sandbox.spy()
       const handleShow = (...args) => {
         onShow(...args)
 
         onShow.should.have.been.calledOnce()
-        onShow.should.have.been.calledWithMatch(null, {
-          duration: 0,
-          status: TRANSITION_STATUS_ENTERED,
-        })
+        onShow.should.have.been.calledWithMatch(
+          null,
+          {
+            duration: 0,
+          },
+          TRANSITION_STATUS_ENTERED,
+        )
 
         done()
       }
@@ -552,16 +561,19 @@ describe('Transition', () => {
   })
 
   describe('onStart', () => {
-    it('is called with (null, props) when transition started', (done) => {
+    it('is called when transition started', (done) => {
       const onStart = sandbox.spy()
       const handleStart = (...args) => {
         onStart(...args)
 
         onStart.should.have.been.calledOnce()
-        onStart.should.have.been.calledWithMatch(null, {
-          duration: 0,
-          status: TRANSITION_STATUS_ENTERING,
-        })
+        onStart.should.have.been.calledWithMatch(
+          null,
+          {
+            duration: 0,
+          },
+          TRANSITION_STATUS_ENTERING,
+        )
 
         done()
       }


### PR DESCRIPTION
Resolves #4464

All callbacks to components which need to process some internal value of the component have had to pull the data out of the object intended to mirrors the props that were passed into the component back to the parent. This PR separates those concepts, so that the callbacks receive internal values of components as separate parameters from the props object.

These are clearly breaking changes but they make the API cleaner and make it possible to see what values (including their types) the callbacks.

To make them easier to review, the changes are broken up into commits by each component which needed to be updated. All tests pass locally after every commit.