### PR TITLE
docs(migrations): fix incorrect spelling of Visibility deprecation

### DIFF
--- a/docs/src/pages/MigrationGuide.mdx
+++ b/docs/src/pages/MigrationGuide.mdx
@@ -90,7 +90,7 @@ As we exported `Ref` component and recommended its usage everywhere we moved out
 
 More details on this change in [Semantic-Org/Semantic-UI-React#4286](https://github.com/Semantic-Org/Semantic-UI-React/pull/4286).
 
-## Removal of `Visibity` component
+## Removal of `Visibility` component
 
 <Message
   compact


### PR DESCRIPTION
This PR corrects the spelling of `Visibity` to `Visibility` in the V3 migration guide.