### PR TITLE
chore(Popup): replace event-stack

### DIFF
--- a/src/addons/Portal/Portal.d.ts
+++ b/src/addons/Portal/Portal.d.ts
@@ -37,6 +37,9 @@ export interface StrictPortalProps {
   /** Event pool namespace that is used to handle component events. */
   eventPool?: string
 
+  /** Hide the Popup when scrolling the window. */
+  hideOnScroll?: boolean
+
   /** The node where the portal should mount. */
   mountNode?: any
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -152,26 +152,23 @@ function Portal(props) {
     if (!hideOnScroll) {
       return
     }
-    const abortController = new AbortController()
 
-    window.addEventListener(
-      'scroll',
-      (e) => {
-        debug('handleHideOnScroll()')
+    const handleScroll = (e) => {
+      debug('handleHideOnScroll()')
 
-        // Do not hide the popup when scroll comes from inside the popup
-        // https://github.com/Semantic-Org/Semantic-UI-React/issues/4305
-        if (_.isElement(e.target) && contentRef.current.contains(e.target)) {
-          return
-        }
+      // Do not hide the popup when scroll comes from inside the popup
+      // https://github.com/Semantic-Org/Semantic-UI-React/issues/4305
+      if (_.isElement(e.target) && contentRef.current.contains(e.target)) {
+        return
+      }
 
-        closePortal(e)
-      },
-      { signal: abortController.signal, passive: true },
-    )
+      closePortal(e)
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
 
     return () => {
-      abortController.abort()
+      window.removeEventListener('scroll', handleScroll)
     }
   }, [closePortal, hideOnScroll])
 

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -38,6 +38,7 @@ function Portal(props) {
     openOnTriggerClick = true,
     openOnTriggerFocus,
     openOnTriggerMouseEnter,
+    hideOnScroll = false,
   } = props
 
   const [open, setOpen] = useAutoControlledValue({
@@ -145,6 +146,33 @@ function Portal(props) {
   // ----------------------------------------
   // Component Event Handlers
   // ----------------------------------------
+
+  React.useEffect(() => {
+    if (!hideOnScroll) {
+      return
+    }
+    const abortController = new AbortController()
+
+    window.addEventListener(
+      'scroll',
+      (e) => {
+        debug('handleHideOnScroll()')
+
+        // Do not hide the popup when scroll comes from inside the popup
+        // https://github.com/Semantic-Org/Semantic-UI-React/issues/4305
+        if (_.isElement(e.target) && contentRef.current.contains(e.target)) {
+          return
+        }
+
+        closePortal(e)
+      },
+      { signal: abortController.signal, passive: true },
+    )
+
+    return () => {
+      abortController.abort()
+    }
+  }, [closePortal, hideOnScroll])
 
   const handlePortalMouseLeave = (e) => {
     if (!closeOnPortalMouseLeave) {
@@ -317,6 +345,9 @@ Portal.propTypes = {
 
   /** Event pool namespace that is used to handle component events */
   eventPool: PropTypes.string,
+
+  /** Hide the Popup when scrolling the window. */
+  hideOnScroll: PropTypes.bool,
 
   /** The node where the portal should mount. */
   mountNode: PropTypes.any,

--- a/src/addons/Portal/Portal.js
+++ b/src/addons/Portal/Portal.js
@@ -9,6 +9,7 @@ import {
   doesNodeContainClick,
   makeDebugger,
   useAutoControlledValue,
+  useEventCallback,
 } from '../../lib'
 import useTrigger from './utils/useTrigger'
 import PortalInner from './PortalInner'
@@ -74,12 +75,12 @@ function Portal(props) {
     return setTimeout(() => openPortal(eventClone), delay || 0)
   }
 
-  const closePortal = (e) => {
+  const closePortal = useEventCallback((e) => {
     debug('close()')
 
     setOpen(false)
     _.invoke(props, 'onClose', e, { ...props, open: false })
-  }
+  })
 
   const closePortalWithTimeout = (e, delay) => {
     debug('closeWithTimeout()', delay)


### PR DESCRIPTION
I think that removing event-stack might be better done incrementally as each the components are independent.

I've replicated that Popup only listens for scroll when the Popup is open and enabled.
I would prefer the whole useEffect hidden under the condition however that might require much more refactoring. This way it's cleaner to see what happened in the diff. Let me know the other way would be preferred.