### PR TITLE
fix: add "linkedin in" icon name to enumeration to fix console error

### DIFF
--- a/src/generic.d.ts
+++ b/src/generic.d.ts
@@ -1967,6 +1967,7 @@ export type SemanticICONS =
   | 'lightning'
   | 'like'
   | 'line graph'
+  | 'linkedin in'
   | 'linkedin square'
   | 'linkify'
   | 'lira'

--- a/src/lib/SUI.js
+++ b/src/lib/SUI.js
@@ -1936,6 +1936,7 @@ export const ICON_ALIASES = [
   'lightning',
   'like',
   'line graph',
+  'linkedin in',
   'linkedin square',
   'linkify',
   'lira',


### PR DESCRIPTION
fixes #4470 by adding the "linkedin in" name to the existing enumerations