### PR TITLE
fix(Popup): fix ability to not hide popup on scroll

### DIFF
--- a/src/modules/Popup/Popup.js
+++ b/src/modules/Popup/Popup.js
@@ -124,6 +124,7 @@ const Popup = React.forwardRef(function (props, ref) {
     eventsEnabled = true,
     flowing,
     header,
+    hideOnScroll,
     inverted,
     offset,
     pinned = false,
@@ -179,8 +180,8 @@ const Popup = React.forwardRef(function (props, ref) {
     _.invoke(props, 'onOpen', e, { ...props, open: true })
   }
 
-  const hideOnScroll = (e) => {
-    debug('hideOnScroll()')
+  const handleHideOnScroll = (e) => {
+    debug('handleHideOnScroll()')
 
     // Do not hide the popup when scroll comes from inside the popup
     // https://github.com/Semantic-Org/Semantic-UI-React/issues/4305
@@ -253,7 +254,7 @@ const Popup = React.forwardRef(function (props, ref) {
         ) : (
           children
         )}
-        {hideOnScroll && <EventStack on={hideOnScroll} name='scroll' target='window' />}
+        {hideOnScroll && <EventStack on={handleHideOnScroll} name='scroll' target='window' />}
       </ElementType>
     )
 


### PR DESCRIPTION
Fixes #4483 and #4476

In some implementations `hideOnScroll` being always truthy could cause popups to close and open all the time, for example if body height gets changed which could trigger scroll event and automatically close just opened popup. 

As a result the issue could be a bit showstopper to migrate to v3 as there doesn't seem to be a way to workaround the issue without merging this PR and deploying next beta version (CC @layershifter)