### PR TITLE
update react and react-dom peerdeps to include v 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,8 +181,8 @@
     "webpack-dev-middleware": "^3.7.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0" || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0" || ^19.0.0"
   },
   "resolutions": {
     "babel-plugin-universal-import": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -181,8 +181,8 @@
     "webpack-dev-middleware": "^3.7.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0" || ^19.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0" || ^19.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "resolutions": {
     "babel-plugin-universal-import": "^2.0.2",


### PR DESCRIPTION
I have been using semantic-ui-react (v3 beta) with react 19 for a good while without any issues. Can we please include that version in the react peer deps range so I can avoid having to do --legacy-peer-deps?

I do not update the package version in this PR, but if you can do that and release a new version, that would be amazing.

many thanks 🙏🏼