### PR TITLE
chore(eslint): enable react-hooks/recommended

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "root": true,
   "parser": "babel-eslint",
-  "extends": ["airbnb", "prettier"],
+  "extends": ["airbnb", "prettier", "plugin:react-hooks/recommended"],
   "env": {
     "browser": true
   },

--- a/src/modules/Accordion/AccordionAccordion.js
+++ b/src/modules/Accordion/AccordionAccordion.js
@@ -64,6 +64,9 @@ const AccordionAccordion = React.forwardRef(function (props, ref) {
   })
 
   if (process.env.NODE_ENV !== 'production') {
+    // Following eslint error is ignored because process.env.NODE_ENV does not change during runtime,
+    // so it is not actually a problem because the useEffect will be called either always or never
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
       /* eslint-disable no-console */
       if (exclusive && typeof activeIndex !== 'number') {


### PR DESCRIPTION
The only problem is that there are few internal functions that have prefix "use" and eslint thinks that they are hooks.

Should the code be refactored along with this PR or it is just ok that some false positive errors would pop up with accepting this PR?